### PR TITLE
fix(deploy): ship empty manifest so CF edge overwrites stale content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,15 @@ out/
 apps/standalone/public/chat-arch-data/*
 # Keep empty chat-arch-data dir on fresh clones.
 !apps/standalone/public/chat-arch-data/.gitkeep
+# Track the empty default manifest. Shipping it (instead of relying on a
+# 404 for the initial empty state) forces CF Pages' edge cache to
+# overwrite any previously-cached populated manifest on every deploy —
+# CF auto-invalidates files it serves in the new build, but files that
+# were *removed* from a build get orphaned at the edge indefinitely.
+# The viewer's EmptyState path handles `sessions.length === 0` cleanly,
+# so an empty manifest and a missing manifest produce the same UX
+# modulo the edge-cache behavior.
+!apps/standalone/public/chat-arch-data/manifest.json
 
 # Internal scratch spaces — never ship
 _audit/

--- a/apps/standalone/public/chat-arch-data/manifest.json
+++ b/apps/standalone/public/chat-arch-data/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": 0,
+  "counts": {
+    "cloud": 0,
+    "cowork": 0,
+    "cli-direct": 0,
+    "cli-desktop": 0
+  },
+  "sessions": []
+}


### PR DESCRIPTION
## Summary

Follow-up to [PR #5](https://github.com/BryceEWatson/chat-arch/pull/5). Stripping `seed-demo-data` from the build was the right call for the empty-state UX, but it left the previously-deployed `manifest.json` orphaned at Cloudflare Pages' edge cache — CF auto-invalidates files *present* in a new build, but files that were *removed* keep serving the prior-cached content. Net result on https://chat-arch.dev/: the custom domain was still handing out the 100-session populated manifest from the first successful deploy, while `chat-arch.pages.dev/chat-arch-data/manifest.json` correctly 404s (matches the removed file).

Ship an always-empty `apps/standalone/public/chat-arch-data/manifest.json` so every deploy *overwrites* the cached entry with new content rather than orphaning it:

```json
{
  "schemaVersion": 1,
  "generatedAt": 0,
  "counts": { "cloud": 0, "cowork": 0, "cli-direct": 0, "cli-desktop": 0 },
  "sessions": []
}
```

The viewer's [`EmptyState`](packages/viewer/src/components/EmptyState.tsx) path at [ChatArchViewer.tsx:2029](packages/viewer/src/ChatArchViewer.tsx:2029) handles `sessions.length === 0` identically to a missing manifest — same upload + load-demo CTAs — so UX is unchanged modulo the edge-cache behavior.

## .gitignore

Narrow allowlist for the empty manifest only:

```gitignore
apps/standalone/public/chat-arch-data/*
!apps/standalone/public/chat-arch-data/.gitkeep
!apps/standalone/public/chat-arch-data/manifest.json
```

Rest of `chat-arch-data/*` stays ignored because it's local exporter output with potentially-personal content.

## Verification

`astro preview` against the fresh build:
- Manifest loads as empty JSON (200 OK, `sessions: []`).
- Viewer chrome renders with zero values (`$0.00`, `top tool none`, `top project none`).
- Session area shows EmptyState with "choose cloud export zip" + "load demo data" buttons.
- Delete button visible, dropdown opens as expected.

## Test plan

- [x] CI passes.
- [ ] After merge + auto-deploy, https://chat-arch.dev/chat-arch-data/manifest.json returns the empty manifest (200 OK, `sessions: []`).
- [ ] https://chat-arch.dev/ renders the empty state on first load (in a private window / after wiping IDB; returning visitors with persisted uploads still see their own data, which is correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)