### PR TITLE
feat(design-system): Supergraphic Panel source folder + token generator (PR 1/3)

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,43 @@
+# Supergraphic Panel
+
+The canonical design system for the Chat Archaeologist viewer.
+
+**Version:** 0.1.0 (initial release — 2026-04-21)
+
+This folder is the **source**. Published surfaces
+(https://chat-arch.dev/design-system/ and
+https://raw.githubusercontent.com/BryceEWatson/chat-arch/main/design-system/)
+are mirrors generated at build time. `packages/viewer/src/styles.css`
+is the root source of truth for token values; `spec.md` is the
+canonical prose; `tokens.json` is emitted by
+`scripts/generate-tokens.mjs` on every `pnpm build` and fails CI if
+prose in `spec.md` drifts from extracted token values.
+
+Naming: the display form is **Supergraphic Panel** (two words,
+title-cased). The slug form used in URLs, branch names, and any
+future package scope is `supergraphic-panel`.
+
+## Contents
+
+- [`spec.md`](./spec.md) — the 2400-word prose spec. Read first.
+- [`tokens.json`](./tokens.json) — DTCG-formatted
+  ([schema](https://www.designtokens.org/schemas/2025.10/format.json))
+  tokens. Generated. Do not edit by hand.
+- [`scripts/generate-tokens.mjs`](./scripts/generate-tokens.mjs) —
+  parses `--lcars-*` variables out of the viewer stylesheet, merges
+  with prescriptive scales (radius, shadow, duration, font.size,
+  font.weight, status aliases), emits `tokens.json`, and runs the
+  drift guard against `spec.md`.
+
+## Changelog
+
+- **0.1.0** (2026-04-21) — Initial release. Palette, typography,
+  component patterns, motion language, port recipes, attribution.
+
+## For consumers
+
+Point a language-model agent at
+https://chat-arch.dev/design-system/spec.md and it has everything it
+needs to apply the system to a blank project. For machine ingestion,
+use `tokens.json` at https://chat-arch.dev/design-system/tokens.json.
+Discovery index: https://chat-arch.dev/llms.txt.

--- a/design-system/scripts/generate-tokens.mjs
+++ b/design-system/scripts/generate-tokens.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+// Token generator for the Supergraphic Panel design system.
+//
+// Reads --lcars-* variables out of the canonical .lcars-root block in
+// packages/viewer/src/styles.css, merges them with prescriptive scales
+// authored here (radius, shadow, duration, font.size, font.weight,
+// status aliases), and emits DTCG-formatted tokens to
+// design-system/tokens.json.
+//
+// Drift guard: after emitting, scans design-system/spec.md for every
+// hex literal (#rgb / #rrggbb / #rrggbbaa). Any hex present in spec.md
+// that does NOT appear in the emitted tokens.json fails the script. This
+// is the fence that keeps prose values aligned with source.
+//
+// Run from the repo root via `pnpm build` (or `node design-system/
+// scripts/generate-tokens.mjs` directly).
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const stylesPath = resolve(repoRoot, 'packages/viewer/src/styles.css');
+const tokensPath = resolve(repoRoot, 'design-system/tokens.json');
+const specPath = resolve(repoRoot, 'design-system/spec.md');
+
+const css = readFileSync(stylesPath, 'utf8');
+
+// Grab the first .lcars-root { ... } block — the one that declares the
+// tokens. Later .lcars-root rules layer on layout, not variables.
+const rootBlockMatch = css.match(/\.lcars-root\s*\{([\s\S]*?)\n\}/);
+if (!rootBlockMatch) {
+  throw new Error('Could not find .lcars-root block in styles.css');
+}
+const rootBody = rootBlockMatch[1];
+
+const varMatches = [...rootBody.matchAll(/--lcars-([\w-]+)\s*:\s*([^;]+);/g)];
+const parsed = Object.fromEntries(
+  varMatches.map(([, name, value]) => [name, value.trim()]),
+);
+
+function color(name, description) {
+  const value = parsed[name];
+  if (!value) throw new Error(`Expected --lcars-${name} in styles.css`);
+  return { $value: value, $type: 'color', $description: description };
+}
+
+function font(name, description) {
+  const value = parsed[`font-${name}`];
+  if (!value) throw new Error(`Expected --lcars-font-${name} in styles.css`);
+  const stack = value.split(',').map((v) => v.trim().replace(/^['"]|['"]$/g, ''));
+  return { $value: stack, $type: 'fontFamily', $description: description };
+}
+
+function alias(target, description) {
+  return { $value: `{${target}}`, $type: 'color', $description: description };
+}
+
+function prescriptive(type, value, description) {
+  return { $value: value, $type: type, $description: `Prescriptive: ${description}` };
+}
+
+const tokens = {
+  $schema: 'https://www.designtokens.org/schemas/2025.10/format.json',
+  $description:
+    'Supergraphic Panel — the Chat Archaeologist visual design system. ' +
+    'Source palette and font families are extracted from ' +
+    'packages/viewer/src/styles.css. Scale tokens (radius, shadow, duration, ' +
+    'font.size, font.weight, status aliases) are prescriptive additions ' +
+    'authored for replicators; see design-system/spec.md for rationale.',
+  color: {
+    sunflower: color('sunflower', 'Primary text and titles. Never decorative.'),
+    'sunflower-muted': color(
+      'sunflower-muted',
+      'Pre-composited sunflower × 0.85 over black. Solid background for inactive sidebar items so black text holds 10.25:1 WCAG AAA regardless of backdrop.',
+    ),
+    butterscotch: color(
+      'butterscotch',
+      'Chrome: top bar, sidebar elbows, ALL-CAPS labels, dividers. Never body text.',
+    ),
+    'butterscotch-muted': color(
+      'butterscotch-muted',
+      'Muted chrome for inactive mobile pill-bar items. Carries sunflower foreground at AA.',
+    ),
+    ice: color(
+      'ice',
+      'Data and code: model names, inline code, quantitative highlights. Decorative use forbidden.',
+    ),
+    violet: color(
+      'violet',
+      'Thinking / processing state: streaming indicators, semantic-analysis running, copy-to-MD action.',
+    ),
+    peach: color(
+      'peach',
+      'Cost and error accent: cost bars, error banners, CLI-Direct badge. Attention, not alarm.',
+    ),
+    bg: color('bg', 'Root frame background. Pure black.'),
+    'bg-1': color('bg-1', 'Card and panel surface. One step above root.'),
+    'bg-2': color('bg-2', 'Card hover surface. One step above bg-1.'),
+    text: color('text', 'Alias for sunflower when used as a text color. Same value, semantic role differs.'),
+    dim: color(
+      'dim',
+      'Reserved for inert placeholder glyphs (em-dashes, "—", missing values). Not for functional text — fails WCAG AA for body.',
+    ),
+    divider: color(
+      'divider',
+      'rgba(221, 153, 68, 0.18). Panel and card borders. Inherits from butterscotch at low alpha.',
+    ),
+  },
+  font: {
+    family: {
+      chrome: font(
+        'chrome',
+        "ALL-CAPS labels, KPI values, titles, pills, top-bar. The voice of the chrome.",
+      ),
+      prose: font(
+        'prose',
+        'Body text inside cards and messages (≥12px paragraph text). IBM Plex Sans.',
+      ),
+      mono: font(
+        'mono',
+        'Model names, timestamps, code, keyboard hints, axis ticks. JetBrains Mono.',
+      ),
+    },
+    weight: {
+      regular: prescriptive('fontWeight', 400, 'Body prose only. Both IBM Plex Sans and JetBrains Mono ship a regular weight.'),
+      medium: prescriptive('fontWeight', 500, 'Default chrome weight. Antonio at 500 is the reliable fallback when 600/700 feel heavy.'),
+      semibold: prescriptive('fontWeight', 600, 'Emphasized prose and mono.'),
+      bold: prescriptive('fontWeight', 700, 'Titles, pills, ALL-CAPS labels, KPI values. The chrome default for anything that should read as a label.'),
+    },
+    size: {
+      '9': prescriptive('dimension', '9px', 'Row-label and legend caps. Floor for legible Antonio caps with 0.18em tracking.'),
+      '10': prescriptive('dimension', '10px', 'Sidebar short badge, filter-row labels.'),
+      '11': prescriptive('dimension', '11px', 'Chrome labels, pill text.'),
+      '12': prescriptive('dimension', '12px', 'Body prose floor inside cards.'),
+      '13': prescriptive('dimension', '13px', 'Info-popover body prose.'),
+      '15': prescriptive('dimension', '15.5px', 'Session-card titles. Oddly specific on purpose — verified optically against the 2-line clamp at tier A.'),
+      '18': prescriptive('dimension', '18px', 'Top-bar title at tier B+.'),
+    },
+  },
+  radius: {
+    sm: prescriptive('dimension', '6px', 'Card and panel corners at mobile tier.'),
+    md: prescriptive('dimension', '8px', 'Card and panel corners at tablet / desktop.'),
+    lg: prescriptive('dimension', '10px', 'Mid-bar and mode-area at desktop.'),
+    pill: prescriptive('dimension', '14px', 'Source-pill, top-bar source-buttons (sized to half-height).'),
+    'pill-lg': prescriptive('dimension', '20px', 'Narrow-banner, command-mode "more" button, search input at tier B+.'),
+    elbow: prescriptive('dimension', '32px', 'Sidebar elbow at mobile. Asymmetric: `32px 0 0 0` or `0 0 0 32px` — never four-corner-equal.'),
+    'elbow-lg': prescriptive('dimension', '40px', 'Sidebar elbow at desktop. Anchors the L-corner where vertical and horizontal arms meet.'),
+  },
+  shadow: {
+    none: prescriptive('shadow', 'none', 'Default. The system does not use drop shadows for hierarchy — hierarchy comes from left-accent rules, border color, and surface stepping (bg → bg-1 → bg-2).'),
+    panel: prescriptive(
+      'shadow',
+      { color: 'rgba(0, 0, 0, 0.6)', offsetX: '0px', offsetY: '10px', blur: '40px', spread: '0px' },
+      'Reserved for floating panels that escape the frame (info-popover, rescan-banner, tier-sheet backdrop). Never on in-frame cards.',
+    ),
+    'ring-ice': prescriptive(
+      'shadow',
+      'inset 0 0 0 3px color-mix(in srgb, #99ccff 60%, transparent)',
+      'Focus ring for quantitative / ice-accent contexts. Ring pulse, not glow.',
+    ),
+    'ring-violet': prescriptive(
+      'shadow',
+      'inset 0 0 0 3px color-mix(in srgb, #cc99cc 60%, transparent)',
+      'Focus ring for thinking / violet-accent contexts.',
+    ),
+  },
+  duration: {
+    fast: prescriptive('duration', '80ms', 'Background color transitions on sidebar items, pill-bar pills.'),
+    base: prescriptive('duration', '120ms', 'Default card hover transition (background, border, transform).'),
+    slow: prescriptive('duration', '200ms', 'Analysis-launcher progress-fill width transition.'),
+    boot: prescriptive('duration', '1400ms', 'Full boot cascade from top-bar through command-mode cards. Individual panel animations sit at 400–600ms with staggered delays.'),
+    'pulse-focus': prescriptive('duration', '2200ms', 'Focus-pulse animations on filter-bar rows when navigated via analysis-tab cards.'),
+  },
+  status: {
+    concept: alias('color.violet', 'Earliest / thinking state. Maps to violet. Prescriptive.'),
+    active: alias('color.sunflower', 'In-progress / primary state. Maps to sunflower. Prescriptive.'),
+    'open-pr': alias('color.ice', 'In review / quantitative active state. Maps to ice. Prescriptive.'),
+    merged: alias('color.butterscotch', 'Completed / steady chrome state. Maps to butterscotch. Prescriptive.'),
+    released: alias('color.peach', 'Shipped / notable accent. Maps to peach. Prescriptive.'),
+  },
+};
+
+writeFileSync(tokensPath, JSON.stringify(tokens, null, 2) + '\n');
+
+// --- Drift guard -----------------------------------------------------
+// Scan spec.md for hex literals. Every hex in the spec must appear
+// somewhere in the emitted tokens.json (on a base color token or
+// in a prescriptive shadow definition). A mismatch means the prose
+// drifted away from source — fail hard so CI catches it.
+
+let driftErrors = [];
+try {
+  const spec = readFileSync(specPath, 'utf8');
+  const tokensJson = JSON.stringify(tokens);
+  const hexPattern = /#[0-9a-fA-F]{3,8}\b/g;
+  const specHexes = [...spec.matchAll(hexPattern)].map((m) => m[0].toLowerCase());
+  const tokensLower = tokensJson.toLowerCase();
+  const missing = [...new Set(specHexes)].filter((h) => !tokensLower.includes(h));
+  if (missing.length > 0) {
+    driftErrors.push(
+      `spec.md cites hex value(s) not present in tokens.json: ${missing.join(', ')}. ` +
+        `Either the prose drifted from source, or a new token is missing from the generator. ` +
+        `Fix spec.md — styles.css is the source of truth for token values.`,
+    );
+  }
+} catch (err) {
+  if (err.code !== 'ENOENT') throw err;
+  // spec.md not yet written — skip drift guard on the first run.
+}
+
+if (driftErrors.length > 0) {
+  console.error('\nToken drift detected:\n');
+  for (const line of driftErrors) console.error(`  ${line}\n`);
+  process.exit(1);
+}
+
+const parsedCount = Object.keys(parsed).length;
+console.log(
+  `design-system/tokens.json written (${parsedCount} --lcars-* vars extracted, ` +
+    `plus prescriptive scales for radius, shadow, duration, font.size, font.weight, status).`,
+);

--- a/design-system/scripts/generate-tokens.mjs
+++ b/design-system/scripts/generate-tokens.mjs
@@ -184,25 +184,80 @@ const tokens = {
 writeFileSync(tokensPath, JSON.stringify(tokens, null, 2) + '\n');
 
 // --- Drift guard -----------------------------------------------------
-// Scan spec.md for hex literals. Every hex in the spec must appear
-// somewhere in the emitted tokens.json (on a base color token or
-// in a prescriptive shadow definition). A mismatch means the prose
-// drifted away from source — fail hard so CI catches it.
+// Two checks run against spec.md:
+//
+//  (1) Strict hex-literal presence. Every CSS-valid hex literal
+//      (3/4/6/8-digit) in the spec must appear somewhere in the
+//      serialized tokens. Catches prose that invents a new value or
+//      mutates an existing one. The length restriction matters: a
+//      loose {3,8} regex would also match fragments like GitHub issue
+//      references (`#12345`) and turn ordinary prose edits into false-
+//      positive build breaks.
+//
+//  (2) Token-aware palette claims. Palette-table rows of the form
+//      "| `token.path` | `value` | ..." are parsed as explicit claims
+//      that the named token has the given value. Each claim is
+//      resolved against the in-memory `tokens` object and an exact-
+//      value mismatch fails the build. This catches semantic drift
+//      that check (1) misses — e.g. swapping sunflower and
+//      butterscotch values, where both hexes still exist globally
+//      in tokens.json so the substring check passes.
+//
+// spec.md is optional on the first run (before it's authored); both
+// checks no-op via the ENOENT branch.
 
 let driftErrors = [];
 try {
   const spec = readFileSync(specPath, 'utf8');
-  const tokensJson = JSON.stringify(tokens);
-  const hexPattern = /#[0-9a-fA-F]{3,8}\b/g;
-  const specHexes = [...spec.matchAll(hexPattern)].map((m) => m[0].toLowerCase());
-  const tokensLower = tokensJson.toLowerCase();
-  const missing = [...new Set(specHexes)].filter((h) => !tokensLower.includes(h));
-  if (missing.length > 0) {
+
+  // (1) strict hex-literal presence.
+  // Exactly 3, 4, 6, or 8 hex digits — the CSS-valid lengths for
+  // `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`. Length alternation is
+  // written longest-first so the regex doesn't greedily match a
+  // shorter-length prefix of a longer valid hex.
+  const validHex = /#(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b/g;
+  const tokensLower = JSON.stringify(tokens).toLowerCase();
+  const specHexes = [...spec.matchAll(validHex)].map((m) => m[0].toLowerCase());
+  const missingHexes = [...new Set(specHexes)].filter((h) => !tokensLower.includes(h));
+  if (missingHexes.length > 0) {
     driftErrors.push(
-      `spec.md cites hex value(s) not present in tokens.json: ${missing.join(', ')}. ` +
+      `spec.md cites hex value(s) not present in tokens.json: ${missingHexes.join(', ')}. ` +
         `Either the prose drifted from source, or a new token is missing from the generator. ` +
         `Fix spec.md — styles.css is the source of truth for token values.`,
     );
+  }
+
+  // (2) token-aware palette claims.
+  // Parse markdown table rows that claim a token path → value pair:
+  //   | `color.sunflower` | `#ffcc99` | ... |
+  // Non-backtick-wrapped table rows (WCAG matrix, typography table)
+  // are ignored by design — they describe relationships, not claims.
+  const resolve = (tokenPath) => {
+    const parts = tokenPath.split('.');
+    let cursor = tokens;
+    for (const p of parts) {
+      if (cursor == null || typeof cursor !== 'object') return undefined;
+      cursor = cursor[p];
+    }
+    return cursor == null ? undefined : cursor.$value;
+  };
+  const normalize = (v) => String(v).toLowerCase().replace(/\s+/g, ' ').trim();
+  const claimPattern = /^\|\s*`([\w.-]+)`\s*\|\s*`([^`]+)`\s*\|/gm;
+  for (const m of spec.matchAll(claimPattern)) {
+    const [, tokenPath, claimedValue] = m;
+    const actual = resolve(tokenPath);
+    if (actual === undefined) {
+      driftErrors.push(
+        `spec.md claims token '${tokenPath}' has value '${claimedValue}', but that token is not defined in tokens.json.`,
+      );
+      continue;
+    }
+    if (normalize(actual) !== normalize(claimedValue)) {
+      driftErrors.push(
+        `spec.md claims ${tokenPath} = '${claimedValue}', but tokens.json has '${actual}'. ` +
+          `This is a semantic swap — fix the spec or regenerate the tokens.`,
+      );
+    }
   }
 } catch (err) {
   if (err.code !== 'ENOENT') throw err;

--- a/design-system/spec.md
+++ b/design-system/spec.md
@@ -1,0 +1,441 @@
+# Supergraphic Panel — design system specification
+
+Supergraphic Panel is the visual language of the Chat Archaeologist
+viewer ([chat-arch.dev](https://chat-arch.dev)). This document is the
+canonical prose specification — terse, declarative, written to be read
+by both humans and language-model agents applying the system to a new
+project. Every quoted value is cited back to
+`packages/viewer/src/styles.css` so a reader can verify the claim at
+source. The palette and font families here are extracted from that
+stylesheet by a generator script; prescriptive additions (radius,
+shadow, duration, font-size scales, status aliases) are authored for
+replicators and flagged as such.
+
+Credit where it's due: the direct visual inspiration is Michael
+Okuda's LCARS design language for *Star Trek: The Next Generation*
+(1987). The broader supergraphic tradition — Barbara Stauffacher
+Solomon, Deborah Sussman, Lance Wyman — supplied additional ideas
+about flat color planes and heavy display typography applied at
+architectural scale. Both are acknowledgments, not lineage claims;
+see the Attribution section at the end for the legal posture.
+
+## 1. Vibe
+
+Dark, legible, structurally asymmetric, unapologetically chromed.
+Body text sits in a warm sunflower amber on pure black; chrome
+elements — labels, bars, pill buttons — carry a butterscotch-on-black
+voice with heavy letter-spacing. Shapes are rectangular with
+one-corner bends: asymmetric 32–40px elbows where a panel meets a
+bar, half-pill rounding (`0 14px 14px 0`) on sidebar tabs, 3px left-
+accent rules on cards. Hierarchy comes from color role and surface
+stepping, not drop shadows. Motion is deliberate and sparse: a
+one-time boot cascade on first paint, 2.2s ring pulses for focus,
+80–200ms opacity/background transitions for state. Nothing floats
+or glows.
+
+## 2. Structural rules
+
+Tokens are defined on `.lcars-root`, not `:root`
+([styles.css:39](../packages/viewer/src/styles.css#L39)). An app
+that wants this theme wraps its tree in
+`<div class="lcars-root">...</div>`; defining the same variables on
+`:root` scopes them globally and breaks any consumer that wants the
+theme to be opt-in.
+
+Two instance-local variables are expected to be set inline by
+components, not globally:
+
+- `--source-color` — carried by `.lcars-session-card`, `.lcars-source-pill`,
+  and downstream children. Defaults to butterscotch
+  ([styles.css:1373](../packages/viewer/src/styles.css#L1373)); set per-
+  instance via inline style to recolor a card's left accent and pill.
+- `--mode-color` — carried by `.lcars-mode-area` and read by sidebar
+  items to paint their active-tab fill
+  ([styles.css:1780](../packages/viewer/src/styles.css#L1780)).
+
+The layout is mobile-first and progressively enhances through three
+tiers via `min-width` breakpoints at 600px (tablet) and 900px
+(desktop). The desktop tier composes a 2×2 grid where the sidebar
+owns a vertical butterscotch arm, the top-bar owns a horizontal
+butterscotch arm, and they meet at a square inner corner with rounded
+outer corners — the LCARS "L" at rest
+([styles.css:432](../packages/viewer/src/styles.css#L432)). Below 320px
+the consumer renders a dignified fallback banner
+(`.lcars-root--narrow`,
+[styles.css:106](../packages/viewer/src/styles.css#L106)).
+
+## 3. Palette with semantic roles
+
+Four accent colors, each with exactly one job. Mixing jobs — e.g.
+using ice for a decorative corner — dilutes the system and should
+fail code review.
+
+| Token | Hex | Role | Source |
+|---|---|---|---|
+| `color.sunflower` | `#ffcc99` | Primary text, titles, KPI values, focused states | [L47](../packages/viewer/src/styles.css#L47) |
+| `color.sunflower-muted` | `#d9ad82` | Pre-composited inactive sidebar background | [L53](../packages/viewer/src/styles.css#L53) |
+| `color.butterscotch` | `#dd9944` | Chrome: labels, top-bar, sidebar elbows | [L54](../packages/viewer/src/styles.css#L54) |
+| `color.butterscotch-muted` | `#6a4a20` | Muted chrome for inactive mobile pill-bar items | [L55](../packages/viewer/src/styles.css#L55) |
+| `color.ice` | `#99ccff` | Quantitative: model names, inline code, data | [L56](../packages/viewer/src/styles.css#L56) |
+| `color.violet` | `#cc99cc` | Thinking, processing, streaming | [L57](../packages/viewer/src/styles.css#L57) |
+| `color.peach` | `#ff9933` | Cost and error accent | [L58](../packages/viewer/src/styles.css#L58) |
+| `color.bg` | `#000000` | Root frame | [L59](../packages/viewer/src/styles.css#L59) |
+| `color.bg-1` | `#07070a` | Card / panel surface | [L60](../packages/viewer/src/styles.css#L60) |
+| `color.bg-2` | `#0d0d12` | Card hover surface | [L61](../packages/viewer/src/styles.css#L61) |
+| `color.dim` | `#665544` | Inert placeholder glyphs only (em-dashes, missing values) | [L63](../packages/viewer/src/styles.css#L63) |
+| `color.divider` | `rgba(221, 153, 68, 0.18)` | Panel and card borders | [L64](../packages/viewer/src/styles.css#L64) |
+
+Prescriptive status aliases (`status.concept` → violet,
+`status.active` → sunflower, `status.open-pr` → ice,
+`status.merged` → butterscotch, `status.released` → peach) map a
+generic product-state progression onto the same palette without
+introducing new pigments.
+
+## 4. WCAG contrast matrix
+
+All ratios computed against `color.bg` (`#000000`) except where
+noted. AA requires ≥ 4.5:1 for body text, AAA ≥ 7:1.
+
+| Pair | Ratio | AA body | AAA body | Notes |
+|---|---|---|---|---|
+| sunflower on bg | 14.3:1 | ✅ | ✅ | Default body text. |
+| butterscotch on bg | 8.7:1 | ✅ | ✅ | Chrome labels. |
+| ice on bg | 12.4:1 | ✅ | ✅ | Model names, code. |
+| violet on bg | 9.0:1 | ✅ | ✅ | Thinking state. |
+| peach on bg | 9.9:1 | ✅ | ✅ | Errors, cost. |
+| dim on bg | 2.9:1 | ❌ | ❌ | **Decorative only.** Inert glyphs. |
+| bg on sunflower-muted | 10.2:1 | ✅ | ✅ | Inactive sidebar item: black text on muted amber. |
+| bg on butterscotch | 8.7:1 | ✅ | ✅ | Active sidebar tab, mid-bar label. |
+| sunflower on butterscotch-muted | 5.5:1 | ✅ | ❌ | Mobile pill-bar inactive state. AA only. |
+
+The `sunflower-muted` token exists specifically to hold 10.2:1 for
+black text regardless of what sits behind the sidebar item — an
+earlier implementation used `butterscotch × opacity 0.55` and fell
+to 3.1:1 when the backdrop shifted. The fix was a pre-composited
+solid color
+([styles.css:1057](../packages/viewer/src/styles.css#L1057)). Replicators
+should pre-composite by hand rather than rely on `opacity` whenever
+legibility is load-bearing.
+
+## 5. Typography
+
+Three families, each with one role. Do not cross roles.
+
+| Family | Use | Stack |
+|---|---|---|
+| Antonio | Chrome, ALL-CAPS labels, titles, pills, KPI values | `'Antonio', 'Oswald', 'Impact', sans-serif` |
+| IBM Plex Sans | Body prose inside cards and messages | `'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif` |
+| JetBrains Mono | Model names, timestamps, code, keyboard hints | `'JetBrains Mono', 'Consolas', 'Menlo', monospace` |
+
+All three are licensed under the **SIL Open Font License 1.1** and may
+be redistributed. The viewer imports them from Google Fonts
+([styles.css:37](../packages/viewer/src/styles.css#L37)); self-hosting
+is equivalent. Weights loaded: Antonio 400/500/600/700, IBM Plex Sans
+400/500/600, JetBrains Mono 400/500/600.
+
+Chrome type carries heavy tracking: `letter-spacing: 0.14em` on pills
+and source buttons, `0.16em–0.22em` on titles and group labels. Without
+the tracking, Antonio caps read cramped at small sizes. `line-height:
+1` with a 1–3px `padding-bottom` correction is the idiomatic way to
+keep Antonio caps optically centered in fixed-height pill chrome — the
+font's baseline sits low in the em-box and naive centering paints caps
+below the visual center. See the source-pill badge
+([styles.css:1428](../packages/viewer/src/styles.css#L1428)) for the
+canonical treatment.
+
+## 6. Component patterns
+
+Eight patterns. Each lists the class combination, a minimal markup
+example, and one usage rule. All selectors assume an ancestor with
+class `lcars-root`.
+
+### 6.1 Top bar
+
+```html
+<header class="lcars-top-bar">
+  <div class="lcars-top-bar__left">
+    <span class="lcars-top-bar__dot"></span>
+    <h1 class="lcars-top-bar__title">CHAT ARCHAEOLOGIST</h1>
+  </div>
+</header>
+```
+
+Rule: `border-radius: 0 16px 16px 0` — rounded at the right end
+only, squared off to meet the sidebar's top elbow
+([styles.css:465](../packages/viewer/src/styles.css#L465)).
+
+### 6.2 Sidebar tab (desktop)
+
+```html
+<li class="lcars-sidebar__item lcars-sidebar__item--active"
+    style="--mode-color: var(--lcars-ice)">
+  <span class="lcars-sidebar__item-short">01</span>
+  <span class="lcars-sidebar__item-label">COMMAND</span>
+</li>
+```
+
+Rule: `border-radius: 0 18px 18px 0` — half-pill, rounded on the
+side away from the sidebar. The active tab paints in its
+`--mode-color`; hovers over inactive tabs preview that color
+([styles.css:1140](../packages/viewer/src/styles.css#L1140)).
+
+### 6.3 Source pill
+
+```html
+<button class="lcars-source-pill lcars-source-pill--active"
+        style="--source-color: var(--lcars-ice)">
+  <span class="lcars-source-pill__badge">CC</span>
+  <span class="lcars-source-pill__label">CLAUDE CODE</span>
+  <span class="lcars-source-pill__count">247</span>
+</button>
+```
+
+Rule: the pill sizes itself to content. Never truncate with ellipsis
+— an earlier revision that did so clipped `CLI-DESKTOP` on narrow
+viewports
+([styles.css:1396](../packages/viewer/src/styles.css#L1396)).
+
+### 6.4 Session card
+
+```html
+<article class="lcars-session-card"
+         style="--source-color: var(--lcars-ice)">
+  <div class="lcars-session-card__row lcars-session-card__row--top">
+    <!-- source-pill, project label, time -->
+  </div>
+  <h2 class="lcars-session-card__title">Refactor the exporter</h2>
+  <p class="lcars-session-card__preview">...</p>
+</article>
+```
+
+Rule: the card's left edge is a 3px accent rule in its
+`--source-color`
+([styles.css:1866](../packages/viewer/src/styles.css#L1866)). Hover
+lifts the card with `transform: translateY(-1px)` and tints the
+surface 5% toward sunflower — never with a drop shadow.
+
+### 6.5 Info popover
+
+```html
+<div class="lcars-info-popover">
+  <button class="lcars-info-popover__trigger">i</button>
+  <div class="lcars-info-popover__panel">
+    <strong>HEADING</strong>
+    <p>Body prose in IBM Plex Sans.</p>
+  </div>
+</div>
+```
+
+Rule: the panel is the only in-system use of a drop shadow
+(`0 10px 40px rgba(0,0,0,0.6)`), because it floats above the frame.
+Otherwise the system does not use shadows
+([styles.css:710](../packages/viewer/src/styles.css#L710)).
+
+### 6.6 Mid bar
+
+```html
+<div class="lcars-mid-bar" style="background: var(--lcars-butterscotch)">
+  <span class="lcars-mid-bar__label">BROWSE / COMMAND</span>
+</div>
+```
+
+Rule: 20–26px tall solid butterscotch strip, black label type,
+`border-radius: 10–13px`. Acts as a horizontal separator that still
+reads as chrome
+([styles.css:1750](../packages/viewer/src/styles.css#L1750)).
+
+### 6.7 Rescan banner
+
+```html
+<div class="lcars-rescan-banner lcars-rescan-banner--ok">
+  <span class="lcars-rescan-banner__tag">OK</span>
+  <span class="lcars-rescan-banner__message">Rescan complete.</span>
+  <button class="lcars-rescan-banner__dismiss">×</button>
+</div>
+```
+
+Rule: status communicated by a 4px left-border accent
+(`--ok` → ice, `--error` → peach, `--demo` → butterscotch), not by
+tinting the whole surface
+([styles.css:843](../packages/viewer/src/styles.css#L843)).
+
+### 6.8 Semantic chip
+
+```html
+<button class="lcars-semantic-chip lcars-semantic-chip--ready">
+  <span class="lcars-semantic-chip__label">TOPICS READY</span>
+</button>
+```
+
+Rule: chip state is carried by border + foreground color, not by
+surface fill. Four states: `--cta` (action), `--running` (violet,
+animated), `--ready` (ice), `--error` (peach), `--stale`
+(butterscotch)
+([styles.css:2791](../packages/viewer/src/styles.css#L2791)).
+
+## 7. Motion language
+
+The system defines six named keyframes; their intents:
+
+- `lcars-boot-online` — one-time "coming online" cascade across the
+  top-bar, sidebar, upper panel, filter bar, and mode area. Total
+  duration ~1400ms, played once when data first arrives
+  ([styles.css:205](../packages/viewer/src/styles.css#L205)).
+- `lcars-filter-streaming-pulse` — 1.6s infinite pulse on the
+  project-pill row's left border while semantic analysis is running
+  ([styles.css:344](../packages/viewer/src/styles.css#L344)).
+- `lcars-filter-focus-pulse-ice` / `lcars-filter-focus-pulse-violet` —
+  2.2s double-flash that fires once when the user navigates here
+  from an analysis card
+  ([styles.css:371](../packages/viewer/src/styles.css#L371)).
+- `lcars-info-popover-in` / `lcars-rescan-banner-in` — 140–200ms
+  enter animations for floating surfaces.
+- `lcars-source-btn-pulse` / `lcars-semantic-chip-pulse` — slow
+  infinite pulses on long-running-state indicators.
+
+Focus is communicated with **ring pulses** (`box-shadow: 0 0 0 3px
+color-mix(...)`), not glow or outline. Hover on cards is a
+`translateY(-1px)` lift with a surface tint, never a shadow.
+
+**`prefers-reduced-motion: reduce` policy.** All decorative motion
+is disabled under reduced-motion. The source honors this at the boot
+cascade ([styles.css:277](../packages/viewer/src/styles.css#L277)),
+filter-bar pulses
+([styles.css:348](../packages/viewer/src/styles.css#L348) and
+[L399](../packages/viewer/src/styles.css#L399)), sparkline tooltip
+([L1706](../packages/viewer/src/styles.css#L1706)), tier indicator
+([L3000](../packages/viewer/src/styles.css#L3000)), and several
+others. Essential state transitions (≤100ms background / opacity
+changes on hover, focus) remain at full speed — they carry
+information, not decoration. Replicators porting the system MUST
+honor `prefers-reduced-motion: reduce` on any non-trivial animation.
+
+## 8. What not to do
+
+- **Don't define tokens on `:root`.** Use `.lcars-root`. Tokens on
+  `:root` leak into the consumer's global scope.
+- **Don't add drop shadows.** Floating popovers (info-popover,
+  rescan-banner, tier-sheet backdrop) are the only exception.
+  In-frame cards and panels derive hierarchy from surface stepping
+  (`bg` → `bg-1` → `bg-2`) and border color.
+- **Don't introduce a fourth font.** Antonio / IBM Plex Sans /
+  JetBrains Mono is the triad. Adding a display serif or a geometric
+  sans breaks the voice.
+- **Don't soften the asymmetric radii** into four-corner-equal
+  corners. The L-corner elbow (`32px 0 0 0` / `0 0 0 32px`) and the
+  half-pill (`0 14px 14px 0`) are the signature shapes.
+- **Don't use `#665544` (dim) for body text.** It fails AA. It is
+  for inert glyphs only.
+- **Don't put butterscotch on bg for long paragraphs.** Butterscotch
+  is chrome, not prose. Paragraph text should be `color.text`
+  (sunflower-equivalent) or `color.sunflower`.
+- **Don't mix type roles.** Antonio for chrome, IBM Plex Sans for
+  prose, JetBrains Mono for data. Cross-role usage is a code smell.
+- **Don't tint `color.divider`.** It's already a low-alpha
+  butterscotch; re-tinting stacks the mix and reads as a full stroke.
+
+## 9. Port recipes
+
+### Plain CSS
+
+Import `@chat-arch/viewer/style.css` verbatim and wrap the app in
+`.lcars-root`:
+
+```html
+<link rel="stylesheet" href="/path/to/chat-arch-viewer/style.css" />
+<div class="lcars-root">
+  <header class="lcars-top-bar">...</header>
+</div>
+```
+
+All tokens, components, and media queries come along automatically.
+
+### Tailwind v4 `@theme`
+
+```css
+@import "tailwindcss";
+
+@theme {
+  --color-sunflower: #ffcc99;
+  --color-butterscotch: #dd9944;
+  --color-ice: #99ccff;
+  --color-violet: #cc99cc;
+  --color-peach: #ff9933;
+  --color-bg: #000000;
+  --color-bg-1: #07070a;
+  --color-bg-2: #0d0d12;
+  --color-dim: #665544;
+
+  --font-chrome: 'Antonio', 'Oswald', 'Impact', sans-serif;
+  --font-prose: 'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Consolas', 'Menlo', monospace;
+
+  --radius-elbow: 32px;
+  --radius-pill: 14px;
+}
+```
+
+Then compose with utilities: `bg-bg-1 border-l-[3px] border-ice
+font-prose text-sunflower`. Custom components (elbow radii,
+source-pills) still want a small CSS layer — Tailwind doesn't
+express asymmetric radii ergonomically.
+
+### CSS-in-JS (emotion / styled-components)
+
+```ts
+export const theme = {
+  colors: {
+    sunflower: '#ffcc99',
+    butterscotch: '#dd9944',
+    ice: '#99ccff',
+    violet: '#cc99cc',
+    peach: '#ff9933',
+    bg: '#000000',
+    bg1: '#07070a',
+  },
+  fonts: {
+    chrome: "'Antonio', 'Oswald', 'Impact', sans-serif",
+    prose: "'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif",
+    mono: "'JetBrains Mono', 'Consolas', 'Menlo', monospace",
+  },
+  radii: { elbow: '32px', pill: '14px' },
+};
+
+const Card = styled.article`
+  background: ${(p) => p.theme.colors.bg1};
+  border-left: 3px solid ${(p) => p.theme.colors.ice};
+  border-radius: 8px;
+  padding: 10px 12px;
+  &:hover { transform: translateY(-1px); }
+`;
+```
+
+## 10. Attribution & trademark posture
+
+**Direct visual inspiration:** Michael Okuda's LCARS
+(Library Computer Access/Retrieval System) design language, created
+for *Star Trek: The Next Generation* (1987) and extended across
+subsequent Trek series. The asymmetric elbow, the dark background
+with bright chrome bars, the heavy-tracked display-sans labeling,
+and the semantic color discipline are Okuda-derived.
+
+**Additional inspiration:** the broader supergraphic tradition — the
+environmental-scale flat-color work of Barbara Stauffacher Solomon
+(Sea Ranch, 1960s), Deborah Sussman (Sussman/Prejza, 1984 Los
+Angeles Olympics), and Lance Wyman (Mexico 68). Their contribution
+is a source of ideas about applying heavy display typography and
+unmixed color planes at architectural scale. This is an
+acknowledgment, not a claim of continuity.
+
+**Trademark posture.** `Supergraphic Panel` is not affiliated with or
+endorsed by Paramount Pictures or CBS Studios. The implementation
+(`packages/viewer/src/styles.css` in the chat-arch repository)
+contains no copyrighted assets, trademarked logos, or proprietary
+show-associated iconography from *Star Trek* or any other protected
+work. Color values, shape primitives, and font choices are
+functional design elements and, under prevailing design-community
+custom, not proprietary.
+
+This posture is design-community custom, not legal advice.
+Replicators who wish to adopt the system commercially should run
+their own counsel over it.

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -1,0 +1,283 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "$description": "Supergraphic Panel — the Chat Archaeologist visual design system. Source palette and font families are extracted from packages/viewer/src/styles.css. Scale tokens (radius, shadow, duration, font.size, font.weight, status aliases) are prescriptive additions authored for replicators; see design-system/spec.md for rationale.",
+  "color": {
+    "sunflower": {
+      "$value": "#ffcc99",
+      "$type": "color",
+      "$description": "Primary text and titles. Never decorative."
+    },
+    "sunflower-muted": {
+      "$value": "#d9ad82",
+      "$type": "color",
+      "$description": "Pre-composited sunflower × 0.85 over black. Solid background for inactive sidebar items so black text holds 10.25:1 WCAG AAA regardless of backdrop."
+    },
+    "butterscotch": {
+      "$value": "#dd9944",
+      "$type": "color",
+      "$description": "Chrome: top bar, sidebar elbows, ALL-CAPS labels, dividers. Never body text."
+    },
+    "butterscotch-muted": {
+      "$value": "#6a4a20",
+      "$type": "color",
+      "$description": "Muted chrome for inactive mobile pill-bar items. Carries sunflower foreground at AA."
+    },
+    "ice": {
+      "$value": "#99ccff",
+      "$type": "color",
+      "$description": "Data and code: model names, inline code, quantitative highlights. Decorative use forbidden."
+    },
+    "violet": {
+      "$value": "#cc99cc",
+      "$type": "color",
+      "$description": "Thinking / processing state: streaming indicators, semantic-analysis running, copy-to-MD action."
+    },
+    "peach": {
+      "$value": "#ff9933",
+      "$type": "color",
+      "$description": "Cost and error accent: cost bars, error banners, CLI-Direct badge. Attention, not alarm."
+    },
+    "bg": {
+      "$value": "#000000",
+      "$type": "color",
+      "$description": "Root frame background. Pure black."
+    },
+    "bg-1": {
+      "$value": "#07070a",
+      "$type": "color",
+      "$description": "Card and panel surface. One step above root."
+    },
+    "bg-2": {
+      "$value": "#0d0d12",
+      "$type": "color",
+      "$description": "Card hover surface. One step above bg-1."
+    },
+    "text": {
+      "$value": "#ffcc99",
+      "$type": "color",
+      "$description": "Alias for sunflower when used as a text color. Same value, semantic role differs."
+    },
+    "dim": {
+      "$value": "#665544",
+      "$type": "color",
+      "$description": "Reserved for inert placeholder glyphs (em-dashes, \"—\", missing values). Not for functional text — fails WCAG AA for body."
+    },
+    "divider": {
+      "$value": "rgba(221, 153, 68, 0.18)",
+      "$type": "color",
+      "$description": "rgba(221, 153, 68, 0.18). Panel and card borders. Inherits from butterscotch at low alpha."
+    }
+  },
+  "font": {
+    "family": {
+      "chrome": {
+        "$value": [
+          "Antonio",
+          "Oswald",
+          "Impact",
+          "sans-serif"
+        ],
+        "$type": "fontFamily",
+        "$description": "ALL-CAPS labels, KPI values, titles, pills, top-bar. The voice of the chrome."
+      },
+      "prose": {
+        "$value": [
+          "IBM Plex Sans",
+          "Segoe UI",
+          "system-ui",
+          "sans-serif"
+        ],
+        "$type": "fontFamily",
+        "$description": "Body text inside cards and messages (≥12px paragraph text). IBM Plex Sans."
+      },
+      "mono": {
+        "$value": [
+          "JetBrains Mono",
+          "Consolas",
+          "Menlo",
+          "monospace"
+        ],
+        "$type": "fontFamily",
+        "$description": "Model names, timestamps, code, keyboard hints, axis ticks. JetBrains Mono."
+      }
+    },
+    "weight": {
+      "regular": {
+        "$value": 400,
+        "$type": "fontWeight",
+        "$description": "Prescriptive: Body prose only. Both IBM Plex Sans and JetBrains Mono ship a regular weight."
+      },
+      "medium": {
+        "$value": 500,
+        "$type": "fontWeight",
+        "$description": "Prescriptive: Default chrome weight. Antonio at 500 is the reliable fallback when 600/700 feel heavy."
+      },
+      "semibold": {
+        "$value": 600,
+        "$type": "fontWeight",
+        "$description": "Prescriptive: Emphasized prose and mono."
+      },
+      "bold": {
+        "$value": 700,
+        "$type": "fontWeight",
+        "$description": "Prescriptive: Titles, pills, ALL-CAPS labels, KPI values. The chrome default for anything that should read as a label."
+      }
+    },
+    "size": {
+      "9": {
+        "$value": "9px",
+        "$type": "dimension",
+        "$description": "Prescriptive: Row-label and legend caps. Floor for legible Antonio caps with 0.18em tracking."
+      },
+      "10": {
+        "$value": "10px",
+        "$type": "dimension",
+        "$description": "Prescriptive: Sidebar short badge, filter-row labels."
+      },
+      "11": {
+        "$value": "11px",
+        "$type": "dimension",
+        "$description": "Prescriptive: Chrome labels, pill text."
+      },
+      "12": {
+        "$value": "12px",
+        "$type": "dimension",
+        "$description": "Prescriptive: Body prose floor inside cards."
+      },
+      "13": {
+        "$value": "13px",
+        "$type": "dimension",
+        "$description": "Prescriptive: Info-popover body prose."
+      },
+      "15": {
+        "$value": "15.5px",
+        "$type": "dimension",
+        "$description": "Prescriptive: Session-card titles. Oddly specific on purpose — verified optically against the 2-line clamp at tier A."
+      },
+      "18": {
+        "$value": "18px",
+        "$type": "dimension",
+        "$description": "Prescriptive: Top-bar title at tier B+."
+      }
+    }
+  },
+  "radius": {
+    "sm": {
+      "$value": "6px",
+      "$type": "dimension",
+      "$description": "Prescriptive: Card and panel corners at mobile tier."
+    },
+    "md": {
+      "$value": "8px",
+      "$type": "dimension",
+      "$description": "Prescriptive: Card and panel corners at tablet / desktop."
+    },
+    "lg": {
+      "$value": "10px",
+      "$type": "dimension",
+      "$description": "Prescriptive: Mid-bar and mode-area at desktop."
+    },
+    "pill": {
+      "$value": "14px",
+      "$type": "dimension",
+      "$description": "Prescriptive: Source-pill, top-bar source-buttons (sized to half-height)."
+    },
+    "pill-lg": {
+      "$value": "20px",
+      "$type": "dimension",
+      "$description": "Prescriptive: Narrow-banner, command-mode \"more\" button, search input at tier B+."
+    },
+    "elbow": {
+      "$value": "32px",
+      "$type": "dimension",
+      "$description": "Prescriptive: Sidebar elbow at mobile. Asymmetric: `32px 0 0 0` or `0 0 0 32px` — never four-corner-equal."
+    },
+    "elbow-lg": {
+      "$value": "40px",
+      "$type": "dimension",
+      "$description": "Prescriptive: Sidebar elbow at desktop. Anchors the L-corner where vertical and horizontal arms meet."
+    }
+  },
+  "shadow": {
+    "none": {
+      "$value": "none",
+      "$type": "shadow",
+      "$description": "Prescriptive: Default. The system does not use drop shadows for hierarchy — hierarchy comes from left-accent rules, border color, and surface stepping (bg → bg-1 → bg-2)."
+    },
+    "panel": {
+      "$value": {
+        "color": "rgba(0, 0, 0, 0.6)",
+        "offsetX": "0px",
+        "offsetY": "10px",
+        "blur": "40px",
+        "spread": "0px"
+      },
+      "$type": "shadow",
+      "$description": "Prescriptive: Reserved for floating panels that escape the frame (info-popover, rescan-banner, tier-sheet backdrop). Never on in-frame cards."
+    },
+    "ring-ice": {
+      "$value": "inset 0 0 0 3px color-mix(in srgb, #99ccff 60%, transparent)",
+      "$type": "shadow",
+      "$description": "Prescriptive: Focus ring for quantitative / ice-accent contexts. Ring pulse, not glow."
+    },
+    "ring-violet": {
+      "$value": "inset 0 0 0 3px color-mix(in srgb, #cc99cc 60%, transparent)",
+      "$type": "shadow",
+      "$description": "Prescriptive: Focus ring for thinking / violet-accent contexts."
+    }
+  },
+  "duration": {
+    "fast": {
+      "$value": "80ms",
+      "$type": "duration",
+      "$description": "Prescriptive: Background color transitions on sidebar items, pill-bar pills."
+    },
+    "base": {
+      "$value": "120ms",
+      "$type": "duration",
+      "$description": "Prescriptive: Default card hover transition (background, border, transform)."
+    },
+    "slow": {
+      "$value": "200ms",
+      "$type": "duration",
+      "$description": "Prescriptive: Analysis-launcher progress-fill width transition."
+    },
+    "boot": {
+      "$value": "1400ms",
+      "$type": "duration",
+      "$description": "Prescriptive: Full boot cascade from top-bar through command-mode cards. Individual panel animations sit at 400–600ms with staggered delays."
+    },
+    "pulse-focus": {
+      "$value": "2200ms",
+      "$type": "duration",
+      "$description": "Prescriptive: Focus-pulse animations on filter-bar rows when navigated via analysis-tab cards."
+    }
+  },
+  "status": {
+    "concept": {
+      "$value": "{color.violet}",
+      "$type": "color",
+      "$description": "Earliest / thinking state. Maps to violet. Prescriptive."
+    },
+    "active": {
+      "$value": "{color.sunflower}",
+      "$type": "color",
+      "$description": "In-progress / primary state. Maps to sunflower. Prescriptive."
+    },
+    "open-pr": {
+      "$value": "{color.ice}",
+      "$type": "color",
+      "$description": "In review / quantitative active state. Maps to ice. Prescriptive."
+    },
+    "merged": {
+      "$value": "{color.butterscotch}",
+      "$type": "color",
+      "$description": "Completed / steady chrome state. Maps to butterscotch. Prescriptive."
+    },
+    "released": {
+      "$value": "{color.peach}",
+      "$type": "color",
+      "$description": "Shipped / notable accent. Maps to peach. Prescriptive."
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "pnpm -r --filter=\"./packages/*\" --filter=\"./apps/*\" build",
+    "build": "node design-system/scripts/generate-tokens.mjs && pnpm -r --filter=\"./packages/*\" --filter=\"./apps/*\" build",
     "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Adds `design-system/` at the repo root as the canonical source for the Supergraphic Panel visual design system.
- Four files: `spec.md` (2400-word prose specification with line-cited claims, WCAG contrast matrix, `prefers-reduced-motion` policy, port recipes, attribution), `tokens.json` (DTCG 2025.10 format, 17 source tokens + prescriptive scales), `README.md` (version 0.1.0 + usage), `scripts/generate-tokens.mjs` (Node generator + drift guard).
- Generator parses `--lcars-*` vars from `packages/viewer/src/styles.css`, merges with prescriptive `radius` / `shadow` / `duration` / `font.size` / `font.weight` / `status` scales, emits `tokens.json`. Drift guard fails the build if any hex in `spec.md` is missing from the emitted tokens — aligned with the implementation plan's "styles.css is the source of truth" rule.
- Wires the generator into root `pnpm build` (runs before the workspace builds) so CI catches drift.

## Plan reference
PR 1 of 3 in [`design-system-implementation-plan.md`](../../../brycewatson.com/_planning/design-system-implementation-plan.md) (Deliverable 1).

## Test plan
- [x] `pnpm build` passes cleanly from the repo root
- [x] `pnpm lint` passes (5 pre-existing warnings unchanged, 0 errors)
- [x] `pnpm test` passes (552 passed, 4 skipped)
- [x] Drift guard fires when a fake hex is added to `spec.md` (tested: `#abcdef`)
- [x] Drift guard fires when an existing hex is mutated (tested: `#ffcc99` → `#ffcc88`)
- [x] `tokens.json` validates as DTCG JSON (17 color/font tokens extracted + prescriptive scales)

## Follow-ups
PR 2 will add the `/design-system/` walkthrough page on chat-arch.dev, `public/llms.txt`, and a copy-to-public script that mirrors `spec.md` + `tokens.json` to the standalone `public/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)