### PR TITLE
fix(design-system): swap inline styles for classes so CSP stops blocking swatches

### DIFF
--- a/apps/standalone/src/pages/design-system/index.astro
+++ b/apps/standalone/src/pages/design-system/index.astro
@@ -82,7 +82,7 @@ const durations = Object.entries(tokens.duration);
             <tbody>
               {palette.map(([name, token]) => (
                 <tr>
-                  <td><span class="ds-swatch" style={`background:${token.$value}`} aria-hidden="true"></span></td>
+                  <td><span class={`ds-swatch ds-swatch--${name}`} aria-hidden="true"></span></td>
                   <td><code>color.{name}</code></td>
                   <td><code>{token.$value}</code></td>
                   <td>{token.$description}</td>
@@ -156,17 +156,17 @@ const durations = Object.entries(tokens.duration);
           <div class="ds-component">
             <div class="ds-component__title">Source pill</div>
             <div class="ds-component__demo">
-              <button class="lcars-source-pill lcars-source-pill--active" style="--source-color: var(--lcars-ice)">
+              <button class="lcars-source-pill lcars-source-pill--active ds-accent--ice">
                 <span class="lcars-source-pill__badge">CC</span>
                 <span class="lcars-source-pill__label">CLAUDE CODE</span>
                 <span class="lcars-source-pill__count">247</span>
               </button>
-              <button class="lcars-source-pill" style="--source-color: var(--lcars-violet)">
+              <button class="lcars-source-pill ds-accent--violet">
                 <span class="lcars-source-pill__badge">GT</span>
                 <span class="lcars-source-pill__label">CHATGPT</span>
                 <span class="lcars-source-pill__count">82</span>
               </button>
-              <button class="lcars-source-pill" style="--source-color: var(--lcars-peach)">
+              <button class="lcars-source-pill ds-accent--peach">
                 <span class="lcars-source-pill__badge">CD</span>
                 <span class="lcars-source-pill__label">CLI-DIRECT</span>
                 <span class="lcars-source-pill__count">6</span>
@@ -203,9 +203,9 @@ const durations = Object.entries(tokens.duration);
           <div class="ds-component">
             <div class="ds-component__title">Session card</div>
             <div class="ds-component__demo">
-              <article class="lcars-session-card ds-demo-card" style="--source-color: var(--lcars-ice)">
+              <article class="lcars-session-card ds-demo-card ds-accent--ice">
                 <div class="lcars-session-card__row lcars-session-card__row--top">
-                  <button class="lcars-source-pill" style="--source-color: var(--lcars-ice)">
+                  <button class="lcars-source-pill ds-accent--ice">
                     <span class="lcars-source-pill__badge">CC</span>
                     <span class="lcars-source-pill__label">CLAUDE CODE</span>
                   </button>
@@ -229,15 +229,15 @@ const durations = Object.entries(tokens.duration);
             <div class="ds-component__title">Sidebar tab</div>
             <div class="ds-component__demo">
               <ul class="ds-inline-sidebar">
-                <li class="lcars-sidebar__item lcars-sidebar__item--active" style="--mode-color: var(--lcars-ice)">
+                <li class="lcars-sidebar__item lcars-sidebar__item--active ds-accent--ice">
                   <span class="lcars-sidebar__item-short">01</span>
                   <span class="lcars-sidebar__item-label">COMMAND</span>
                 </li>
-                <li class="lcars-sidebar__item" style="--mode-color: var(--lcars-violet)">
+                <li class="lcars-sidebar__item ds-accent--violet">
                   <span class="lcars-sidebar__item-short">02</span>
                   <span class="lcars-sidebar__item-label">TOPICS</span>
                 </li>
-                <li class="lcars-sidebar__item" style="--mode-color: var(--lcars-peach)">
+                <li class="lcars-sidebar__item ds-accent--peach">
                   <span class="lcars-sidebar__item-short">03</span>
                   <span class="lcars-sidebar__item-label">COSTS</span>
                 </li>
@@ -254,7 +254,7 @@ const durations = Object.entries(tokens.duration);
           <div class="ds-component">
             <div class="ds-component__title">Mid bar</div>
             <div class="ds-component__demo">
-              <div class="lcars-mid-bar" style="background: var(--lcars-butterscotch)">
+              <div class="lcars-mid-bar ds-mid-bar--butterscotch">
                 <span class="lcars-mid-bar__label">BROWSE / COMMAND</span>
               </div>
             </div>
@@ -267,17 +267,17 @@ const durations = Object.entries(tokens.duration);
           <div class="ds-component">
             <div class="ds-component__title">Source pill — grouped</div>
             <div class="ds-component__demo">
-              <button class="lcars-source-pill lcars-source-pill--active" style="--source-color: var(--lcars-sunflower)">
+              <button class="lcars-source-pill lcars-source-pill--active ds-accent--sunflower">
                 <span class="lcars-source-pill__badge">A</span>
                 <span class="lcars-source-pill__label">ALL</span>
                 <span class="lcars-source-pill__count">335</span>
               </button>
-              <button class="lcars-source-pill" style="--source-color: var(--lcars-ice)">
+              <button class="lcars-source-pill ds-accent--ice">
                 <span class="lcars-source-pill__badge">CC</span>
                 <span class="lcars-source-pill__label">CLAUDE CODE</span>
                 <span class="lcars-source-pill__count">247</span>
               </button>
-              <button class="lcars-source-pill" style="--source-color: var(--lcars-violet)">
+              <button class="lcars-source-pill ds-accent--violet">
                 <span class="lcars-source-pill__badge">GT</span>
                 <span class="lcars-source-pill__label">CHATGPT</span>
                 <span class="lcars-source-pill__count">82</span>
@@ -706,6 +706,43 @@ LLM discovery: https://chat-arch.dev/llms.txt`}</code></pre>
       border-radius: 4px;
       border: 1px solid rgba(255, 204, 153, 0.2);
     }
+    /* Per-token swatch backgrounds. Previously these lived as inline
+       style="background:#xxx" attributes on each <span>, but the page's
+       CSP has auto-hashed style-src (which voids 'unsafe-inline' per CSP3
+       spec), so inline style attributes get blocked. Moving the values
+       into this scoped <style> block lets Astro auto-hash them cleanly.
+       Values mirror design-system/tokens.json — update both when adding
+       a palette entry. */
+    .ds-swatch--sunflower { background: #ffcc99; }
+    .ds-swatch--sunflower-muted { background: #d9ad82; }
+    .ds-swatch--butterscotch { background: #dd9944; }
+    .ds-swatch--butterscotch-muted { background: #6a4a20; }
+    .ds-swatch--ice { background: #99ccff; }
+    .ds-swatch--violet { background: #cc99cc; }
+    .ds-swatch--peach { background: #ff9933; }
+    .ds-swatch--bg { background: #000000; }
+    .ds-swatch--bg-1 { background: #07070a; }
+    .ds-swatch--bg-2 { background: #0d0d12; }
+    .ds-swatch--text { background: #ffcc99; }
+    .ds-swatch--dim { background: #665544; }
+    .ds-swatch--divider { background: rgba(221, 153, 68, 0.18); }
+
+    /* Per-accent helpers for demo components. Same CSP reason — the
+       spec shows per-instance inline style="--source-color: var(...)",
+       but the walkthrough page can't emit inline style attrs. These
+       helper classes set both --source-color and --mode-color so the
+       same class works on source-pill, sidebar-item, and session-card
+       demos. */
+    .ds-accent--sunflower { --source-color: var(--lcars-sunflower); --mode-color: var(--lcars-sunflower); }
+    .ds-accent--butterscotch { --source-color: var(--lcars-butterscotch); --mode-color: var(--lcars-butterscotch); }
+    .ds-accent--ice { --source-color: var(--lcars-ice); --mode-color: var(--lcars-ice); }
+    .ds-accent--violet { --source-color: var(--lcars-violet); --mode-color: var(--lcars-violet); }
+    .ds-accent--peach { --source-color: var(--lcars-peach); --mode-color: var(--lcars-peach); }
+
+    /* .lcars-mid-bar sets structural properties only (height, radius,
+       padding); the background is set per-instance. */
+    .ds-mid-bar--butterscotch { background: var(--lcars-butterscotch); }
+
     /* High-contrast users: the 20%-alpha sunflower border on a swatch
        can read as invisible against either the bg or the swatch color.
        Lift to a solid 2px sunflower border and adopt a square corner


### PR DESCRIPTION
## What broke

Every palette swatch on [chat-arch.dev/design-system/](https://chat-arch.dev/design-system/) rendered transparent — the dark card color showed through, hence the "all colors are showing as black" report. The same bug affected every component demo that relied on `--source-color` or `--mode-color`: source pills, sidebar tabs, session cards, the mid-bar — all fell through to the butterscotch default instead of their intended accent.

## Why

Astro 5.9+'s auto-hashing CSP was quietly voiding the `'unsafe-inline'` allowance for styles. Per [CSP3 spec](https://w3c.github.io/webappsec-csp/#match-element-to-source-list): when `style-src` contains *any* hash or nonce, `'unsafe-inline'` is ignored. The config kept `'unsafe-inline'` with a comment saying React runtime injection needs it — but the auto-hashing silently neutralized it for `style=\"...\"` attributes.

Browser console confirmed:
\`\`\`
error: Applying inline style violates the following Content Security Policy directive
'style-src 'self' 'unsafe-inline' https://fonts.googleapis.com 'sha256-...' 'sha256-...''.
Note that 'unsafe-inline' is ignored if either a hash or nonce value is present in the source list.
The action has been blocked.
\`\`\`

The walkthrough's 15 inline `style=\"...\"` attributes all got blocked.

## Fix

Moved the dynamic style values into the page's scoped `<style>` block (which Astro auto-hashes and therefore allows) and referenced them via classes.

- **`.ds-swatch--<token>`** (13 helpers) mirroring `tokens.json` palette values.
- **`.ds-accent--<color>`** (sunflower/butterscotch/ice/violet/peach) setting both `--source-color` and `--mode-color` so the same class works on source-pill, sidebar-item, and session-card demos.
- **`.ds-mid-bar--butterscotch`** for the mid-bar demo (base `.lcars-mid-bar` sets structure only — verified in `packages/viewer/src/styles.css`).

Swapped 15 inline attributes for the new classes. Left the `<pre><code>` block on line ~176 alone — that's showing consumers what the canonical source-pill markup looks like in *their* projects where CSP policy may differ, so the literal `style=\"--source-color: var(--lcars-ice)\"` has teaching value.

## Verification

Built with \`pnpm --filter @chat-arch/standalone build\` and served with \`astro preview\` (port 4325 — the same static HTML + meta-CSP that production gets). Playwright probe:

- **All 13 swatches compute their correct backgrounds** (sunflower `#ffcc99`, butterscotch `#dd9944`, ice `#99ccff`, violet `#cc99cc`, peach `#ff9933`, bg `#000`, bg-1 `#07070a`, etc.)
- **Source pills** get their `--source-color` (ice, violet, peach, sunflower) and render backgrounds accordingly
- **Sidebar tabs** get their `--mode-color` (ice/violet/peach)
- **Mid-bar** gets the butterscotch background
- **Zero `style-src` CSP violations** on the walkthrough

Production screenshot (localhost:4325 under production CSP) is visible with real colors; previously-transparent swatches now render.

## Drift note

Swatch hex literals now live in three places: `design-system/tokens.json`, `design-system/spec.md`, and this walkthrough. The generator script in `design-system/scripts/generate-tokens.mjs` already fails the build if `spec.md` drifts from tokens; the walkthrough doesn't currently share that check. A comment in the new CSS block points back to `tokens.json` as the source of truth. Could add a grep check to the generator in a follow-up if drift bites.

## Test plan

- [x] \`pnpm --filter @chat-arch/standalone build\` — completes without errors
- [x] \`astro preview\` on port 4325 — walkthrough renders all colors
- [x] Playwright probe confirms 0 style-src CSP violations + correct computed backgrounds
- [ ] After merge: verify on chat-arch.dev that all palette swatches + component demos render in color (same check as #9's acceptance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)