### PR TITLE
fix(viewer): route empty manifest through minimal NO DATA YET layout

### DIFF
--- a/packages/viewer/src/ChatArchViewer.test.tsx
+++ b/packages/viewer/src/ChatArchViewer.test.tsx
@@ -156,9 +156,16 @@ describe('ChatArchViewer', () => {
     expect(screen.getByLabelText(/choose cloud export zip/i)).toBeDefined();
   });
 
-  it('shows EmptyState when manifest has zero sessions', () => {
+  it('routes a well-formed empty manifest to the NO DATA YET landing', () => {
+    // A shipped-empty manifest.json (schemaVersion + counts + `sessions: []`)
+    // now takes the same minimal "no data yet" code path as a 404'd manifest.
+    // Previously it rendered EmptyState inside the full viewer chrome (KPIs,
+    // filter pills, projects list) — a distracting "nothing here but here's
+    // all the chrome" state. See the empty-manifest-minimal-layout PR.
     render(<ChatArchViewer manifest={emptyManifest} />);
-    expect(screen.getByText('NO SESSIONS')).toBeDefined();
+    expect(screen.getByRole('heading', { name: /NO DATA YET/i })).toBeDefined();
+    // Upload + load-demo CTAs are the actionable path out.
+    expect(screen.getByLabelText(/choose cloud export zip/i)).toBeDefined();
   });
 
   it('filters by search query (case-insensitive substring, debounced)', async () => {

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -1697,7 +1697,28 @@ export function ChatArchViewer({
     );
   }
 
-  if (!uploadedData && manifestState.status === 'error') {
+  // Minimal "NO DATA YET" layout. Two triggers now, both producing
+  // the same UX (top bar + ErrorState + upload/load-demo panel):
+  //
+  //   1. Manifest fetch errored (404, network, parse).
+  //   2. Manifest fetch succeeded but the file is the empty shipped
+  //      default (`sessions.length === 0`). This is what new visitors
+  //      to the hosted deploy hit on first load — `public/chat-arch-
+  //      data/manifest.json` ships as `{...counts all 0, sessions: []}`
+  //      so CF Pages' edge cache overwrites any prior populated
+  //      manifest; see the empty-manifest PR for the full story.
+  //
+  // Before this branch existed, case 2 fell through to the populated
+  // render path, which dressed the empty-state component in the full
+  // KPI tiles + filter pills + projects list chrome — a distracting
+  // "nothing here, but here's all the chrome anyway" state for a
+  // first-time visitor. Routing both cases here keeps the landing
+  // stripped down to the two actions a first-time visitor cares
+  // about: upload their export, or load the demo fixture.
+  const manifestIsEmpty = manifest !== null && manifest.sessions.length === 0;
+  if (!uploadedData && (manifestState.status === 'error' || manifestIsEmpty)) {
+    const fetchErrorSuffix =
+      manifestState.status === 'error' ? ` (fetch: ${manifestState.message})` : '';
     return (
       <div className="lcars-root" data-tier={tier}>
         <div className="lcars-frame lcars-frame--empty">
@@ -1726,7 +1747,7 @@ export function ChatArchViewer({
           <main className="lcars-empty-main">
             <ErrorState
               title="NO DATA YET"
-              detail={`Click SCAN LOCAL above to index your Claude Code / Desktop / Cowork transcripts, or UPLOAD CLOUD for a claude.ai Privacy-Export ZIP. Restart the dev server with pnpm dev to seed a sample corpus instead. See the README for the full walkthrough. (fetch: ${manifestState.message})`}
+              detail={`Click SCAN LOCAL above to index your Claude Code / Desktop / Cowork transcripts, or UPLOAD CLOUD for a claude.ai Privacy-Export ZIP. Or hit LOAD DEMO DATA below to populate the viewer with a generated sample corpus. See the README for the full walkthrough.${fetchErrorSuffix}`}
             />
             <UploadPanel onLoaded={onUpload} variant="prominent" onLoadDemo={onLoadDemo} />
           </main>

--- a/packages/viewer/src/components/ErrorBoundary.test.tsx
+++ b/packages/viewer/src/components/ErrorBoundary.test.tsx
@@ -68,7 +68,12 @@ describe('ChatArchViewer manifest ingestion (R12 F12.1)', () => {
     );
   });
 
-  it('renders UC-8 NO SESSIONS for a well-formed empty manifest', () => {
+  it('routes a well-formed empty manifest to NO DATA YET, not a blank page', () => {
+    // UC-8 predecessor asserted the full-chrome EmptyState ("NO SESSIONS"
+    // heading). That branch is unreachable on first load now — a shipped-
+    // empty manifest routes through the same minimal "NO DATA YET" layout
+    // as a 404'd fetch. What this test still pins: an empty manifest must
+    // never crash or render a blank page.
     const empty = {
       schemaVersion: 1 as const,
       generatedAt: 0,
@@ -76,6 +81,6 @@ describe('ChatArchViewer manifest ingestion (R12 F12.1)', () => {
       sessions: [] as const,
     };
     render(<ChatArchViewer manifest={empty} />);
-    expect(screen.getByText('NO SESSIONS')).toBeDefined();
+    expect(screen.getByRole('heading', { name: /NO DATA YET/i })).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to [PR #6](https://github.com/BryceEWatson/chat-arch/pull/6). Shipping an always-empty manifest fixed the edge-cache staleness but regressed the first-load UX — the well-formed empty manifest took the populated render path, which wrapped EmptyState in the full viewer chrome (KPI tiles, OVERVIEW/ANALYSIS tabs, source-filter pills with zero counts, PROJECTS label, command sort bar). Distracting "wall of zero-value dashboard widgets around an upload CTA" for a first-time visitor.

## Fix

The `NO DATA YET` early return at [ChatArchViewer.tsx:1700](packages/viewer/src/ChatArchViewer.tsx:1700) was already the right layout for the 404 case — just TopBar + ErrorState + UploadPanel. Expand its guard to also fire when the fetch succeeded but `manifest.sessions.length === 0` and there's no uploaded data. Same invariant in both cases: "no data" means "no data", whether expressed as a 404 or a served-empty file.

### Copy cleanups in the same file

- Dropped the stale "Restart the dev server with pnpm dev to seed a sample corpus" hint — pnpm dev stopped seeding in [PR #5](https://github.com/BryceEWatson/chat-arch/pull/5); the actionable path out now is Load Demo Data in the panel below.
- Gated the `(fetch: <msg>)` diagnostic tail on it actually being a fetch error — dangling it under a successful empty fetch implied something went wrong when nothing did.

### Tests updated (2)

Both were pinning `NO SESSIONS` (the old full-chrome heading); updated to `NO DATA YET`. What they actually guarantee is unchanged: empty manifest must render a viable empty state, not a blank page or crash.

## Side-effect audit (user requested)

Swept the viewer for other behaviors that flip when the manifest transitions from 404 → shipped-empty:

- **[analysisFetch.ts](packages/viewer/src/data/analysisFetch.ts)**: safe. GET + JSON.parse chain — CF Pages' SPA fallback returns HTML on missing files, fails JSON parse, caught as `{present: false}`. Correct.
- **`.demo` probe** ([ChatArchViewer.tsx:366](packages/viewer/src/ChatArchViewer.tsx:366)): pre-existing bug, surfaces now. HEAD + `res.ok` can't distinguish a real sentinel from CF's SPA-fallback HTML (both return 200). Left for a separate fix — it's orthogonal to this layout issue.

## Verification

`astro preview` at port 4325 against the fresh monorepo build. Minimal layout confirmed: only `<banner>` (top bar: UPLOAD CLOUD, SCAN LOCAL, DELETE, SEARCH) and `<main>` (NO DATA YET alert + LOAD CLOUD EXPORT panel with choose-zip + load-demo buttons). No KPI tiles, no filter pills, no projects list. 325/325 tests pass.

## Test plan

- [ ] CI passes.
- [ ] After merge + deploy, https://chat-arch.dev/ (fresh / private window) renders ONLY the top bar + NO DATA YET + upload/demo panel.
- [ ] Clicking Load Demo transitions to the full populated viewer.
- [ ] Uploading a ZIP transitions to the full populated viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)