### PR TITLE
ci: bypass wrangler-action to dodge pnpm workspace guard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,9 +67,21 @@ jobs:
       # (not a preview). CF resolves the project by name; the project
       # must already exist — create it once in the dashboard or via
       # `wrangler pages project create chat-arch`.
+      #
+      # We invoke wrangler directly rather than via `cloudflare/
+      # wrangler-action@v3`. The action detects a package manager from
+      # pnpm-lock.yaml and runs `pnpm add wrangler@<pinned>`, which
+      # pnpm's workspace-root guard rejects (`ERR_PNPM_ADDING_TO_ROOT`)
+      # unless you pass `-w`. The action has no input to override the
+      # install command, so the cleanest path is to bypass it entirely
+      # and install wrangler globally via npm — which ignores pnpm's
+      # workspace machinery because it's a different tool installing
+      # to a different prefix.
+      - name: Install Wrangler
+        run: npm install -g wrangler@3
+
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/standalone/dist/client --project-name=chat-arch --branch=main --commit-dirty=true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy apps/standalone/dist/client --project-name=chat-arch --branch=main --commit-dirty=true


### PR DESCRIPTION
## Summary

Fixes the first Cloudflare Pages deploy that failed on main (commit `34fe701`). The `cloudflare/wrangler-action@v3` step errored with:

```
/usr/local/bin/pnpm add wrangler@3.90.0
ERR_PNPM_ADDING_TO_ROOT  Running this command will add the dependency
to the workspace root, which might not be what you want — if you
really meant it, make it explicit by running this command again with
the -w flag.
```

The action auto-detects pnpm from `pnpm-lock.yaml` and runs `pnpm add <wrangler>`; pnpm's workspace-root guard refuses. The action has no input to override the install command, so this swaps the action for a direct wrangler invocation:

```yaml
- name: Install Wrangler
  run: npm install -g wrangler@3

- name: Deploy to Cloudflare Pages
  env:
    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
  run: wrangler pages deploy apps/standalone/dist/client --project-name=chat-arch --branch=main --commit-dirty=true
```

`npm install -g` writes to npm's global prefix (outside the pnpm workspace), so the workspace-root guard never fires. Wrangler reads credentials from the two env vars and behaves identically to the action's command path.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, the Deploy workflow on `main` completes the Install-Wrangler + Deploy steps without errors.
- [ ] https://chat-arch.dev/ serves the viewer (DNS already points to CF Pages per the prior setup).
- [ ] `curl -I https://chat-arch.dev/ | grep -i cross-origin` shows COOP + COEP present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)