### PR TITLE
fix(design-system): two-tone backing for palette swatches

### DIFF
--- a/apps/standalone/src/pages/design-system/index.astro
+++ b/apps/standalone/src/pages/design-system/index.astro
@@ -82,7 +82,7 @@ const durations = Object.entries(tokens.duration);
             <tbody>
               {palette.map(([name, token]) => (
                 <tr>
-                  <td><span class={`ds-swatch ds-swatch--${name}`} aria-hidden="true"></span></td>
+                  <td><span class="ds-swatch-frame" aria-hidden="true"><span class={`ds-swatch ds-swatch--${name}`}></span></span></td>
                   <td><code>color.{name}</code></td>
                   <td><code>{token.$value}</code></td>
                   <td>{token.$description}</td>
@@ -699,11 +699,34 @@ LLM discovery: https://chat-arch.dev/llms.txt`}</code></pre>
       font-size: 11.5px;
       color: var(--lcars-ice);
     }
+    /* Two-tone backing frame. The system's bg family (bg #000, bg-1
+       #07070a, bg-2 #0d0d12) differs by 7–13 RGB units — intentional
+       subtle surface stepping that works in the viewer's large-area
+       context but disappears in a 36×22 swatch on a dark card (the
+       swatch and the card are both near-black, so the swatch visually
+       vanishes). The divider token (rgba butterscotch at 18% alpha)
+       has the same problem for a different reason: it composites
+       against whatever's behind it, and against a dark card it reads
+       as empty. Wrapping every swatch in a frame with a half-dark /
+       half-light backing gives the near-blacks a visible edge against
+       the light half, and lets the divider's translucency show through
+       both halves. Gray neutrals rather than design-system colors so
+       the backing doesn't bias the perceived hue of the swatch. */
+    .ds-swatch-frame {
+      display: inline-flex;
+      width: 44px;
+      height: 26px;
+      padding: 2px;
+      border-radius: 5px;
+      background: linear-gradient(to right, #1a1a1a 50%, #e5e5e5 50%);
+      box-sizing: border-box;
+      vertical-align: middle;
+    }
     .ds-swatch {
-      display: inline-block;
-      width: 36px;
-      height: 22px;
-      border-radius: 4px;
+      display: block;
+      width: 100%;
+      height: 100%;
+      border-radius: 3px;
       border: 1px solid rgba(255, 204, 153, 0.2);
     }
     /* Per-token swatch backgrounds. Previously these lived as inline
@@ -746,8 +769,14 @@ LLM discovery: https://chat-arch.dev/llms.txt`}</code></pre>
     /* High-contrast users: the 20%-alpha sunflower border on a swatch
        can read as invisible against either the bg or the swatch color.
        Lift to a solid 2px sunflower border and adopt a square corner
-       so the swatch reads as a distinct object, not a tinted region. */
+       so the swatch reads as a distinct object, not a tinted region.
+       Replace the neutral two-tone frame with solid sunflower so the
+       boundary stays unambiguous regardless of the swatch fill. */
     @media (prefers-contrast: more) {
+      .ds-swatch-frame {
+        background: var(--lcars-sunflower);
+        border-radius: 0;
+      }
       .ds-swatch {
         border: 2px solid var(--lcars-sunflower);
         border-radius: 0;


### PR DESCRIPTION
## Problem

Reported by Bryce: the three near-black swatches on the palette (\`color.bg\`, \`color.bg-1\`, \`color.bg-2\`) are indistinguishable from empty boxes. The divider swatch has the same issue for a different reason.

Root cause: the bg family tones are intentionally close — 7–13 RGB units apart — because the system's "surface stepping" is supposed to be subtle in the viewer's large-area context. But a 36×22 swatch on a ~\`#07070a\` card is just a thin 20%-alpha border around a fill that's within a couple of RGB units of its surroundings. The swatch visually vanishes.

The \`divider\` token (\`rgba(221, 153, 68, 0.18)\`) has a parallel problem: 18%-alpha butterscotch composited against a dark card reads as a thin warm tint that's easy to miss.

## Fix

Wrapped every swatch in a \`.ds-swatch-frame\` with a half-dark (\`#1a1a1a\`) / half-light (\`#e5e5e5\`) linear-gradient backing and 2px padding:

- **Near-black swatches** now read as solid black/near-black against the light half of the frame. You can see the swatch is there.
- **Divider** composites against both halves through its alpha — the left half becomes dark-tinted butterscotch, the right half pale cream. The translucency is now visible at a glance.
- **Opaque colored swatches** (sunflower, ice, violet, peach, etc.) are unchanged apart from a 2px frame edge around them.

Gray neutrals rather than design-system tokens on the frame so the backing doesn't bias the perceived hue of the swatch interior. The \`prefers-contrast: more\` path swaps the two-tone for solid sunflower to match the existing high-contrast rule.

## Verification

Built + previewed locally on port 4325 under the production CSP + meta. Screenshot of the palette section post-fix: divider now clearly reads as translucent (dark-tinted left, cream-tinted right); bg/bg-1/bg-2 swatches are each visibly a distinct square against the light half (their near-identity to each other is by design and still reads as a tight cluster).

Probe confirms: 13 frames rendered, all with the expected `linear-gradient(to right, rgb(26, 26, 26) 50%, rgb(229, 229, 229) 50%)` backing, divider swatch computes `rgba(221, 153, 68, 0.18)` as expected.

## Test plan

- [x] \`pnpm --filter @chat-arch/standalone build\` — completes without errors
- [x] \`astro preview\` on :4325 — all 13 swatches clearly visible, divider's translucency reads
- [ ] After merge: verify on chat-arch.dev that swatches show the two-tone frame under production CSP
- [ ] Follow-up on brycewatson.com: refresh the walkthrough screenshot embedded in the blog post once this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)