### PR TITLE
fix(csp): use Astro auto-hashing CSP so island hydration can boot

### DIFF
--- a/apps/standalone/astro.config.mjs
+++ b/apps/standalone/astro.config.mjs
@@ -47,6 +47,46 @@ export default defineConfig({
   integrations: [react()],
   output: 'static',
   adapter: node({ mode: 'standalone' }),
+  // Astro 5.9+ ships an auto-hashing CSP. It computes a SHA-256 hash
+  // for every inline <script> and <style> block it emits (including
+  // the astro-island loader + hydration bootstrap) and injects those
+  // hashes into script-src / style-src — so inline scripts we ship
+  // are permitted while anything injected at runtime (e.g. from
+  // transcript content that bypassed the viewer's sanitizer) still
+  // gets blocked.
+  //
+  // Replaces the hand-written <meta http-equiv="Content-Security-
+  // Policy"> that used to live in BaseLayout.astro. That pinned
+  // script-src to 'self' with no inline allowance, which blocked the
+  // island loader and stranded every page on "LOADING MANIFEST…"
+  // because hydration never started.
+  //
+  // `resources` *replaces* Astro's default resources for each
+  // directive (it does not merge), so anything we want permitted has
+  // to be listed explicitly alongside the auto-generated hashes.
+  // style-src keeps 'unsafe-inline' because React components can
+  // inject runtime <style> tags that Astro doesn't see at build
+  // time (no hash generated); scripts have no equivalent runtime
+  // injection path, so script-src stays tight.
+  experimental: {
+    csp: {
+      directives: [
+        "default-src 'self'",
+        "font-src 'self' https://fonts.gstatic.com",
+        "img-src 'self' data: blob:",
+        "connect-src 'self'",
+        "base-uri 'self'",
+        "form-action 'self'",
+        "object-src 'none'",
+      ],
+      scriptDirective: {
+        resources: ["'self'"],
+      },
+      styleDirective: {
+        resources: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
+      },
+    },
+  },
   vite: {
     server: {
       headers: crossOriginIsolationHeaders,

--- a/apps/standalone/src/layouts/BaseLayout.astro
+++ b/apps/standalone/src/layouts/BaseLayout.astro
@@ -3,37 +3,21 @@ interface Props {
   title: string;
 }
 const { title } = Astro.props;
-// Vite/Astro dev mode relies on inline scripts and eval for HMR + the
-// React fast-refresh preamble; a strict script-src 'self' CSP breaks
-// hydration. Production builds emit only bundled scripts, so the
-// strict policy applies cleanly there. Gate on import.meta.env.PROD.
-const isProd = import.meta.env.PROD;
 ---
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    {isProd && (
-      /*
-        Defense-in-depth Content Security Policy. The viewer's transcript
-        renderer escapes user content before passing it to
-        dangerouslySetInnerHTML; this policy guarantees that even if that
-        escape order ever regresses, an injected <script> from transcript
-        content cannot execute. Allowed:
-          - scripts only from same origin (no inline, no eval)
-          - styles inline (BaseLayout has a <style> tag) + Google Fonts
-          - fonts from Google Fonts
-          - images from same origin, data:, and blob: (upload previews)
-          - fetch only to same origin (covers /api/rescan, manifest, etc.)
-        frame-ancestors via meta is ignored by browsers; a future
-        production deployment should set it as an HTTP response header.
-      */
-      <meta
-        http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self'; base-uri 'self'; form-action 'self'; object-src 'none'"
-      />
-    )}
+    {/*
+      Content Security Policy is emitted by Astro's experimental CSP
+      machinery (see astro.config.mjs). It auto-hashes every inline
+      script/style we ship and merges that with the directive list in
+      the config. Keeping the meta tag out of here means the CSP can't
+      silently diverge from what Astro actually emits for hashes.
+      frame-ancestors lives in apps/standalone/public/_headers because
+      it only takes effect as an HTTP response header.
+    */}
     <title>{title}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

Fixes the live site that's been stuck on "LOADING MANIFEST…" since the first green deploy.

## Root cause

The hand-written CSP meta tag in [BaseLayout.astro](apps/standalone/src/layouts/BaseLayout.astro) pinned `script-src 'self'` with no inline allowance. Astro's build ships two inline `<script>` blocks into every page — the astro-island loader and the hydration bootstrap — and without them the `<astro-island>` custom element is never registered. That means the `component-url` / `renderer-url` dynamic imports (which pull `/_astro/viewer.*.js` and `/_astro/client.*.js`) never fire, the viewer never hydrates, and the "LOADING MANIFEST…" pre-hydration fallback is all users see.

Network inspection on https://chat-arch.dev/ confirmed: HTML/CSS/fonts all 200, but no request for any `/_astro/*.js` bundle or `manifest.json` ever left the browser.

## Fix

Switch to Astro's experimental CSP (available since 5.9, we're on 5.18). Astro computes a SHA-256 for every inline script/style it emits and injects those hashes into `script-src` / `style-src`. Inline scripts we ship are permitted via hash; anything runtime-injected (e.g. a sanitizer regression) still gets blocked for lack of a matching hash.

- **[astro.config.mjs](apps/standalone/astro.config.mjs):** add `experimental.csp` with the full directive list (default-src, font-src, img-src, connect-src, base-uri, form-action, object-src) plus explicit `scriptDirective.resources: ["'self'"]` and `styleDirective.resources: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com']`. `resources` replaces Astro's defaults rather than merging, so 'self' has to be listed explicitly.
- **[BaseLayout.astro](apps/standalone/src/layouts/BaseLayout.astro):** remove the hardcoded `<meta http-equiv="Content-Security-Policy">` — Astro now emits one with the correct hashes.

`style-src` keeps `'unsafe-inline'` because React components can inject runtime `<style>` tags that aren't visible at build time, so hashing alone isn't enough. Scripts have no equivalent runtime-injection path, so `script-src` stays tight (self + hashes only).

## Verification

Built the production bundle locally and ran `astro preview` on port 4325. Network trace of the initial page load:

```
/                                       200
/_astro/viewer.FOnrnHQg.js              200  ← was missing in prod
/_astro/client.BJHgAj4G.js              200  ← was missing in prod
/_astro/index._OACqPSs.js               200  ← was missing in prod
/chat-arch-data/manifest.json           200  ← was missing in prod
```

The generated CSP meta tag includes seven script-hash entries for Astro's inline blocks plus the style-hash entries.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge + auto-deploy, https://chat-arch.dev/ renders the viewer with the demo corpus visible (not just "LOADING MANIFEST…").
- [ ] View-source on the live site shows a CSP meta with sha256 hashes in `script-src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)