### PR TITLE
refocus(phase-0): workshop pitch + persona evals + plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 # chat-arch
 
-> The personal archive for your Claude conversation history.
+> Find the rules Claude keeps breaking. Patch your CLAUDE.md. Prove the loop closed.
 
-A local-first viewer + indexer for your own Claude Code transcripts. Reads the
+A local-first workshop for turning your Claude conversation history into
+reusable improvements. Mines your transcripts for correction patterns —
+places where you pushed back on Claude — clusters them into recurring
+rules, and helps you encode fixes into your CLAUDE.md, skills, and agent
+configs. Then watches whether those fixes hold on the next pass through
+your data.
+
+Underneath the workshop is a fast viewer + indexer for the corpus
+itself: search, project rollups, and a unified timeline across Claude
+Code CLI, Desktop, Cowork, and claude.ai cloud-export ZIPs. Reads the
 JSONL files Claude Code writes to disk plus the ZIP you get from
-**Settings → Privacy → Export data**, unifies them into a single timeline, and
-gives you search, filters, cost analytics, and a duplicate / zombie-project
-view for the corpus you've already built.
+**Settings → Privacy → Export data**.
 
 **Local-first by construction.** Your transcripts never leave your machine.
 The hosted viewer at **[chat-arch.dev](https://chat-arch.dev)** is a static
-Cloudflare Pages build with no backend — Privacy-Export ZIPs are parsed
-entirely in the browser. A local `pnpm dev` checkout additionally exposes
-a same-origin `/api/rescan` endpoint so **SCAN LOCAL** can walk
-`~/.claude/projects/` and `%APPDATA%\Claude` via the Astro dev server
-(`localhost` only; nothing egresses). The only cross-origin fetch on
-either path is the optional Hugging Face model-weight download on first
-**Analyze Topics** run — see [Model-weight trust boundary](#model-weight-trust-boundary)
-below. No telemetry, no analytics beacons, no transcript upload.
+Cloudflare Pages build with no backend — it's a demo of what chat-arch
+can do. The full workshop loop (SCAN LOCAL, mine corrections, apply
+fixes) runs on a local `pnpm dev` checkout that exposes a same-origin
+`/api/rescan` endpoint so **SCAN LOCAL** can walk `~/.claude/projects/`
+and `%APPDATA%\Claude` (`localhost` only; nothing egresses). The only
+cross-origin fetch on either path is the optional Hugging Face
+model-weight download on first **Analyze Topics** run — see
+[Model-weight trust boundary](#model-weight-trust-boundary) below. No
+telemetry, no analytics beacons, no transcript upload.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Live demo: chat-arch.dev](https://img.shields.io/badge/demo-chat--arch.dev-5b7cff)](https://chat-arch.dev)

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -1868,6 +1868,9 @@ export function ChatArchViewer({
   if (!uploadedData && (manifestState.status === 'error' || manifestIsEmpty)) {
     const fetchErrorSuffix =
       manifestState.status === 'error' ? ` (fetch: ${manifestState.message})` : '';
+    const emptyDetail = rescanCtl.available
+      ? `Drop a claude.ai Privacy-Export ZIP, scan your local Claude Code / Desktop / Cowork transcripts, or load demo data to populate the viewer with a generated sample corpus. See the README for the full walkthrough.${fetchErrorSuffix}`
+      : `Drop a claude.ai Privacy-Export ZIP, or load demo data to populate the viewer with a generated sample corpus. To index local Claude Code / Desktop / Cowork transcripts, run the dev server (pnpm --filter @chat-arch/standalone dev). See the README for the full walkthrough.${fetchErrorSuffix}`;
     return (
       <div className="lcars-root" data-tier={tier}>
         <div className="lcars-frame lcars-frame--empty">
@@ -1876,19 +1879,36 @@ export function ChatArchViewer({
             onQueryChange={() => {}}
             tier={tier}
             disabled
-            // v2 spec §6 / D4: data-source actions (UPLOAD CLOUD,
-            // SCAN LOCAL, DELETE) live in the DATA panel triggered
-            // from the empty-state UploadPanel below — the TopBar
-            // stays informational even on the no-data landing.
-            locationLabel="WELCOME"
+            // v2 spec §6 / D4: TopBar stays informational on the
+            // empty-state landing — no location pill (the previous
+            // "WELCOME" chip read as a button but had no action).
           />
           <main className="lcars-empty-main">
             <TrustStrip />
-            <ErrorState
-              title="NO DATA YET"
-              detail={`Click SCAN LOCAL above to index your Claude Code / Desktop / Cowork transcripts, or UPLOAD CLOUD for a claude.ai Privacy-Export ZIP. Or hit LOAD DEMO DATA below to populate the viewer with a generated sample corpus. See the README for the full walkthrough.${fetchErrorSuffix}`}
+            <section className="lcars-empty-pitch" aria-label="what chat-arch does">
+              <h2 className="lcars-empty-pitch__headline">
+                FIND THE RULES CLAUDE KEEPS BREAKING.
+                <br />
+                PATCH YOUR CLAUDE.MD. PROVE THE LOOP CLOSED.
+              </h2>
+              <p className="lcars-empty-pitch__sub">
+                A local-first workshop for turning your Claude conversation history into
+                reusable improvements. Mines your transcripts for correction patterns —
+                places where you pushed back on Claude — clusters them into recurring
+                rules, and helps you encode fixes into CLAUDE.md, skills, and agent
+                configs.
+              </p>
+            </section>
+            <ErrorState title="NO DATA YET" detail={emptyDetail} />
+            <UploadPanel
+              onLoaded={onUpload}
+              variant="prominent"
+              onLoadDemo={onLoadDemo}
+              onScanLocal={onRescan}
+              scanAvailable={rescanCtl.available}
+              scanStatus={rescanCtl.status}
+              scanProgress={rescanCtl.progress}
             />
-            <UploadPanel onLoaded={onUpload} variant="prominent" onLoadDemo={onLoadDemo} />
           </main>
         </div>
       </div>

--- a/packages/viewer/src/components/UploadPanel.tsx
+++ b/packages/viewer/src/components/UploadPanel.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { parseCloudZip } from '../data/zipUpload.js';
 import { maskedUploadLabel } from '../data/uploadLabel.js';
+import type { RescanProgress, RescanStatus } from '../data/rescan.js';
 import type { UploadedCloudData } from '../types.js';
 
 export interface UploadPanelProps {
@@ -15,6 +16,19 @@ export interface UploadPanelProps {
    * `onUpload`.
    */
   onLoadDemo?: () => void;
+  /**
+   * Optional SCAN LOCAL affordance for the empty-state landing. The
+   * canonical home for SCAN LOCAL is DataPanel, but DataPanel is only
+   * reachable from the populated view (via the sidebar's DATA pill).
+   * On the empty-state landing the sidebar isn't rendered, so a user
+   * with only local Claude data would otherwise be stuck. Wiring this
+   * prop surfaces the same `useRescan()` action inline. The hosted web
+   * build can't spawn the scanner, so the host gates with `scanAvailable`.
+   */
+  onScanLocal?: () => void;
+  scanAvailable?: boolean;
+  scanStatus?: RescanStatus;
+  scanProgress?: RescanProgress;
 }
 
 /**
@@ -37,9 +51,34 @@ type UploadState =
  * parses it in the browser via `parseCloudZip`, and calls `onLoaded` with the
  * resulting in-memory manifest. LCARS-styled, mobile-responsive.
  */
-export function UploadPanel({ onLoaded, variant = 'prominent', onLoadDemo }: UploadPanelProps) {
+export function UploadPanel({
+  onLoaded,
+  variant = 'prominent',
+  onLoadDemo,
+  onScanLocal,
+  scanAvailable,
+  scanStatus = 'idle',
+  scanProgress,
+}: UploadPanelProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [state, setState] = useState<UploadState>({ status: 'idle' });
+
+  const scanRunning = scanStatus === 'running';
+  const scanShown = !!onScanLocal && scanAvailable === true;
+  const scanLabel = (() => {
+    if (scanStatus === 'running') {
+      const phase = scanProgress?.phase;
+      const ix = scanProgress?.ix ?? 0;
+      const total = scanProgress?.total ?? 0;
+      if (phase && ix > 0 && total > 0) return `SCANNING · ${phase.toUpperCase()} ${ix}/${total}`;
+      if (phase) return `SCANNING · ${phase.toUpperCase()}`;
+      return 'SCANNING…';
+    }
+    if (scanStatus === 'error') return 'SCAN FAILED';
+    if (scanStatus === 'ok') return 'SCANNED ✓';
+    return 'SCAN LOCAL';
+  })();
+  const scanCaption = scanRunning ? (scanProgress?.latest ?? null) : null;
 
   const openPicker = () => {
     if (state.status === 'parsing') return;
@@ -88,9 +127,26 @@ export function UploadPanel({ onLoaded, variant = 'prominent', onLoadDemo }: Upl
       )}
 
       <div className="lcars-upload-panel__buttons">
+        {scanShown && (
+          <button
+            type="button"
+            className="lcars-upload-panel__button"
+            onClick={onScanLocal}
+            disabled={scanRunning}
+            aria-label="scan local chat sources: ~/.claude and %APPDATA%\Claude"
+            aria-busy={scanRunning || undefined}
+            title="Scan local chat sources: ~/.claude and %APPDATA%\Claude. Cloud data only refreshes when you upload a new ZIP."
+          >
+            {scanLabel}
+          </button>
+        )}
         <button
           type="button"
-          className="lcars-upload-panel__button"
+          className={
+            scanShown
+              ? 'lcars-upload-panel__button lcars-upload-panel__button--cloud-secondary'
+              : 'lcars-upload-panel__button'
+          }
           onClick={openPicker}
           disabled={state.status === 'parsing'}
           aria-label="choose cloud export zip"
@@ -110,6 +166,11 @@ export function UploadPanel({ onLoaded, variant = 'prominent', onLoadDemo }: Upl
           </button>
         )}
       </div>
+      {scanShown && scanCaption && (
+        <div className="lcars-upload-panel__status" role="status" aria-live="polite">
+          {scanCaption}
+        </div>
+      )}
       {onLoadDemo && variant === 'prominent' && (
         <p className="lcars-upload-panel__hint lcars-upload-panel__hint--demo">
           No export handy? Load the bundled fixture — about 100 hand-written fake conversations

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -2778,6 +2778,20 @@
   background: var(--lcars-violet);
   color: var(--lcars-bg);
 }
+/* CHOOSE ZIP demoted to outlined when SCAN LOCAL is the primary
+   action (i.e. running locally). Keeps cloud-export branded as
+   butterscotch — this is the same palette as the primary, just
+   outlined to read as the secondary path. */
+.lcars-upload-panel__button--cloud-secondary {
+  background: transparent;
+  color: var(--lcars-butterscotch);
+  border: 1.5px solid var(--lcars-butterscotch);
+}
+.lcars-upload-panel__button--cloud-secondary:hover:not(:disabled),
+.lcars-upload-panel__button--cloud-secondary:focus-visible:not(:disabled) {
+  background: var(--lcars-butterscotch);
+  color: var(--lcars-bg);
+}
 .lcars-upload-panel__hint--demo {
   font-size: 11px;
   color: var(--lcars-text);
@@ -6283,6 +6297,43 @@
 .lcars-empty-main .lcars-trust-strip {
   align-self: center;
   max-width: 640px;
+}
+/* The "what chat-arch does" pitch on the empty-state landing.
+   Sits between the TrustStrip (privacy framing) and the
+   "NO DATA YET" ErrorState. Priya complained the landing showed
+   chrome and an empty-state error but never said what the product
+   does — this is the answer. */
+.lcars-empty-pitch {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-self: center;
+  padding: 0 8px;
+  text-align: center;
+}
+.lcars-empty-pitch__headline {
+  margin: 0;
+  font-family: inherit;
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  line-height: 1.2;
+  color: var(--lcars-sunflower);
+}
+.lcars-empty-pitch__sub {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--lcars-text);
+  opacity: 0.85;
+}
+@media (min-width: 600px) {
+  .lcars-empty-pitch__headline {
+    font-size: 26px;
+  }
+  .lcars-empty-pitch__sub {
+    font-size: 14px;
+  }
 }
 
 /* ---------------------------------------------------------------- *

--- a/research/persona-evals/david.md
+++ b/research/persona-evals/david.md
@@ -1,0 +1,647 @@
+# David — Cloud-Only Knowledge Worker — chat-arch.dev evaluation
+
+David is a PM/researcher who has only ever used claude.ai in the browser.
+He has no idea what `pnpm`, a "manifest", or `~/.claude/projects/` are.
+He arrives via the **hosted** chat-arch.dev (static Cloudflare Pages
+build — no `/api/rescan`, `/api/mine-corrections`, `/api/clear`,
+`/api/clear-corrections`, `/api/repo-ground`, `/api/save-prompt`, or
+`/api/encode-pattern` endpoints). His goal: see what his AI use
+actually looks like.
+
+This evaluation reads code only — the dev server is up but David's
+experience doesn't include any of its SSR routes.
+
+---
+
+## 1. Landing on chat-arch.dev (cold)
+
+### Verdict
+**Solid.** The empty-state landing is the strongest part of the
+product for David. SCAN LOCAL hides cleanly when `useRescan().available`
+is false; the fallback copy and CTA are accurate to what he can do.
+
+### Friction
+- The empty-state heading reads `"NO DATA YET"` and the body copy
+  starts `"Drop a claude.ai Privacy-Export ZIP…"`
+  (`packages/viewer/src/ChatArchViewer.tsx:1873`). That's correct for
+  David. But the surrounding chrome — a `TopBar` titled "CHAT
+  ARCHAEOLOGIST" plus a `lcars-top-bar__earthdate` chip showing
+  `2026.05.08` — leans hard into the LCARS bit before the user knows
+  what the product does (`packages/viewer/src/components/TopBar.tsx:75`,
+  `:101`). A first-time visitor who clicked a Twitter link doesn't yet
+  have the trust to find "EARTHDATE" charming.
+- The page title "Chat Archaeologist" is set in `BaseLayout`
+  (`apps/standalone/src/pages/index.astro:6`) — David read about
+  "chat-arch" on Twitter and now the tab title reads something
+  different. Minor, but it's the kind of thing that makes him
+  double-check he's on the right site.
+
+### Suggestions
+- Add a one-line subtitle under the title on the empty state: "*See
+  what your Claude conversations actually add up to.*" Right now the
+  trust strip handles the privacy framing but nothing on the page
+  answers "what is this?" until the user reads the upload-panel hint
+  (`UploadPanel.tsx:122`).
+- Either rename the document title to "chat-arch" or "chat-arch —
+  Claude conversation viewer" so the tab matches the URL/Twitter
+  link he followed in (`apps/standalone/src/pages/index.astro:6`).
+
+---
+
+## 2. Privacy framing — TrustStrip / README / no-telemetry copy
+
+### Verdict
+**Strong content, slightly muted placement.** The TrustStrip text is
+exactly what David needs to read. The footnote disclosing the HF
+model fetch is honest in a way most products don't bother with
+(`packages/viewer/src/components/TrustStrip.tsx:43-47`). But the
+strip is rendered as a quiet `<aside>` between TopBar and ErrorState
+(`ChatArchViewer.tsx:1887`) — visually it reads more like a status
+chip than a headline pledge.
+
+### Friction
+- The TrustStrip **disappears once data is loaded**. Comment at
+  `TrustStrip.tsx:27` confirms this is by design: "returning users
+  don't need the re-pitch every session." But David is not a
+  returning user — and the moment he uploads, he's effectively
+  trusted the page. If he shows it to a coworker afterward, the
+  pledge is gone and only "VIEW SOURCE ↗" survives in the sidebar
+  footer.
+- The CorrectionsPanel and DataPanel both contain CLI-flavored copy
+  (DataPanel: "run `pnpm --filter @chat-arch/standalone dev`",
+  `DataPanel.tsx:31`; "[`~/.claude/projects/`]" lists in InfoPopover
+  at `:315-320`). David opens DATA out of curiosity → reads about
+  filesystem paths he doesn't have → trust drops a notch ("is this
+  for me?").
+- The README's headline "**Local-first by construction**" is
+  technically accurate, but the sentence "A local `pnpm dev` checkout
+  additionally exposes a same-origin `/api/rescan` endpoint…"
+  (`README.md:14-21`) lands as jargon. David clicks the chat-arch.dev
+  link from the README badge and never reads the rest.
+
+### Suggestions
+- Render the TrustStrip permanently in the sidebar footer area on
+  populated views, not just empty (`Sidebar.tsx:240` — there's already
+  a `RepoLink` in the footer; one more compact line ("LOCAL-FIRST · No
+  telemetry") would keep the pledge live).
+- Move the "what is this?" sentence to the top of the README, before
+  the local-first paragraph, so the chat-arch.dev visitor reading the
+  homepage repo link sees product-purpose before infrastructure
+  posture (`README.md:1-21`).
+
+---
+
+## 3. CHOOSE ZIP flow
+
+### Verdict
+**Works correctly. Filename masking is solid.** `maskedUploadLabel`
+strips the email-bearing filename to `upload.zip (27.6 MB)` before any
+React state or DOM render
+(`packages/viewer/src/data/uploadLabel.ts:33-39`,
+`UploadPanel.tsx:96-104`). The single-source-of-truth comment at
+`uploadLabel.ts:14-18` is the right architectural call — covered
+by `UploadPanel.test.tsx` and `uploadLabel.test.ts`.
+
+### Friction
+- The hint copy on the panel reads "Drop a Settings → Privacy →
+  Export data ZIP from claude.ai to browse your conversations
+  **without running the CLI**" (`UploadPanel.tsx:122-125`). For
+  David, "without running the CLI" is unreadable noise — he never
+  considered the CLI option in the first place. It signals "this
+  product is mostly for CLI people, you're using the lesser path."
+- Path to the ZIP is buried in two places: `UploadPanel.tsx:122` says
+  "Settings → Privacy → Export data" (good) but the InfoPopover with
+  the same instructions only appears in the populated DataPanel
+  (`DataPanel.tsx:233-238`). On the empty state, no popover, no
+  visual cue that the user has to **wait for an email** with the ZIP
+  before they can do anything.
+- The success state "LOADED 1,047 CONVERSATIONS FROM upload.zip
+  (27.6 MB)" reads fine. The error state shows raw error messages
+  from `fflate` (`UploadPanel.tsx:108-111`) — if David picks the
+  wrong file, he sees a stack-flavored string.
+
+### Suggestions
+- Replace "without running the CLI" with "It's parsed in this tab
+  — no upload, no account needed."
+  (`UploadPanel.tsx:122-125`).
+- Add a one-line walkthrough above the CHOOSE ZIP button: *"Don't
+  have one yet? In claude.ai, click your avatar → Settings → Privacy
+  → Export data, then wait for the email."* Right now the closest
+  equivalent is the README, which David didn't read.
+- Wrap the parse error in a friendlier framer when the message
+  doesn't include `conversations.json` — a missing-file error is the
+  most likely "wrong ZIP picked" case (`zipUpload.ts:39-44`
+  produces a useful one; `:33-37` is fflate-flavored).
+
+---
+
+## 4. Post-upload sessions list
+
+### Verdict
+**Good for David.** SESSIONS grid + KPI tiles + sparkline + filter
+bar is intuitive output for a PM. The session card design surfaces
+project, topic chips, and "DUP/ZOMBIE" chips without explanation,
+but the chips are hover-tooltipped and don't block the read.
+
+### Friction
+- The mode is labeled "SESSIONS" in the sidebar but the underlying
+  internal id is `command` (`Sidebar.tsx:61`). User-facing copy is
+  fine; David never sees the internal name.
+- "ZOMBIE" chip language on cards (`SessionCard.tsx`) — a PM who
+  hasn't read the README will read it as judgmental jargon ("am I a
+  zombie?"). It's clickable into ConstellationMode and explains itself
+  there, but the chip stands alone on the card.
+- The sparkline + KPI tiles deliver insight quickly — "6 months,
+  1,047 conversations, $0 cost" — but the Cost row will literally
+  show `$0.00` for cloud-only data (the `allCloud` notice at
+  `CostMode.tsx:91-101` exists but only fires inside CostMode itself,
+  not on the KPI tile in `UpperPanel`).
+
+### Suggestions
+- Make the KPI cost tile dim or hide entirely when `allCloud === true`
+  on the manifest, replacing it with a small "COST UNAVAILABLE FOR
+  CLOUD" chip. Exposing `$0.00` reads as a bug.
+  (`UpperPanel.tsx`, around the OVERVIEW tab cost KPI; needs the
+  `allCloud` predicate from `CostMode.tsx:91`.)
+- Consider replacing "ZOMBIE" with "DORMANT" or "STALLED" on
+  cloud-only data — the original CLI framing ("project I started
+  and abandoned") doesn't translate cleanly to a claude.ai user
+  whose "projects" are organizational, not directories.
+
+---
+
+## 5. Session detail (DetailMode)
+
+### Verdict
+**Works.** Cloud drill-in renders directly from the in-memory
+`uploadedConversationsById` map, no network round trip
+(`DetailMode.tsx:91-99`). Prev/next nav, copy-as-markdown, all
+function for David's use case.
+
+### Friction
+- The cost meta strip on detail uses `detailCostTooltip`
+  (`DetailMode.tsx:47-58`), which says "No cost signal for this
+  session — neither CLI logs nor an estimate are available." for
+  cloud rows. That copy is honest but leaks the CLI framing.
+
+### Suggestions
+- For cloud sources, replace the cost line with a quiet "claude.ai
+  doesn't expose cost for cloud conversations" rather than implying
+  a missing signal (`DetailMode.tsx:55-57`).
+
+---
+
+## 6. TopicsMode
+
+### Verdict
+**Mostly works for David, but only after he runs ANALYZE TOPICS.**
+The topic system's primary input on cloud-only data is the BGE-small
+embedding pass via `AnalysisLauncher` (`UpperPanel.tsx`'s ANALYSIS
+tab, `AnalysisLauncher.tsx`). The launcher's armed-preview is
+genuinely good UX — it explains scope, mode, steps, runtime
+(`AnalysisLauncher.tsx:288-356`). David will read it and feel
+oriented.
+
+### Friction
+- Without running ANALYZE TOPICS, `TopicsMode` shows an empty state:
+  "*No topics discovered in the active manifest. Run the analyzer or
+  load a richer fixture to populate.*"
+  (`TopicsMode.tsx:53-58`). "the analyzer" is undefined here —
+  David doesn't know which analyzer or where it lives. A v1 fix
+  is to point this empty state at the AnalysisLauncher / ANALYSIS
+  tab.
+- The 36 MB model download is gated by a click on the launcher's
+  primary button which arms a preview, then a second click to start.
+  That's the right shape, but for a "I'm just kicking the tires"
+  user it's a lot to commit to. The download is cached after first
+  run, but the *first-visit* time-to-first-topic-insight is
+  download (~30s on good wifi) + embed (~1-3 min on WebGPU) = the
+  product's slowest path is also its most insight-dense one.
+
+### Suggestions
+- TopicsMode empty state should link directly to the ANALYSIS
+  launcher rather than to a vague "analyzer" — "*Click ANALYZE
+  TOPICS in the OVERVIEW tab to discover topic clusters.*"
+  (`TopicsMode.tsx:53-58`).
+- Pre-render the demo data's topics in the TopicsMode empty
+  state's example so David sees what the surface *can* look like
+  before he commits to the embed pass. (Demo data already has
+  topics — but TopicsMode doesn't render them differently from
+  real ones.)
+
+---
+
+## 7. ProjectsMode
+
+### Verdict
+**Good when projects.json is present in the export.** A claude.ai
+Privacy-Export ZIP includes projects.json for users who organized
+their conversations into projects. For users who didn't (David might
+not have), the surface degrades to one big `[UNASSIGNED]`
+pseudo-project (`ProjectsMode.tsx:9` references
+`isUnassignedProject`).
+
+### Friction
+- The empty state copy is "*No projects discovered in the active
+  manifest. Upload a cloud export or scan local sources to populate.*"
+  (`ProjectsMode.tsx:115-122`). David already uploaded — this copy
+  reads as if his upload didn't work.
+- An `[UNASSIGNED]` pseudo-project is the most likely David-case
+  and the surface doesn't explain what it means.
+
+### Suggestions
+- When `projects.length === 1 && projects[0].isUnassigned`, show a
+  dedicated empty state: *"You haven't organized your conversations
+  into projects in claude.ai. The TOPICS view can group them by
+  semantic similarity instead."* (`ProjectsMode.tsx:115-122`).
+
+---
+
+## 8. CommandMode + ConstellationMode + TimelineMode + CostMode
+
+### Verdict — by mode for David
+- **CommandMode (SESSIONS):** ✓ resonates — it's the "what did I
+  ask?" surface.
+- **TimelineMode (in-SESSIONS toggle):** ✓ resonates as a sparkline
+  he can hover (`TimelineMode.tsx`).
+- **CostMode:** mostly inert for David. The "CLOUD-ONLY DATA"
+  notice (`CostMode.tsx:91-101`) is honest but it dominates the
+  page, and three of the four sub-sections render zero data. Plus
+  a `LocalAnalyzerEmpty` for `COST · DIAGNOSED`
+  (`CostMode.tsx:122-129`) — see Hosted-build dead-ends below.
+- **ConstellationMode (ANALYSIS):** Mixed. Exact-duplicates and
+  zombie-projects are useful. But the bottom of the page is a
+  `LocalAnalyzerAccordion` whose CTA ends in `pnpm analyze`
+  (`LocalAnalyzerAccordion.tsx:77`,
+  `LocalAnalyzerEmpty.tsx:67`).
+
+### Friction
+- ConstellationMode's `[+] UNLOCK WITH LOCAL ANALYSIS` accordion
+  with three `LocalAnalyzerEmpty` children renders the literal
+  string `"LOCAL ANALYZER REQUIRED — install chat-arch-analyzer
+  skill and run 'pnpm analyze'."` for any visitor — hosted or dev.
+  David has no skill to install, no `pnpm` to run. Dead-end CTA.
+  (`LocalAnalyzerEmpty.tsx:67-68`,
+  `LocalAnalyzerAccordion.tsx:87-104`,
+  `CostMode.tsx:122-129`.)
+- CostMode for an all-cloud manifest renders its all-cloud notice
+  AND four cost panels (stacked-bar, by-model, by-project, top-20)
+  AND the `LocalAnalyzerEmpty` for COST · DIAGNOSED — a four-empty
+  state plus a fifth jargon-CTA. David should not see this surface
+  populated this way.
+
+### Suggestions
+- **Gate `LocalAnalyzerEmpty` behind a `scanAvailable === true` /
+  dev-server check** — render it only when the user has actually
+  reached for `pnpm analyze` is a real next step. On hosted builds,
+  hide the accordion entirely or replace the CTA with "*Available
+  when running chat-arch locally — see the README.*" with a link.
+  (`LocalAnalyzerEmpty.tsx:67-68`,
+  `LocalAnalyzerAccordion.tsx:75-79`.)
+- Alternatively, replace the hosted-build CTA with the same
+  language pattern that DataPanel uses for SCAN LOCAL: clear
+  "available when running locally" framing rather than imperative
+  install instructions (`DataPanel.tsx:299-309`).
+
+---
+
+## 9. PracticeMode
+
+### Verdict
+**Pleasantly surprising for David.** The "PRACTICE" surface delivers
+genuine insight without an LLM round-trip — it's mechanical findings
+across four lenses (`PracticeMode.tsx:44-49`). Severity chips,
+linkable evidence, no jargon. This is the closest thing to a "what
+is my AI use *actually* like" insight moment.
+
+### Friction
+- The sidebar label "PRACTICE" is opaque (`Sidebar.tsx:73`). David
+  doesn't know if "PRACTICE" means his practice (his use), the
+  agent's practice, or something else. The lead copy in the surface
+  itself is good (`PracticeMode.tsx:91-96`) but he has to click to
+  get there.
+- Lens names: `your-patterns`, `agent-patterns`, `process-gaps`,
+  `value-leaks` (`PracticeMode.tsx:44-49`). "value leaks" reads as
+  jargon for "places you're wasting time/money" — which David could
+  parse, but it's not obvious on first sight.
+
+### Suggestions
+- Rename the sidebar label "PRACTICE" → "REVIEW" or "INSIGHTS" or
+  "AUDIT" (`Sidebar.tsx:73`). Keep the inline title "PRACTICE" if
+  the design system is committed to single-word LCARS labels.
+- Add a one-sentence sidebar tooltip on hover that previews the
+  surface's purpose.
+
+---
+
+## 10. Search (TopBar)
+
+### Verdict
+**Works.** Right-aligned, debounced, scoped to title/summary/preview
+(`TopBar.tsx:60-66`). Placeholder copy is tier-aware and friendly.
+
+### Friction
+- The search disabled-state placeholder reads "exit detail view to
+  search" (`TopBar.tsx:62`) — a polite UX, but David might not
+  realize that detail view captures search at all. Minor.
+
+---
+
+## 11. Sidebar — modes David understands
+
+### Verdict
+**Mixed.** Six modes plus DATA. Comprehensible:
+- `PROJECTS` ✓ (matches claude.ai concept)
+- `TOPICS` ✓
+- `SESSIONS` ✓
+- `COST` ✓ (but mostly inert for him)
+
+Less obvious:
+- `PRACTICE` — covered above; opaque
+- `CORRECTIONS` — opaque, and dead-ends for hosted (see §12)
+- `ANALYSIS` (internal id `constellation`) — sounds like a generic
+  word for the whole app, not a specific surface
+  (`Sidebar.tsx:75`)
+
+### Friction
+- Sidebar groups are `BROWSE` and `INSIGHTS` — fine — but
+  `CORRECTIONS` lives under INSIGHTS and on hosted builds it has
+  almost nothing useful (see §12).
+
+### Suggestions
+- Hide `CORRECTIONS` from the sidebar when `probeMineCorrections()`
+  returns null AND `corrections.json` isn't present in the dataRoot
+  (the panel currently renders even on hosted builds, just empty).
+  (`Sidebar.tsx:74`, `CorrectionsPanel.tsx:115-198`.)
+
+---
+
+## 12. CorrectionsPanel — hosted dead-end
+
+### Verdict
+**Dead-end on hosted, presented with no graceful degradation.**
+The panel always loads and always shows its full chrome — header,
+"CORRECTIONS" title, lead copy about "Apply manually for now"
+(`CorrectionsPanel.tsx:866-882`), pipeline coverage meter (or zero
+state), MINE CORRECTIONS button.
+
+On hosted: `loadCorrectionCandidatesFile` and `loadCorrectionsFile`
+both 404 → empty state with copy "*No correction candidates yet.
+Run the chat-arch exporter first to populate
+`analysis/correction-candidates.json`, then click MINE CORRECTIONS
+above to run the LLM classification pass…*"
+(`CorrectionsPanel.tsx:494-498`).
+
+David sees: a sidebar item labeled CORRECTIONS, a panel that loads
+empty, copy mentioning "the chat-arch exporter," `analysis/`
+file paths, and an LLM classification pass he has no way to start.
+
+### Friction
+- `probeMineCorrections()` and `probeClearCorrections()` both
+  return null/false on hosted. The panel does NOT use these to hide
+  itself — `clearAvailable` only gates the Danger Zone visibility
+  (`CorrectionsPanel.tsx:511-520`), not the rest of the panel.
+- The MINE CORRECTIONS button is rendered via `MiningTrigger`
+  (`CorrectionsPanel.tsx:473-489`) regardless of probe state. The
+  `disabled` flag is computed from `autoWindow?.mode` and candidate
+  count — both null on hosted — so the button shows but is disabled
+  with a confusing tooltip ("Run the chat-arch exporter first to
+  produce candidates.").
+- All copy assumes a CLI-using user: "exporter," "skill,"
+  "CLAUDE.md upgrades" (`CorrectionsPanel.tsx:870-873`).
+
+### Suggestions (high impact)
+- **When `probeMineCorrections()` returns null AND no
+  corrections-data files exist, hide the entire CORRECTIONS sidebar
+  item.** This is the single biggest fix for David's experience —
+  the surface is meaningless to him.
+  (`Sidebar.tsx:74` plus a probe-gating effect in
+  `ChatArchViewer.tsx`.)
+- If the project wants the surface discoverable to web visitors as
+  a teaser, replace the panel body with a one-screen explainer
+  ("This view requires running chat-arch locally. It mines
+  recurring corrections from your CLI transcripts and proposes
+  CLAUDE.md upgrades.") instead of the broken pipeline UI.
+
+---
+
+## 13. DataPanel — gracefully unavailable, but jargon-leaky
+
+### Verdict
+**Mostly degrades correctly.** SCAN LOCAL is shown disabled with
+clear "Available when running locally" copy on hosted
+(`DataPanel.tsx:29-32` + `:299-309`). The `scanAvailable` prop
+gates the disabled state correctly via `useRescan().available`.
+
+### Friction
+- The InfoPopover for SCAN LOCAL on hosted says "*To enable, clone
+  the repo and run `pnpm --filter @chat-arch/standalone dev`, then
+  reload this page.*" (`DataPanel.tsx:303-308`). For David that's
+  Mandarin — "clone," "pnpm," "filter."
+- The DELETE section uses NuclearReset which renders fine when
+  there's something to delete, hides when empty
+  (`NuclearReset.tsx:107-117`). This part works.
+
+### Suggestions
+- Replace the hosted-build SCAN LOCAL hint with a non-developer
+  alternative: "*Available in the local app — see [docs] for setup.
+  For now, your claude.ai export covers cloud conversations.*"
+  (`DataPanel.tsx:299-309`.)
+
+---
+
+## 14. NuclearReset
+
+### Verdict
+**Hard for David to find — but that's intentionally OK.** It lives
+inside the DATA sidebar panel, which itself is a sidebar item not
+on the empty-state landing. David won't stumble onto it. If he goes
+looking for "delete my data," he'll click DATA → see DELETE… →
+panel pops with checkboxes labeled by source.
+
+### Friction
+- The dropdown row labels are technical: "cli-direct," "cli-desktop,"
+  "cowork" with file paths (`NuclearReset.tsx:60-85`). David has 0
+  sessions for those rows, so they're greyed but visible — and they
+  show paths he doesn't have on his machine. Reads as inventory of
+  *Bryce's* data, not his.
+- The cloud row labels work: "claude.ai (cloud)" + subtitle "cloud
+  + uploaded ZIP" + explain "From claude.ai Privacy Export, or
+  drag-and-dropped ZIP" (`NuclearReset.tsx:79-85`).
+
+### Suggestions
+- When all non-cloud rows have count=0, **hide them entirely** in
+  the dropdown. The current behavior shows them with greyed counts
+  + jargon paths, which makes the panel read as a complex multi-source
+  tool when from David's POV it's a single-source tool.
+  (`NuclearReset.tsx:325-353`.)
+
+---
+
+## 15. Design system page (`/design-system/`)
+
+### Verdict
+**Doesn't break David's experience, but he might land on it.** The
+RepoLink chip in the sidebar footer points to GitHub, not to the
+design system. The TopBar's "i" InfoPopover next to the title does
+link to `/design-system/` (`TopBar.tsx:85-87`) — so a curious click
+on the InfoPopover lands David on a page about LCARS, DTCG tokens,
+and Michael Okuda
+(`apps/standalone/src/pages/design-system/index.astro:50-66`).
+
+### Friction
+- `/design-system/spec.md` link is a raw markdown file — fine for
+  designers, weird for a casual visitor (it'll render as plain text
+  or download depending on browser).
+- The page exists primarily for design-system reuse; David has no
+  reason to spend time there.
+
+### Suggestions
+- The TopBar InfoPopover's "*View the walkthrough →*" link could be
+  scoped to "*View the design system →*" with the qualifier "*(for
+  designers — feel free to skip)*" so a non-designer realizes it's
+  not the product manual. (`TopBar.tsx:81-87`.)
+
+---
+
+# Hosted-build dead-ends (CLI/local-only affordances visible on hosted)
+
+These are surfaces or copy strings that render on the hosted build
+but assume a developer/CLI environment. Each is a friction point
+or trust-eroder for David.
+
+| # | Surface / copy                                                                                           | File:line                                                                                |
+|---|----------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
+| 1 | `LocalAnalyzerEmpty` CTA: *"install chat-arch-analyzer skill and run 'pnpm analyze'"*                     | `packages/viewer/src/components/LocalAnalyzerEmpty.tsx:67-68`                            |
+| 2 | `LocalAnalyzerAccordion` renders 3 LocalAnalyzerEmpty children inside ANALYSIS surface unconditionally    | `packages/viewer/src/components/constellation/LocalAnalyzerAccordion.tsx:87-104`         |
+| 3 | `CostMode` renders `LocalAnalyzerEmpty` for `COST · DIAGNOSED` regardless of `scanAvailable`              | `packages/viewer/src/components/modes/CostMode.tsx:122-129`                              |
+| 4 | `CorrectionsPanel` renders MINE CORRECTIONS button + full pipeline UI even when `probeMineCorrections()` returned null | `packages/viewer/src/components/CorrectionsPanel.tsx:473-489, :115-198`        |
+| 5 | `CorrectionsPanel` empty-state copy mentions "Run the chat-arch exporter," `analysis/correction-candidates.json` | `packages/viewer/src/components/CorrectionsPanel.tsx:494-498`                  |
+| 6 | `CorrectionsPanel` lead copy refers to "proposed CLAUDE.md upgrades. Apply manually for now"              | `packages/viewer/src/components/CorrectionsPanel.tsx:870-873`                            |
+| 7 | `DataPanel` SCAN LOCAL InfoPopover: *"clone the repo and run `pnpm --filter @chat-arch/standalone dev`"* | `packages/viewer/src/components/DataPanel.tsx:299-309`                                   |
+| 8 | `DataPanel` lead copy includes `~/.claude/projects/` and `%APPDATA%\Claude\` paths in scan info-popover    | `packages/viewer/src/components/DataPanel.tsx:312-322`                                   |
+| 9 | `EmptyState` default `message` prop: *"Run pnpm --filter @chat-arch/exporter start to produce a manifest."* — only used when caller doesn't override (e.g. `TopicsMode.tsx:53-58` overrides; `ProjectsMode.tsx:115-122` overrides) | `packages/viewer/src/components/EmptyState.tsx:23` |
+| 10 | `ChatArchViewer` empty-state detail copy says "run the dev server (pnpm --filter @chat-arch/standalone dev)" when `rescanCtl.available === false`. Accurate but jargon-flavored. | `packages/viewer/src/ChatArchViewer.tsx:1872-1873`                |
+| 11 | `TierSheet` body copy mentions running SCAN LOCAL and references "extended tier" / "local pass"          | `packages/viewer/src/components/TierSheet.tsx:104-117`                                   |
+| 12 | `AnalysisLauncher` armed-preview note: *"If you're running Chat Archaeologist locally (not web-only), the richer local-analysis pipeline produces more detailed results from your CLI / Desktop / Cowork transcripts too…"* — at least flags itself, but reads as "you're getting the lesser tier" | `packages/viewer/src/components/AnalysisLauncher.tsx:308-316` |
+| 13 | `NuclearReset` shows 3 rows with file paths and "0 sessions" counts even when those sources are unreachable on hosted | `packages/viewer/src/components/NuclearReset.tsx:60-85, :325-353`                |
+
+The four most-impactful hosted dead-ends are #1-2 (the
+`LocalAnalyzerEmpty` jargon CTA), #4-6 (the entire CORRECTIONS
+surface), and #7 (DATA → SCAN LOCAL hint). The rest are paper-cuts.
+
+---
+
+# Top 5 Improvements ranked by impact for David
+
+### 1. Hide CORRECTIONS sidebar item when `/api/mine-corrections` is unreachable
+**Where:** `packages/viewer/src/components/Sidebar.tsx:74` (NAV
+INSIGHTS group), gated on a probe done in `ChatArchViewer.tsx`.
+
+**Why:** The current panel renders empty with copy mentioning
+"the chat-arch exporter," `analysis/correction-candidates.json`, and
+a disabled MINE CORRECTIONS button with a tooltip about an
+"exporter." A non-developer reading this reaches one of two
+conclusions: (a) "this is broken," or (b) "this isn't for me, I
+don't belong here." Either way, trust drops. Hiding the surface
+when there's nothing to show is the strongest single win.
+
+### 2. Replace `LocalAnalyzerEmpty` CLI CTA with a hosted-aware variant
+**Where:** `packages/viewer/src/components/LocalAnalyzerEmpty.tsx:67-68`,
+plus the three callers
+(`LocalAnalyzerAccordion.tsx:87-104`, `CostMode.tsx:122-129`).
+
+**Why:** "*LOCAL ANALYZER REQUIRED — install chat-arch-analyzer
+skill and run 'pnpm analyze'…*" is the most jargon-dense piece of
+copy in the hosted build. It appears in **four places** across
+ANALYSIS and COST. Either (a) hide entirely on hosted (probe via
+`useRescan().available`), or (b) swap the CTA for "*Available when
+running chat-arch locally — see the [getting started] guide.*"
+mirroring the DataPanel pattern (`DataPanel.tsx:299-309`).
+
+### 3. Pre-render demo-data topics + projects without requiring ANALYZE TOPICS click
+**Where:** `packages/viewer/src/data/demoUpload.ts` (already
+generates rich data), but `TopicsMode.tsx:52-58` and
+`ProjectsMode.tsx:115-122` empty states force the user to run the
+embed pass before they see anything.
+
+**Why:** David's stated goal is "I wonder what my AI use actually
+*looks* like." The fastest insight surface — TOPICS — currently
+requires a 36 MB model download + ~1-3 min embed pass before
+showing anything for *real* uploads. The demo data could
+short-circuit this for the LOAD DEMO DATA path so David immediately
+sees clusters, then he can decide whether to commit the embed pass
+on his own data. Time-from-landing-to-first-insight goes from
+~3 min to ~10 sec on the demo path.
+
+### 4. Keep the TrustStrip live in the sidebar footer on populated views
+**Where:** `packages/viewer/src/components/Sidebar.tsx:240-243`
+(footer slot already exists with `RepoLink`); add a compact
+single-line variant of `TrustStrip.tsx`.
+
+**Why:** The privacy pledge disappears the moment data is loaded
+(`TrustStrip.tsx:27` comment makes this explicit). David is most
+likely to share the link with a coworker *after* he's seen the
+populated view — and at that point, the page he'd ask his coworker
+to look at has zero on-screen privacy framing. A single "LOCAL-FIRST
+· No telemetry · [VIEW SOURCE ↗]" line in the sidebar footer keeps
+the pledge present without re-pitching.
+
+### 5. Replace "without running the CLI" hint copy in UploadPanel
+**Where:** `packages/viewer/src/components/UploadPanel.tsx:122-125`
+("*Drop a Settings → Privacy → Export data ZIP from claude.ai to
+browse your conversations without running the CLI.*").
+
+**Why:** This is the first sentence David reads on the empty-state
+landing. "Without running the CLI" signals that the cloud upload is
+the lesser of two paths — implying the product is mostly for CLI
+users. A friendlier framing: "*Drop a Settings → Privacy → Export
+data ZIP from claude.ai. We'll parse it in this tab — no upload, no
+account needed.*" The same one-line change can pull double duty
+documenting the privacy promise inline.
+
+---
+
+# What works (3-5 things David would appreciate)
+
+1. **TrustStrip honesty.** The "*One caveat: the optional Analyze
+   Topics step downloads a 36 MB embedding model from huggingface.co*"
+   footnote (`TrustStrip.tsx:43-47`) is the kind of disclosure
+   competing tools omit. David would notice and trust the rest of
+   the page more for it.
+
+2. **Filename masking.** `maskedUploadLabel` (`uploadLabel.ts:33-39`)
+   is invisible in the happy path, but the moment David screenshots
+   the viewer to share it, his email is gone. Not a marketed feature
+   but exactly the kind of detail a privacy-conscious PM appreciates
+   when he discovers it.
+
+3. **AnalysisLauncher's armed preview.** `AnalysisLauncher.tsx:288-356`
+   spells out scope, mode, steps, and runtime *before* the work
+   starts. "*Typically 1-5 minutes on WebGPU; longer on WASM
+   fallback.*" is what David needs to decide whether to commit.
+   This pattern is what the CORRECTIONS panel and the
+   LocalAnalyzerEmpty CTAs lack.
+
+4. **PracticeMode delivers an insight moment.** Severity-tagged
+   findings with linked evidence (`PracticeMode.tsx:104-175`),
+   no LLM dependency, no ML cost. This is the closest thing to
+   "what your AI use actually looks like" that the product offers
+   without a model download. Worth marketing harder.
+
+5. **NuclearReset's "nothing to delete" auto-hide.** The chip
+   silently disappears when there's nothing to wipe
+   (`NuclearReset.tsx:107-117`) instead of presenting a destructive
+   action against an empty inventory. That's the right pattern; it
+   should be applied to CORRECTIONS, the LocalAnalyzerEmpty CTAs,
+   and the unused-source rows in the NuclearReset dropdown itself.
+
+6. **The README's "Try it without installing"** section
+   (`README.md:27-42`) is well-positioned. If David follows the
+   chat-arch.dev link from there, the path matches what he expects.
+   The first paragraph above it (the local-first disclosure) is
+   the part that needs softening.
+
+---
+
+*End of David evaluation.*

--- a/research/persona-evals/maya.md
+++ b/research/persona-evals/maya.md
@@ -1,0 +1,502 @@
+# Persona evaluation — Maya, the daily power user
+
+Maya is a senior IC with multi-month corpus across Claude Code CLI, Desktop,
+Cowork, and cloud. She self-hosts via `pnpm dev` and has hundreds-to-thousands
+of sessions on disk. Today's question:
+
+> "What corrections have piled up since last week, and is there a CLAUDE.md
+> upgrade worth shipping?"
+
+The walk below is in the same order the user requested. Every observation
+cites file:line. Code was not modified.
+
+---
+
+## 1. Empty-state landing
+
+**Verdict.** Clean and on-message for a first-time visitor, but Maya is
+*never* a first-time visitor. The landing only renders when the manifest is
+empty or errored, so for her the surface is dead — she reaches all data
+actions through the DataPanel after load. As a "first day with chat-arch"
+on-ramp it is fine; as a returning-user reorientation surface it does not
+exist.
+
+**Friction.**
+- TrustStrip pitches local-first / no telemetry / "view source" on every
+  empty render (`packages/viewer/src/components/TrustStrip.tsx:29-50`). On a
+  re-visit after a wipe Maya sees the pitch again with no shortcut to "skip
+  the pledge, just give me the buttons."
+- The empty branch logic in `ChatArchViewer.tsx:1868-1902` only fires when
+  `manifestState.status === 'error'` OR `manifest.sessions.length === 0`. A
+  populated manifest jumps straight into the SESSIONS grid, so there is no
+  surface that says "your last index was N days ago."
+- Scan / Upload buttons are competing CTAs side-by-side
+  (`UploadPanel.tsx:129-168`); on a fresh demo deploy the SCAN-LOCAL button
+  is hidden behind the `scanAvailable` probe, leaving CHOOSE ZIP and LOAD
+  DEMO DATA — fine, but the empty-state copy at line 1872-1873 is a wall of
+  text that buries the actual CTAs.
+
+**Suggestions.**
+- When the manifest is populated AND `manifest.generatedAt` is older than ~7
+  days, surface a returning-user reorientation banner above the SESSIONS
+  grid: "Last indexed N days ago — UPDATE LOCAL?" Wire it into the existing
+  `lcars-rescan-banner` slot used at `ChatArchViewer.tsx:2013-2032`.
+- TrustStrip could render a compact pill ("LOCAL-FIRST · view source") on
+  the *populated* layout's footer for ongoing reassurance without the wall
+  of copy.
+
+---
+
+## 2. SCAN LOCAL flow
+
+**Verdict.** Mature. The streaming NDJSON progress
+(`data/rescan.ts:160-220`), structured `phase` events, and per-phase
+counters (`SCANNING · COWORK 1/3` at `UploadPanel.tsx:69-80`) are exactly
+the right level of detail for a power user watching her terminal anyway.
+The post-scan delta banner is the standout — it reports `12 new local
+sessions (1,247 total local)` rather than blindly restating totals
+(`ChatArchViewer.tsx:1607-1681`). Maya gets her "was this scan worth doing"
+answer in one glance.
+
+**Friction.**
+- The success banner only stays visible for 6 seconds
+  (`ChatArchViewer.tsx:1686-1690`). If Maya was tabbed away running a code
+  review and comes back to see the green border fade out before reading it,
+  the delta is gone with no log of "what changed in the last rescan." There
+  is no "rescan history" anywhere.
+- The delta is a single number ("12 new"). It does not break out *which
+  source* added them (cowork vs cli-direct vs cli-desktop), even though
+  `priorCounts` carries that breakdown (`ChatArchViewer.tsx:1613-1619`).
+  Maya often debugs which CLI she was actually in, so per-source delta
+  would be more useful.
+- The rescan banner persists when an error happens (good) but the success
+  banner does not survive a refresh (lost on F5). For a 90s rescan she
+  often hits F5 to reload the manifest; the celebratory message is gone.
+
+**Suggestions.**
+- Persist the last-rescan summary into `localStorage` and render a small
+  "RESCAN · 2 min ago · 12 new" chip in the TopBar (next to EARTHDATE)
+  until the next rescan. Keeps the answer to "did anything change?" visible
+  for hours, not seconds.
+- Expand the success message to per-source: "12 new · cowork +5,
+  cli-direct +6, cli-desktop +1." The numbers are already in the
+  `priorCounts` snapshot at `ChatArchViewer.tsx:1613-1619`.
+- Add a low-key activity-log entry on every rescan (the
+  `ActivityLogPanel.tsx` ring buffer is already wired up and ideal for
+  this) so even a missed banner becomes findable history.
+
+---
+
+## 3. DataPanel sidebar
+
+**Verdict.** Clean three-section layout (`DataPanel.tsx:174-345`),
+state-aware labels (SCAN LOCAL → UPDATING · COWORK 1/3 → UPDATED ✓), and an
+InfoPopover that doubles as documentation for "what does this button
+actually scan?" (`DataPanel.tsx:293-328`). For Maya this is the canonical
+home and works well.
+
+**Friction.**
+- The DELETE NuclearReset is gated by `nothingToDelete` at
+  `NuclearReset.tsx:107-116`, which hides the chip on an empty manifest.
+  Sane in principle, but the NuclearReset is rendered *inside* the
+  DataPanel which the user only opens when there *is* data — the gate is
+  defensive in a place it never fires. Not a bug, just dead code worth
+  knowing about.
+- The DataPanel does not show a "last indexed at" timestamp anywhere.
+  `manifest.generatedAt` is in the schema (`packages/schema/src/unified.ts:300`)
+  but `grep` across the viewer finds zero references that surface it to the
+  user. Maya cannot tell whether the open panel reflects today's disk state
+  or last week's without scrolling the SESSIONS grid for the most recent
+  date.
+
+**Suggestions.**
+- Render `manifest.generatedAt` as "last indexed YYYY-MM-DD HH:MM · 3d ago"
+  inside `DataPanel.tsx:196-199` (the lead paragraph slot). Same string
+  could power a small chip in the TopBar.
+- A keybinding (e.g. `g d` or `Cmd-Shift-D`) to open the DataPanel from
+  anywhere would save Maya the mouse trip when she rescans 5 times a day.
+
+---
+
+## 4. Sessions list (default mode)
+
+**Verdict.** The shared chrome is dense and useful — KPI tiles, sparkline,
+source pills, project chips, GRID/TIMELINE toggle, sort dropdown
+(`ChatArchViewer.tsx:2178-2235`). For Maya specifically the SORT dropdown
+is the right primitive and "load 50 more" pagination
+(`CommandMode.tsx:32-100`) is a defensible tradeoff over react-virtualized
+at the corpus sizes she's running.
+
+**Friction.**
+- "SHOW 50 MORE (N REMAINING)" is the only way to surface tail sessions —
+  no jump-to-bottom, no jump-to-week, no infinite scroll. With ~2000
+  sessions Maya clicks 40 times to reach 2024-Q4
+  (`CommandMode.tsx:88-99`).
+- The Sparkline (`Sparkline.tsx:18-100`) renders one bar per week. At >2y
+  history the bars compress to ~3px wide and the per-source coloring
+  becomes hard to read. There is no zoom or pan.
+- Filter precedence is unclear. Source pills + project chips + UNKNOWN +
+  SHOW EMPTY + sort + free-text query is six axes; there's no "active
+  filters: [...] · clear all" summary chip even though `onClearFilters`
+  exists (`UpperPanel.tsx:58`). Maya can lose track of why a session she
+  expected to see is missing.
+- The free-text search (`data/search.ts:12-43`) is substring-only across
+  title/summary/preview/cwd/project/topTools/modelsUsed. No regex, no
+  field-scoped queries (`tool:WebFetch`, `project:chat-arch`), no boolean.
+  For a corpus where she half-remembers a session, this is the weakest
+  link.
+
+**Suggestions.**
+- Add a visible "active filters" summary line above the grid with quick
+  toggles + a single CLEAR ALL pill. Wires through existing state in
+  `ChatArchViewer.tsx`.
+- Add a "JUMP TO" affordance on the sparkline: clicking a week-bar scopes
+  the grid to that week. The bucketing already runs at
+  `data/search.ts:128-148`.
+- Promote field-scoped search syntax (`tool:`, `project:`, `source:`,
+  `model:`) by extending `data/search.ts:filterSessions` — the field names
+  match what the UnifiedSessionEntry already exposes.
+
+---
+
+## 5. Session detail overlay
+
+**Verdict.** Solid. PREV/NEXT with `[`/`]` keybinding
+(`DetailMode.tsx:120-149`) is the kind of detail that earns Maya's loyalty.
+COPY TRANSCRIPT (`DetailMode.tsx:153-180`) and the meta strip with cost
+breakdown tooltip (`DetailMode.tsx:46-58`) cover the obvious power-user
+needs.
+
+**Friction.**
+- No way to mark a session "interesting" / "needs revisit" / "applied a
+  CLAUDE.md rule from this." The detail view is read-only — the entire
+  app's notion of state ends at "what's on disk."
+- No deep-link copy from inside detail. There's a hash-based selection
+  (`HASH_*` constants) but no visible "copy link" affordance for sharing
+  with herself in a paste-bin or another tool.
+- Detail does not surface whether this session contains a known correction
+  candidate. Crossing the corrections schema (`Correction.sessionId` at
+  `packages/schema/src/correction.ts:44`) into detail would let Maya read
+  the correcting message in context — currently she has to bounce.
+
+**Suggestions.**
+- Add a "CORRECTIONS IN THIS SESSION" strip below the meta dl when the
+  current session.id appears in any `Correction.sessionId` of the loaded
+  `corrections.json`. Anchor + scroll to the correcting userTurnIndex.
+- Add a "COPY LINK" chip next to COPY TRANSCRIPT (1-line addition reusing
+  `window.location.href`).
+
+---
+
+## 6. Other modes (Command / Constellation / Timeline / Cost)
+
+**Verdict.** Each mode is a complete feature. CommandMode pagination is
+covered above. CostMode is well-structured (`CostMode.tsx:67-80`) with
+section-scoped scroll-and-highlight behavior and KPI deep-links.
+TimelineMode is purely presentational with per-source lanes
+(`TimelineMode.tsx:38-90`). ConstellationMode handles cluster
+chip-navigation and zombie-project sections
+(`ConstellationMode.tsx:44-80`).
+
+**Friction (Maya-specific).**
+- TimelineMode has no zoom/pan and no aggregation — at multi-thousand-session
+  corpora the dots overlap into a smear (`TimelineMode.tsx:69-80`).
+- CostMode TOP-20 is hard-capped, with no "show 50 more" or filter — Maya
+  cannot ask "show me only sessions over $1.00" from inside this mode.
+- ConstellationMode "ZOMBIE PROJECTS" depends on Phase-7 analyzer output;
+  the empty state is informative but doesn't tell Maya "to populate this,
+  run X."
+
+**Suggestions.**
+- Timeline: add a click-and-drag zoom (selectable date window).
+- Cost: cost-threshold filter chip ("≥ $0.10").
+- Constellation: explicit "RUN LOCAL ANALYZER" CTA inside each empty
+  section pointing at the same `useRescan()` machinery.
+
+---
+
+## 7. ProjectsMode
+
+**Verdict.** The strongest "synthesis" surface. Narrative cards with
+sentiment, evidence pills (`ProjectsMode.tsx:439-457`), and the
+ENCODE-AS-PATTERN / GENERATE-CORRECTIVE-PROMPT actions
+(`ProjectsMode.tsx:467-491`) are exactly the model Maya wants for
+corrections too — synthesis → "ship it" in one click.
+
+**Friction.**
+- ProjectsIndex renders the entire `filtered` list at
+  `ProjectsMode.tsx:194-235` with no pagination/virtualization. With many
+  projects this is fine; with hundreds it'll repaint slowly.
+- ProjectDetail also renders every session card eagerly
+  (`ProjectsMode.tsx:337-343`). A project with 200+ sessions ships 200+
+  SessionCard renders.
+- The "ENCODE AS PATTERN" only exists for narratives, not for sessions
+  directly. If Maya is reading a single session and wants to encode a
+  one-off rule, she can't.
+
+**Suggestions.**
+- Apply the same `PAGE_SIZE = 50 · SHOW MORE` pattern from
+  `CommandMode.tsx:32-100` to `ProjectsMode` index + detail session lists.
+- Mirror the narrative-encoding action onto a "ENCODE FROM SESSION" menu
+  on the detail header, so Maya can ship a CLAUDE.md tweak from a single
+  exemplar without going through corrections-mining.
+
+---
+
+## 8. TopicsMode
+
+**Verdict.** Functional but thinner than Projects. Index + detail follow
+the same shape (`TopicsMode.tsx:29-145`), filter input is local-state
+(`TopicsMode.tsx:93-101`), cross-project chips are clickable
+(`TopicsMode.tsx:200-213`).
+
+**Friction.**
+- Same "renders everything" concern as Projects — TopicsIndex maps over
+  `filtered` and emits a row per topic
+  (`TopicsMode.tsx:121-144`).
+- No way to *do* anything with a topic. Unlike narratives, topics carry no
+  encode/generate actions. For Maya "I want to ship a CLAUDE.md hint
+  about THIS topic" requires bouncing to corrections or hand-copying.
+- Sort is hardcoded by `sessionIds.length desc` at `TopicsMode.tsx:94-96`.
+  No "by recency" or "by emergence."
+
+**Suggestions.**
+- Add a session-count filter (`≥10 sessions`) and a sort toggle.
+- Wire a "use this topic in a prompt" affordance — even just COPY-TO-CLIPBOARD
+  of a templated `${topic.displayName}` string into a CLAUDE.md hint.
+
+---
+
+## 9. PracticeMode
+
+**Verdict.** Conceptually perfect for Maya: a four-lens audit
+(`PracticeMode.tsx:44-49`) with severity-tagged findings and clickable
+evidence (`PracticeMode.tsx:118-167`). Every finding cites a session or
+project — "nothing is a model judgment, everything links to evidence"
+(`PracticeMode.tsx:93-96`). This is the page she wants to see first on a
+weekly check-in.
+
+**Friction.**
+- No "since last visit" filter. Maya wants to see "what audit findings are
+  NEW since I read this last week" — currently every load shows everything.
+- No way to dismiss a finding or mark it "won't fix." If
+  `your-patterns/value-leaks` cite the same five sessions for a month, she
+  scrolls past them.
+- No prioritization beyond severity. Two ALERTs side-by-side give no hint
+  about which Maya should fix first.
+
+**Suggestions.**
+- Persist a "last-viewed audit timestamp" in `localStorage`; flag findings
+  whose evidence sessions postdate it as NEW.
+- Add a per-finding DISMISS button that writes to localStorage; respect on
+  re-render. Optional UNDISMISS in a footer.
+- Sort findings by severity then by evidence-count (more evidence = higher
+  priority within severity).
+
+---
+
+## 10. Corrections panel + mining flow
+
+**Verdict.** This is THE surface Maya came for, and it's both the deepest
+and the most short-on-payoff. The pipeline (heuristic recall → LLM
+classify → embed/cluster → propose) is present end-to-end
+(`CorrectionsPanel.tsx:265-363`), the auto-window logic
+(`CorrectionsPanel.tsx:135-162`) and "BACKFILL OLDER (N)" button
+(`CorrectionsPanel.tsx:951-960`) handle exactly her question
+("corrections since last week"), and the running-banner has elapsed +
+staleness + DETACH (`CorrectionsPanel.tsx:1099-1145`). The CoverageMeter
+(`CorrectionsPanel.tsx:558-639`) is excellent. **But the last 20% — going
+from a pattern to a shipped CLAUDE.md upgrade — is broken.**
+
+**Friction.**
+- The APPLY button on every proposed upgrade is `disabled` and
+  `aria-disabled` with the title "Apply flow not yet implemented — copy
+  the patch and apply manually" (`CorrectionPatternCard.tsx:246-254`).
+  COPY PATCH works, but Maya then has to (1) open the right file in her
+  editor (path is shown at `CorrectionPatternCard.tsx:234`), (2) decide
+  where to insert, (3) paste, (4) save, (5) ideally commit. The schema
+  has `appliedAt` (`packages/schema/src/correction.ts:125`) so the
+  "RECURRING AFTER APPLIED" bucket can light up post-fact, but there's
+  no UI to write `appliedAt`.
+- Each `Correction` carries `sessionId`
+  (`packages/schema/src/correction.ts:44`), but
+  `CorrectionPatternCard.tsx:158-180` renders the instance excerpts as
+  inert `<p>` blocks. Maya cannot click through to the session that
+  contained the correction. She gets the *what* and *where to fix* but
+  not the *original context*. Verifying a proposed rule against the
+  actual transcript becomes a manual ID lookup.
+- Mining a fresh window takes 3-8 minutes wall-clock
+  (`CorrectionsPanel.tsx:998-1003`). The progress UI is good. There is no
+  scheduling — a daily/weekly cron is out of scope, but there's also no
+  "always mine on rescan" toggle that would amortize the wait.
+- The "ARMED" preview (`CorrectionsPanel.tsx:980-1025`) shows
+  `~3-8 min wall-clock` and "Counts against your Claude Code plan usage"
+  — good honesty — but no estimate of cost in dollars or token count. A
+  power user about to mine 800 candidates wants to know "this is ~$2"
+  not just "3-8 min."
+- The DangerZone CLEAR ALL CORRECTIONS button
+  (`CorrectionsPanel.tsx:768-860`) is a power tool, but there is no
+  "CLEAR APPLIED ONLY" or "CLEAR PATTERNS WITHOUT NEW INSTANCES." The
+  only granularity is nuclear.
+
+**Suggestions (high impact).**
+- **Implement APPLY.** A `/api/apply-correction` endpoint mirroring
+  `/api/encode-pattern` (already used by ProjectsMode at
+  `packages/viewer/src/data/narrativeActions.ts`) that takes
+  `{ correctionId, upgrade }`, writes the patch into the target file,
+  and stamps `appliedAt` on the correction. The architecture for it is
+  *already there* for narratives.
+- Add a "OPEN SESSION" button to each instance row in
+  `CorrectionPatternCard.tsx:165-180`. Pass through `onSelectSession`
+  from `CorrectionsPanel` (which has access via the host) — same model
+  PracticeMode uses (`PracticeMode.tsx:140-146`).
+- Show a per-pattern "APPLIED N DAYS AGO" badge next to the
+  RECURRING-AFTER-APPLIED chip, sourced from
+  `pattern.proposedUpgrades[].appliedAt` once writes are wired up.
+- Add an opt-in "AUTO-MINE AFTER RESCAN" toggle stored in localStorage —
+  if Maya rescans daily, she'd happily trade 3-8 minutes of background
+  work for a corrections feed that's always fresh.
+- Show estimated *cost* alongside estimated time in ArmedPreview
+  (`CorrectionsPanel.tsx:996-1004`) — the candidate count × an avg
+  tokens/candidate × claude pricing is a one-line addition.
+
+---
+
+## 11. ActivityLogPanel
+
+**Verdict.** Right idea, underutilized. Slide-in panel
+(`ActivityLogPanel.tsx:119-189`), severity-tagged entries, auto-scroll
+that respects user scroll position (`ActivityLogPanel.tsx:60-89`), edge
+tab when closed (`ActivityLogPanel.tsx:99-117`). Maya would use this *if*
+it carried more events.
+
+**Friction.**
+- The empty-state hint enumerates "Upload a ZIP, scan local, or click
+  ANALYZE TOPICS" (`ActivityLogPanel.tsx:158-162`) — those are the only
+  three event sources. Mining a corrections run, the event of greatest
+  interest to Maya, doesn't appear here. She has to be on the
+  CORRECTIONS surface to see mining progress.
+- No filter / search inside the log. With 500 entries the only way to
+  find "the failed scan from yesterday" is to scroll.
+- No persistence across reloads — the ring buffer is in-memory.
+
+**Suggestions.**
+- Pipe the corrections-mining stream events
+  (`mineCorrectionsClient.ts:startMineCorrections`) through the same log
+  sink. One-line wiring per event type.
+- Add a tail-N filter input and a severity-only toggle.
+- Persist the log buffer to localStorage with a 7-day TTL.
+
+---
+
+## 12. Search affordance
+
+**Verdict.** Sound but minimal — debounced free-text input
+(`ChatArchViewer.tsx:237-414` for the debounce path; `TopBar.tsx:106-122`
+for the input). Substring across a useful set of fields
+(`data/search.ts:19-42`).
+
+**Friction.** Covered in §4 (no field-scoped operators, no regex, no
+boolean). Maya half-remembers "the session where I asked about WebFetch
+in the chat-arch repo last month" — she can search `WebFetch` but cannot
+combine it with `project:chat-arch` to scope further.
+
+**Suggestions.** Promote field-scoped syntax in
+`data/search.ts:filterSessions`. Even `field:value` substring matching
+without regex would be a major QoL bump.
+
+---
+
+## 13. NuclearReset
+
+**Verdict.** Best-in-class destructive UX. Source-by-source checkboxes
+with counts (`NuclearReset.tsx:60-85`, `NuclearReset.tsx:326-353`),
+two-step "ARE YOU SURE?" arming (`NuclearReset.tsx:363-371`), and an
+explicit explainer for *what each source even is* doubling as
+documentation (`NuclearReset.tsx:60-85`). The IDB+localStorage cleanup
+order is documented inline (`NuclearReset.tsx:218-278`).
+
+**Friction.** Genuinely none for Maya specifically. The dropdown self-
+hides on empty data, which she'll appreciate.
+
+**Suggestions.** Optionally surface a "EXPORT BEFORE DELETING" affordance
+— one-click ZIP-and-download of `chat-arch-data/` before the wipe — but
+this is a nice-to-have, not a bug.
+
+---
+
+## 14. /bench dev-only page
+
+**Verdict.** Correctly gated by `import.meta.env.DEV` and a runtime
+redirect for safety in prod (`apps/standalone/src/pages/bench.astro:33-35`).
+The dev-only memo at `bench.astro:1-28` is good documentation.
+
+**Friction.** None for Maya in normal use. As a dev-only surface it's
+out-of-band of her daily workflow.
+
+**Suggestions.** Out of scope for this persona.
+
+---
+
+## Top 5 improvements ranked for Maya
+
+1. **Implement APPLY for corrections** — `CorrectionPatternCard.tsx:246-254`
+   + new `/api/apply-correction` endpoint mirroring
+   `apps/standalone/src/pages/api/encode-pattern.ts`. The single change
+   that turns the corrections surface from "passive list" to "shipped
+   workflow." `appliedAt` is already in the schema
+   (`packages/schema/src/correction.ts:125`); the bucketing logic at
+   `CorrectionsPanel.tsx:60-94` already lights up RECURRING-AFTER-APPLIED
+   automatically once writes happen.
+
+2. **Click-through from correction instance to source session** —
+   `CorrectionPatternCard.tsx:165-180`. Each `Correction` already has
+   `sessionId`; the host already has `onSelectSession` plumbing
+   (PracticeMode uses it at `PracticeMode.tsx:140-146`). Without this,
+   Maya cannot verify a rule against its original context in <3 clicks.
+
+3. **Surface "indexed N days ago" reorientation** — `manifest.generatedAt`
+   exists (`packages/schema/src/unified.ts:300`) but is referenced zero
+   times in the viewer's UI code. Render it as a TopBar chip or a
+   conditional banner near `ChatArchViewer.tsx:2013-2032` when older than
+   ~7d. Closes Maya's first-question loop ("am I looking at fresh data?")
+   without forcing her into the DataPanel.
+
+4. **Field-scoped search syntax** —
+   `packages/viewer/src/data/search.ts:12-43`. Adding
+   `tool:`/`project:`/`source:`/`model:` prefixes to the existing
+   substring matcher is ~30 lines of code and converts the search input
+   from "find that one keyword" to "actually navigate the corpus."
+
+5. **Per-source rescan delta + persistent banner / activity-log entry** —
+   `ChatArchViewer.tsx:1607-1681`. The data is already in `priorCounts`
+   (line 1613-1619); split the delta phrase by source and persist into
+   the activity log + a `localStorage`-backed TopBar chip. Maya tabs
+   between terminals, and a 6-second toast does not survive her workflow.
+
+---
+
+## What works — keep these
+
+- **Rescan delta reporting** — `ChatArchViewer.tsx:1607-1681` already
+  reports "12 new local sessions" rather than restating totals; this is
+  the kind of detail that makes returning users feel seen.
+- **Streaming rescan progress** — NDJSON phase events
+  (`data/rescan.ts:160-220`) + per-phase counters in the button label
+  (`UploadPanel.tsx:69-80`) match a power-user mental model exactly.
+- **CoverageMeter on the corrections panel** —
+  `CorrectionsPanel.tsx:558-757` answers "how much of the archive has
+  been analyzed for this view?" with a funnel that reads "transcripts →
+  prompts → candidates → classified → actionable → patterns." This is
+  literal pipeline observability and Maya will love it.
+- **Auto-window + BACKFILL OLDER button** —
+  `CorrectionsPanel.tsx:135-162` and `951-960`. Recognises the two
+  natural mining cadences without ceremony.
+- **NuclearReset's source-by-source pick-list** —
+  `NuclearReset.tsx:60-85` and `326-353`. A destructive surface that
+  doubles as documentation for "what data does this app even see?" is
+  rare and worth defending.
+- **PracticeMode evidence-pill clickthrough** —
+  `PracticeMode.tsx:118-167`. The "every finding cites evidence,
+  evidence is a button" pattern is exactly what corrections needs to
+  copy.

--- a/research/persona-evals/priya.md
+++ b/research/persona-evals/priya.md
@@ -1,0 +1,494 @@
+# Persona eval — Priya, the Curious Drive-By
+
+**Persona shorthand.** Engineer with 90 seconds before standup. Clicked an HN
+link to **chat-arch.dev**. Goal: bookmark, share, or close the tab. She'll click
+LOAD DEMO DATA, poke at 2-3 surfaces, maybe peek at `/design-system`, and
+leave. She has no claude.ai Privacy-Export ZIP in arm's reach and won't be
+fetching one mid-tab.
+
+---
+
+## 1. Landing page (cold load)
+
+**Files:**
+- `apps/standalone/src/pages/index.astro:1-18`
+- `packages/viewer/src/ChatArchViewer.tsx:1867-1902` (empty branch)
+- `packages/viewer/src/components/TrustStrip.tsx:29-50`
+- `packages/viewer/src/components/UploadPanel.tsx:114-212`
+
+### Verdict
+**Cautiously good — but the promise is muted.** The landing renders
+`TopBar` (CHAT ARCHAEOLOGIST + InfoPopover linking to /design-system),
+`TrustStrip`, an `ErrorState` titled `NO DATA YET`, then `UploadPanel`
+with three buttons (`SCAN LOCAL` is hidden on chat-arch.dev because the
+endpoint is dev-only — `UploadPanel.tsx:67` gates on `scanAvailable`).
+What Priya sees on the live deploy is functionally just two buttons:
+**CHOOSE ZIP** and **LOAD DEMO DATA**.
+
+The first three things she'd clock in 10s:
+1. The product name "CHAT ARCHAEOLOGIST" + the LCARS Star-Trek aesthetic
+   (signal: "this is a project, not a product"). The retro look is
+   *strongly* differentiating but doesn't tell her *what* it does.
+2. The "LOCAL-FIRST" pledge in the trust strip — **this is great copy**.
+   Three claims (parsed in browser / no telemetry / never leaves your
+   machine) plus a `VIEW SOURCE ↗` chip right inline.
+3. The **NO DATA YET** title in `ErrorState` — which reads like an error
+   even though it isn't. Below it sits `LOAD DEMO DATA` as a *secondary*
+   button (gray-outlined, second position; see
+   `UploadPanel.tsx:156-167` and the styling note at
+   `styles.css:2769`).
+
+### Friction
+- **No "what does this do?" headline** above the fold. The README opens
+  with "The personal archive for your Claude conversation history" —
+  that single sentence isn't on the landing page anywhere. The closest
+  thing is the InfoPopover anchored to the title, but it talks about
+  the *design system*, not the product (`TopBar.tsx:76-88`).
+- `LOAD DEMO DATA` is the secondary CTA, not the primary. For a drive-
+  by visitor without a ZIP, it should be primary. CHOOSE ZIP is useless
+  to her — she literally cannot complete that path in 90 seconds.
+- "NO DATA YET" reads as broken. A fresh first-load message
+  ("Click LOAD DEMO DATA to explore" / "Drop your Privacy-Export ZIP")
+  would be warmer than "NO DATA YET" + a paragraph of fetch-error
+  detail (`ChatArchViewer.tsx:1872-1873` builds an `emptyDetail` string
+  that includes README references — fine for a returning user, dense
+  for a first-timer).
+- **No screenshot / preview / hero image.** The landing is pure chrome
+  + buttons. Priya can't form a "yes I want to see the inside" guess
+  before clicking.
+
+### Suggestions
+1. Demote `NO DATA YET` to friendlier "EXPLORE WITH DEMO DATA" + add a
+   one-line product description above it
+   (`packages/viewer/src/components/ErrorState.tsx` consumer at
+   `ChatArchViewer.tsx:1888`).
+2. Promote `LOAD DEMO DATA` to primary CTA when there's no uploaded
+   data (swap the `--secondary` modifier in `UploadPanel.tsx:159`).
+3. Add a static screenshot of the populated SESSIONS grid to
+   `index.astro` above the `<ChatArchViewer />` mount, gated on the
+   empty state — give Priya something to *see* before she clicks.
+
+---
+
+## 2. LOAD DEMO DATA path
+
+**Files:**
+- `packages/viewer/src/data/demoUpload.ts:65-267` (fixture)
+- `packages/viewer/src/ChatArchViewer.tsx:1511-1548` (`onLoadDemo`)
+- `packages/viewer/src/ChatArchViewer.tsx:1976-2012` (DEMO DATA banner)
+
+### Verdict
+**This is the strongest part of the product.** The fixture is hand-
+written, opinionated, and reads as plausible:
+- 6 named projects with one-sentence descriptions
+  (`demoUpload.ts:65-72`).
+- Project titles + previews are domain-specific and varied —
+  Bluefin Mobile / Prism Highlight / Ledger Dashboard / Codex Archive
+  prompts read like real engineer-to-AI questions, not lorem ipsum
+  (`demoUpload.ts:81-150`).
+- A planted **zombie project** ("Codex Archive") that's deliberately
+  silent for 200 days (`demoUpload.ts:139-149`, `ZOMBIE_BURST_CENTER` at
+  `demoUpload.ts:352`).
+- Two **byte-identical duplicate clusters** (SSH ProxyJump + webpack-
+  in-pnpm) so the duplicate detector lights up
+  (`demoUpload.ts:164-177`).
+- Singletons grouped into ~9 thematic clusters (Postgres / auth /
+  React / Docker / k8s / testing / observability / streaming / runtime
+  — `demoUpload.ts:194-267`) so the semantic classifier can produce
+  emergent topics.
+- Deterministic seeded PRNG so the fixture looks identical between
+  loads (`demoUpload.ts:33-43`, comment at `:30-31`).
+
+### Friction
+- **Every conversation has the same robot reply turns.** Lines 314-322
+  show every non-first turn is *literally* `'Follow-up: can you expand
+  on the trade-offs?'` (human) and `'Here's a summary of the key
+  considerations, with an example.'` (assistant). If Priya drills into
+  any single conversation she sees the same canned exchange. This
+  would be the moment she goes "oh, it's all fake," because *the
+  message bodies* — the headline thing in a conversation viewer —
+  are templated. Strongest single weakness in the fixture.
+- The DEMO DATA banner copy is slightly on-the-nose / instructional
+  (`ChatArchViewer.tsx:1983-1995` — six lines of "to see your own
+  Claude transcripts: click X for Y, Z for W"). For a curious visitor
+  this banner says "you should leave and come back with a ZIP" rather
+  than "look at all this neat stuff."
+- The demo loads ~100 sessions instantly with no animation/intro —
+  there's a 1500ms boot animation (`ChatArchViewer.tsx:117`) but the
+  demo bypasses any "look what we found in your archive" reveal.
+
+### Suggestions
+1. Vary the canned reply turns — even 4-5 templates that interpolate
+   the project name would make session detail readable
+   (`demoUpload.ts:314-322`). Better: 2-3 hand-written multi-turn
+   transcripts seeded into the fixture so at least the first session
+   she opens has a "real" feel.
+2. Soften the demo banner: lead with "100 fake conversations to
+   explore" before the upgrade pitch (`ChatArchViewer.tsx:1984-1986`).
+3. Consider auto-scrolling/highlighting the most "demo-able" thing
+   (the RE-ASKED card showing 2 dup clusters?) on first demo load.
+
+---
+
+## 3. First populated screen (SESSIONS grid + KPIs)
+
+**Files:**
+- `packages/viewer/src/components/UpperPanel.tsx:285-659` (the chrome
+  Priya looks at first)
+- `packages/viewer/src/components/UpperPanel.tsx:604-643` (4 analysis
+  summary cards: RE-ASKED / ZOMBIES / INFERRED / TOPICS)
+- `packages/viewer/src/components/modes/CommandMode.tsx:34-90`
+  (the grid)
+- `packages/viewer/src/components/FilterBar.tsx`
+- `packages/viewer/src/ChatArchViewer.tsx:1976-2012` (DEMO banner up top)
+
+### Verdict
+**Visually arresting, cognitively dense.** Everything fires at once:
+TopBar (title, tier indicator, location chip, EARTHDATE, search) +
+DEMO DATA banner + UpperPanel (sparkline + 4 analysis cards on the
+ANALYSIS tab + tab bar + KPI tiles on OVERVIEW + AnalysisLauncher) +
+FilterBar (source pills + project chips + UNKNOWN + SHOW EMPTY) +
+sidebar (BROWSE: PROJECTS/TOPICS/SESSIONS; INSIGHTS: PRACTICE /
+CORRECTIONS / ANALYSIS / COST; ACTIONS: DATA) + the 100-card grid.
+
+That's roughly **20+ distinct affordances** visible simultaneously
+above any single piece of content. Pretty, but no single feature reads
+as *the* feature.
+
+### Friction
+- **No headline insight.** The four analysis cards (RE-ASKED, ZOMBIES,
+  INFERRED, TOPICS — `UpperPanel.tsx:604-643`) are arguably the most
+  interesting things in the product, but they sit on the **ANALYSIS
+  tab** which is not the default — `tab` defaults to `'overview'`
+  (`UpperPanel.tsx:334`). Priya lands on a list of session cards and
+  KPI tiles, not on the differentiating analysis surfaces.
+- The KPI tiles (top tool, top project, exact cost, output tokens) all
+  show numbers — but for the demo fixture, costs are randomly synthesized
+  (`demoUpload.ts:462-474` via `mulberry32`-seeded random in `[0,
+  1.8]`). Astute viewers will notice prices have no relationship to
+  conversation length and the "exact cost" KPI is grayed because none
+  of the demo entries have `totalCostUsd`.
+- The sparkline is good — it has shape (240-day window with a zombie
+  burst at -200d, demo fixture intentionally produces this).
+- Source pills include CHATGPT / CLAUDE CODE / CLI-DIRECT (visible in
+  `design-system/index.astro:159-173`) but in the demo, all sessions
+  are `cloud` source — the source filter pills do nothing on demo data
+  except show one count and three zeros.
+
+### Suggestions
+1. **Default the upper panel to the ANALYSIS tab when demo data is
+   loaded** so the four cards (RE-ASKED, ZOMBIES, …) are the first
+   thing on screen. Drive-by users need to see the differentiator
+   (`UpperPanel.tsx:334` — initial `tab` state).
+2. Hide the source pills row when the manifest only has one source
+   (FilterBar always renders them — see consumer in
+   `ChatArchViewer.tsx:2236-2249`).
+3. Consider hiding cost KPIs on a cloud-only fixture; the random-walk
+   numbers are the easiest "obviously synthetic" tell.
+
+---
+
+## 4. Sidebar mode names
+
+**File:** `packages/viewer/src/components/Sidebar.tsx:52-79`
+
+### Verdict
+**Mixed — three are clear, four are jargon.**
+
+| Mode | Label | Read in 1 second? |
+|---|---|---|
+| `projects` | PROJECTS | ✅ |
+| `topics` | TOPICS | ✅ |
+| `command` | SESSIONS | ✅ |
+| `practice` | PRACTICE | ❌ "practice what?" |
+| `corrections` | CORRECTIONS | ⚠️ "corrections to what?" |
+| `constellation` | ANALYSIS | ✅ (renamed from CONSTELLATION — good) |
+| `cost` | COST | ✅ |
+
+### Friction
+- **PRACTICE** and **CORRECTIONS** read as jargon. PRACTICE is internal-
+  speak for "adversarial audit" (see `PracticeMode.tsx:15-20` —
+  "adversarial audit dashboard"). CORRECTIONS is "moments where you
+  pushed back on the AI" but the sidebar gives no hint. Priya, with no
+  context, will skip both. They might be the most strategically
+  interesting features (RAG-able lessons from your own AI use!) and
+  she'll never click them.
+- The internal mode id `command` showing as label `SESSIONS` is fine
+  for users but adds confusion for anyone scanning code (commented
+  about at `Sidebar.tsx:43-46`, kept stable for "code stability").
+
+### Suggestions
+1. Rename PRACTICE → something action-y. From the spec: "adversarial
+   audit", "value leaks", "process gaps". A label like `LEAKS` or
+   `AUDIT` reads as "tell me what I'm doing wrong" much faster.
+2. Rename CORRECTIONS → `PUSHBACKS` or `DISAGREEMENTS`. The current
+   label suggests *Claude correcting you*, not the inverse.
+
+---
+
+## 5. Drill-down: clicking a session
+
+**File:** `packages/viewer/src/components/modes/DetailMode.tsx`
+
+### Verdict
+**Will betray the demo.** The DetailMode renders the conversation's
+messages via `MessageList` for cloud sessions. For the demo, the *first*
+message is the unique preview (e.g. "Designing the CloudKit schema so
+fishing-log notes sync between paired devices…") but every subsequent
+turn is the canned `'Follow-up: can you expand on the trade-offs?'` /
+`'Here's a summary of the key considerations, with an example.'` pair
+(`demoUpload.ts:314-322`). This is the single concrete moment Priya
+catches the fixture being fake.
+
+### Suggestions
+- See section 2 — vary canned turns, or hand-author 2-3 fully-formed
+  fake sessions and seed them at known positions in the fixture.
+
+---
+
+## 6. ProjectsMode + TopicsMode
+
+**Files:**
+- `packages/viewer/src/components/modes/ProjectsMode.tsx:83-100`
+- `packages/viewer/src/components/modes/TopicsMode.tsx:29-100`
+
+### Verdict
+**ProjectsMode demos OK; TopicsMode is gated behind running analysis.**
+
+ProjectsMode shows the 6 project cards with sentiment labels (POSITIVE
+/ NEGATIVE / NEUTRAL / MIXED — `ProjectsMode.tsx:55-67`), narrative
+chips, last-activity. Codex Archive (the zombie) lights up nicely as a
+trailing card with "200d ago" — that's a good demo moment.
+
+TopicsMode index `topics.length === 0` shows EmptyState
+(`TopicsMode.tsx:52-58`). Topics are populated by the semantic
+classifier (BGE-small embedding model run in browser). Priya hasn't
+clicked Analyze. She lands on **NO TOPICS YET / Run the analyzer or
+load a richer fixture to populate** — bad first impression on a tab
+the sidebar told her to click. If she's curious enough to click
+Analyze, she gets a 36 MB Hugging Face download warning (TrustStrip
+footnote `TrustStrip.tsx:43-47`) — not a 90-second-standup decision.
+
+### Suggestions
+1. Pre-compute topics into the demo fixture (run the BGE-small
+   classification once at build time; ship the resulting label
+   assignments alongside the fixture). The thematic clusters are
+   already designed for it (`demoUpload.ts:188-193`).
+2. Or: if topics are empty AND the source is demo, show a one-click
+   "GENERATE TOPICS (downloads 36 MB)" instead of a vague EmptyState.
+
+---
+
+## 7. /design-system page
+
+**File:** `apps/standalone/src/pages/design-system/index.astro:1-1193`
+
+### Verdict
+**This is excellent and may be the *real* headline feature for an
+engineer drive-by.** Walks through palette / typography / shapes /
+components / motion / port recipes — all generated from the actual
+DTCG `tokens.json` (`index.astro:11-14`). Component examples use real
+classes from `styles.css` and include copy-pasteable code blocks
+(`index.astro:175-180`). Top nav has SPEC.MD, TOKENS.JSON, LLMS.TXT,
+GITHUB links (`index.astro:24-28`).
+
+For an HN-clicker, "this is a Star-Trek-styled retro UI you can
+*fork as a token system*" is a more bookmarkable hook than "view your
+Claude conversations." That distinction matters because **Priya isn't
+yet a chat-arch user, but she might be a Supergraphic Panel user
+tomorrow.**
+
+### Friction
+- The trust-strip footnote on the landing page (`TrustStrip.tsx:43-47`)
+  doesn't link to /design-system — only the InfoPopover anchored to
+  the title does (`TopBar.tsx:86`), and that's hidden behind a hover/
+  click on a tiny "i".
+- The spec.md / tokens.json / GitHub links from `/design-system` are
+  great, but there's no *back-to-app* breadcrumb if she navigates
+  there and wants to return.
+
+### Suggestions
+1. Add a visible "Built with Supergraphic Panel — view design system"
+   chip on the landing page near the trust strip. Right now /design-
+   system is mostly discoverable through the README and the popover.
+2. Add a "← Chat Archaeologist" backlink on the design-system header.
+
+---
+
+## 8. README + VIEW SOURCE → GitHub
+
+**Files:**
+- `README.md:1-23` (top of README)
+- `packages/viewer/src/components/RepoLink.tsx:16` (REPO_URL)
+
+### Verdict
+**Strong.** The README opens with the elevator pitch ("The personal
+archive for your Claude conversation history") plus a one-paragraph
+local-first explainer that maps cleanly to the trust-strip claim. The
+"Try it without installing" section directly addresses Priya:
+
+> 1. Open chat-arch.dev. 2. Click LOAD DEMO DATA … 3. Everything
+>    renders client-side …
+
+That's the on-ramp the landing page itself is missing. The "How
+chat-arch compares" table (`README.md:170-177`) positions chat-arch
+against ccusage (13k★), simonw/claude-code-transcripts (1.4k★), etc.
+— credibility-by-association.
+
+The VIEW SOURCE chip lands on the public repo. Bryce's GitHub profile
++ commit history + LICENSE + SECURITY.md are visible. Nothing to
+embarrass.
+
+### Friction
+- README is *long* (~400 lines). For a 90-second visit, the lead
+  paragraph carries the weight — the rest is reference. That's okay
+  but means the *landing page* must do the elevator-pitch work since
+  most drive-bys don't open the README.
+
+---
+
+## 9. "Come back later" affordances
+
+### Verdict
+**Adequate, not great.**
+- **Bookmarkable URL:** Yes — the deep-link hash router supports
+  `#projects`, `#project/<id>`, `#topics`, `#session/<uuid>`,
+  `#practice` (`ChatArchViewer.tsx:92-165`). She can bookmark a
+  specific demo session URL.
+- **Product name:** "CHAT ARCHAEOLOGIST" sticky in the top bar. The
+  bookmark in her bar will read as "Chat Archaeologist" or whatever
+  Astro sets via `<BaseLayout title>` — fine.
+- **Repo link:** Two visible places — `TrustStrip` inline VIEW SOURCE
+  (empty state only — `TrustStrip.tsx:41`) and `Sidebar` footer chip
+  (always-on once data is loaded — `Sidebar.tsx:240-242`). Mobile gets
+  a horizontal-variant footer chip (`Sidebar.tsx:149-151`).
+- **Share:** No share button. Hash-based deep links work but there's
+  no copy-link affordance per session/project — she'd have to grab
+  the URL bar manually.
+
+### Suggestions
+1. Add a tiny COPY URL chip per surface (PROJECTS detail, session
+   detail) — so when she sees something interesting in the demo
+   ("look at this zombie project!") she can paste it into Slack
+   without selecting the URL bar.
+
+---
+
+## Demo-fixture critique
+
+### Reads as plausible
+- Project names (Bluefin Mobile, Prism Highlight, Ledger Dashboard,
+  Relay Rebuild, SingleHop Pipeline, Codex Archive) — domain-varied,
+  none feel like placeholders.
+- First-message previews — hand-written, domain-aware, technically
+  specific. ("WidgetKit reloads are hitting the 15-minute minimum.";
+  "Module-scope pytest fixture got torn down per-test after a
+  dependency-graph refactor.") `demoUpload.ts:81-267`.
+- Duplicate-cluster previews — full paragraphs, not titles.
+  `demoUpload.ts:164-177`.
+- The zombie project gets historical timestamps that genuinely cluster
+  in a 14-day burst 200 days ago (`demoUpload.ts:351-354`).
+- Project descriptions explicitly carry "Demo fixture · pretend …"
+  prefix — defensive but appropriate for a demo
+  (`demoUpload.ts:66-71`).
+
+### Reads as fake
+- **Repeated assistant turns** — every non-first message in every
+  conversation is one of two strings. (`demoUpload.ts:316-322`.) This
+  is the load-bearing tell.
+- **Cost figures are random** — uniform `[0, 1.80]` USD per session
+  with no relationship to turn count or model. (`demoUpload.ts:466`.)
+  An engineer scanning the COST tab would catch this.
+- **Models assigned uniformly** — 25% chance each of Sonnet, Opus,
+  Haiku, or null (`demoUpload.ts:269-274`). Real corpora are heavily
+  one-model-dominant.
+- **Conversation summaries are blank 60% of the time** — the other
+  40% are 1 of 4 templates with `{topic}` interpolation
+  (`demoUpload.ts:276-282`, sampled at `:388-392`).
+- **All sessions are `source: cloud`** — the source-filter pills show
+  three zeros. The sparkline is one color. The whole multi-source
+  story (Claude Code CLI / Cowork / Desktop / cloud) is invisible in
+  the demo.
+
+### Single highest-leverage fixture fix
+Replace lines 314-322 (`makeConversation`'s template loop) with at
+least 6-8 varied templates, OR hand-author 3-5 fully-formed
+multi-turn transcripts and intersperse them through the fixture.
+
+---
+
+## Headline-feature assessment
+
+**Today's headline (what the UI steers toward):**
+A retro LCARS-styled session list + KPI dashboard. SESSIONS is the
+default mode. The OVERVIEW tab is the default upper-panel tab. So
+Priya's first read is "this is a viewer for AI conversations with a
+sparkline and tag pills."
+
+**What it could be:**
+The four ANALYSIS cards (RE-ASKED / ZOMBIES / INFERRED / TOPICS) plus
+the CORRECTIONS surface tell a much sharper story:
+> "Find the questions you've asked Claude more than once. Find the
+> projects you abandoned. Find the rules Claude breaks even when
+> CLAUDE.md says don't. Get patches for your CLAUDE.md."
+
+That story is *unique to chat-arch* — the comparison table in the
+README leans on it (no other tool in that table mines pushback patterns
+or proposes CLAUDE.md upgrades). But the landing page surfaces zero of
+it. Priya doesn't see "RE-ASKED · 2 prompts" until she's clicked LOAD
+DEMO DATA *and* manually clicked the ANALYSIS tab in the upper panel.
+
+**One-sentence-to-a-friend test today:** "It's like a Star-Trek-themed
+viewer for your Claude history." Pretty, low share-rate.
+
+**One-sentence-to-a-friend test it could be:** "Finds the rules Claude
+keeps breaking in your transcripts and writes the CLAUDE.md patch for
+you." High share-rate.
+
+---
+
+## Top 5 improvements ranked by impact on bookmark/share
+
+1. **Lead with the unique value, not the chrome.** Above the empty-
+   state CTAs, render a one-line product description: *"Find the
+   questions you've asked twice, the projects you abandoned, and the
+   rules Claude keeps breaking — all from your local transcripts."*
+   (`apps/standalone/src/pages/index.astro:6-8` or
+   `ChatArchViewer.tsx:1874-1888`.) **Cost: tiny. Impact: large.**
+2. **Default the upper panel to ANALYSIS tab on demo load** so the
+   RE-ASKED / ZOMBIES / INFERRED / TOPICS cards are the *first* thing
+   visible after the demo populates. (`UpperPanel.tsx:334` — set
+   initial `tab` to `'analysis'` when `demoMode` is true.)
+3. **Vary the canned conversation turns** in `demoUpload.ts:314-322`
+   so a session drill-in doesn't betray the fixture instantly. Even
+   a per-project array of 4-5 plausible follow-up question/response
+   pairs would suffice.
+4. **Promote LOAD DEMO DATA to primary CTA** when the user has no
+   uploaded data — and demote CHOOSE ZIP to secondary, since 90% of
+   first-time visitors don't have a ZIP handy
+   (`UploadPanel.tsx:143-167`).
+5. **Rename PRACTICE / CORRECTIONS** in the sidebar to something less
+   jargon-heavy — `LEAKS` and `PUSHBACKS` would tell a stranger what
+   they do (`Sidebar.tsx:71-77`).
+
+---
+
+## What works (the things that pull her in within 30s)
+
+1. **The trust-strip copy.** Three claims, one VIEW SOURCE link, one
+   honest caveat about the HF download. It's a master-class in saying
+   "this is local-first" credibly. (`TrustStrip.tsx:29-50`.)
+2. **The retro LCARS aesthetic.** Distinctive enough to be memorable;
+   internally-consistent enough to feel intentional. The
+   `/design-system/` walkthrough means it's not just decoration —
+   it's a portable token system. That's bookmark-worthy on its own.
+3. **The fixture's project & prompt content.** Hand-authored,
+   domain-varied, technically credible. The Codex Archive zombie
+   project landing 200 days back is a genuinely satisfying demo
+   moment.
+4. **Hash-based deep links** mean the URL stays meaningful and
+   bookmarkable as she explores (`ChatArchViewer.tsx:92-165`).
+5. **The README's "Try it without installing" section** plus the
+   comparison table — credibility-by-association with simonw,
+   ccusage, et al. Once she clicks VIEW SOURCE she sees a serious
+   project, not a hobby. (`README.md:27-42`, `README.md:168-184`.)

--- a/research/persona-evals/sam.md
+++ b/research/persona-evals/sam.md
@@ -1,0 +1,353 @@
+# Persona evaluation — Sam, the Returning Forgetter
+
+Sam self-hosted chat-arch ~3 months ago, ran one local index, and walks away. Today he opens `localhost:4323` (or boots `pnpm dev` on 4324) and asks: "What was I working on? What changed since I left?" His IndexedDB still holds his cloud upload. The on-disk `manifest.json` still points to a corpus from 3 months ago. Nothing on disk has changed.
+
+This evaluation walks his journey surface by surface and audits whether the product *signals staleness*, *rewards re-orientation*, and *protects him from accidental destruction*.
+
+---
+
+## Surface 1 — The opening view (manifest exists + non-empty, stale)
+
+**Verdict — borderline. He lands on a chrome-heavy SESSIONS grid sorted by recent, but with zero "you're seeing 3-month-old data" signal.**
+
+### What he actually sees
+
+`ChatArchViewer.tsx:219-229` initializes `mode` from URL hash; absent a hash, the default is `'command'` — which the rest of the app calls SESSIONS. So he lands on the SESSIONS GRID with:
+
+- TopBar (`TopBar.tsx:71-104`): title, tier indicator, location chip "SESSIONS", **today's** EARTHDATE (`TopBar.tsx:69, 101-103`) — note the date displayed is *today*, not the manifest's `generatedAt`.
+- UpperPanel "OVERVIEW" tab (`UpperPanel.tsx:483-487`): KPI strip + sparkline. The sparkline + RANGE chip (`UpperPanel.tsx:411-413`) show the corpus date span (e.g. `2023-08-12 → 2026-02-08`) — but this is **the date span of conversations in the corpus**, not "when this index was generated".
+- MidBar with SORT default = `recent` (`ChatArchViewer.tsx:246`, `MidBar.tsx`). Sessions land sorted by `updatedAt desc` so his most-recent-touched sessions are top-left of the grid.
+- FilterBar with project pills + emergent topics row.
+
+### Friction
+
+- Today's EARTHDATE next to a 3-month-old corpus is **actively misleading** — the "current" feel of the chrome makes the data feel fresh. There is no "AS OF …" anywhere.
+- The sparkline ends in February (whenever his last session was) but the chart title is just "weekly session volume" (`Sparkline.tsx:191`). A returning user does not read "no recent bars in this sparkline" as "your data is stale" — he reads it as "I haven't been chatting with Claude lately".
+- Sessions are sorted RECENT, so his top-left card is dated `Feb 8` (his last session). That's a recency cue but not framed as "this is also the manifest's last write".
+
+### Suggestions
+
+- Render `manifest.generatedAt` (`packages/schema/src/unified.ts:300`) somewhere persistent — TopBar, UpperPanel stats row, or as a chip beside RANGE. Suggested copy: `INDEXED 92d ago` (using `formatRelative` from `util/time.ts:30`).
+- Consider a one-shot welcome banner when `Date.now() - manifest.generatedAt > 30d` AND the user hasn't visited in this browser session: "Your index is 3 months old — RE-SCAN to catch up."
+
+---
+
+## Surface 2 — Indications of staleness
+
+**Verdict — almost entirely missing for the manifest itself; AnalysisLauncher and CorrectionsPanel each have isolated staleness UI but they don't add up to a returning-user story.**
+
+### Where staleness surfaces today
+
+- `AnalysisLauncher.tsx:380-411`: a STALE badge + "N new sessions since the last run" subtitle on the FINDINGS tab. **But** this is gated on `bundle.analyzedSessionIds` vs current cloud session ids — it only fires for the in-browser semantic analyzer, not for "your manifest is old". And it is buried under the OVERVIEW/FINDINGS tab toggle, which Sam will never click on his first re-orientation.
+- `CorrectionsPanel.tsx:1085-1132`: a `staleness` field shown only **while a mining run is in flight** ("updated 12s ago" relative to last status-file write). Not a re-orientation signal.
+- `CorrectionsPanel.tsx:875-879`: the corrections Header shows `Generated <ISO timestamp>` — but only on the CORRECTIONS surface, and as raw ISO, not relative ("3mo ago").
+- `TierSheet.tsx:140-141`: per-file `generatedAt` shown when the user pops the tier indicator. Hidden behind a chip click.
+- `UploadPanel`'s upload chip shows ZIP size, not "uploaded N days ago" (`UpperPanel.tsx:416-441`).
+
+### What's missing
+
+Nothing on the SESSIONS landing surface tells Sam how old his manifest is. The exporter writes `manifest.generatedAt` (`packages/schema/src/unified.ts:300`, `packages/exporter/...` writes `Date.now()`), but the viewer reads it for type purposes only — see `ChatArchViewer.tsx:1217` (sets it on synthetic uploaded manifests) and `data/fetch.test.ts:6` (test fixture). **There is no `useMemo`/render path in `ChatArchViewer.tsx` or `UpperPanel.tsx` that surfaces it.**
+
+### Suggestions
+
+- Add a STALENESS chip to `UpperPanel.tsx`'s stats row (next to RANGE, line 408-414). Copy: `INDEXED 92d ago` with hover tooltip showing the ISO timestamp. Color the chip warning-yellow when `>30d` and danger-red when `>90d`.
+- Hoist the AnalysisLauncher `STALE` pattern into a viewer-wide banner when `(Date.now() - manifest.generatedAt) > 30d` — same persistent banner mechanism as `rescanBanner` (`ChatArchViewer.tsx:2013-2032`), reading "Index is 3 months old · RE-SCAN" with a primary action button.
+- The "boot" animation logic (`ChatArchViewer.tsx:370-400`) is gated on `BOOT_SEEN_KEY` — already a per-browser-once flag. A parallel "stale-banner-seen-this-session" flag would let the warning show once and dismiss without re-nagging.
+
+---
+
+## Surface 3 — UPDATE LOCAL flow
+
+**Verdict — the *delta phrasing* is well-designed (the best returning-user touch in the product), but the discoverability is poor and the success banner only stays for 6 seconds.**
+
+### What works (`ChatArchViewer.tsx:1607-1681`)
+
+- Pre-rescan snapshot of per-source counts (line 1613-1619), then post-rescan delta computation (line 1630-1642).
+- Honest copy variants: `"12 new local sessions"`, `"3 local sessions removed"`, `"no new local sessions"` (line 1637-1642).
+- Delta + duration + new total: `"Rescan complete in 4.2s · 12 new local sessions (847 total local)"` (line 1643).
+- Banner + toast, with auto-dismiss only for `ok` (errors persist until ✕ click, line 1686-1690). This is correct.
+
+### Friction
+
+- **The button is buried.** Sam has to (a) notice the sidebar `DAT/DATA` item (`Sidebar.tsx:207-232`), (b) open the panel, (c) click `UPDATE LOCAL`. Returning users won't think "I bet there's a panel". TopBar used to host the action but v2 deliberately moved it (`TopBar.tsx:8-23`); the result is that the most-rewarding action is now two clicks deep.
+- **6-second auto-dismiss is too short** for a returning user reading "12 new local sessions" — that line is the entire reward. Sam glances at the screen, looks down to read, looks back, and the banner is gone (`ChatArchViewer.tsx:1686-1690` clears at 6000ms).
+- **No "what's new" surface** after the rescan. The banner says "12 new", but there's no link/button to "show me those 12". Sam must mentally re-orient by sorting RECENT and trusting the top-N rows are the new ones.
+- The empty case ("no new local sessions") reads as anticlimactic — there's no "your last activity was X days ago" framing to tell him he simply hasn't been chatting.
+
+### Suggestions
+
+- Either keep RESCAN in the TopBar (regress the v2 D4 decision) or auto-prompt the panel open when manifest is stale (`>30d`).
+- Lengthen success banner to ~15s, or until the user clicks elsewhere — the message has more information density than typical toasts.
+- Make the banner clickable: clicking "12 new local sessions" sets `sortBy = 'recent'`, scrolls SESSIONS to top, and visually highlights the top-12 rows for a few seconds.
+- For empty deltas: include "Last session was Feb 8 (92 days ago)" in the no-new-sessions copy.
+
+---
+
+## Surface 4 — Sessions list (KPI tiles + sparkline + filter bar)
+
+**Verdict — recent-first sort is the right default; sparkline is excellent but doesn't say "you stopped here"; KPI strip is cost-focused, not activity-focused.**
+
+### What works
+
+- Default SORT = `recent` (`ChatArchViewer.tsx:246`, `data/search.ts:62-78`), persisted in localStorage so a returning user sees the same ordering they left.
+- Sparkline shows weekly session volume + peak + avg (`Sparkline.tsx:100-200`); a 3-month gap of empty buckets at the right edge would visually telegraph "you stopped chatting" — but only if Sam interprets that gap.
+- SessionCard uses relative time (`util/time.ts:30-50`): cards say "92d ago" / "Feb 8" instead of raw timestamps, which helps recency parsing.
+
+### Friction
+
+- The KPI strip (`UpperPanel.tsx:485-543`-ish) is cost/token/tool-focused: TOTAL COST, OUTPUT TOKENS, TOP TOOL, TOP PROJECT. None of these answer "what was I working on lately" — they're aggregate-over-corpus metrics. Three-month-stale cost is the same number as today's cost, so the user gets no "since last visit" reward.
+- No "RECENT WEEK" / "LAST 7 DAYS" filter pill — Sam who wants to see "what did I do recently" must eyeball the grid and trust the sort.
+- The sparkline tooltip surfaces per-bucket counts on hover but doesn't call out the latest week vs the all-time peak.
+
+### Suggestions
+
+- Add a "LAST 7 DAYS" / "LAST 30 DAYS" quick-filter chip to the FilterBar (or the SORT dropdown could gain a "RECENT 7d" option).
+- Surface a "LATEST: Feb 8" or "STOPPED: 92d ago" annotation on the right edge of the sparkline, anchored to the last non-empty bucket.
+- Replace one KPI tile (or add a fifth) with "RECENT" — sessions in last 7 days, click → filters to that window.
+
+---
+
+## Surface 5 — Sidebar mode-switcher
+
+**Verdict — the default mode is `command` (SESSIONS), which is reasonable but not optimal for re-orientation. PROJECTS would be a stronger default for a returning user.**
+
+### Layout (`Sidebar.tsx:52-79`)
+
+```
+BROWSE       INSIGHTS      ACTIONS
+PROJECTS     PRACTICE      DATA
+TOPICS       CORRECTIONS
+SESSIONS     ANALYSIS
+             COST
+```
+
+PROJECTS sits above SESSIONS in the BROWSE group (intentionally — see comment line 56-58: "narratives live on projects, so PROJECTS is where users land for insights about how their work is going"). But the *default mode* is SESSIONS (`ChatArchViewer.tsx:228`), contradicting the IA's stated priority.
+
+### Friction
+
+- The sidebar puts PROJECTS first visually but the default-on-load is the third entry. A returning user who scans the sidebar reads "PROJECTS · TOPICS · SESSIONS" but lands on SESSIONS — the implicit message of the IA ordering is "PROJECTS is the primary surface" but the bootstrap state contradicts that.
+
+### Suggestions
+
+- Either default to `mode = 'projects'` for users with non-empty `analysis/projects.json` (the v2 spec's intent), or keep SESSIONS as default but make PROJECTS visually less primary in the sidebar order.
+- A fully-resolved approach: a "WELCOME BACK" landing for users whose last visit was >30d ago — see Surface 13 below.
+
+---
+
+## Surface 6 — ProjectsMode
+
+**Verdict — strong re-orientation surface IF projects.json was generated; sorted by `lastActivityAt desc` so the top row IS the project Sam last touched.**
+
+`ProjectsMode.tsx:165-174` sorts real projects by `lastActivityAt desc`, with `[UNASSIGNED]` pinned last. Each row shows `last 92d ago` (line 228, via `lastActivityRelative` line 69-81 — this is one of the few places in the viewer that writes "Nmo ago" / "Ny ago" for spans >30d).
+
+### Friction
+
+- The "last activity" relative time is *per-project*, not "since you last looked at chat-arch". Sam can't tell which projects had activity *since his last visit*. There's no "NEW SINCE 92d" indicator.
+- If `projects.json` is empty (analysis never ran in his stale dataset, since the corrections + topics tier-2 runs require manual triggering), this surface degrades to `<EmptyState>` "NO PROJECTS YET" — a frustrating welcome.
+- No "I've been working on X lately" callout — just a sorted list. He has to read 5-10 rows to absorb the picture.
+
+### Suggestions
+
+- Highlight projects whose `lastActivityAt > now - 30d` with a "RECENT" badge.
+- Group rows: "Active recently (last 30d)" / "Older". Visual chunking.
+
+---
+
+## Surface 7 — TopicsMode
+
+**Verdict — sorted by session-count, not recency. Useless for re-orientation as it stands.**
+
+`TopicsMode.tsx:94-96` sorts by `sessionIds.length desc`. Sam's most-frequent topic over 3 years dominates; his most-recent topic doesn't surface unless it happens to be high-volume.
+
+### Suggestions
+
+- Add a sort toggle: count vs most-recent. Or add a "ACTIVE LAST 30d" filter.
+
+---
+
+## Surface 8 — CommandMode + TimelineMode + CostMode
+
+### CommandMode (`CommandMode.tsx`)
+- The grid renders sessions in the order it receives them (already sorted by `recent` from the parent). No "since last visit" reward.
+
+### TimelineMode (`TimelineMode.tsx`)
+- Lane chart by source. The right edge is the most recent activity. **A 3-month gap visually shows up here** — the cluster of dots ends in February. This is one of the better visual returning-user signals, but Sam must (a) toggle GRID → TIMELINE in the MidBar (`ChatArchViewer.tsx:2192-2213`), and (b) know to read the gap. No annotation.
+
+### CostMode (`CostMode.tsx`)
+- All-time aggregate. Doesn't answer "what changed since last visit".
+
+### Suggestions
+
+- Annotate the timeline's right edge: "Latest: Feb 8 (92d ago)" + dotted vertical line at "today" so the gap is read as data, not as the chart's edge.
+
+---
+
+## Surface 9 — Search (TopBar)
+
+**Verdict — substring search is broad (title + summary + preview + cwd + project + tools + models per `data/search.ts:12-43`), but doesn't help "I half-remember a thing in February".**
+
+Sam typing `"the migration thing"` works **only** if those literal words appear in title/summary/preview. There's no semantic search, no date-scoped search ("February"), no "since 2026-01-01" qualifier.
+
+### Suggestions
+
+- Honor `before:`/`after:` operators in the query. E.g. `migration after:2026-01-01`.
+- If the embed pipeline is already loaded (he ran semantic analysis once), reuse the BGE embeddings for semantic search.
+
+---
+
+## Surface 10 — CorrectionsPanel
+
+**Verdict — Sam would NOT see a returning-user reward here unless he knows to navigate to CORRECTIONS and re-run mining. The panel doesn't tell him "N new corrections accumulated since last mining run".**
+
+### What's there (`CorrectionsPanel.tsx`)
+
+- Header shows `Generated <ISO>` (line 875-879) — raw timestamp, not relative.
+- `MiningTrigger` (line 895-970) shows "AUTO WINDOW · Nd · M candidates" or "no new candidates" (line 920-924).
+- Mining is gated on `candidateCount` from the heuristic, which itself only refreshes when the exporter rescans (so a stale manifest gives stale candidates).
+
+### Friction
+
+- No top-of-panel banner reading "5 new candidates since you last mined" — Sam has to read the AUTO WINDOW row to figure that out.
+- The "no new candidates" idle state reads correctly but doesn't explain *why* there are no new candidates ("because your manifest is 92 days old — try RE-SCAN first"). The two systems (rescan + mining) have no cross-reference in the UI.
+
+### Suggestions
+
+- When `manifest.generatedAt < corrections.generatedAt - 30d`, show a one-liner: "Manifest is older than corrections; re-scan first" with a RE-SCAN button.
+
+---
+
+## Surface 11 — NuclearReset (accidental-destruction risk)
+
+**Verdict — well-defended via the two-step armed-then-confirm pattern AND auto-hidden when counts are zero. But the `DELETE…` chip is rendered as a full sidebar peer to other modes, which feels too visible for a "delete my data" action.**
+
+### Defenses in place (`NuclearReset.tsx`)
+
+- Self-hides when all source counts are 0 (line 108-116). A returning Sam **with data** sees the chip. A wiped-state Sam doesn't.
+- Two-step confirm: first click sets `phase='armed'`, button label becomes `"YES — DELETE 12"` (line 187-195, 291-297). Second click commits.
+- Editing checkboxes in armed state re-disarms (line 179-180, 184-185) — good.
+- "Are you sure?" copy with consequence summary (line 364-371): "This wipes 12 sessions and regenerates analysis files on the next scan. It cannot be undone."
+- Cache-busts the post-wipe reload (line 281-283).
+- All-cloud-derived IDBs wiped together via `Promise.allSettled` (line 257-261, matches CLAUDE.md guidance).
+
+### Friction
+
+- The DATA panel (`DataPanel.tsx:334-343`) renders the DELETE section AS A PEER to UPLOAD/SCAN. A user opening DATA to re-scan sees three sections — UPLOAD CLOUD, SCAN LOCAL, **DELETE …** — at equal visual weight. The destructive section should be visually de-emphasized (collapsed accordion, "Advanced" footer, or a separate confirmation surface).
+- The DELETE button label `DELETE…` (line 311) and the panel button `DELETE SELECTED` are uppercase-LCARS-style, which matches the rest of the chrome — but that means destructive actions look the same as `UPDATE LOCAL` / `LOAD ✓`. No visual hierarchy says "this one is dangerous".
+- `lcars-top-bar__source-btn--destructive` peach-styled chip is the only visual differentiation; on first glance it reads as "another colored button" rather than "warning".
+- If Sam clicks `DELETE…` purely out of curiosity, the dropdown opens with all checkboxes off. Good. But the dev-comment at lines 13-32 is correct that the dropdown also "doubles as the viewer's documentation of its own data sources" — so curious clicks are *expected*. Risk is low IF the user reads the panel before checking boxes.
+
+### Where the risk lives
+
+The biggest risk is **muscle memory misclick**: Sam opens DATA panel for SCAN LOCAL, his cursor lands one row too low, hits DELETE…, and is now in the dropdown. The dropdown is non-modal; clicking outside closes it (line 144-153). If he's quick and unobservant, he could check `[x] cloud` and click `DELETE SELECTED` (label includes count, so he sees `DELETE SELECTED (847)`) → button arms → clicks again → gone. Two clicks total, both with affirmative-styled labels.
+
+### Suggestions
+
+- Move DELETE to a separate "Danger zone" foldout at the bottom of the DATA panel, collapsed by default with a "Show advanced" / "Delete data ▸" toggle.
+- For the all-selected case (`DELETE EVERYTHING`), require typed confirmation — "type DELETE to confirm" — even though the dev-comment at line 20-22 reasons against this. The all-everything path is the irreversible one; bureaucracy is appropriate.
+- Render the armed-button state in red (currently `lcars-delete-dropdown__primary--armed` modifier exists — verify it has danger styling in `styles.css`).
+
+---
+
+## Surface 12 — ActivityLogPanel
+
+**Verdict — pure session-scoped log, NOT a "you did X recently" timeline. Useless for re-orientation.**
+
+`ActivityLogPanel.tsx`: in-memory ring buffer, `useActivityLog` hook is initialized empty on every page load (line 1-28 description). After Sam's reload it shows "No activity yet" until he triggers something.
+
+### Suggestion
+
+- This is fine for what it is (a runtime activity console). Don't repurpose it. A "your timeline" surface should be a separate view — see Suggestion below for a "WELCOME BACK" landing.
+
+---
+
+## Surface 13 — Empty-state copy after accidental data wipe
+
+**Verdict — sets him up to recover but with cold-start framing, no "we still know your old data exists somewhere" hint.**
+
+`ChatArchViewer.tsx:1867-1901`: empty manifest path renders TrustStrip + ErrorState "NO DATA YET" + UploadPanel (with onScanLocal when local available). Copy at line 1872-1873 explains the three paths (upload ZIP / scan local / load demo).
+
+### Friction
+
+- After `NuclearReset`, the page reloads with `?_reset=<ts>` (`NuclearReset.tsx:281-283`). The viewer strips this and renders the empty state. There is **no acknowledgment** that the user just performed a destructive action. He gets the same empty state a fresh-clone user gets. Bug-recovery framing ("Just deleted by mistake? Re-scan to rebuild local data") would be valuable.
+
+### Suggestions
+
+- Persist a `chat-arch:last-reset-at` timestamp in localStorage (it's a `chat-arch:*` key but NuclearReset only wipes those when `allSelected` — line 267-278). Set it on every wipe. If `Date.now() - lastResetAt < 5min`, show a "JUST DELETED — re-scan to rebuild your local index" banner above the empty state.
+
+---
+
+## Staleness audit — surfaces that *could* show "last indexed" but don't
+
+| Surface | File:line | Could show | Currently shows |
+|---|---|---|---|
+| TopBar EARTHDATE | `TopBar.tsx:101-103` | manifest.generatedAt | TODAY's date — actively misleading |
+| UpperPanel stats row (next to RANGE) | `UpperPanel.tsx:408-414` | "INDEXED 92d ago" | RANGE chip (corpus span) only |
+| MidBar | `MidBar.tsx` / `ChatArchViewer.tsx:2178-2235` | last-scan timestamp | mode label only |
+| DataPanel header | `DataPanel.tsx:183-199` | "Last scanned 92d ago" near UPDATE LOCAL | "Add chat data, refresh, or delete" lead copy |
+| UPDATE LOCAL button caption | `DataPanel.tsx:286-291` | "Last 92d ago" | hint copy / running phase only |
+| Sidebar | `Sidebar.tsx` | DAT pill could badge "STALE" | no temporal info |
+| AnalysisLauncher idle states | `AnalysisLauncher.tsx:380-411, 414-444` | bundle.generatedAt relative | "STALE" / "DONE" by id-set comparison only |
+| CorrectionsPanel header | `CorrectionsPanel.tsx:875-879` | "Mined 3mo ago" | raw ISO timestamp |
+| TierSheet | `TierSheet.tsx:140-141` | already shows ISO; should also show relative | ISO date only |
+| Boot animation | `ChatArchViewer.tsx:370-400` | could be skipped + replaced with "WELCOME BACK · last visit Nd ago" | one-shot per browser |
+| Empty state | `ChatArchViewer.tsx:1867-1901` | "Your last index ran Nd ago, but no manifest is loaded" — recovery hint | cold-start copy |
+
+**One change** would improve almost all of these: a single shared `LastIndexedChip` component that renders `manifest.generatedAt` relative-formatted (warning color when >30d) — drop it into UpperPanel, DataPanel, Sidebar's DATA pill, and the empty state.
+
+---
+
+## Returning-user default-mode assessment
+
+The default is `mode = 'command'` (SESSIONS) per `ChatArchViewer.tsx:219-229`. The hash-driven branches override only if a deep-link hash is present.
+
+For a 3-months-stale returning user, **SESSIONS is acceptable but not optimal**:
+
+- **Pros**: recent-sort default puts his last session top-left. He can scan and re-anchor by title.
+- **Cons**: chrome-heavy (KPI strip is cost-focused, sparkline trails into 3 months of zeros without annotation, FilterBar pills demand interaction). The first thing he sees is a wall of cards and aggregates — not "here's what you were doing".
+
+**Better options**:
+- For users with `analysis/projects.json` populated (the v2 happy path): default to `mode = 'projects'`. ProjectsMode is sorted `lastActivityAt desc` so the top row IS the project he last worked on. Single-row scan → re-orientation done.
+- A "WELCOME BACK" mini-mode for `manifest.generatedAt < now - 30d`: project rollup + "since last visit" delta + one-click RE-SCAN. This is what the product is missing entirely.
+
+---
+
+## Accidental-destruction risk audit
+
+| Path | Confirm steps | Where | Risk |
+|---|---|---|---|
+| NuclearReset DELETE … | 2 clicks (armed → commit), checkbox-gated, count shown in CTA, "Are you sure?" copy | `NuclearReset.tsx:187-289` | Low — well-defended. Risk only if Sam misclicks DATA → DELETE… in muscle-memory and is sloppy. |
+| `/api/clear` POST | x-requested-with header CSRF gate, requires explicit source list in body | `apps/standalone/src/pages/api/clear.ts` | Low — only the panel calls it. |
+| `/api/clear-corrections` POST | (not audited here, presumed similar) | `apps/standalone/src/pages/api/clear-corrections.ts` | Low |
+| UNLOAD chip | one click, irreversible (drops uploaded ZIP from IDB) | `UpperPanel.tsx:430-438` | **Moderate** — single click, no confirm. Sam clicking out of curiosity loses his cloud upload. |
+| All-cloud wipe via NuclearReset | wipes 3 IDBs (chat-arch, semantic-labels, bench-results) — matches CLAUDE.md spec | `NuclearReset.tsx:244-262` | Low — correctly scoped. |
+| All-selected wipe wipes localStorage `chat-arch:*` | `NuclearReset.tsx:267-278` | Loses sortBy, demo banner dismissal, etc. | Acceptable — gated on all-selected. |
+
+**Surprise finding**: the **UNLOAD** chip in the UpperPanel (`UpperPanel.tsx:430-438`) is a single-click destructive action with no confirm. It's labeled `UNLOAD` (not DELETE), which softens the perceived risk, but the consequence is identical: the uploaded ZIP is dropped from IDB and the manifest reverts to disk-only. For Sam exploring chrome out of curiosity, this is more accident-prone than NuclearReset because there's no two-step.
+
+---
+
+## Top 5 Improvements (ranked by returning-user impact)
+
+1. **Surface `manifest.generatedAt` everywhere it matters.** Add a `LastIndexedChip` (relative time, warning at >30d, danger at >90d) to UpperPanel stats row, DataPanel header, and as a Sidebar DATA-pill badge. Single source of truth: `manifest.generatedAt` from `packages/schema/src/unified.ts:300`. **Impact: Sam knows his data is stale within ~3 seconds of landing.** *Files to touch: `UpperPanel.tsx:408-414`, `DataPanel.tsx:183-199`, `Sidebar.tsx:207-232`, plus a new component.*
+
+2. **Add a "WELCOME BACK" banner / soft-modal for stale returners.** When `Date.now() - manifest.generatedAt > 30d` AND `chat-arch:welcome-back-seen-this-session` is unset, render a persistent banner at the top of the viewer: "Your index is 92 days old · 47 unprocessed local sessions · [RE-SCAN]". Reuse the `rescanBanner` slot (`ChatArchViewer.tsx:2013-2032`). **Impact: turns the staleness signal into a one-click recovery.** *Files: `ChatArchViewer.tsx` + a new banner state.*
+
+3. **Make the rescan delta clickable and persistent.** The "12 new local sessions" reward currently auto-dismisses at 6s (`ChatArchViewer.tsx:1686-1690`). Lengthen to 20-30s, and make the message a button that filters SESSIONS to "last 7 days" (or the post-scan delta window) and scrolls to top with a 2s flash on the new rows. **Impact: post-scan moment becomes a re-orientation surface, not a fleeting toast.** *Files: `ChatArchViewer.tsx:1607-1690`.*
+
+4. **Default to PROJECTS mode for returning users with projects.json.** When `mode` is not URL-hash-overridden AND `projects.length > 0` AND `Date.now() - manifest.generatedAt > 7d`, default to `mode='projects'` instead of `'command'`. ProjectsMode's `lastActivityAt desc` sort gives instant re-orientation. Keep SESSIONS default for fresh users. **Impact: the default surface answers "what was I working on" without a click.** *Files: `ChatArchViewer.tsx:219-229`.*
+
+5. **Move DELETE behind a "Danger zone" foldout in DataPanel.** Currently rendered at equal visual weight to UPDATE/UPLOAD (`DataPanel.tsx:334-343`). Risk of muscle-memory misclick is low but non-zero, and the visual prominence implies the action is routine. Collapse it under "Advanced ▸" by default. Also: add typed-confirmation (`type DELETE to confirm`) for the all-everything path only. **Impact: protects curious returners from accidental wipes; doesn't burden routine UPDATE flows.** *Files: `DataPanel.tsx:334-343`, `NuclearReset.tsx:299-403`.*
+
+---
+
+## What works (Sam would appreciate)
+
+1. **Persisted SORT preference** (`ChatArchViewer.tsx:107-116, 246-254`): default `recent`, persisted in localStorage. He left sorted-by-recent; he returns sorted-by-recent. The grid arrangement matches his memory.
+
+2. **Honest delta phrasing on rescan** (`ChatArchViewer.tsx:1630-1643`): "12 new local sessions" / "no new local sessions" / "3 local sessions removed" with the time + total in tow. This is the most thoughtful returning-user touch in the product. The fact that someone wrote a code comment ("delta reads immediately as 'scan was worth doing'", line 1611-1612) suggests this was deliberate.
+
+3. **NuclearReset's two-step confirm + count-in-label** (`NuclearReset.tsx:291-297`): `DELETE SELECTED (847)` → `YES — DELETE 847`. The count travels with the affirmation, so Sam can't accidentally confirm without seeing the consequence.
+
+4. **TopBar SEARCH disabled in detail overlay** (`TopBar.tsx:60, 117-122`, `ChatArchViewer.tsx:2086`). Returning users who drill into a session and start typing aren't silently mutating the underlying list they'll come back to.
+
+5. **`hasLocalData`-aware button labels** (`DataPanel.tsx:123-138, 148-160`): SCAN LOCAL → UPDATE LOCAL, UPLOAD CLOUD → UPDATE CLOUD. This is exactly the right copy adjustment for returners — it telegraphs "you've done this before; this just refreshes". Pity the actual stale-detection isn't equally surfaced.

--- a/research/refocus-plan.md
+++ b/research/refocus-plan.md
@@ -1,0 +1,100 @@
+# chat-arch refocus plan
+
+Source: persona evaluations in `research/persona-evals/{maya,david,priya,sam}.md`.
+
+## North star
+
+> **Find the rules Claude keeps breaking. Patch your CLAUDE.md / skills.
+> Prove the loop closed.**
+
+The unique pitch is the closed-loop self-improvement workshop. Browsing
+and analytics are commodity; the workshop is the moat. Every UI surface,
+copy choice, and feature decision must serve this loop or be demoted.
+
+## What "refocus" requires (3 levers)
+
+| Lever | What it controls | Failure mode if skipped |
+|---|---|---|
+| **Visual hierarchy** | What is loud vs. quiet — sidebar order, default mode, empty-state copy, headlines | Loop is buried; users find the dashboard, not the workshop |
+| **Feature gating** | What is available vs. hidden — hosted vs. local, modes behind disclosure, CTA visibility | David's hosted dead-ends; Maya's loop never closes |
+| **Code mass** | What stays in the repo vs. gets deleted | Maintenance budget bleeds into modes that don't earn it; quality of the loop suffers |
+
+A visual-only refocus is reversible noise. A gating-only refocus leaves
+dead code rotting. Both are half-measures. Real refocus hits all three.
+
+## Phasing
+
+### Phase 0 — Commit (this PR)
+- This document.
+- Update `README.md` opening to lead with the workshop pitch (not "personal archive").
+- Update empty-state `ErrorState` detail to state what the product does in one line above the action buttons.
+
+### Phase 1 — Close the loop (load-bearing)
+Validates the framing. Maya is the user.
+- New `POST /api/apply-correction` endpoint writing `appliedAt` (schema already supports it at `packages/schema/src/correction.ts`).
+- Wire APPLY button at `CorrectionPatternCard.tsx:246-254`.
+- Make correction instances clickable → source session (mirror `PracticeMode.tsx:140-146`).
+- New `applied-improvements.json` ledger: timestamped patches + the rule they patched.
+- Persistent rescan delta (drop the 6s toast at `ChatArchViewer.tsx:1686-1690`; pin into ActivityLogPanel).
+
+### Phase 2 — Refocus the UI
+- Sidebar restructure: **WORKSHOP** (Corrections, Practice, Skill seeds, Applied) | **BROWSE** (Sessions, Detail, Search) | **ANALYTICS** (collapsed disclosure: Projects, Topics, Sparkline).
+- Default mode for returning users with `appliedAt` history: a new **Workshop / "Since you patched"** surface — N new violations of patched rules, M new clusters since last patch, freshness chip with `manifest.generatedAt`.
+- Default mode for first-time users with data: Sessions list with a single "RUN MINING" CTA banner.
+- Pin `LastIndexedChip` (manifest.generatedAt) in the TopBar — replaces or sits next to EARTHDATE.
+- TrustStrip stays footer-pinned post-load (David's complaint).
+
+### Phase 3 — Gate or cut misaligned modes
+
+| Mode | Decision | Rationale |
+|---|---|---|
+| ConstellationMode | **Cut** | Visualization without a clear job-to-be-done; doesn't feed the loop |
+| TopicsMode | **Defer behind opt-in disclosure** | 36MB embed download is expensive; topics are commodity insight; not load-bearing for workshop |
+| CostMode | **Cut** (or defer to ANALYTICS disclosure) | Cost is interesting but doesn't drive a patch decision |
+| CommandMode | **Defer behind ANALYTICS disclosure** | Useful for power users but not the headline |
+| TimelineMode | **Keep** but demote to ANALYTICS group | Sparkline overlaps; one of them becomes the canonical timeline |
+| ProjectsMode | **Keep** in BROWSE — useful re-orientation | Sam's path; cheap to keep |
+| PracticeMode | **Promote to WORKSHOP group** | Already has the clickthrough pattern Maya needs |
+| DetailMode | **Keep** — table stakes | – |
+
+Cutting means deleting the source files + tests, not hiding behind a
+flag. Hiding behind flags is how code mass accumulates. If we're wrong,
+git history brings them back in one revert.
+
+### Phase 4 — Hosted = demo + sales
+
+- chat-arch.dev becomes a sales site: hero pitch + live demo (LOAD DEMO DATA pre-loaded) + install instructions + GitHub link.
+- No CHOOSE ZIP on the hosted build. Cloud-only users are not the target customer for the workshop pitch — the loop requires patching CLAUDE.md, which assumes local Claude Code use.
+- All four CLI-only CTAs David flagged disappear because hosted no longer pretends to be a full product.
+- Self-host is the actual product surface; hosted is the storefront.
+
+### Phase 5 — High-leverage additions
+- **Weekly digest** — "Sunday review: 3 patterns to patch this week."
+- **Applied-improvements timeline** — patch ledger with rule-broken-since-applied counts. The ROI artifact.
+- **Diff-against-yourself** — "Your tool-use changed since you patched X 6 weeks ago."
+
+## Decisions to confirm before Phase 3
+
+These are real cuts. None of them is reversible without revert work.
+
+- [ ] **Cut ConstellationMode entirely**
+- [ ] **Defer TopicsMode behind opt-in disclosure** (don't cut — costly to rebuild)
+- [ ] **Cut CostMode entirely**
+- [ ] **Defer CommandMode behind ANALYTICS disclosure**
+- [ ] **Drop CHOOSE ZIP from hosted build**
+- [ ] **Promote PracticeMode + Corrections to top-level WORKSHOP group**
+- [ ] **Make APPLY + clickthrough P0 (this sprint)**
+
+## Anti-goals (what we are explicitly NOT building)
+
+- A general AI conversation dashboard (David's product). Anthropic + others will out-feature us on this.
+- A topic-clustering analytics tool. The 36MB embed cost only pays off for the workshop loop, not as a standalone feature.
+- A team / org / multi-user product. Personal workshop only.
+- A hosted SaaS. Self-host is the product; hosted is the storefront.
+
+## Success metric
+
+For Maya, in one sentence: *"I came back today, ran UPDATE LOCAL, saw 3
+new violations of rules I patched last month, hit APPLY on a new
+correction, and re-scanned to verify the loop closed."* If a session
+that doesn't end this way is the failure mode.


### PR DESCRIPTION
## Summary

Phase 0 of the refocus plan ([research/refocus-plan.md](../blob/feature/refocus-phase-0-pitch/research/refocus-plan.md)). Commits the new framing to writing — workshop, not archive — and surfaces it on the empty-state landing + README so future phases have a north star.

The plan came out of 4 persona walkthroughs ([research/persona-evals/](../tree/feature/refocus-phase-0-pitch/research/persona-evals)). The headline finding across all four: chat-arch's unique pitch is the closed-loop self-improvement workshop (mine corrections → patch CLAUDE.md → prove the loop closed), but it's currently buried under 8 modes + 5 sidecar analyses + a generic "personal archive" framing that doesn't differentiate from any other chat viewer.

- **README opening**: leads with *Find the rules Claude keeps breaking. Patch your CLAUDE.md. Prove the loop closed.* Demotes browsing/analytics to "underneath the workshop."
- **Empty-state landing**: new `lcars-empty-pitch` section between TrustStrip and the NO DATA YET ErrorState — directly addresses Priya's "landing never says what the product does" finding.
- **Bundled SCAN LOCAL empty-state work**: the earlier session's UploadPanel SCAN LOCAL button + WELCOME-pill removal + button-reorder also ride along, since they touch the same surface and are part of the same pitch refresh.

## Phase 0 is the alignment commit

Phase 1 (close Maya's corrections loop: APPLY endpoint, instance clickthrough, applied-improvements ledger, persistent rescan delta) starts as the next PR. Phases 2–5 are queued in the plan; Phase 3 (the irreversible cuts: ConstellationMode, CostMode, etc.) explicitly pauses for confirmation.

## Test plan

- [x] `pnpm test` — 363/363 viewer tests pass
- [x] `pnpm lint` — clean (5 pre-existing warnings, untouched)
- [x] `pnpm build` — clean
- [ ] Visual check on http://localhost:4323/ — pitch renders above NO DATA YET; SCAN LOCAL is primary on local-build; CHOOSE ZIP demoted; LOAD DEMO DATA unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)