### PR TITLE
fix(deploy): empty-state landing + DELETE works on static deploys

### DIFF
--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "node scripts/seed-demo-data.mjs && astro dev",
-    "build": "node scripts/seed-demo-data.mjs && astro check && astro build",
+    "dev": "astro dev",
+    "build": "astro check && astro build",
     "preview": "astro preview",
     "typecheck": "astro check",
     "lint": "eslint src",

--- a/packages/viewer/src/components/NuclearReset.tsx
+++ b/packages/viewer/src/components/NuclearReset.tsx
@@ -21,12 +21,19 @@ import { clearBenchResults } from '../data/benchResultsStore.js';
  * checkboxes already force a deliberate decision — adding typed
  * confirmation on top felt bureaucratic for "delete my CLI data only".
  *
- * Auto-hides when `available === false` — static-build deploys
- * without `/api/clear` get no surface.
+ * Always renders. `available` gates the server-side POST, not the
+ * surface itself — on a static-build deploy (no Astro backend, so no
+ * `/api/clear`) the dropdown still appears and the commit path runs
+ * client-only: skip the POST, wipe the three IndexedDB stores that
+ * belong to an uploaded ZIP. The other three sources (cli-direct /
+ * cli-desktop / cowork) have count=0 on static deploys since there's
+ * no exporter to have produced them, so selecting them is a no-op
+ * rather than an error.
  */
 
 export interface NuclearResetProps {
-  /** True when `/api/clear` is reachable. Controls button visibility. */
+  /** True when `/api/clear` is reachable. Gates the server POST only;
+   *  the client-IDB wipe path always runs. */
   available: boolean;
   /** Host's in-memory-ZIP unload handler. Called before the post-wipe
    *  reload so a stale upload doesn't survive into the fresh state. */
@@ -129,8 +136,6 @@ export function NuclearReset({ available, onUnload, counts }: NuclearResetProps)
     return () => document.removeEventListener('keydown', onKey);
   }, [open, phase]);
 
-  if (!available) return null;
-
   const countOf = (id: SourceId): number => counts?.[id] ?? 0;
   const totalSelectedSessions = Array.from(selected).reduce((a, id) => a + countOf(id), 0);
   const allSelected = selected.size === SOURCES.length;
@@ -161,18 +166,26 @@ export function NuclearReset({ available, onUnload, counts }: NuclearResetProps)
     setErrorMsg(null);
     try {
       const sources = Array.from(selected);
-      const res = await fetch('/api/clear', {
-        method: 'POST',
-        headers: {
-          'x-requested-with': 'chat-arch-clear',
-          'content-type': 'application/json',
-        },
-        credentials: 'same-origin',
-        body: JSON.stringify({ sources }),
-      });
-      if (!res.ok) {
-        const body = await res.text().catch(() => '');
-        throw new Error(`HTTP ${res.status}${body ? ': ' + body.slice(0, 200) : ''}`);
+      // Skip the POST on static-build deploys — the endpoint doesn't
+      // exist. The client-IDB wipe below still runs, which is the only
+      // state a static deploy can meaningfully wipe anyway (uploaded
+      // ZIP + derived labels/bench). The non-cloud checkboxes have
+      // count=0 on static, so selecting them does nothing on either
+      // side of this branch.
+      if (available) {
+        const res = await fetch('/api/clear', {
+          method: 'POST',
+          headers: {
+            'x-requested-with': 'chat-arch-clear',
+            'content-type': 'application/json',
+          },
+          credentials: 'same-origin',
+          body: JSON.stringify({ sources }),
+        });
+        if (!res.ok) {
+          const body = await res.text().catch(() => '');
+          throw new Error(`HTTP ${res.status}${body ? ': ' + body.slice(0, 200) : ''}`);
+        }
       }
       // Wipe ALL cloud-derived IDBs when cloud is among the victims:
       //


### PR DESCRIPTION
## Summary

Follow-up to the initial [chat-arch.dev](https://chat-arch.dev) deploy. The site went live pre-populated with 100 demo sessions and without a visible DELETE button — not the empty-with-upload-CTA experience the viewer's [EmptyState](packages/viewer/src/components/EmptyState.tsx) component was designed for. Two separate misses, fixed independently:

### 1. Strip `seed-demo-data` from the build

[apps/standalone/package.json](apps/standalone/package.json) wired [seed-demo-data.mjs](apps/standalone/scripts/seed-demo-data.mjs) into both `dev` and `build` scripts. It copies viewer test fixtures into `public/chat-arch-data/` before Astro snapshots it, so the prod artifact shipped with a populated manifest and the viewer rendered straight into the populated layout — never hitting the empty-state branch at [ChatArchViewer.tsx:2029](packages/viewer/src/ChatArchViewer.tsx:2029).

The demo corpus is still available, just on-demand: [`generateDemoUpload()`](packages/viewer/src/data/demoUpload.ts) produces the same fixture in-browser, and the "Load Demo Data" button in [UploadPanel](packages/viewer/src/components/UploadPanel.tsx) is already wired to it via `onLoadDemo` on [ChatArchViewer.tsx:1362](packages/viewer/src/ChatArchViewer.tsx:1362). Dropping the build-time seed routes users through those existing affordances.

### 2. Unhook NuclearReset from `/api/clear` availability

[NuclearReset.tsx](packages/viewer/src/components/NuclearReset.tsx)'s `available` prop was gating *button visibility* on `/api/clear` reachability — which is always false on static deploys, because the endpoint only exists under the Astro Node adapter. But the component also wipes three client-side IndexedDB stores (uploaded ZIP, semantic labels, bench results), which work identically with or without a backend.

The fix retitles `available` as "gates the server POST only":
- Button always renders.
- `fetch('/api/clear')` runs only when a backend is present.
- Client-IDB wipe path always runs.

Static deploys get a working DELETE that wipes the user's own upload and drops them back into the empty state on reload.

## Verification

Locally, with seed-demo removed + clean build + `astro preview`:

- Manifest.json 404s on first load → viewer renders **EmptyState** with:
  - "choose cloud export zip" button
  - "load demo data" button
- Clicking Load Demo → populates the full demo corpus (Bluefin Mobile, Prism Highlight, Codex Archive, …) via the in-browser generator.
- DELETE button visible in the top bar — opens the 4-source dropdown (SELECT ALL, CANCEL, DELETE SELECTED).

325/325 existing viewer tests still pass.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge + auto-deploy, https://chat-arch.dev/ renders the empty state (upload + load-demo buttons) on first load.
- [ ] Clicking Load Demo populates the demo corpus client-side.
- [ ] DELETE button visible in the top bar.
- [ ] DELETE flow from a populated demo state wipes client IDB and reloads to empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)