### PR TITLE
docs: reference chat-arch.dev and correct stale README claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,32 @@ JSONL files Claude Code writes to disk plus the ZIP you get from
 gives you search, filters, cost analytics, and a duplicate / zombie-project
 view for the corpus you've already built.
 
-**Local-first.** Runs entirely in a browser tab against a local web server.
-No API calls, no cloud sync, no analytics beacons. Your transcripts never
-leave your machine.
+**Local-first by construction.** All parsing happens in the browser. No API
+calls, no cloud sync, no analytics beacons — true for both the hosted viewer
+at **[chat-arch.dev](https://chat-arch.dev)** (static files on Cloudflare
+Pages, no backend) and a local `pnpm dev` checkout. Your transcripts never
+leave the tab they were opened in.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Live demo: chat-arch.dev](https://img.shields.io/badge/demo-chat--arch.dev-5b7cff)](https://chat-arch.dev)
+
+---
+
+## Try it without installing
+
+The fastest path to kick the tires:
+
+1. Open **[chat-arch.dev](https://chat-arch.dev)**.
+2. Click **LOAD DEMO DATA** to populate the viewer with a synthetic
+   fixture corpus (clearly marked `DEMO DATA`), or drop a claude.ai
+   **Privacy-Export ZIP** on **UPLOAD CLOUD** to view your own archive.
+3. Everything renders client-side — the page ships as static files with
+   no server routes, so nothing you upload is transmitted anywhere.
+
+The hosted viewer can't read files from disk (it has no filesystem
+access). To index your local `~/.claude/projects/` or `%APPDATA%\Claude`
+transcripts from Claude Code CLI / Desktop / Cowork, run chat-arch
+locally via the [Quickstart](#quickstart) below and use **SCAN LOCAL**.
 
 ---
 
@@ -36,17 +57,26 @@ pnpm install
 pnpm dev
 ```
 
-Open http://localhost:4321. You'll see a populated viewer immediately —
-the first run auto-seeds a **synthetic demo corpus** so nothing ever renders
-empty. A `DEMO DATA` chip marks it as fictional. The demo is only useful for
-getting a feel for the interface; jump to **[Getting your own data](#getting-your-own-data)**
-below to wire up a real corpus.
+Open http://localhost:4321. The viewer lands on a **NO DATA YET** screen
+with three ways in:
+
+- **SCAN LOCAL** — index your on-disk transcripts (Claude Code CLI,
+  Desktop, Cowork). Dev-server-only, since it hits a local `/api/rescan`
+  route that isn't part of the static deploy.
+- **UPLOAD CLOUD** — drop a claude.ai Privacy-Export ZIP. Pure browser,
+  works in dev and on [chat-arch.dev](https://chat-arch.dev).
+- **LOAD DEMO DATA** — populate with a synthetic fixture corpus so you
+  can explore the UI without exposing real conversations. A `DEMO DATA`
+  chip marks it as fictional.
+
+See [Getting your own data](#getting-your-own-data) below for the full
+walkthrough of each ingestion path.
 
 > **No Claude Code or Anthropic account required to _run_ chat-arch.** The
-> tool is a plain Node app — it just reads Claude transcripts that already
-> exist on your disk or in a Privacy-Export ZIP you download from claude.ai.
-> No API calls, no login, no telemetry. If you've never used any Claude
-> product, chat-arch has nothing to show you beyond the demo; see
+> tool is a plain static web app — it just reads Claude transcripts that
+> already exist on your disk or in a Privacy-Export ZIP you download from
+> claude.ai. No API calls, no login, no telemetry. If you've never used any
+> Claude product, chat-arch has nothing to show you beyond the demo; see
 > [Not a Claude user (yet)](#not-a-claude-user-yet) at the bottom.
 
 ### Requirements
@@ -89,8 +119,10 @@ email with a download link, usually within a few minutes.
 3. Open the **Privacy** tab → click **Export data**.
 4. Wait for the confirmation email. The ZIP is typically under 50 MB even
    for heavy users.
-5. Back in chat-arch, click **UPLOAD CLOUD** in the top bar and pick the
-   ZIP you just downloaded.
+5. Open chat-arch — either [chat-arch.dev](https://chat-arch.dev) or a
+   local `pnpm dev` checkout — click **UPLOAD CLOUD** in the top bar, and
+   pick the ZIP you just downloaded. Parsing happens entirely in the
+   browser; nothing is transmitted.
 
 The same ZIP can be re-uploaded any time — chat-arch deduplicates by
 conversation id, so re-exporting monthly to pull in new conversations is
@@ -143,26 +175,55 @@ sparkline timeline) computed on the user's own machine — everything needed
 to navigate the corpus is live the moment the viewer loads, no pre-compute
 step required.
 
+## Design system
+
+The viewer's retro-computing look — chunky supergraphic panels, dual-track
+typography, a stepped butterscotch/salmon/peach palette — is extracted into
+a standalone, replicable design system called **Supergraphic Panel**:
+
+- [**Walkthrough**](https://chat-arch.dev/design-system/) — human-facing
+  tour with live specimens, swatches, and port recipes.
+- [**Prose spec**](https://chat-arch.dev/design-system/spec.md) — the
+  canonical ~2400-word specification, written to be consumable by an LLM
+  agent applying the system to another project.
+- [**Design tokens**](https://chat-arch.dev/design-system/tokens.json) —
+  [DTCG 2025.10](https://www.designtokens.org/schemas/2025.10/format.json)
+  format. Source palette and font families are extracted from the viewer
+  stylesheet; scale tokens are prescriptive.
+
+Source lives under [`design-system/`](design-system/) at the repo root;
+the standalone build mirrors it to the hosted deploy.
+
 ## Repo layout
 
 ```
 apps/
-  standalone/        Astro shell that serves the viewer + the dev-only
-                     /api/rescan endpoint. The dev server seeds a demo
-                     corpus on first run if no real data is present.
+  standalone/        Astro shell. Hosts the viewer and, in dev, the
+                     /api/rescan + /api/clear endpoints. The `pnpm build`
+                     output (static client bundle) is what ships to
+                     chat-arch.dev via Cloudflare Pages.
 packages/
   schema/            UnifiedSessionEntry + manifest types. Pure TypeScript.
   exporter/          CLI + parsers for the four input sources, plus the
                      core-tier analysis writers (duplicates.exact,
                      zombies.heuristic, meta).
+  analysis/          Shared cloud-mapping + clustering utilities used by
+                     both the exporter (at build time) and the viewer
+                     (at runtime).
   viewer/            React viewer. Mounts against
                      /chat-arch-data/manifest.json.
+design-system/       Supergraphic Panel source — prose spec + token
+                     generator. Mirrored to chat-arch.dev/design-system/
+                     at build time.
 ```
 
 ## Privacy
 
 `chat-arch` is local-first by construction — no telemetry, no API calls, no
-cloud sync. Your transcripts stay on your disk.
+cloud sync. Transcripts stay in the environment you loaded them from: on
+disk if you ran `pnpm dev` and clicked **SCAN LOCAL**, or in the browser
+tab's memory / IndexedDB if you uploaded a Privacy-Export ZIP to
+chat-arch.dev. Nothing is transmitted to a server in either case.
 
 **Note for users**: your own transcripts may contain other people's content
 (prompts about colleagues, pasted client work, customer data). If you publish
@@ -177,11 +238,15 @@ For security-sensitive issues, please open a private security advisory on
 GitHub rather than a public issue. See [`SECURITY.md`](SECURITY.md) for
 the full disclosure policy and the list of known limitations.
 
-The most relevant points for the typical local-dev use case:
+Headline points:
 
-- The `/api/rescan` dev-server endpoint requires same-origin Origin and a
-  custom `X-Requested-With` header — a hostile cross-origin page in your
-  browser cannot trigger a rescan.
+- **The hosted deploy has no server-side endpoints.** `chat-arch.dev`
+  serves only static HTML/JS/CSS from Cloudflare Pages — there is no
+  `/api/rescan`, no `/api/clear`, and no backend that can read the
+  filesystem or mutate server-side state.
+- In a local `pnpm dev` checkout, the `/api/rescan` endpoint requires
+  same-origin Origin and a custom `X-Requested-With` header — a hostile
+  cross-origin page in your browser cannot trigger a rescan.
 - The viewer escapes user content before passing it to React's
   `dangerouslySetInnerHTML`, with regression tests pinning the escape order.
 - The production build emits a strict Content-Security-Policy header

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ JSONL files Claude Code writes to disk plus the ZIP you get from
 gives you search, filters, cost analytics, and a duplicate / zombie-project
 view for the corpus you've already built.
 
-**Local-first by construction.** All parsing happens in the browser. No API
-calls, no cloud sync, no analytics beacons — true for both the hosted viewer
-at **[chat-arch.dev](https://chat-arch.dev)** (static files on Cloudflare
-Pages, no backend) and a local `pnpm dev` checkout. Your transcripts never
-leave the tab they were opened in.
+**Local-first by construction.** Your transcripts never leave your machine.
+The hosted viewer at **[chat-arch.dev](https://chat-arch.dev)** is a static
+Cloudflare Pages build with no backend — Privacy-Export ZIPs are parsed
+entirely in the browser. A local `pnpm dev` checkout additionally exposes
+a same-origin `/api/rescan` endpoint so **SCAN LOCAL** can walk
+`~/.claude/projects/` and `%APPDATA%\Claude` via the Astro dev server
+(`localhost` only; nothing egresses). The only cross-origin fetch on
+either path is the optional Hugging Face model-weight download on first
+**Analyze Topics** run — see [Model-weight trust boundary](#model-weight-trust-boundary)
+below. No telemetry, no analytics beacons, no transcript upload.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Live demo: chat-arch.dev](https://img.shields.io/badge/demo-chat--arch.dev-5b7cff)](https://chat-arch.dev)
@@ -73,13 +78,14 @@ See [Getting your own data](#getting-your-own-data) below for the full
 walkthrough of each ingestion path.
 
 > **No Claude Code or Anthropic account required to _run_ chat-arch.** The
-> viewer parses Claude transcripts that already exist on your disk or in
-> a Privacy-Export ZIP you downloaded from claude.ai — no API calls, no
-> login, no telemetry. Never used Claude? Click **LOAD DEMO DATA** to
-> explore the full viewer (filters, sparkline, duplicate detection,
-> topic clustering) against ~100 hand-written synthetic sessions; see
-> [Not a Claude user (yet)](#not-a-claude-user-yet) at the bottom for
-> multi-provider alternatives if Claude isn't your primary assistant.
+> viewer reads Claude transcripts that already exist on your disk or in
+> a Privacy-Export ZIP you downloaded from claude.ai — no Claude-API
+> calls, no login, no telemetry. Never used Claude? Click **LOAD DEMO
+> DATA** to explore the full viewer (filters, sparkline, duplicate
+> detection, topic clustering) against ~120 hand-written synthetic
+> sessions; see [Not a Claude user (yet)](#not-a-claude-user-yet) at the
+> bottom for multi-provider alternatives if Claude isn't your primary
+> assistant.
 
 ### Requirements
 
@@ -186,15 +192,18 @@ a standalone, replicable design system called **Supergraphic Panel**:
 - [**Walkthrough**](https://chat-arch.dev/design-system/) — human-facing
   tour with live specimens, swatches, and port recipes.
 - [**Prose spec**](https://chat-arch.dev/design-system/spec.md) — the
-  canonical ~2400-word specification, written to be consumable by an LLM
-  agent applying the system to another project.
+  canonical specification, written to be consumable by an LLM agent
+  applying the system to another project.
 - [**Design tokens**](https://chat-arch.dev/design-system/tokens.json) —
   [DTCG 2025.10](https://www.designtokens.org/schemas/2025.10/format.json)
   format. Source palette and font families are extracted from the viewer
   stylesheet; scale tokens are prescriptive.
 
-Source lives under [`design-system/`](design-system/) at the repo root;
-the standalone build mirrors it to the hosted deploy.
+The prose spec and token source live under
+[`design-system/`](design-system/) at the repo root and are mirrored to
+the hosted deploy by the standalone build. The walkthrough page source
+is an Astro page at
+[`apps/standalone/src/pages/design-system/index.astro`](apps/standalone/src/pages/design-system/index.astro).
 
 ## Repo layout
 
@@ -221,11 +230,15 @@ design-system/       Supergraphic Panel source — prose spec + token
 
 ## Privacy
 
-`chat-arch` is local-first by construction — no telemetry, no API calls, no
-cloud sync. Transcripts stay in the environment you loaded them from: on
-disk if you ran `pnpm dev` and clicked **SCAN LOCAL**, or in the browser
-tab's memory / IndexedDB if you uploaded a Privacy-Export ZIP to
-chat-arch.dev. Nothing is transmitted to a server in either case.
+`chat-arch` is local-first by construction — no telemetry, no analytics
+beacons, no transcript upload. Transcripts stay in the environment you
+loaded them from: on disk if you ran `pnpm dev` and clicked **SCAN LOCAL**
+(parsed by the Astro dev server on `localhost`), or in the browser tab's
+memory / IndexedDB if you uploaded a Privacy-Export ZIP to chat-arch.dev.
+The one cross-origin fetch on either path is the optional Hugging Face
+model-weight download on first **Analyze Topics** run — see
+[Model-weight trust boundary](#model-weight-trust-boundary) below for the
+full disclosure.
 
 **Note for users**: your own transcripts may contain other people's content
 (prompts about colleagues, pasted client work, customer data). If you publish
@@ -251,8 +264,9 @@ Headline points:
   cross-origin page in your browser cannot trigger a rescan.
 - The viewer escapes user content before passing it to React's
   `dangerouslySetInnerHTML`, with regression tests pinning the escape order.
-- The production build emits a strict Content-Security-Policy header
-  (`script-src 'self'`, no inline, no eval) as defense-in-depth.
+- The production build emits a strict Content-Security-Policy
+  (`script-src 'self'` plus hash-allowlisted inline scripts for Astro's
+  island loader; no eval; no remote script origins) as defense-in-depth.
 - **Session IDs appear in the URL hash** (`#session/<uuid>`) so a specific
   conversation can be deep-linked. The hash lands in browser history and
   in any outbound `Referer` header to a clicked external link. The IDs

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ See [Getting your own data](#getting-your-own-data) below for the full
 walkthrough of each ingestion path.
 
 > **No Claude Code or Anthropic account required to _run_ chat-arch.** The
-> tool is a plain static web app — it just reads Claude transcripts that
-> already exist on your disk or in a Privacy-Export ZIP you download from
-> claude.ai. No API calls, no login, no telemetry. If you've never used any
-> Claude product, chat-arch has nothing to show you beyond the demo; see
-> [Not a Claude user (yet)](#not-a-claude-user-yet) at the bottom.
+> viewer parses Claude transcripts that already exist on your disk or in
+> a Privacy-Export ZIP you downloaded from claude.ai — no API calls, no
+> login, no telemetry. Never used Claude? Click **LOAD DEMO DATA** to
+> explore the full viewer (filters, sparkline, duplicate detection,
+> topic clustering) against ~100 hand-written synthetic sessions; see
+> [Not a Claude user (yet)](#not-a-claude-user-yet) at the bottom for
+> multi-provider alternatives if Claude isn't your primary assistant.
 
 ### Requirements
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,18 +16,32 @@ preferred for anything exploitable.
 
 ## Threat model
 
-`chat-arch` is a local-first developer tool. The realistic attackers and
-attack surfaces:
+`chat-arch` ships in two postures, both with a deliberately narrow
+attack surface:
 
-| Surface                        | Realistic attacker                                                        |
-| ------------------------------ | ------------------------------------------------------------------------- |
-| `/api/rescan` (Astro dev mode) | Hostile cross-origin page in the same browser; DNS-rebinding probes       |
-| Privacy-Export ZIP upload      | A maliciously crafted ZIP given to a user                                 |
-| Transcript content rendering   | A transcript containing attacker-supplied content (e.g. pasted from a PR) |
-| `chat-arch-data/` re-share     | A user sharing or downloading someone else's `chat-arch-data/` bundle     |
+1. **Local dev checkout** (`pnpm dev` on `localhost:4321`) — has the
+   `/api/rescan` + `/api/clear` endpoints, which walk the user's own
+   filesystem. CSRF gates below apply here.
+2. **Hosted static deploy** at [chat-arch.dev](https://chat-arch.dev)
+   (Cloudflare Pages) — the `pnpm build` client bundle only. The server
+   routes are not deployed, so there is no endpoint that reads the
+   filesystem, no endpoint that mutates server-side state, and nothing
+   for a cross-origin attacker to reach besides the static HTML/JS/CSS
+   and the CF edge.
 
-Production and cloud-deployment threat models are out of scope — the tool
-is designed for `localhost:4321` against the user's own filesystem.
+The realistic attackers and surfaces across both:
+
+| Surface                       | Realistic attacker                                                        |
+| ----------------------------- | ------------------------------------------------------------------------- |
+| `/api/rescan` (dev-only)      | Hostile cross-origin page in the same browser; DNS-rebinding probes       |
+| Privacy-Export ZIP upload     | A maliciously crafted ZIP given to a user                                 |
+| Transcript content rendering  | A transcript containing attacker-supplied content (e.g. pasted from a PR) |
+| `chat-arch-data/` re-share    | A user sharing or downloading someone else's `chat-arch-data/` bundle     |
+| Hosted deploy (chat-arch.dev) | Supply-chain compromise of a build dependency; CF edge misconfiguration   |
+
+Server-side threats against the hosted deploy are bounded by it being a
+static build with no backend — there is no application logic running at
+chat-arch.dev beyond CF's own edge.
 
 ## Current mitigations
 
@@ -64,10 +78,13 @@ is designed for `localhost:4321` against the user's own filesystem.
 - **GET `/api/rescan` is unauthenticated**: it returns only
   `{ok, available, busy}` with no side effects, so the unauthenticated probe
   is intentional.
-- **`frame-ancestors` via meta-CSP is ignored by browsers**: a future
-  production deployment behind a real reverse proxy should set
-  `frame-ancestors 'none'` as an actual HTTP response header to fully
-  prevent clickjacking.
+- **`frame-ancestors` via meta-CSP is ignored by browsers**: the
+  chat-arch.dev Cloudflare Pages deploy sets `X-Frame-Options: DENY` as
+  an HTTP response header via `apps/standalone/public/_headers`, which
+  is the widely-supported predecessor of `frame-ancestors` and prevents
+  clickjacking on the hosted surface. Any other deployment host needs
+  to set an equivalent header at its own edge — a meta-CSP won't cover
+  this.
 
 ## Out of scope
 

--- a/packages/viewer/src/components/TopBar.tsx
+++ b/packages/viewer/src/components/TopBar.tsx
@@ -270,10 +270,11 @@ export function TopBar({
                 className="lcars-top-bar__source-info"
               >
                 <strong>Upload / Update Cloud</strong>
+                <p>Add or refresh conversations from a Claude.ai cloud export.</p>
                 <p>
-                  Add or refresh conversations from a Claude.ai cloud export. The word
-                  &ldquo;upload&rdquo; means loading the file into the viewer, not pushing it to a
-                  server.
+                  The word &ldquo;upload&rdquo; means loading the file into the viewer, not sending
+                  it anywhere. The ZIP is parsed in this tab and kept in IndexedDB so a refresh
+                  doesn&rsquo;t lose it.
                 </p>
                 <p>
                   <strong>How to get the ZIP:</strong> open claude.ai →{' '}
@@ -351,10 +352,7 @@ export function TopBar({
                 </>
               ) : (
                 <>
-                  <p>
-                    Walks the two local chat-data directories and rebuilds the manifest served by
-                    the Astro dev server on <code>localhost</code>:
-                  </p>
+                  <p>Walks the two local chat-data directories:</p>
                   <ul>
                     <li>
                       <code>~/.claude/projects/</code> — Claude Code CLI transcripts
@@ -363,6 +361,11 @@ export function TopBar({
                       <code>%APPDATA%\Claude\</code> — Cowork + Desktop-CLI sessions
                     </li>
                   </ul>
+                  <p>
+                    The Astro dev server on <code>localhost</code> reads those files, writes the
+                    refreshed manifest to a local directory, and serves it back to this tab.
+                    Nothing leaves your machine.
+                  </p>
                   <p>
                     Cloud data is <em>not</em> touched — it only refreshes when you upload a fresh
                     ZIP via the Cloud button.

--- a/packages/viewer/src/components/TopBar.tsx
+++ b/packages/viewer/src/components/TopBar.tsx
@@ -270,12 +270,10 @@ export function TopBar({
                 className="lcars-top-bar__source-info"
               >
                 <strong>Upload / Update Cloud</strong>
-                <p>Add or refresh conversations from a Claude.ai cloud export.</p>
                 <p>
-                  <strong>Local-only:</strong> the ZIP is parsed in your browser and kept in this
-                  tab&rsquo;s IndexedDB — it&rsquo;s never sent to a server. The word
-                  &ldquo;upload&rdquo; here means you&rsquo;re loading the file into the viewer,
-                  not pushing it anywhere.
+                  Add or refresh conversations from a Claude.ai cloud export. The word
+                  &ldquo;upload&rdquo; means loading the file into the viewer, not pushing it to a
+                  server.
                 </p>
                 <p>
                   <strong>How to get the ZIP:</strong> open claude.ai →{' '}
@@ -283,9 +281,8 @@ export function TopBar({
                   when it&rsquo;s ready; download it and pick it here.
                 </p>
                 <p>
-                  Uploading the same ZIP twice is harmless — duplicates are merged by conversation
-                  id, and a second ZIP that&rsquo;s newer just adds the new conversations on top of
-                  what&rsquo;s already loaded.
+                  Re-uploading the same ZIP is harmless — duplicates are merged by conversation id,
+                  and a newer ZIP just adds its new conversations on top.
                 </p>
               </InfoPopover>
             </div>
@@ -355,8 +352,8 @@ export function TopBar({
               ) : (
                 <>
                   <p>
-                    Walks the two local chat-data directories and rebuilds the viewer&rsquo;s
-                    manifest:
+                    Walks the two local chat-data directories and rebuilds the manifest served by
+                    the Astro dev server on <code>localhost</code>:
                   </p>
                   <ul>
                     <li>
@@ -367,18 +364,12 @@ export function TopBar({
                     </li>
                   </ul>
                   <p>
-                    <strong>Local-only:</strong> the scan reads JSONL files off your own disk and
-                    writes the manifest to a local directory served by the Astro dev server on{' '}
-                    <code>localhost</code>. Nothing leaves your machine.
-                  </p>
-                  <p>
                     Cloud data is <em>not</em> touched — it only refreshes when you upload a fresh
                     ZIP via the Cloud button.
                   </p>
                   <p>
-                    The scan is incremental: unchanged transcripts are reused from the previous run
-                    via cached file mtimes, so repeated runs are sub-second when nothing&rsquo;s
-                    new.
+                    The scan is incremental: unchanged transcripts are reused via cached file
+                    mtimes, so repeated runs are sub-second when nothing&rsquo;s new.
                   </p>
                 </>
               )}

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -5559,6 +5559,21 @@
   font-size: 13px;
   line-height: 1.4;
   color: var(--lcars-text);
+  transition:
+    opacity 140ms ease-out,
+    visibility 140ms ease-out;
+}
+/* When a TopBar info-popover is open, fade the TrustStrip out — the
+   popover drops down from the TopBar and would otherwise partially
+   occlude the strip. Hiding the strip while the user is reading the
+   popover removes the z-stack awkwardness without any React-side
+   state coupling. CSS :has() is supported in all evergreen browsers
+   (Chrome 105+, Safari 15.4+, Firefox 121+) — well within our
+   browser baseline. */
+.lcars-frame--empty:has(.lcars-top-bar .lcars-info-popover__trigger--open)
+  .lcars-trust-strip {
+  opacity: 0;
+  visibility: hidden;
 }
 .lcars-trust-strip__row {
   display: flex;


### PR DESCRIPTION
## Summary

- Adds a **Try it without installing** section pointing to chat-arch.dev with a three-step walkthrough (plus a live-demo badge next to the MIT one), and mentions the hosted URL in the Privacy-Export flow so ZIP-only users don't need to `pnpm install`.
- Fixes a stale accuracy bug: the README still claimed `pnpm dev` "auto-seeds a synthetic demo corpus on first run," but since the empty-manifest deploy fix (#6 / #7) both local and hosted checkouts land on **NO DATA YET** with three CTAs. Quickstart rewritten to describe what actually happens, and **SCAN LOCAL** is called out as dev-server-only.
- New **Design system** section linking to the three public artifacts mirrored at `chat-arch.dev/design-system/` (walkthrough, `spec.md`, `tokens.json`). Repo layout adds the missing `packages/analysis` and the `design-system/` root folder.
- `SECURITY.md` threat model reframed around the two deployment postures (local dev vs. the hosted CF Pages static build), with a new table row for the hosted deploy. Corrected the clickjacking "known limitation" — `apps/standalone/public/_headers` already sets `X-Frame-Options: DENY` on chat-arch.dev.

## Test plan

- [ ] `pnpm format:check` passes on touched files (verified locally — `README.md`, `SECURITY.md`, `CONTRIBUTING.md` all prettier-clean).
- [ ] Every new link resolves: `https://chat-arch.dev`, `https://chat-arch.dev/design-system/`, `https://chat-arch.dev/design-system/spec.md`, `https://chat-arch.dev/design-system/tokens.json`.
- [ ] Anchor links in the README still resolve (`#quickstart`, `#getting-your-own-data`, `#not-a-claude-user-yet`).
- [ ] GitHub renders the README without layout regressions (table widths, `---` separators, badge row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)