### PR TITLE
feat(viewer): design-system colophon in TopBar

### DIFF
--- a/packages/viewer/src/components/TopBar.tsx
+++ b/packages/viewer/src/components/TopBar.tsx
@@ -220,6 +220,29 @@ export function TopBar({
       <div className="lcars-top-bar__left">
         <span className="lcars-top-bar__dot" aria-hidden="true" />
         <h1 className="lcars-top-bar__title">CHAT ARCHAEOLOGIST</h1>
+        {/*
+          Design-system colophon. A small ⓘ anchored to the title that
+          opens a sentence-length credit and a link to
+          /design-system/. Reuses the existing InfoPopover pattern so
+          it reads as a natural help chip rather than new chrome —
+          the goal was a subtle discovery affordance, not another CTA.
+          The link navigates same-origin to the walkthrough page
+          served by the standalone app (apps/standalone/src/pages/
+          design-system/index.astro).
+        */}
+        <InfoPopover
+          ariaLabel="about the Supergraphic Panel design system"
+          className="lcars-top-bar__title-info"
+        >
+          <strong>Supergraphic Panel</strong>
+          <p>
+            This UI uses the Supergraphic Panel design system — published with
+            its source, DTCG tokens, and an LLM-consumable specification.
+          </p>
+          <p>
+            <a href="/design-system/">View the walkthrough →</a>
+          </p>
+        </InfoPopover>
         {onCloudUpload && (
           <>
             <div className="lcars-top-bar__source-group">

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -5329,3 +5329,41 @@
   border-color: var(--lcars-sunflower);
   outline: none;
 }
+
+/* --- info popover: link styling ---
+   Minimal anchor treatment for links inside info-popover panels.
+   Ice blue follows the palette's quantitative/data role; on hover
+   the color lifts to sunflower (primary) so the state change reads
+   without needing a new underline treatment. Added late on purpose:
+   appending here avoids shifting the line numbers cited by the
+   design-system spec at design-system/spec.md. */
+.lcars-info-popover__panel a {
+  color: var(--lcars-ice);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.lcars-info-popover__panel a:hover,
+.lcars-info-popover__panel a:focus-visible {
+  color: var(--lcars-sunflower);
+  outline: none;
+}
+
+/* --- design-system colophon popover ---
+   The leftmost info-popover in the top bar (attached to the
+   CHAT ARCHAEOLOGIST title for the Supergraphic Panel link) has
+   its anchor flush with the page gutter. The default right-anchor
+   positioning pushes the panel off the left viewport edge on
+   narrow devices. Below 480px we detach the panel to viewport-
+   fixed coordinates and pin it between 8px margins so it always
+   lands fully on screen. Desktop behavior is unchanged. */
+@media (max-width: 480px) {
+  .lcars-top-bar__title-info .lcars-info-popover__panel {
+    position: fixed;
+    top: 56px;
+    left: 8px;
+    right: 8px;
+    width: auto;
+    max-width: none;
+    min-width: 0;
+  }
+}


### PR DESCRIPTION
## Summary
Small ⓘ chip right after the \`CHAT ARCHAEOLOGIST\` title. Opens a two-line popover crediting the Supergraphic Panel design system and linking to \`/design-system/\`. Uses the existing \`InfoPopover\` component so it reads as part of the app's established help-chip vocabulary (alongside UPLOAD CLOUD, SCAN LOCAL, tier indicator), not as new chrome.

## Plan context
Follow-up to [#9](https://github.com/BryceEWatson/chat-arch/pull/9) per the user's "subtle way to link from the main app" request. This PR is **based on** PR #9's branch so the diff shows only this delta; merge order is #9 → this.

## Changes
- \`packages/viewer/src/components/TopBar.tsx\` — add an \`<InfoPopover>\` immediately after the title with the colophon copy + walkthrough link.
- \`packages/viewer/src/styles.css\` — append link styling for \`.lcars-info-popover__panel a\` (ice blue, hover → sunflower) and a responsive fix for the title-info popover on narrow viewports (viewport-fixed positioning below 480px to prevent the left-clip the default right-anchor produces when the trigger sits flush against the page gutter).

## Why end-of-file for the CSS
The design-system spec (\`design-system/spec.md\`) cites \`styles.css\` by GitHub line anchor (e.g. \`#L47\`, \`#L710\`). Appending avoids shifting those anchors. Noted inline in the CSS comment.

## Test plan
- [x] \`pnpm build\` — clean
- [x] \`pnpm lint\` — no new warnings
- [x] \`pnpm test\` — 552 passed, 4 skipped (unchanged)
- [x] Verified at 1440×900: popover opens, link reads in ice blue, hover lifts to sunflower, click navigates to \`/design-system/\`
- [x] Verified at 375×812: popover detaches to viewport-fixed at 8px insets, fits fully on screen (before the fix it clipped ~35px off the left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)