### PR TITLE
ci: auto-deploy to Cloudflare Pages on main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy to Cloudflare Pages
+
+# Triggers on merges to main (post-PR). CI already gates the PR, so
+# this workflow trusts the build passed and just re-builds + ships.
+# `workflow_dispatch` lets us redeploy the current main manually from
+# the Actions tab without pushing an empty commit.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Never cancel an in-flight deploy — cutting a deploy off mid-upload
+# leaves CF Pages thinking the build failed, which is noisier to
+# recover from than just letting the prior run finish. A newer push
+# queues behind; CF keeps every successful deploy addressable by its
+# commit SHA anyway, so no production state is lost.
+concurrency:
+  group: deploy-cloudflare-pages
+  cancel-in-progress: false
+
+# Read-only by default; the deploy step uses its own CF API token, not
+# GITHUB_TOKEN, so no extra permissions are needed here.
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: build + deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://chat-arch.dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Same corepack + Node 22 toolchain ci.yml uses, so the build
+      # that lands on main is byte-for-byte the one that passed CI.
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm build` walks every workspace. The standalone app imports
+      # @chat-arch/viewer and @chat-arch/schema at build time; those
+      # packages resolve via each package's `main: dist/…`, so they
+      # must build before the Astro build tries to bundle them.
+      - name: Build
+        run: pnpm build
+
+      # Ship the static output. Astro with `output: 'static'` + the
+      # Node adapter emits static files to `apps/standalone/dist/client/`
+      # and the server bundle (for /api/rescan, /api/clear) to
+      # `dist/server/`. On CF Pages the server bundle is dead weight —
+      # we intentionally upload only the client directory, and the
+      # API routes' GET probes will 404 in production, which the UI
+      # already handles by hiding the RESCAN/DELETE buttons.
+      #
+      # `--branch=main` tells Wrangler this is a production deploy
+      # (not a preview). CF resolves the project by name; the project
+      # must already exist — create it once in the dashboard or via
+      # `wrangler pages project create chat-arch`.
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy apps/standalone/dist/client --project-name=chat-arch --branch=main --commit-dirty=true

--- a/apps/standalone/astro.config.mjs
+++ b/apps/standalone/astro.config.mjs
@@ -39,6 +39,11 @@ const crossOriginIsolationHeaders = {
 };
 
 export default defineConfig({
+  // Public URL of the hosted deploy. Used for sitemap generation and
+  // any canonical-URL emission. The custom domain resolves via
+  // Cloudflare Pages (DNS CNAME → chat-arch.pages.dev); the Pages
+  // default `.pages.dev` subdomain continues to serve the same build.
+  site: 'https://chat-arch.dev',
   integrations: [react()],
   output: 'static',
   adapter: node({ mode: 'standalone' }),

--- a/apps/standalone/public/_headers
+++ b/apps/standalone/public/_headers
@@ -1,0 +1,25 @@
+# Cloudflare Pages response headers. Astro copies `public/_headers`
+# verbatim into `dist/client/_headers`, which CF Pages reads at the
+# edge and applies to every matching response.
+#
+# Why each header is here:
+#
+#   Cross-Origin-Opener-Policy + Cross-Origin-Embedder-Policy
+#     Enable cross-origin isolation so SharedArrayBuffer is available.
+#     Transformers.js's WASM backend (the Phase-3 "Analyze Topics"
+#     feature) refuses to boot without SAB. Without these headers the
+#     feature fails at ORT init with an opaque heap-pointer error.
+#     `credentialless` (not `require-corp`) lets the HuggingFace CDN
+#     weight download work: HF doesn't send CORP headers on its static
+#     assets, so `require-corp` would block the fetch. See
+#     `astro.config.mjs` for the matching dev-server headers.
+#
+#   X-Frame-Options: DENY
+#     No page in this app is meant to be iframed. The BaseLayout CSP
+#     notes that `frame-ancestors` via <meta> is ignored by browsers
+#     and wants an HTTP header; this is that header. XFO is the
+#     widely-supported predecessor and does the same job here.
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: credentialless
+  X-Frame-Options: DENY


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy.yml` — builds on every `push: main` and ships `apps/standalone/dist/client/` to Cloudflare Pages via `cloudflare/wrangler-action@v3`.
- Adds `apps/standalone/public/_headers` — Astro copies it verbatim into `dist/client/_headers`; CF Pages reads it at the edge. Carries COOP/COEP (unblocks the transformers.js WASM backend + `SharedArrayBuffer` for Analyze Topics) plus `X-Frame-Options: DENY`.
- Adds `site: 'https://chat-arch.dev'` to `astro.config.mjs` — canonical URL for sitemap + any metadata emission.

## Design notes

- **Why CF Pages, not GH Pages.** GH Pages can't set response headers, and without COOP/COEP the viewer's Phase-3 semantic-labels feature fails at ORT init with an opaque heap-pointer error. CF Pages has `public/_headers` support.
- **Why `dist/client/` only.** The Node adapter is still wired for the dev-mode `/api/rescan` and `/api/clear` endpoints. On a static deploy the server bundle (`dist/server/`) is dead weight; the UI already hides RESCAN/DELETE when the GET probe 404s.
- **Why PR-only CI stays unchanged.** The deploy job trusts the build that merged to main already passed CI. It re-runs `pnpm install --frozen-lockfile` + `pnpm build` because that's the artifact-producing step, but no lint/test duplication.
- **Why `X-Frame-Options` in `_headers`.** `BaseLayout.astro`'s CSP comment already flags `frame-ancestors` via `<meta>` as ignored by browsers and wants an HTTP header. This is that header.

## Manual setup required before first green deploy

The workflow references two repo secrets and a Cloudflare Pages project that don't exist yet:

1. Register `chat-arch.dev` (CF Registrar recommended — keeps DNS + Pages binding in one place).
2. In Cloudflare dashboard, create a Pages project named `chat-arch` (or `wrangler pages project create chat-arch`). **Don't** connect the Git integration — this workflow uploads via API.
3. Add the custom domain `chat-arch.dev` (and `www.chat-arch.dev` if desired) to the Pages project.
4. Generate an API token with **Account / Cloudflare Pages / Edit** permission.
5. Add two GitHub repo secrets: `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.

Before step 5 is done, merging this PR will land the workflow but the first run will fail at the deploy step — that's fine, rerun from the Actions tab after secrets land.

## Test plan

- [ ] Local build still succeeds (`pnpm --filter @chat-arch/standalone build`) — verified, `dist/client/_headers` lands and COOP/COEP are readable.
- [ ] CI passes on this PR (install + lint + build + test).
- [ ] After merge + secrets setup: first push to main triggers deploy, `chat-arch.pages.dev` serves the viewer with demo corpus visible.
- [ ] Custom domain resolves to the same build.
- [ ] COOP/COEP headers present on response (`curl -I https://chat-arch.dev/ | grep -i cross-origin`).
- [ ] Analyze Topics works in the hosted build (indirect proof SAB is available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)