### PR TITLE
refocus(phase-2a): chrome refocus — sidebar IA + LastIndexedChip + footer TrustStrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,38 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-08
+
+### Added
+
+- **Applied-improvement ledger** — a new sidecar
+  `analysis/applied-improvements.json` records every `ProposedUpgrade`
+  the user has clicked APPLY on. The viewer merges it over
+  `corrections.json` at read time so `applied`/`appliedAt`/
+  `recurringPostApplication` reflect the user's actions, while
+  `corrections.json` itself stays a pure mining-pipeline output (a
+  re-mine never clobbers the apply history).
+- **`POST /api/apply-correction` endpoint** writes the ledger.
+  Idempotency key: `(patternId, proposedUpgrade.target,
+  proposedUpgrade.targetPath)`. Re-applying replaces the prior entry.
+- **APPLY button** in the corrections panel — replaces the placeholder
+  disabled button. Inline confirm row → POST → "APPLIED ✓" pessimistic
+  swap. Concurrent applies in one card are blocked while a write is
+  in flight.
+- **Instance clickthrough** — each instance excerpt in a correction
+  pattern card is now a button that opens the source session in detail
+  view, matching the Practice-mode evidence-pill pattern.
+- **Persistent rescan-delta chip** — the rescan success banner gains an
+  explicit ✕ dismiss button (no more 6s auto-vanish), per-source
+  delta breakdown is logged to the activity log, and a `RESCAN: +N`
+  TopBar chip persists until dismiss or the next rescan.
+
+### Changed
+
+- `EXPORTER_VERSION` bump (0.7.0 → 0.8.0) signals the new
+  `applied-improvements.json` shape under `analysis/`. The file is
+  optional — viewers older than this release ignore it cleanly.
+
 ## [0.7.0] — 2026-05-08
 
 ### Added

--- a/apps/standalone/src/pages/api/apply-correction.ts
+++ b/apps/standalone/src/pages/api/apply-correction.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -70,8 +70,15 @@ function badRequest(message: string): Response {
  * race the `read → splice → write` cycle and one would silently
  * clobber the other. Concurrent callers get 409, matching the
  * `inFlight` posture in `/api/mine-corrections.ts`.
+ *
+ * IMPORTANT (TOCTOU): `inFlight` is set SYNCHRONOUSLY at handler entry,
+ * before any `await` (including `request.json()`), so two POSTs that
+ * arrive in the same microtask cannot both pass the gate. Earlier
+ * versions of this handler set `inFlight` after parsing the body; both
+ * concurrent calls saw `null`, parsed in parallel, and raced the
+ * read-modify-write of the ledger.
  */
-let inFlight: Promise<void> | null = null;
+let inFlight: Promise<Response> | null = null;
 
 function repoRoot(): string {
   const here = dirname(fileURLToPath(import.meta.url));
@@ -197,26 +204,87 @@ export function isSameApplyKey(
   );
 }
 
-async function loadLedger(path: string): Promise<AppliedImprovementsFile> {
-  try {
-    const raw = await readFile(path, 'utf8');
-    const parsed = JSON.parse(raw) as Partial<AppliedImprovementsFile>;
-    if (
-      parsed &&
-      typeof parsed === 'object' &&
-      Array.isArray(parsed.entries)
-    ) {
-      return {
-        schemaVersion: 1,
-        generatedAt:
-          typeof parsed.generatedAt === 'number' ? parsed.generatedAt : Date.now(),
-        entries: parsed.entries as AppliedImprovement[],
-      };
-    }
-  } catch {
-    // Missing or malformed — fall through to fresh envelope.
+/**
+ * Sentinel error thrown when the ledger file exists but is unreadable
+ * (parse failure, wrong shape, …). The POST handler converts this to
+ * a 500 with a recovery hint rather than silently overwriting the file
+ * — silently producing a fresh empty envelope on parse failure is how
+ * apply history would get erased by a single write following a crash
+ * or partial save.
+ */
+export class LedgerCorruptError extends Error {
+  constructor(public readonly path: string, cause?: unknown) {
+    super(
+      `ledger appears corrupted at ${path}; refusing to overwrite. ` +
+        `Inspect manually${cause instanceof Error ? `: ${cause.message}` : ''}.`,
+    );
+    this.name = 'LedgerCorruptError';
   }
-  return { schemaVersion: 1, generatedAt: Date.now(), entries: [] };
+}
+
+interface NodeFsError extends Error {
+  code?: string;
+}
+
+function isMissingFile(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as NodeFsError).code === 'ENOENT'
+  );
+}
+
+export async function loadLedger(path: string): Promise<AppliedImprovementsFile> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (err) {
+    if (isMissingFile(err)) {
+      // First-ever apply for this repo — fresh envelope is correct.
+      return { schemaVersion: 1, generatedAt: Date.now(), entries: [] };
+    }
+    // Permission errors etc. — surface, don't silently overwrite.
+    throw new LedgerCorruptError(path, err);
+  }
+  let parsed: Partial<AppliedImprovementsFile> | null = null;
+  try {
+    parsed = JSON.parse(raw) as Partial<AppliedImprovementsFile>;
+  } catch (err) {
+    throw new LedgerCorruptError(path, err);
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !Array.isArray(parsed.entries)
+  ) {
+    throw new LedgerCorruptError(path);
+  }
+  return {
+    schemaVersion: 1,
+    generatedAt:
+      typeof parsed.generatedAt === 'number' ? parsed.generatedAt : Date.now(),
+    entries: parsed.entries as AppliedImprovement[],
+  };
+}
+
+/**
+ * Atomic ledger write. Writes to a sibling `.tmp` file and renames
+ * over the destination — `fs.promises.rename` is atomic on both POSIX
+ * and Windows (NTFS rename overwrites the target in a single syscall).
+ * A kill mid-write leaves the original ledger intact rather than
+ * truncating it to zero bytes, which (combined with the strict
+ * `loadLedger` parse) would erase apply history on next read.
+ */
+export async function atomicWriteLedger(
+  ledgerPath: string,
+  next: AppliedImprovementsFile,
+): Promise<void> {
+  const tmpPath = join(
+    dirname(ledgerPath),
+    '.applied-improvements.json.tmp',
+  );
+  await writeFile(tmpPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+  await rename(tmpPath, ledgerPath);
 }
 
 /**
@@ -273,6 +341,13 @@ export function applyToLedger(
   return { next, entry };
 }
 
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
 export const POST: APIRoute = async ({ request }) => {
   if (!isLocalOrigin(request.headers.get('origin'))) {
     return csrfReject('cross-origin or missing Origin');
@@ -281,64 +356,88 @@ export const POST: APIRoute = async ({ request }) => {
     return csrfReject('missing X-Requested-With token');
   }
 
+  // Fast-fail concurrent callers BEFORE we touch the body. Two POSTs
+  // arriving in the same microtask must not both observe `inFlight ===
+  // null`; see the TOCTOU note above the `inFlight` declaration.
   if (inFlight) {
-    return new Response(
-      JSON.stringify({
+    return jsonResponse(
+      {
         ok: false,
         error:
           'Another apply is already writing the ledger. Retry in a moment.',
-      }),
-      { status: 409, headers: { 'content-type': 'application/json' } },
+      },
+      409,
     );
   }
 
-  let parsed: unknown;
-  try {
-    parsed = await request.json();
-  } catch {
-    return badRequest('invalid JSON body');
-  }
-  const validation = validateApplyBody(parsed);
-  if (!validation.ok) return badRequest(validation.error);
-
-  const sidecarDir = join(standaloneDataDir(), 'analysis');
-  const ledgerPath = join(sidecarDir, 'applied-improvements.json');
-
-  let release: () => void = () => {};
-  inFlight = new Promise<void>((res) => {
-    release = res;
+  // Claim the slot synchronously (no `await` between this assignment
+  // and the gate above). The deferred-promise pattern lets us resolve
+  // the slot with the actual response when the body finishes — same
+  // shape as `mine-corrections.ts`'s `completed` promise but inlined
+  // because this handler is request/response, not streaming.
+  let resolveInFlight!: (r: Response) => void;
+  let rejectInFlight!: (e: unknown) => void;
+  const slot = new Promise<Response>((res, rej) => {
+    resolveInFlight = res;
+    rejectInFlight = rej;
   });
+  inFlight = slot;
 
   try {
-    await mkdir(sidecarDir, { recursive: true });
-    const prev = await loadLedger(ledgerPath);
-    const { next, entry } = applyToLedger(
-      prev,
-      validation.payload,
-      Date.now(),
-      randomUUID(),
-    );
-    await writeFile(ledgerPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
-    return new Response(
-      JSON.stringify({
-        ok: true,
-        appliedImprovementId: entry.id,
-        ledgerPath,
-        entriesCount: next.entries.length,
-      }),
-      { status: 200, headers: { 'content-type': 'application/json' } },
-    );
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      const r = badRequest('invalid JSON body');
+      resolveInFlight(r);
+      return r;
+    }
+    const validation = validateApplyBody(parsed);
+    if (!validation.ok) {
+      const r = badRequest(validation.error);
+      resolveInFlight(r);
+      return r;
+    }
+
+    const sidecarDir = join(standaloneDataDir(), 'analysis');
+    const ledgerPath = join(sidecarDir, 'applied-improvements.json');
+
+    try {
+      await mkdir(sidecarDir, { recursive: true });
+      const prev = await loadLedger(ledgerPath);
+      const { next, entry } = applyToLedger(
+        prev,
+        validation.payload,
+        Date.now(),
+        randomUUID(),
+      );
+      await atomicWriteLedger(ledgerPath, next);
+      const r = jsonResponse(
+        {
+          ok: true,
+          appliedImprovementId: entry.id,
+          ledgerPath,
+          entriesCount: next.entries.length,
+        },
+        200,
+      );
+      resolveInFlight(r);
+      return r;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const r = jsonResponse({ ok: false, error: message }, 500);
+      resolveInFlight(r);
+      return r;
+    }
   } catch (err) {
-    return new Response(
-      JSON.stringify({
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
-      }),
-      { status: 500, headers: { 'content-type': 'application/json' } },
-    );
+    rejectInFlight(err);
+    throw err;
   } finally {
-    inFlight = null;
-    release();
+    // Clear the slot only AFTER the response is resolved/rejected so
+    // any second POST that observed the slot (and got 409) gets that
+    // 409 immediately rather than blocking on `slot`. The slot promise
+    // itself is GC'd once nothing references it.
+    if (inFlight === slot) inFlight = null;
   }
 };
 

--- a/apps/standalone/src/pages/api/apply-correction.ts
+++ b/apps/standalone/src/pages/api/apply-correction.ts
@@ -1,0 +1,350 @@
+import type { APIRoute } from 'astro';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type {
+  AppliedImprovement,
+  AppliedImprovementsFile,
+  ProposedUpgrade,
+  UpgradeTarget,
+} from '@chat-arch/schema';
+
+/**
+ * Phase 1 corrections-loop closure. Persists APPLY clicks to
+ * `analysis/applied-improvements.json` — a sidecar the viewer's
+ * loader merges over the canonical `corrections.json` at read time.
+ * `corrections.json` itself is never mutated, so the next mining
+ * pass can overwrite it cleanly without losing apply history.
+ *
+ * Idempotency key: `(patternId, proposedUpgrade.target,
+ * proposedUpgrade.targetPath)`. Re-applying the same upgrade
+ * REPLACES the existing entry rather than duplicating it.
+ *
+ * CSRF posture mirrors `/api/encode-pattern.ts` exactly:
+ *   1. `Origin` must parse to a loopback hostname.
+ *   2. `X-Requested-With: chat-arch-apply-correction`.
+ */
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-apply-correction';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+const VALID_TARGETS: ReadonlySet<UpgradeTarget> = new Set<UpgradeTarget>([
+  'global-claude-md',
+  'project-claude-md',
+  'settings-hook',
+  'skill',
+  'agent',
+  'command',
+  'prompt-snippet',
+]);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function badRequest(message: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: message }), {
+    status: 400,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Serializes concurrent ledger writes. Two parallel applies would
+ * race the `read → splice → write` cycle and one would silently
+ * clobber the other. Concurrent callers get 409, matching the
+ * `inFlight` posture in `/api/mine-corrections.ts`.
+ */
+let inFlight: Promise<void> | null = null;
+
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+function standaloneDataDir(): string {
+  return join(repoRoot(), 'apps', 'standalone', 'public', 'chat-arch-data');
+}
+
+interface ApplyCorrectionRequest {
+  patternId?: unknown;
+  proposedUpgrade?: unknown;
+  ruleSummary?: unknown;
+  targetFiles?: unknown;
+  notes?: unknown;
+}
+
+export interface ApplyCorrectionPayload {
+  patternId: string;
+  proposedUpgrade: ProposedUpgrade;
+  ruleSummary: string;
+  targetFiles?: string[];
+  notes?: string;
+}
+
+const MAX_NOTES_LEN = 4_000;
+const MAX_FILES_COUNT = 16;
+const MAX_FILE_PATH_LEN = 1_024;
+
+export function isValidProposedUpgrade(p: unknown): p is ProposedUpgrade {
+  if (!p || typeof p !== 'object') return false;
+  const o = p as Record<string, unknown>;
+  if (typeof o.target !== 'string') return false;
+  if (!VALID_TARGETS.has(o.target as UpgradeTarget)) return false;
+  if (typeof o.targetPath !== 'string' || o.targetPath.length === 0) return false;
+  if (typeof o.patch !== 'string') return false;
+  if (typeof o.rationale !== 'string') return false;
+  if (typeof o.applied !== 'boolean') return false;
+  if (o.appliedAt !== null && typeof o.appliedAt !== 'number') return false;
+  return true;
+}
+
+/**
+ * Validate the POST body and coerce to a strongly-typed payload.
+ * Returns `{ ok: false, error }` on any validation miss so the
+ * handler can surface a 400 with a useful message.
+ */
+export function validateApplyBody(
+  body: unknown,
+):
+  | { ok: true; payload: ApplyCorrectionPayload }
+  | { ok: false; error: string } {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, error: 'body must be a JSON object' };
+  }
+  const b = body as ApplyCorrectionRequest;
+  if (typeof b.patternId !== 'string' || b.patternId.length === 0) {
+    return { ok: false, error: 'patternId is required' };
+  }
+  if (typeof b.ruleSummary !== 'string' || b.ruleSummary.length === 0) {
+    return { ok: false, error: 'ruleSummary is required' };
+  }
+  if (!isValidProposedUpgrade(b.proposedUpgrade)) {
+    return { ok: false, error: 'proposedUpgrade is missing required fields' };
+  }
+  let targetFiles: string[] | undefined;
+  if (b.targetFiles !== undefined && b.targetFiles !== null) {
+    if (!Array.isArray(b.targetFiles)) {
+      return { ok: false, error: 'targetFiles must be an array of strings' };
+    }
+    if (b.targetFiles.length > MAX_FILES_COUNT) {
+      return { ok: false, error: `targetFiles exceeds ${MAX_FILES_COUNT} entries` };
+    }
+    const cleaned: string[] = [];
+    for (const entry of b.targetFiles) {
+      if (typeof entry !== 'string') {
+        return { ok: false, error: 'targetFiles entries must be strings' };
+      }
+      const trimmed = entry.trim();
+      if (trimmed.length === 0) continue;
+      if (trimmed.length > MAX_FILE_PATH_LEN) {
+        return { ok: false, error: 'targetFiles entry too long' };
+      }
+      cleaned.push(trimmed);
+    }
+    if (cleaned.length > 0) targetFiles = cleaned;
+  }
+  let notes: string | undefined;
+  if (b.notes !== undefined && b.notes !== null) {
+    if (typeof b.notes !== 'string') {
+      return { ok: false, error: 'notes must be a string' };
+    }
+    if (b.notes.length > MAX_NOTES_LEN) {
+      return { ok: false, error: `notes exceeds ${MAX_NOTES_LEN} chars` };
+    }
+    const trimmed = b.notes.trim();
+    if (trimmed.length > 0) notes = trimmed;
+  }
+  const payload: ApplyCorrectionPayload = {
+    patternId: b.patternId,
+    proposedUpgrade: b.proposedUpgrade,
+    ruleSummary: b.ruleSummary,
+    ...(targetFiles ? { targetFiles } : {}),
+    ...(notes ? { notes } : {}),
+  };
+  return { ok: true, payload };
+}
+
+/**
+ * `(patternId, proposedUpgrade.target, proposedUpgrade.targetPath)`
+ * is the idempotency key — re-applying replaces, never duplicates.
+ */
+export function isSameApplyKey(
+  a: AppliedImprovement,
+  patternId: string,
+  upgrade: Pick<ProposedUpgrade, 'target' | 'targetPath'>,
+): boolean {
+  return (
+    a.patternId === patternId &&
+    a.proposedUpgrade.target === upgrade.target &&
+    a.proposedUpgrade.targetPath === upgrade.targetPath
+  );
+}
+
+async function loadLedger(path: string): Promise<AppliedImprovementsFile> {
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<AppliedImprovementsFile>;
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      Array.isArray(parsed.entries)
+    ) {
+      return {
+        schemaVersion: 1,
+        generatedAt:
+          typeof parsed.generatedAt === 'number' ? parsed.generatedAt : Date.now(),
+        entries: parsed.entries as AppliedImprovement[],
+      };
+    }
+  } catch {
+    // Missing or malformed — fall through to fresh envelope.
+  }
+  return { schemaVersion: 1, generatedAt: Date.now(), entries: [] };
+}
+
+/**
+ * Pure ledger-mutation core. Exported for unit tests so the
+ * idempotency contract can be exercised without touching disk or the
+ * Astro runtime.
+ *
+ * Behavior:
+ *   - If an entry with the same `(patternId, target, targetPath)`
+ *     exists, REPLACE it (preserving its id).
+ *   - Otherwise append a new entry with a fresh UUID.
+ *
+ * Returns the next ledger and the entry that landed (so callers can
+ * surface its id in the response).
+ */
+export function applyToLedger(
+  prev: AppliedImprovementsFile,
+  payload: ApplyCorrectionPayload,
+  now: number,
+  newId: string,
+): { next: AppliedImprovementsFile; entry: AppliedImprovement } {
+  const existingIx = prev.entries.findIndex((e) =>
+    isSameApplyKey(e, payload.patternId, payload.proposedUpgrade),
+  );
+  const existing = existingIx >= 0 ? prev.entries[existingIx] : null;
+  // Mark the persisted ProposedUpgrade as applied — the merge step
+  // expects this on disk too, so a viewer reading the ledger directly
+  // sees consistent state. The live `corrections.json` is untouched.
+  const stampedUpgrade: ProposedUpgrade = {
+    ...payload.proposedUpgrade,
+    applied: true,
+    appliedAt: now,
+  };
+  const entry: AppliedImprovement = {
+    id: existing ? existing.id : newId,
+    patternId: payload.patternId,
+    appliedAt: now,
+    ruleSummary: payload.ruleSummary,
+    proposedUpgrade: stampedUpgrade,
+    ...(payload.targetFiles ? { targetFiles: payload.targetFiles } : {}),
+    ...(payload.notes ? { notes: payload.notes } : {}),
+  };
+  const nextEntries = prev.entries.slice();
+  if (existingIx >= 0) {
+    nextEntries[existingIx] = entry;
+  } else {
+    nextEntries.push(entry);
+  }
+  const next: AppliedImprovementsFile = {
+    schemaVersion: 1,
+    generatedAt: now,
+    entries: nextEntries,
+  };
+  return { next, entry };
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+
+  if (inFlight) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error:
+          'Another apply is already writing the ledger. Retry in a moment.',
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await request.json();
+  } catch {
+    return badRequest('invalid JSON body');
+  }
+  const validation = validateApplyBody(parsed);
+  if (!validation.ok) return badRequest(validation.error);
+
+  const sidecarDir = join(standaloneDataDir(), 'analysis');
+  const ledgerPath = join(sidecarDir, 'applied-improvements.json');
+
+  let release: () => void = () => {};
+  inFlight = new Promise<void>((res) => {
+    release = res;
+  });
+
+  try {
+    await mkdir(sidecarDir, { recursive: true });
+    const prev = await loadLedger(ledgerPath);
+    const { next, entry } = applyToLedger(
+      prev,
+      validation.payload,
+      Date.now(),
+      randomUUID(),
+    );
+    await writeFile(ledgerPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        appliedImprovementId: entry.id,
+        ledgerPath,
+        entriesCount: next.entries.length,
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+      { status: 500, headers: { 'content-type': 'application/json' } },
+    );
+  } finally {
+    inFlight = null;
+    release();
+  }
+};
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify({ ok: true, available: true }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};

--- a/apps/standalone/test/api/apply-correction-handler.test.ts
+++ b/apps/standalone/test/api/apply-correction-handler.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Integration tests for the apply-correction POST handler that exercise
+ * the concurrency gate and the atomic-write / corruption-recovery
+ * paths. The pure helpers live next door in `apply-correction.test.ts`;
+ * this file targets the request/response shape and the global
+ * `inFlight` slot that serializes ledger writes.
+ *
+ * fs is mocked at the module boundary so the tests don't touch the
+ * real `apps/standalone/public/chat-arch-data/analysis/` ledger.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─────────────────────────────────────────────────────────────────────
+// In-memory fs mock. We replicate just enough of `node:fs/promises` to
+// drive the handler (readFile / writeFile / rename / mkdir). Each test
+// resets the store via beforeEach.
+// ─────────────────────────────────────────────────────────────────────
+interface FsState {
+  files: Map<string, string>;
+  /**
+   * When set, the next writeFile call awaits this promise BEFORE
+   * actually writing. Used by the race test to hold the first POST
+   * mid-write while the second one races the gate.
+   */
+  writeGate: Promise<void> | null;
+  writeGateResolve: (() => void) | null;
+}
+
+const fs: FsState = {
+  files: new Map(),
+  writeGate: null,
+  writeGateResolve: null,
+};
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(async (path: string) => {
+    const content = fs.files.get(path);
+    if (content === undefined) {
+      const err = new Error(`ENOENT: no such file '${path}'`) as Error & {
+        code: string;
+      };
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return content;
+  }),
+  writeFile: vi.fn(async (path: string, content: string) => {
+    if (fs.writeGate) await fs.writeGate;
+    fs.files.set(path, content);
+  }),
+  rename: vi.fn(async (from: string, to: string) => {
+    const content = fs.files.get(from);
+    if (content === undefined) {
+      const err = new Error(`ENOENT: no such file '${from}'`) as Error & {
+        code: string;
+      };
+      err.code = 'ENOENT';
+      throw err;
+    }
+    fs.files.set(to, content);
+    fs.files.delete(from);
+  }),
+  mkdir: vi.fn(async () => undefined),
+}));
+
+// Importing AFTER the vi.mock so the handler's `import` resolves to
+// the mock. (Vitest hoists vi.mock calls, but the import statement
+// must follow the mock declaration in source order to keep this
+// readable.)
+const handlerModule = await import('../../src/pages/api/apply-correction.js');
+const { POST, loadLedger, LedgerCorruptError } = handlerModule;
+
+beforeEach(() => {
+  fs.files.clear();
+  fs.writeGate = null;
+  fs.writeGateResolve = null;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Request builder
+// ─────────────────────────────────────────────────────────────────────
+function makeRequest(body: unknown, init?: { origin?: string; xrw?: string }): Request {
+  return new Request('http://localhost:4324/api/apply-correction', {
+    method: 'POST',
+    headers: {
+      origin: init?.origin ?? 'http://localhost:4324',
+      'x-requested-with': init?.xrw ?? 'chat-arch-apply-correction',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  patternId: 'p-race',
+  ruleSummary: 'no docstrings',
+  proposedUpgrade: {
+    target: 'global-claude-md',
+    targetPath: '~/.claude/CLAUDE.md',
+    patch: '- no docstrings',
+    rationale: 'because',
+    applied: false,
+    appliedAt: null,
+  },
+};
+
+// Astro POST handler signature is ({ request, ... }) — we only need
+// `request`, the rest is unused for this endpoint.
+function invoke(req: Request): Promise<Response> {
+  // The cast mirrors how Astro calls the handler in practice.
+  return (POST as unknown as (ctx: { request: Request }) => Promise<Response>)(
+    { request: req },
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// P0.1 — TOCTOU race on inFlight
+// ─────────────────────────────────────────────────────────────────────
+describe('apply-correction POST — concurrency gate', () => {
+  it('serializes concurrent POSTs: exactly one wins, the other gets 409', async () => {
+    // Hold the first writer mid-write so the second POST has time to
+    // hit the gate. Without the synchronous-claim fix, both POSTs
+    // would parse their bodies in parallel, both observe inFlight ===
+    // null, and race the read-modify-write — the second one would
+    // clobber the first's entry.
+    fs.writeGate = new Promise<void>((res) => {
+      fs.writeGateResolve = res;
+    });
+
+    const p1 = invoke(makeRequest(validBody));
+    const p2 = invoke(makeRequest({ ...validBody, patternId: 'p-race-2' }));
+
+    // Drain microtasks so p2 has a chance to run its synchronous
+    // gate-check portion. Without this, the test passes trivially
+    // (microtask ordering may still serialize, but we want to assert
+    // the gate works under contention).
+    await new Promise<void>((r) => setImmediate(r));
+
+    // Release the first writer so it can finish.
+    fs.writeGateResolve?.();
+
+    const [r1, r2] = await Promise.all([p1, p2]);
+    const statuses = [r1.status, r2.status].sort();
+    expect(statuses).toEqual([200, 409]);
+
+    const winner = r1.status === 200 ? r1 : r2;
+    const winnerBody = (await winner.json()) as { ok: boolean; entriesCount: number };
+    expect(winnerBody.ok).toBe(true);
+    expect(winnerBody.entriesCount).toBe(1);
+
+    const loser = r1.status === 409 ? r1 : r2;
+    const loserBody = (await loser.json()) as { ok: boolean; error: string };
+    expect(loserBody.ok).toBe(false);
+    expect(loserBody.error).toMatch(/Another apply is already writing/);
+  });
+
+  it('releases the gate after each request so subsequent POSTs succeed', async () => {
+    // Sanity: no holds, two sequential POSTs both succeed.
+    const r1 = await invoke(makeRequest(validBody));
+    expect(r1.status).toBe(200);
+    const r2 = await invoke(
+      makeRequest({ ...validBody, patternId: 'p-race-second' }),
+    );
+    expect(r2.status).toBe(200);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// P0.2 — Atomic write + corrupt-file recovery
+// ─────────────────────────────────────────────────────────────────────
+describe('apply-correction POST — atomic write', () => {
+  it('writes to a sibling .tmp and renames over the destination', async () => {
+    const r = await invoke(makeRequest(validBody));
+    expect(r.status).toBe(200);
+
+    // Final ledger landed at the canonical path.
+    const ledgerPath = Array.from(fs.files.keys()).find((k) =>
+      k.endsWith('applied-improvements.json'),
+    );
+    expect(ledgerPath).toBeDefined();
+
+    // The .tmp sibling has been renamed away (rename clears it).
+    const tmpPath = Array.from(fs.files.keys()).find((k) =>
+      k.endsWith('.applied-improvements.json.tmp'),
+    );
+    expect(tmpPath).toBeUndefined();
+  });
+
+  it('a kill mid-write (writeFile threw) leaves the ledger intact', async () => {
+    // Seed a known-good ledger.
+    const r1 = await invoke(makeRequest(validBody));
+    expect(r1.status).toBe(200);
+    const ledgerPath = Array.from(fs.files.keys()).find((k) =>
+      k.endsWith('applied-improvements.json'),
+    )!;
+    const before = fs.files.get(ledgerPath);
+
+    // Force the next writeFile to fail (simulates kill / disk full /
+    // fsync error before rename). The atomic-write contract: the
+    // original ledger must be untouched.
+    const fsmod = (await import('node:fs/promises')) as unknown as {
+      writeFile: ReturnType<typeof vi.fn>;
+    };
+    fsmod.writeFile.mockImplementationOnce(async () => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+
+    const r2 = await invoke(
+      makeRequest({ ...validBody, patternId: 'p-second' }),
+    );
+    expect(r2.status).toBe(500);
+    expect(fs.files.get(ledgerPath)).toBe(before);
+  });
+});
+
+describe('apply-correction loadLedger — corruption posture', () => {
+  it('returns a fresh envelope when the file does not exist (ENOENT)', async () => {
+    const r = await loadLedger('/no/such/path/applied-improvements.json');
+    expect(r.entries).toEqual([]);
+    expect(r.schemaVersion).toBe(1);
+  });
+
+  it('throws LedgerCorruptError on parse failure (so POST refuses to overwrite)', async () => {
+    fs.files.set('/tmp/garbage.json', '{ not valid json');
+    await expect(loadLedger('/tmp/garbage.json')).rejects.toBeInstanceOf(
+      LedgerCorruptError,
+    );
+  });
+
+  it('throws LedgerCorruptError on wrong-shape file', async () => {
+    fs.files.set('/tmp/wrong-shape.json', JSON.stringify({ entries: 'not-an-array' }));
+    await expect(loadLedger('/tmp/wrong-shape.json')).rejects.toBeInstanceOf(
+      LedgerCorruptError,
+    );
+  });
+
+  it('POST returns 500 (not 200) when the existing ledger is corrupt', async () => {
+    // Pre-place a corrupt file at the path the handler writes to.
+    const r0 = await invoke(makeRequest(validBody));
+    expect(r0.status).toBe(200);
+    const ledgerPath = Array.from(fs.files.keys()).find((k) =>
+      k.endsWith('applied-improvements.json'),
+    )!;
+    fs.files.set(ledgerPath, '{ corrupted ');
+
+    const r = await invoke(
+      makeRequest({ ...validBody, patternId: 'p-after-corrupt' }),
+    );
+    expect(r.status).toBe(500);
+    const body = (await r.json()) as { ok: boolean; error: string };
+    expect(body.ok).toBe(false);
+    expect(body.error).toMatch(/ledger appears corrupted/);
+  });
+});

--- a/apps/standalone/test/api/apply-correction.test.ts
+++ b/apps/standalone/test/api/apply-correction.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  AppliedImprovement,
+  AppliedImprovementsFile,
+  ProposedUpgrade,
+} from '@chat-arch/schema';
+import {
+  REQUIRED_HEADER,
+  applyToLedger,
+  isLocalOrigin,
+  isSameApplyKey,
+  isValidProposedUpgrade,
+  validateApplyBody,
+  type ApplyCorrectionPayload,
+} from '../../src/pages/api/apply-correction.js';
+
+describe('apply-correction — CSRF gate', () => {
+  it('accepts loopback origins, rejects everything else', () => {
+    expect(isLocalOrigin('http://localhost:4324')).toBe(true);
+    expect(isLocalOrigin('http://127.0.0.1')).toBe(true);
+    expect(isLocalOrigin('http://[::1]')).toBe(true);
+    expect(isLocalOrigin(null)).toBe(false);
+    expect(isLocalOrigin('http://example.com')).toBe(false);
+    expect(isLocalOrigin('file:///etc/passwd')).toBe(false);
+    expect(isLocalOrigin('javascript:alert(1)')).toBe(false);
+  });
+
+  it('exposes a distinct X-Requested-With header from siblings', () => {
+    // CSRF posture: each sibling endpoint pins a unique token so a
+    // malicious page that learns one can't trip another.
+    expect(REQUIRED_HEADER).toBe('chat-arch-apply-correction');
+  });
+});
+
+function upgrade(overrides: Partial<ProposedUpgrade> = {}): ProposedUpgrade {
+  return {
+    target: 'global-claude-md',
+    targetPath: '~/.claude/CLAUDE.md',
+    patch: '- some rule',
+    rationale: 'because',
+    applied: false,
+    appliedAt: null,
+    ...overrides,
+  };
+}
+
+describe('apply-correction — isValidProposedUpgrade', () => {
+  it('accepts a fully-formed upgrade', () => {
+    expect(isValidProposedUpgrade(upgrade())).toBe(true);
+  });
+
+  it('rejects unknown target enum values', () => {
+    expect(isValidProposedUpgrade({ ...upgrade(), target: 'evil-write' })).toBe(false);
+    expect(isValidProposedUpgrade({ ...upgrade(), target: 42 })).toBe(false);
+  });
+
+  it('rejects empty / non-string targetPath', () => {
+    expect(isValidProposedUpgrade({ ...upgrade(), targetPath: '' })).toBe(false);
+    expect(isValidProposedUpgrade({ ...upgrade(), targetPath: 7 })).toBe(false);
+  });
+
+  it('rejects non-bool applied / non-(null|number) appliedAt', () => {
+    expect(isValidProposedUpgrade({ ...upgrade(), applied: 'yes' })).toBe(false);
+    expect(isValidProposedUpgrade({ ...upgrade(), appliedAt: 'now' })).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const o = upgrade() as unknown as Record<string, unknown>;
+    delete o.patch;
+    expect(isValidProposedUpgrade(o)).toBe(false);
+  });
+});
+
+describe('apply-correction — validateApplyBody', () => {
+  const goodBody = {
+    patternId: 'p-1',
+    proposedUpgrade: upgrade(),
+    ruleSummary: 'do not add docstrings',
+  };
+
+  it('accepts a minimal valid body', () => {
+    const r = validateApplyBody(goodBody);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.patternId).toBe('p-1');
+      expect(r.payload.targetFiles).toBeUndefined();
+      expect(r.payload.notes).toBeUndefined();
+    }
+  });
+
+  it('rejects null/non-object bodies', () => {
+    expect(validateApplyBody(null).ok).toBe(false);
+    expect(validateApplyBody('string').ok).toBe(false);
+    expect(validateApplyBody(42).ok).toBe(false);
+  });
+
+  it('rejects empty / missing patternId', () => {
+    const r = validateApplyBody({ ...goodBody, patternId: '' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects missing ruleSummary', () => {
+    const r = validateApplyBody({ ...goodBody, ruleSummary: undefined });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an invalid proposedUpgrade', () => {
+    const r = validateApplyBody({
+      ...goodBody,
+      proposedUpgrade: { target: 'evil', targetPath: '/etc/passwd' },
+    });
+    expect(r.ok).toBe(false);
+  });
+
+  it('coerces blank-stripping for targetFiles + notes', () => {
+    const r = validateApplyBody({
+      ...goodBody,
+      targetFiles: ['  ~/.claude/CLAUDE.md ', '', '<repo>/CLAUDE.md'],
+      notes: '   moved to PostToolUse   ',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.payload.targetFiles).toEqual(['~/.claude/CLAUDE.md', '<repo>/CLAUDE.md']);
+      expect(r.payload.notes).toBe('moved to PostToolUse');
+    }
+  });
+
+  it('rejects a non-array targetFiles or non-string entries', () => {
+    expect(validateApplyBody({ ...goodBody, targetFiles: 'one' }).ok).toBe(false);
+    expect(validateApplyBody({ ...goodBody, targetFiles: [42] }).ok).toBe(false);
+  });
+
+  it('rejects an oversize notes value', () => {
+    const huge = 'x'.repeat(5_000);
+    expect(validateApplyBody({ ...goodBody, notes: huge }).ok).toBe(false);
+  });
+
+  it('rejects too many targetFiles entries', () => {
+    const many = Array.from({ length: 17 }, (_v, i) => `f${i}`);
+    expect(validateApplyBody({ ...goodBody, targetFiles: many }).ok).toBe(false);
+  });
+});
+
+describe('apply-correction — isSameApplyKey', () => {
+  it('matches on (patternId, target, targetPath) — all three must agree', () => {
+    const e: AppliedImprovement = {
+      id: 'e-1',
+      patternId: 'p-1',
+      appliedAt: 0,
+      ruleSummary: 's',
+      proposedUpgrade: upgrade({
+        target: 'global-claude-md',
+        targetPath: '~/.claude/CLAUDE.md',
+      }),
+    };
+    expect(
+      isSameApplyKey(e, 'p-1', { target: 'global-claude-md', targetPath: '~/.claude/CLAUDE.md' }),
+    ).toBe(true);
+    expect(
+      isSameApplyKey(e, 'p-2', { target: 'global-claude-md', targetPath: '~/.claude/CLAUDE.md' }),
+    ).toBe(false);
+    expect(
+      isSameApplyKey(e, 'p-1', { target: 'project-claude-md', targetPath: '~/.claude/CLAUDE.md' }),
+    ).toBe(false);
+    expect(
+      isSameApplyKey(e, 'p-1', { target: 'global-claude-md', targetPath: '/other/path' }),
+    ).toBe(false);
+  });
+});
+
+function payload(overrides: Partial<ApplyCorrectionPayload> = {}): ApplyCorrectionPayload {
+  return {
+    patternId: 'p-1',
+    proposedUpgrade: upgrade(),
+    ruleSummary: 'r',
+    ...overrides,
+  };
+}
+
+function emptyLedger(): AppliedImprovementsFile {
+  return { schemaVersion: 1, generatedAt: 0, entries: [] };
+}
+
+describe('apply-correction — applyToLedger (idempotency contract)', () => {
+  it('appends a fresh entry when the key is new', () => {
+    const { next, entry } = applyToLedger(
+      emptyLedger(),
+      payload(),
+      1_700_000_000_000,
+      'fresh-id',
+    );
+    expect(next.entries).toHaveLength(1);
+    expect(entry.id).toBe('fresh-id');
+    expect(entry.appliedAt).toBe(1_700_000_000_000);
+    // The persisted upgrade has applied: true / appliedAt set.
+    expect(entry.proposedUpgrade.applied).toBe(true);
+    expect(entry.proposedUpgrade.appliedAt).toBe(1_700_000_000_000);
+    expect(next.generatedAt).toBe(1_700_000_000_000);
+  });
+
+  it('replaces (does not duplicate) when re-applying the same (patternId, target, targetPath)', () => {
+    const first = applyToLedger(
+      emptyLedger(),
+      payload({ notes: 'first try' }),
+      1_700_000_000_000,
+      'id-A',
+    );
+    const second = applyToLedger(
+      first.next,
+      payload({ notes: 'second try' }),
+      1_700_500_000_000,
+      'id-B',
+    );
+    expect(second.next.entries).toHaveLength(1);
+    // Preserves the original id.
+    expect(second.entry.id).toBe('id-A');
+    // But updates fields from the new apply.
+    expect(second.entry.notes).toBe('second try');
+    expect(second.entry.appliedAt).toBe(1_700_500_000_000);
+  });
+
+  it('keeps siblings with different (target, targetPath) as separate entries', () => {
+    const a = applyToLedger(
+      emptyLedger(),
+      payload({
+        proposedUpgrade: upgrade({ target: 'global-claude-md', targetPath: '~/g.md' }),
+      }),
+      1_700_000_000_000,
+      'id-A',
+    );
+    const b = applyToLedger(
+      a.next,
+      payload({
+        proposedUpgrade: upgrade({ target: 'project-claude-md', targetPath: '<repo>/CLAUDE.md' }),
+      }),
+      1_700_500_000_000,
+      'id-B',
+    );
+    expect(b.next.entries).toHaveLength(2);
+    expect(b.entry.id).toBe('id-B');
+    // Original entry untouched.
+    expect(b.next.entries[0].id).toBe('id-A');
+  });
+
+  it('keeps siblings with different patternId as separate entries even when path matches', () => {
+    const u = upgrade({ target: 'global-claude-md', targetPath: '~/.claude/CLAUDE.md' });
+    const a = applyToLedger(
+      emptyLedger(),
+      payload({ patternId: 'p-1', proposedUpgrade: u }),
+      1_700_000_000_000,
+      'id-A',
+    );
+    const b = applyToLedger(
+      a.next,
+      payload({ patternId: 'p-2', proposedUpgrade: u }),
+      1_700_500_000_000,
+      'id-B',
+    );
+    expect(b.next.entries).toHaveLength(2);
+  });
+});

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -66,7 +66,7 @@ export interface RunAnalysisResult {
   };
 }
 
-const EXPORTER_VERSION = '0.7.0';
+const EXPORTER_VERSION = '0.8.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/schema/src/applied-improvement.ts
+++ b/packages/schema/src/applied-improvement.ts
@@ -1,0 +1,57 @@
+/**
+ * Applied-improvement ledger — Phase 1 corrections-loop closure.
+ *
+ * When the user clicks APPLY on a `ProposedUpgrade` in the corrections
+ * panel, the standalone server appends an entry to
+ * `analysis/applied-improvements.json` (this module's shape). The
+ * viewer's loader merges that ledger over the canonical
+ * `corrections.json` at read time, flipping each matching upgrade's
+ * `applied`/`appliedAt` and recomputing `recurringPostApplication` —
+ * `corrections.json` is never mutated, so re-mining always overwrites
+ * cleanly without losing the user's apply history.
+ *
+ * Idempotency key is the triple `(patternId, proposedUpgrade.target,
+ * proposedUpgrade.targetPath)`. Re-applying the same upgrade replaces
+ * the existing entry (the user re-confirmed; bookkeeping reflects the
+ * latest decision, not a duplicate).
+ */
+
+import type { ProposedUpgrade } from './correction.js';
+
+export interface AppliedImprovement {
+  /** Stable id assigned at first-apply time. UUID-v4. */
+  id: string;
+  /** `CorrectionPattern.id` whose upgrade was applied. */
+  patternId: string;
+  /** ms-since-epoch of the apply click. */
+  appliedAt: number;
+  /**
+   * Snapshot of `CorrectionPattern.canonicalRule` at apply time, kept so
+   * the ledger remains human-readable even if the pattern is later
+   * dropped from `corrections.json` (a re-mine on a smaller window can
+   * elide patterns whose instances fell outside the window).
+   */
+  ruleSummary: string;
+  /**
+   * Verbatim copy of the applied `ProposedUpgrade`. The merge step uses
+   * `(target, targetPath)` to find the matching upgrade in the live
+   * `corrections.json`; the patch text is preserved here so the viewer
+   * can show "what you applied" even when the live pattern's upgrades
+   * have shifted.
+   */
+  proposedUpgrade: ProposedUpgrade;
+  /**
+   * Optional free-text list of files the user reports they edited
+   * (e.g. `["~/.claude/CLAUDE.md", "<repo>/CLAUDE.md"]`). Not validated
+   * by the server — purely a user-facing audit note.
+   */
+  targetFiles?: string[];
+  /** Optional free-text apply note ("moved to PostToolUse hook" etc.). */
+  notes?: string;
+}
+
+export interface AppliedImprovementsFile {
+  schemaVersion: 1;
+  generatedAt: number;
+  entries: AppliedImprovement[];
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -8,4 +8,5 @@ export * from './topic.js';
 export * from './narrative.js';
 export * from './pattern.js';
 export * from './correction.js';
+export * from './applied-improvement.js';
 export * from './configDocument.js';

--- a/packages/viewer/src/ChatArchViewer.back.test.tsx
+++ b/packages/viewer/src/ChatArchViewer.back.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor, cleanup, act, fireEvent, screen } from '@testing-library/react';
+import type {
+  Correction,
+  CorrectionsFile,
+  SessionManifest,
+  UnifiedSessionEntry,
+} from '@chat-arch/schema';
+import type * as CorrectionsLoaderModule from './data/correctionsLoader.js';
+
+// Match the reroute test's mocking strategy so the viewer mounts
+// without firing real network requests, then drive BACK behavior
+// through real DOM clicks + hashchange events.
+vi.mock('./data/correctionsLoader.js', async () => {
+  const actual = await vi.importActual<typeof CorrectionsLoaderModule>(
+    './data/correctionsLoader.js',
+  );
+  return {
+    loadCorrectionsFile: vi.fn(async () => null),
+    loadCorrectionCandidatesFile: vi.fn(async () => null),
+    loadAppliedImprovementsFile: vi.fn(async () => null),
+    mergeAppliedImprovements: actual.mergeAppliedImprovements,
+  };
+});
+vi.mock('./data/mineCorrectionsClient.js', () => ({
+  startMineCorrections: vi.fn(),
+  fetchCorrectionRunStatus: vi.fn(async () => null),
+  clearCorrections: vi.fn(async () => ({ removed: [] })),
+  probeClearCorrections: vi.fn(async () => false),
+  probeMineCorrections: vi.fn(async () => ({
+    ok: true,
+    available: false,
+    busy: false,
+    busyRequestId: null,
+    autoWindow: null,
+  })),
+}));
+vi.mock('./data/applyCorrectionClient.js', () => ({
+  applyCorrection: vi.fn(),
+  probeApplyCorrection: vi.fn(async () => false),
+}));
+
+import { loadCorrectionsFile } from './data/correctionsLoader.js';
+import { ChatArchViewer } from './ChatArchViewer.js';
+
+const mockedLoadCorrections = vi.mocked(loadCorrectionsFile);
+
+function entry(id: string, overrides: Partial<UnifiedSessionEntry> = {}): UnifiedSessionEntry {
+  return {
+    id,
+    source: 'cloud',
+    rawSessionId: id,
+    startedAt: 0,
+    updatedAt: 100,
+    durationMs: 0,
+    title: `title-${id}`,
+    titleSource: 'cloud-name',
+    preview: `preview-${id}`,
+    userTurns: 1,
+    model: null,
+    cwdKind: 'none',
+    totalCostUsd: null,
+    ...overrides,
+  } as UnifiedSessionEntry;
+}
+
+const sampleManifest: SessionManifest = {
+  schemaVersion: 1,
+  generatedAt: Date.parse('2026-05-01T00:00:00Z'),
+  counts: { cloud: 1, cowork: 0, 'cli-direct': 0, 'cli-desktop': 0 },
+  sessions: [entry('a', { title: 'Apple pie recipe' })],
+};
+
+const sampleCorrection: Correction = {
+  id: 'inst-a',
+  sessionId: 'a',
+  userTurnIndex: 0,
+  excerpt: 'use absolute paths in WSL',
+  precedingAssistantExcerpt: null,
+  signals: [{ kind: 'imperative-override', phrase: 'use absolute paths' }],
+  classification: {
+    kind: 'behavior-rule',
+    distilledRule: 'use absolute paths in WSL',
+    confidence: 0.9,
+    actionable: true,
+  },
+};
+
+function correctionsWithClickablePill(): CorrectionsFile {
+  return {
+    generatedAt: Date.parse('2026-05-01T00:00:00Z'),
+    corrections: [sampleCorrection],
+    patterns: [
+      {
+        id: 'p1',
+        canonicalRule: 'use absolute paths in WSL',
+        instanceIds: ['inst-a'],
+        occurrenceCount: 3,
+        firstSeen: 1_700_000_000_000,
+        lastSeen: 1_700_100_000_000,
+        scope: { kind: 'global' },
+        proposedUpgrades: [],
+        confidence: 0.7,
+        recurringPostApplication: false,
+        alreadyEncoded: false,
+      },
+    ],
+    pipeline: {
+      heuristicRecall: true,
+      llmClassification: true,
+      embeddingClustering: true,
+      claudeMdCrossCheck: true,
+    },
+  };
+}
+
+function locationLabel(): string | null {
+  return document.querySelector('.lcars-top-bar__location-label')?.textContent ?? null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
+  if (window.location.hash) {
+    window.history.replaceState(null, '', window.location.pathname);
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  if (window.location.hash) {
+    window.history.replaceState(null, '', window.location.pathname);
+  }
+});
+
+describe('ChatArchViewer — BACK from detail restores prior surface (P0.1)', () => {
+  it('returns to CORRECTIONS after BACK from a CORRECTIONS instance-pill clickthrough', async () => {
+    // Resolve corrections.json with a clickable instance pill so the
+    // viewer reroutes to CORRECTIONS on mount and a real button is in
+    // the DOM for the click below.
+    mockedLoadCorrections.mockResolvedValue(correctionsWithClickablePill());
+
+    render(<ChatArchViewer manifest={sampleManifest} />);
+
+    await waitFor(() => {
+      expect(locationLabel()).toBe('CORRECTIONS');
+    });
+
+    // Pattern cards collapse instance pills behind a SHOW DETAILS
+    // toggle. Click that first, then the instance pill. The panel's
+    // onSelectSession wrapper sets priorModeBeforeDetail and calls
+    // onSelect, which pushes #session/a and flips mode.
+    const showDetails = await waitFor(() =>
+      screen.getByRole('button', { name: /SHOW DETAILS/i }),
+    );
+    act(() => {
+      fireEvent.click(showDetails);
+    });
+    const pill = await waitFor(() =>
+      screen.getByRole('button', { name: /open session a/i }),
+    );
+    act(() => {
+      fireEvent.click(pill);
+    });
+
+    // Detail surface is now active — location chip is "SESSION".
+    await waitFor(() => {
+      expect(locationLabel()).toBe('DETAIL');
+    });
+
+    // Simulate BACK by popping the session hash and dispatching
+    // hashchange — equivalent to `window.history.back()`. The
+    // listener should consume `priorModeBeforeDetail` (set to
+    // 'corrections' by the panel wrapper above) and restore that
+    // mode instead of falling back to 'command'.
+    act(() => {
+      window.history.replaceState(null, '', window.location.pathname);
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    await waitFor(() => {
+      expect(locationLabel()).toBe('CORRECTIONS');
+    });
+  });
+
+  it('falls back to SESSIONS (command) when BACK fires without priorMode set', async () => {
+    // Empty corrections file so no reroute fires. Mode stays
+    // 'command' (SESSIONS) on mount.
+    mockedLoadCorrections.mockResolvedValueOnce(null);
+
+    render(<ChatArchViewer manifest={sampleManifest} />);
+
+    await waitFor(() => {
+      expect(locationLabel()).toBe('SESSIONS');
+    });
+
+    // Push a session hash directly — bypasses the panel's wrapper,
+    // so priorModeBeforeDetail stays null. The hashchange listener
+    // sets mode='detail'.
+    act(() => {
+      window.history.pushState(null, '', '#session/a');
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+    await waitFor(() => {
+      expect(locationLabel()).toBe('DETAIL');
+    });
+
+    // Pop the hash → listener sees prevMode='detail' but no stashed
+    // prior, so it falls back to 'command'.
+    act(() => {
+      window.history.replaceState(null, '', window.location.pathname);
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+    await waitFor(() => {
+      expect(locationLabel()).toBe('SESSIONS');
+    });
+  });
+});

--- a/packages/viewer/src/ChatArchViewer.reroute.test.tsx
+++ b/packages/viewer/src/ChatArchViewer.reroute.test.tsx
@@ -45,10 +45,15 @@ vi.mock('./data/applyCorrectionClient.js', () => ({
   probeApplyCorrection: vi.fn(async () => false),
 }));
 
-import { loadAppliedImprovementsFile } from './data/correctionsLoader.js';
+import {
+  loadAppliedImprovementsFile,
+  loadCorrectionsFile,
+} from './data/correctionsLoader.js';
 import { ChatArchViewer } from './ChatArchViewer.js';
+import type { CorrectionsFile } from '@chat-arch/schema';
 
 const mockedLoadApplied = vi.mocked(loadAppliedImprovementsFile);
+const mockedLoadCorrections = vi.mocked(loadCorrectionsFile);
 
 function entry(id: string, overrides: Partial<UnifiedSessionEntry> = {}): UnifiedSessionEntry {
   return {
@@ -159,5 +164,43 @@ describe('ChatArchViewer — Phase 2a default-mode reroute', () => {
     // links aren't yanked.
     const locationLabel = document.querySelector('.lcars-top-bar__location-label');
     expect(locationLabel?.textContent).toBe('PROJECTS');
+  });
+
+  it('reroutes to CORRECTIONS when corrections.json has patterns but the ledger is empty (P1.2)', async () => {
+    // Demo / first-mine users have classified patterns to inspect but
+    // haven't clicked APPLY yet — the reroute should still fire so they
+    // land in the workshop loop instead of being dumped on SESSIONS.
+    const correctionsWithPattern: CorrectionsFile = {
+      generatedAt: 1_700_000_000_000,
+      corrections: [],
+      patterns: [
+        {
+          id: 'p-demo',
+          canonicalRule: 'use bullets, not paragraphs',
+          instanceIds: [],
+          occurrenceCount: 4,
+          firstSeen: 1_700_000_000_000,
+          lastSeen: 1_700_100_000_000,
+          scope: { kind: 'global' },
+          proposedUpgrades: [],
+          confidence: 0.6,
+          recurringPostApplication: false,
+          alreadyEncoded: false,
+        },
+      ],
+      pipeline: {
+        heuristicRecall: true,
+        llmClassification: true,
+        embeddingClustering: true,
+        claudeMdCrossCheck: true,
+      },
+    };
+    mockedLoadApplied.mockResolvedValueOnce(ledgerEmpty);
+    mockedLoadCorrections.mockResolvedValueOnce(correctionsWithPattern);
+    render(<ChatArchViewer manifest={sampleManifest} />);
+    await waitFor(() => {
+      const locationLabel = document.querySelector('.lcars-top-bar__location-label');
+      expect(locationLabel?.textContent).toBe('CORRECTIONS');
+    });
   });
 });

--- a/packages/viewer/src/ChatArchViewer.reroute.test.tsx
+++ b/packages/viewer/src/ChatArchViewer.reroute.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor, cleanup } from '@testing-library/react';
+import type {
+  AppliedImprovement,
+  AppliedImprovementsFile,
+  ProposedUpgrade,
+  SessionManifest,
+  UnifiedSessionEntry,
+} from '@chat-arch/schema';
+import type * as CorrectionsLoaderModule from './data/correctionsLoader.js';
+
+// Mock the loader so the viewer's mount-time fetch returns the
+// fixture we control. `mergeAppliedImprovements` stays real (it's
+// pure and the panel still imports it).
+vi.mock('./data/correctionsLoader.js', async () => {
+  const actual = await vi.importActual<typeof CorrectionsLoaderModule>(
+    './data/correctionsLoader.js',
+  );
+  return {
+    loadCorrectionsFile: vi.fn(async () => null),
+    loadCorrectionCandidatesFile: vi.fn(async () => null),
+    loadAppliedImprovementsFile: vi.fn(async () => null),
+    mergeAppliedImprovements: actual.mergeAppliedImprovements,
+  };
+});
+// Mining client probes the standalone server's /api/mine-corrections;
+// stub them so the panel doesn't fire real fetches under jsdom.
+vi.mock('./data/mineCorrectionsClient.js', () => ({
+  startMineCorrections: vi.fn(),
+  fetchCorrectionRunStatus: vi.fn(async () => null),
+  clearCorrections: vi.fn(async () => ({ removed: [] })),
+  probeClearCorrections: vi.fn(async () => false),
+  probeMineCorrections: vi.fn(async () => ({
+    ok: true,
+    available: false,
+    busy: false,
+    busyRequestId: null,
+    autoWindow: null,
+  })),
+}));
+// Apply-correction probe lives in its own module (CorrectionsPanel
+// imports it); stub the probe so it doesn't poke the network.
+vi.mock('./data/applyCorrectionClient.js', () => ({
+  applyCorrection: vi.fn(),
+  probeApplyCorrection: vi.fn(async () => false),
+}));
+
+import { loadAppliedImprovementsFile } from './data/correctionsLoader.js';
+import { ChatArchViewer } from './ChatArchViewer.js';
+
+const mockedLoadApplied = vi.mocked(loadAppliedImprovementsFile);
+
+function entry(id: string, overrides: Partial<UnifiedSessionEntry> = {}): UnifiedSessionEntry {
+  return {
+    id,
+    source: 'cloud',
+    rawSessionId: id,
+    startedAt: 0,
+    updatedAt: 100,
+    durationMs: 0,
+    title: `title-${id}`,
+    titleSource: 'cloud-name',
+    preview: `preview-${id}`,
+    userTurns: 1,
+    model: null,
+    cwdKind: 'none',
+    totalCostUsd: null,
+    ...overrides,
+  } as UnifiedSessionEntry;
+}
+
+const sampleManifest: SessionManifest = {
+  schemaVersion: 1,
+  generatedAt: Date.parse('2026-05-01T00:00:00Z'),
+  counts: { cloud: 1, cowork: 0, 'cli-direct': 0, 'cli-desktop': 0 },
+  sessions: [entry('a', { title: 'Apple pie recipe' })],
+};
+
+const proposedUpgrade: ProposedUpgrade = {
+  target: 'CLAUDE.md',
+  targetPath: '~/.claude/CLAUDE.md',
+  proposedPatch: 'add a guard rule',
+  rationale: 'pattern recurs',
+  suggestedSection: 'Core Directives',
+};
+
+const sampleApplied: AppliedImprovement = {
+  id: 'apply-1',
+  patternId: 'pat-1',
+  appliedAt: 1_700_000_000_000,
+  ruleSummary: 'use absolute paths in WSL',
+  proposedUpgrade,
+};
+
+const ledgerWithEntry: AppliedImprovementsFile = {
+  schemaVersion: 1,
+  generatedAt: 1_700_000_000_000,
+  entries: [sampleApplied],
+};
+
+const ledgerEmpty: AppliedImprovementsFile = {
+  schemaVersion: 1,
+  generatedAt: 1_700_000_000_000,
+  entries: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 });
+  if (window.location.hash) {
+    window.history.replaceState(null, '', window.location.pathname);
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  if (window.location.hash) {
+    window.history.replaceState(null, '', window.location.pathname);
+  }
+});
+
+describe('ChatArchViewer — Phase 2a default-mode reroute', () => {
+  it('reroutes to CORRECTIONS when the applied-improvements ledger has entries', async () => {
+    mockedLoadApplied.mockResolvedValueOnce(ledgerWithEntry);
+    render(<ChatArchViewer manifest={sampleManifest} />);
+    // Location chip mirrors active mode — "CORRECTIONS" appears once
+    // the reroute effect has applied. Use waitFor because the load is
+    // async.
+    await waitFor(() => {
+      const locationLabel = document.querySelector('.lcars-top-bar__location-label');
+      expect(locationLabel?.textContent).toBe('CORRECTIONS');
+    });
+  });
+
+  it('stays on SESSIONS (command) when the ledger is empty', async () => {
+    mockedLoadApplied.mockResolvedValueOnce(ledgerEmpty);
+    render(<ChatArchViewer manifest={sampleManifest} />);
+    // Wait until at least one render cycle has happened post-load,
+    // then assert the location chip is still SESSIONS.
+    await waitFor(() => {
+      expect(mockedLoadApplied).toHaveBeenCalled();
+    });
+    // Give the post-load effect a tick to settle and re-render.
+    await new Promise((r) => setTimeout(r, 0));
+    const locationLabel = document.querySelector('.lcars-top-bar__location-label');
+    expect(locationLabel?.textContent).toBe('SESSIONS');
+  });
+
+  it('stays in URL-hash-encoded mode when a hash is present (URL wins)', async () => {
+    mockedLoadApplied.mockResolvedValueOnce(ledgerWithEntry);
+    window.history.replaceState(null, '', '#projects');
+    render(<ChatArchViewer manifest={sampleManifest} />);
+    await waitFor(() => {
+      expect(mockedLoadApplied).toHaveBeenCalled();
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    // PROJECTS surface stays active despite the ledger having entries —
+    // the URL hash takes precedence over the reroute heuristic so deep
+    // links aren't yanked.
+    const locationLabel = document.querySelector('.lcars-top-bar__location-label');
+    expect(locationLabel?.textContent).toBe('PROJECTS');
+  });
+});

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -2332,7 +2332,10 @@ export function ChatArchViewer({
                         }}
                       />
                     ) : baseMode === 'corrections' ? (
-                      <CorrectionsPanel dataDirBaseUrl={dataRoot} />
+                      <CorrectionsPanel
+                        dataDirBaseUrl={dataRoot}
+                        onSelectSession={onSelect}
+                      />
                     ) : baseMode === 'topics' ? (
                       <TopicsMode
                         topics={effectiveV2Entities.topics ?? []}

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { SessionManifest, UnifiedSessionEntry, SessionSource } from '@chat-arch/schema';
+import type {
+  AppliedImprovementsFile,
+  SessionManifest,
+  UnifiedSessionEntry,
+  SessionSource,
+} from '@chat-arch/schema';
 import type {
   AnalysisState,
   ConversationCache,
@@ -35,6 +40,7 @@ import { PracticeMode } from './components/modes/PracticeMode.js';
 import { CorrectionsPanel } from './components/CorrectionsPanel.js';
 import type { CostKpiSection } from './components/modes/CostMode.js';
 import { fetchManifest } from './data/fetch.js';
+import { loadAppliedImprovementsFile } from './data/correctionsLoader.js';
 import { fetchAnalysisTierStatus } from './data/analysisFetch.js';
 import { fetchV2Entities, buildSessionV2Index } from './data/v2EntitiesFetch.js';
 import { computeV2Entities } from './data/computeV2Entities.js';
@@ -98,6 +104,7 @@ const HASH_PRACTICE = '#practice';
 const DEMO_BANNER_DISMISSED_KEY = 'chat-arch:demo-banner-dismissed';
 const BOOT_SEEN_KEY = 'chat-arch:boot-seen';
 const SORT_BY_KEY = 'chat-arch:sort-by';
+const ANALYTICS_COLLAPSED_KEY = 'chat-arch-analytics-collapsed';
 
 /**
  * Read the stored SORT preference; fall back to `recent` when missing
@@ -281,6 +288,15 @@ export function ChatArchViewer({
     v2Narratives: null,
   });
 
+  // Phase 2a: lift the applied-improvements ledger to the viewer level
+  // so the default-mode reroute decision can consult it before the user
+  // has touched the corrections panel. CorrectionsPanel keeps its own
+  // load (cheap; decoupling it is a follow-up) so the panel stays
+  // self-contained when embedded in isolation.
+  const [appliedImprovements, setAppliedImprovements] =
+    useState<AppliedImprovementsFile | null>(null);
+  const [appliedHydrated, setAppliedHydrated] = useState(false);
+
   // --- Phase 3 semantic-classification state ---
   //
   // Sidecar enrichment layer: BGE-small-en-v1.5 embeddings + cosine-
@@ -312,6 +328,26 @@ export function ChatArchViewer({
   // DATA panel, not the TopBar. Open state is hoisted here so the
   // sidebar's DATA item and the panel itself share the toggle.
   const [dataPanelOpen, setDataPanelOpen] = useState<boolean>(false);
+  // Phase 2a: ANALYTICS group collapse state. Default-collapsed so the
+  // workshop surfaces are above the fold; persisted to localStorage so
+  // the user's preference survives reloads.
+  const [analyticsCollapsed, setAnalyticsCollapsed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return true;
+    try {
+      const v = window.localStorage.getItem(ANALYTICS_COLLAPSED_KEY);
+      return v === null ? true : v === 'true';
+    } catch {
+      return true;
+    }
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(ANALYTICS_COLLAPSED_KEY, String(analyticsCollapsed));
+    } catch {
+      // localStorage unavailable — preference is session-scoped.
+    }
+  }, [analyticsCollapsed]);
   // Log mount once — gives the user a "system online" anchor so an
   // empty log during early interactions doesn't look broken. The ref
   // guard prevents StrictMode's intentional double-invoke from
@@ -532,6 +568,38 @@ export function ChatArchViewer({
     const id = window.requestAnimationFrame(() => window.scrollTo(0, y));
     return () => window.cancelAnimationFrame(id);
   }, [isInDetail]);
+
+  // --- Phase 2a: load applied-improvements ledger once ---
+  // Used to drive the default-mode reroute below. Failures resolve to
+  // null (the loader swallows 404 / network / parse errors) so this
+  // never blocks viewer startup.
+  useEffect(() => {
+    let cancelled = false;
+    loadAppliedImprovementsFile(dataRoot).then((f) => {
+      if (cancelled) return;
+      setAppliedImprovements(f);
+      setAppliedHydrated(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dataRoot]);
+
+  // --- Phase 2a: default-mode reroute ---
+  // When the user has at least one applied improvement, jump them to
+  // CORRECTIONS on first paint so the workshop loop is the landing
+  // surface. Defers to URL hash and any prior user navigation so we
+  // never yank an in-progress session.
+  const defaultRerouteAppliedRef = useRef(false);
+  useEffect(() => {
+    if (!appliedHydrated || defaultRerouteAppliedRef.current) return;
+    defaultRerouteAppliedRef.current = true;
+    if (typeof window !== 'undefined' && window.location.hash) return;
+    if (mode !== 'command') return;
+    if ((appliedImprovements?.entries.length ?? 0) > 0) {
+      setMode('corrections');
+    }
+  }, [appliedHydrated, appliedImprovements, mode]);
 
   // --- fetch manifest ---
   useEffect(() => {
@@ -2124,6 +2192,7 @@ export function ChatArchViewer({
           disabled={showDetailOverlay}
           tierIndicator={tierIndicator}
           locationLabel={LOCATION_LABEL[activeMode]}
+          lastIndexed={manifest?.generatedAt ?? null}
           {...(rescanDelta ? { rescanDelta } : {})}
           onDismissRescanDelta={() => setRescanDelta(null)}
         />
@@ -2133,6 +2202,8 @@ export function ChatArchViewer({
             variant={sidebarVariant}
             onOpenDataPanel={() => setDataPanelOpen(true)}
             dataPanelOpen={dataPanelOpen}
+            analyticsCollapsed={analyticsCollapsed}
+            onToggleAnalyticsCollapsed={() => setAnalyticsCollapsed((c) => !c)}
             onSelectMode={(m) => {
               if (m !== 'detail') {
                 clearHash();
@@ -2443,6 +2514,7 @@ export function ChatArchViewer({
             </main>
           </div>
         </div>
+        <TrustStrip variant="footer" />
       </div>
       <ActivityLogPanel
         entries={logEntries}

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -353,6 +353,16 @@ export function ChatArchViewer({
     kind: 'ok' | 'error';
     message: string;
   } | null>(null);
+  // Persistent per-source delta chip in the TopBar. Survives banner
+  // dismiss / auto-vanish so the user has a long-lived signal of the
+  // last rescan's effect; cleared on next rescan or by the chip's own
+  // ✕ dismiss button.
+  const [rescanDelta, setRescanDelta] = useState<{
+    totalLocal: number;
+    cowork: number;
+    cli: number;
+    desktop: number;
+  } | null>(null);
   // Demo-mode detection: the standalone's `pnpm dev` seed-script writes a
   // sibling `.demo` file alongside the demo manifest. Real exporter output
   // never writes this file, so its presence reliably means "what's loaded
@@ -1630,6 +1640,9 @@ export function ChatArchViewer({
         const newLocal =
           fresh.counts.cowork + fresh.counts['cli-direct'] + fresh.counts['cli-desktop'];
         const deltaLocal = newLocal - priorLocal;
+        const deltaCowork = fresh.counts.cowork - priorCounts.cowork;
+        const deltaCli = fresh.counts['cli-direct'] - priorCounts['cli-direct'];
+        const deltaDesktop = fresh.counts['cli-desktop'] - priorCounts['cli-desktop'];
         const elapsedS = Math.round((result.durationMs ?? 0) / 100) / 10;
         // Describe the delta in plain language. Negative is rare (a
         // session was deleted on disk) — reporting it honestly beats
@@ -1643,6 +1656,19 @@ export function ChatArchViewer({
         const msg = `Rescan complete in ${elapsedS}s · ${deltaPhrase} (${newLocal} total local)`;
         setRescanToast(msg);
         setRescanBanner({ kind: 'ok', message: msg });
+        setRescanDelta({
+          totalLocal: deltaLocal,
+          cowork: deltaCowork,
+          cli: deltaCli,
+          desktop: deltaDesktop,
+        });
+        // Per-source breakdown into the activity log so the detail
+        // survives the banner / chip dismiss.
+        log(
+          'info',
+          'rescan',
+          `+${deltaLocal} sessions: +${deltaCowork}/${deltaCli >= 0 ? '+' : ''}${deltaCli}/${deltaDesktop >= 0 ? '+' : ''}${deltaDesktop} (cowork/cli/desktop)`,
+        );
       } catch (err) {
         const msg =
           'Rescan wrote the manifest but the refetch failed: ' +
@@ -1680,14 +1706,11 @@ export function ChatArchViewer({
     window.setTimeout(() => setRescanToast(null), 6000);
   };
 
-  // Auto-dismiss success banners after 6s. Error banners stay until
-  // the user clicks the ✕ — a failure reason shouldn't disappear
-  // while the user is still reading it.
-  useEffect(() => {
-    if (!rescanBanner || rescanBanner.kind !== 'ok') return;
-    const id = window.setTimeout(() => setRescanBanner(null), 6000);
-    return () => window.clearTimeout(id);
-  }, [rescanBanner]);
+  // Both success and error banners now stay until the user clicks ✕.
+  // The 6s auto-dismiss for `ok` was removed in Phase 1: the user
+  // wanted a persistent signal that the last rescan added N new
+  // sessions, with the breakdown also threaded into the activity log
+  // and a TopBar `RESCAN: +N` chip.
 
   // ZOMBIE chip click → CONSTELLATION filtered to zombie projects.
   const onZombieChipClick = () => {
@@ -2080,6 +2103,8 @@ export function ChatArchViewer({
           disabled={showDetailOverlay}
           tierIndicator={tierIndicator}
           locationLabel={LOCATION_LABEL[activeMode]}
+          {...(rescanDelta ? { rescanDelta } : {})}
+          onDismissRescanDelta={() => setRescanDelta(null)}
         />
         <div className="lcars-body">
           <Sidebar

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -234,6 +234,15 @@ export function ChatArchViewer({
     () => readTopicsHash().selectedTopicId,
   );
   const [selectedId, setSelectedId] = useState<string | null>(() => readSessionHash());
+  // Phase 1 corrections-loop: a CORRECTIONS instance-pill clickthrough
+  // opens session detail. Hitting BACK should land back in CORRECTIONS,
+  // not the default `command` mode — otherwise the loop is broken on
+  // backtrack. We stash the mode at click time and `onBack` restores
+  // it. Only set when a non-default restoration is wanted; cleared
+  // after restoration so a subsequent `onSelect` from an unrelated
+  // surface doesn't accidentally inherit it.
+  const [priorModeBeforeDetail, setPriorModeBeforeDetail] =
+    useState<Mode | null>(null);
   const [rawQuery, setRawQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [sourceFilter, setSourceFilter] = useState<FilterState>(new Set<SessionSource>());
@@ -1575,6 +1584,13 @@ export function ChatArchViewer({
       return;
     }
     setSelectedId(null);
+    // Restore the surface the user came from (e.g. CORRECTIONS) so the
+    // backtrack lands in the loop instead of dumping them on SESSIONS.
+    if (priorModeBeforeDetail) {
+      setMode(priorModeBeforeDetail);
+      setPriorModeBeforeDetail(null);
+      return;
+    }
     setMode('command');
   };
   const onPrev = () => {
@@ -1663,11 +1679,16 @@ export function ChatArchViewer({
           desktop: deltaDesktop,
         });
         // Per-source breakdown into the activity log so the detail
-        // survives the banner / chip dismiss.
+        // survives the banner / chip dismiss. Format as
+        // `+12 total · +8 cowork · +3 CLI · +1 desktop` — easier to
+        // read than the slash-separated tuple it replaced (a reader
+        // had to mentally zip the numbers to the labels).
+        const fmtDelta = (n: number) => (n >= 0 ? `+${n}` : `${n}`);
         log(
           'info',
           'rescan',
-          `+${deltaLocal} sessions: +${deltaCowork}/${deltaCli >= 0 ? '+' : ''}${deltaCli}/${deltaDesktop >= 0 ? '+' : ''}${deltaDesktop} (cowork/cli/desktop)`,
+          `${fmtDelta(deltaLocal)} total · ${fmtDelta(deltaCowork)} cowork · ` +
+            `${fmtDelta(deltaCli)} CLI · ${fmtDelta(deltaDesktop)} desktop`,
         );
       } catch (err) {
         const msg =
@@ -2359,7 +2380,14 @@ export function ChatArchViewer({
                     ) : baseMode === 'corrections' ? (
                       <CorrectionsPanel
                         dataDirBaseUrl={dataRoot}
-                        onSelectSession={onSelect}
+                        onSelectSession={(id) => {
+                          // Stash the source mode so BACK restores
+                          // CORRECTIONS instead of falling to SESSIONS
+                          // (`command`). Cleared by `onBack` after
+                          // restoration.
+                          setPriorModeBeforeDetail('corrections');
+                          onSelect(id);
+                        }}
                       />
                     ) : baseMode === 'topics' ? (
                       <TopicsMode

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -40,7 +40,11 @@ import { PracticeMode } from './components/modes/PracticeMode.js';
 import { CorrectionsPanel } from './components/CorrectionsPanel.js';
 import type { CostKpiSection } from './components/modes/CostMode.js';
 import { fetchManifest } from './data/fetch.js';
-import { loadAppliedImprovementsFile } from './data/correctionsLoader.js';
+import {
+  loadAppliedImprovementsFile,
+  loadCorrectionsFile,
+} from './data/correctionsLoader.js';
+import type { CorrectionsFile } from '@chat-arch/schema';
 import { fetchAnalysisTierStatus } from './data/analysisFetch.js';
 import { fetchV2Entities, buildSessionV2Index } from './data/v2EntitiesFetch.js';
 import { computeV2Entities } from './data/computeV2Entities.js';
@@ -104,7 +108,33 @@ const HASH_PRACTICE = '#practice';
 const DEMO_BANNER_DISMISSED_KEY = 'chat-arch:demo-banner-dismissed';
 const BOOT_SEEN_KEY = 'chat-arch:boot-seen';
 const SORT_BY_KEY = 'chat-arch:sort-by';
-const ANALYTICS_COLLAPSED_KEY = 'chat-arch-analytics-collapsed';
+const ANALYTICS_COLLAPSED_KEY = 'chat-arch:analytics-collapsed';
+// Legacy unprefixed key from the Phase 2a ship — read on first mount
+// for existing users so their preference survives the rename.
+const LEGACY_ANALYTICS_COLLAPSED_KEY = 'chat-arch-analytics-collapsed';
+
+/**
+ * Detect whether this browser has any prior chat-arch state — i.e. is
+ * this a returning user, not a fresh install. We probe the `chat-arch:`
+ * prefix used by every persisted preference (boot-seen, sort-by,
+ * demo-banner-dismissed, embed-device-pref-v1) so the heuristic stays
+ * accurate even as new keys are added. Returning true here flips the
+ * ANALYTICS-collapsed default from "collapsed" to "expanded" so the
+ * Phase 2a IA refocus doesn't quietly hide a surface a returning user
+ * might have been using yesterday.
+ */
+function hasExistingChatArchState(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    for (let i = 0; i < window.localStorage.length; i += 1) {
+      const key = window.localStorage.key(i);
+      if (key && key.startsWith('chat-arch:')) return true;
+    }
+  } catch {
+    // localStorage policy-locked / private mode — treat as fresh install.
+  }
+  return false;
+}
 
 /**
  * Read the stored SORT preference; fall back to `recent` when missing
@@ -244,12 +274,23 @@ export function ChatArchViewer({
   // Phase 1 corrections-loop: a CORRECTIONS instance-pill clickthrough
   // opens session detail. Hitting BACK should land back in CORRECTIONS,
   // not the default `command` mode — otherwise the loop is broken on
-  // backtrack. We stash the mode at click time and `onBack` restores
-  // it. Only set when a non-default restoration is wanted; cleared
-  // after restoration so a subsequent `onSelect` from an unrelated
-  // surface doesn't accidentally inherit it.
+  // backtrack. We stash the mode at click time and the hashchange
+  // listener restores it when the session hash is popped. Only set
+  // when a non-default restoration is wanted; cleared after restoration
+  // so a subsequent `onSelect` from an unrelated surface doesn't
+  // accidentally inherit it.
+  //
+  // The companion ref mirrors state for the hashchange listener: that
+  // listener is registered once on mount (so it doesn't re-subscribe
+  // on every state change) but needs fresh access to the prior mode
+  // when the user hits BACK. State alone would freeze the closure to
+  // its initial null; the ref bridges the gap.
   const [priorModeBeforeDetail, setPriorModeBeforeDetail] =
     useState<Mode | null>(null);
+  const priorModeBeforeDetailRef = useRef<Mode | null>(null);
+  useEffect(() => {
+    priorModeBeforeDetailRef.current = priorModeBeforeDetail;
+  }, [priorModeBeforeDetail]);
   const [rawQuery, setRawQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
   const [sourceFilter, setSourceFilter] = useState<FilterState>(new Set<SessionSource>());
@@ -296,6 +337,17 @@ export function ChatArchViewer({
   const [appliedImprovements, setAppliedImprovements] =
     useState<AppliedImprovementsFile | null>(null);
   const [appliedHydrated, setAppliedHydrated] = useState(false);
+  // Phase 2a: also load corrections.json at the viewer level so the
+  // default-mode reroute fires for demo / first-time users who have
+  // patterns to look at but no APPLY clicks yet. Mirrors the
+  // applied-improvements pattern — CorrectionsPanel still does its own
+  // load (so an embedded panel stays self-contained) and tolerates
+  // duplicate fetches; the small extra request is fine for the
+  // landing-routing benefit.
+  const [correctionsRoute, setCorrectionsRoute] =
+    useState<CorrectionsFile | null>(null);
+  const [correctionsRouteHydrated, setCorrectionsRouteHydrated] =
+    useState(false);
 
   // --- Phase 3 semantic-classification state ---
   //
@@ -334,8 +386,19 @@ export function ChatArchViewer({
   const [analyticsCollapsed, setAnalyticsCollapsed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return true;
     try {
-      const v = window.localStorage.getItem(ANALYTICS_COLLAPSED_KEY);
-      return v === null ? true : v === 'true';
+      // Prefer the canonical (`chat-arch:`-prefixed) key. Fall back to
+      // the legacy unprefixed key written by the Phase 2a ship so
+      // existing users don't lose their preference across the rename.
+      const stored =
+        window.localStorage.getItem(ANALYTICS_COLLAPSED_KEY) ??
+        window.localStorage.getItem(LEGACY_ANALYTICS_COLLAPSED_KEY);
+      if (stored !== null) return stored === 'true';
+      // No persisted preference. New installs land collapsed (workshop
+      // surfaces above the fold, Phase 2a IA intent). Returning users
+      // who never saw this key — i.e. they have OTHER chat-arch state
+      // but no analytics-collapsed entry — land expanded so the
+      // refocus doesn't hide ANALYTICS surfaces they were using.
+      return !hasExistingChatArchState();
     } catch {
       return true;
     }
@@ -532,12 +595,29 @@ export function ChatArchViewer({
       } else if (onPractice) {
         setMode('practice');
       } else {
-        // Hash cleared — reset surface modes back to SESSIONS.
-        setMode((prev) =>
-          prev === 'detail' || prev === 'projects' || prev === 'topics' || prev === 'practice'
-            ? 'command'
-            : prev,
-        );
+        // Hash cleared — reset surface modes back to SESSIONS, OR to
+        // the prior surface the user came from when a session-detail
+        // pill kicked them into `detail` (e.g. CORRECTIONS / PRACTICE
+        // → DETAIL → BACK should return to CORRECTIONS / PRACTICE,
+        // not dump them on SESSIONS). The ref mirrors state so this
+        // closure (registered once) sees the freshest value.
+        setMode((prev) => {
+          if (
+            prev === 'detail' ||
+            prev === 'projects' ||
+            prev === 'topics' ||
+            prev === 'practice'
+          ) {
+            const stashed = priorModeBeforeDetailRef.current;
+            if (prev === 'detail' && stashed) {
+              priorModeBeforeDetailRef.current = null;
+              setPriorModeBeforeDetail(null);
+              return stashed;
+            }
+            return 'command';
+          }
+          return prev;
+        });
       }
     };
     sync();
@@ -569,10 +649,11 @@ export function ChatArchViewer({
     return () => window.cancelAnimationFrame(id);
   }, [isInDetail]);
 
-  // --- Phase 2a: load applied-improvements ledger once ---
-  // Used to drive the default-mode reroute below. Failures resolve to
-  // null (the loader swallows 404 / network / parse errors) so this
-  // never blocks viewer startup.
+  // --- Phase 2a: load applied-improvements ledger + corrections.json once ---
+  // Both feed the default-mode reroute below. Failures resolve to null
+  // (the loaders swallow 404 / network / parse errors) so this never
+  // blocks viewer startup. Loaded in parallel so the reroute decision
+  // doesn't wait for two serial round trips.
   useEffect(() => {
     let cancelled = false;
     loadAppliedImprovementsFile(dataRoot).then((f) => {
@@ -580,26 +661,44 @@ export function ChatArchViewer({
       setAppliedImprovements(f);
       setAppliedHydrated(true);
     });
+    loadCorrectionsFile(dataRoot).then((f) => {
+      if (cancelled) return;
+      setCorrectionsRoute(f);
+      setCorrectionsRouteHydrated(true);
+    });
     return () => {
       cancelled = true;
     };
   }, [dataRoot]);
 
   // --- Phase 2a: default-mode reroute ---
-  // When the user has at least one applied improvement, jump them to
+  // When the corpus has *anything* to act on (any APPLY ledger entry
+  // OR any classified correction pattern), jump the user to
   // CORRECTIONS on first paint so the workshop loop is the landing
-  // surface. Defers to URL hash and any prior user navigation so we
-  // never yank an in-progress session.
+  // surface. Demo / first-mine users have patterns but no APPLYs yet —
+  // requiring applied entries would silently leave them on SESSIONS,
+  // which is the wrong default for the Phase 2a refocus. Defers to
+  // URL hash and any prior user navigation so we never yank an
+  // in-progress session.
   const defaultRerouteAppliedRef = useRef(false);
   useEffect(() => {
-    if (!appliedHydrated || defaultRerouteAppliedRef.current) return;
+    if (!appliedHydrated || !correctionsRouteHydrated) return;
+    if (defaultRerouteAppliedRef.current) return;
     defaultRerouteAppliedRef.current = true;
     if (typeof window !== 'undefined' && window.location.hash) return;
     if (mode !== 'command') return;
-    if ((appliedImprovements?.entries.length ?? 0) > 0) {
+    const hasApplied = (appliedImprovements?.entries.length ?? 0) > 0;
+    const hasPatterns = (correctionsRoute?.patterns?.length ?? 0) > 0;
+    if (hasApplied || hasPatterns) {
       setMode('corrections');
     }
-  }, [appliedHydrated, appliedImprovements, mode]);
+  }, [
+    appliedHydrated,
+    correctionsRouteHydrated,
+    appliedImprovements,
+    correctionsRoute,
+    mode,
+  ]);
 
   // --- fetch manifest ---
   useEffect(() => {
@@ -2435,7 +2534,14 @@ export function ChatArchViewer({
                         narratives={effectiveV2Entities.narratives ?? []}
                         duplicateClusters={mergedClusters}
                         zombieProjects={zombieProjects}
-                        onSelectSession={onSelect}
+                        onSelectSession={(id) => {
+                          // Stash the source mode so BACK restores
+                          // PRACTICE instead of dumping the user on
+                          // SESSIONS — same loop-preservation logic
+                          // CORRECTIONS uses for its instance pills.
+                          setPriorModeBeforeDetail('practice');
+                          onSelect(id);
+                        }}
                         onSelectProject={(id) => {
                           setSelectedProjectId(id);
                           setMode('projects');
@@ -2514,7 +2620,14 @@ export function ChatArchViewer({
             </main>
           </div>
         </div>
-        <TrustStrip variant="footer" />
+        {/*
+          Detail-mode hides the footer TrustStrip — the modal-style
+          overlay benefits from the full vertical real estate, and the
+          local-first pledge already had a hundred-row read on the way
+          in. Re-renders on close so the persistent reassurance is
+          back the moment the user returns to a content surface.
+        */}
+        {!showDetailOverlay && <TrustStrip variant="footer" />}
       </div>
       <ActivityLogPanel
         entries={logEntries}

--- a/packages/viewer/src/components/CorrectionPatternCard.test.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.test.tsx
@@ -137,4 +137,162 @@ describe('CorrectionPatternCard', () => {
       expect(apply.getAttribute('title')).toMatch(/copy/i);
     });
   });
+
+  describe('apply state machine', () => {
+    it('renders APPLY as enabled when an onApply handler is provided', () => {
+      const onApply = vi.fn();
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          onApply={onApply}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      const apply = screen.getByRole('button', { name: /^APPLY$/ });
+      expect((apply as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('shows the confirm row after the first APPLY click', () => {
+      const onApply = vi.fn();
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          onApply={onApply}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^APPLY$/ }));
+      // onApply is NOT called yet — only after CONFIRM APPLY.
+      expect(onApply).not.toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: /CONFIRM APPLY/i })).toBeDefined();
+      expect(screen.getByRole('button', { name: /CANCEL/i })).toBeDefined();
+    });
+
+    it('passes the proposed-upgrade payload (with extras) when CONFIRM APPLY is clicked', async () => {
+      const onApply = vi.fn().mockResolvedValue({ ok: true });
+      const u = upgrade({ targetPath: '~/.claude/CLAUDE.md', patch: '- rule X' });
+      const p = pattern({ proposedUpgrades: [u] });
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          onApply={onApply}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^APPLY$/ }));
+      // Type into the optional fields to confirm they thread through.
+      const textareas = screen.getAllByRole('textbox');
+      fireEvent.change(textareas[0], {
+        target: { value: '~/.claude/CLAUDE.md\n<repo>/CLAUDE.md' },
+      });
+      fireEvent.change(textareas[1], { target: { value: 'moved to PostToolUse' } });
+      fireEvent.click(screen.getByRole('button', { name: /CONFIRM APPLY/i }));
+      await waitFor(() => {
+        expect(onApply).toHaveBeenCalledTimes(1);
+      });
+      expect(onApply).toHaveBeenCalledWith(u, {
+        targetFiles: ['~/.claude/CLAUDE.md', '<repo>/CLAUDE.md'],
+        notes: 'moved to PostToolUse',
+      });
+    });
+
+    it('swaps to APPLIED ✓ on success', async () => {
+      const onApply = vi.fn().mockResolvedValue({ ok: true });
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          onApply={onApply}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^APPLY$/ }));
+      fireEvent.click(screen.getByRole('button', { name: /CONFIRM APPLY/i }));
+      await waitFor(() => {
+        expect(screen.getByText(/APPLIED ✓/)).toBeDefined();
+      });
+      // The APPLY button is gone now — replaced by the APPLIED ✓ pill.
+      expect(screen.queryByRole('button', { name: /^APPLY$/ })).toBeNull();
+    });
+
+    it('shows an inline error + RETRY when onApply returns ok: false', async () => {
+      const onApply = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, error: 'disk full' });
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          onApply={onApply}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^APPLY$/ }));
+      fireEvent.click(screen.getByRole('button', { name: /CONFIRM APPLY/i }));
+      await waitFor(() => {
+        expect(screen.getByText(/Apply failed: disk full/)).toBeDefined();
+      });
+      // RETRY pulls the user back into the confirm step rather than throwing.
+      const retry = screen.getByRole('button', { name: /RETRY/i });
+      expect(retry).toBeDefined();
+      fireEvent.click(retry);
+      expect(screen.getByRole('button', { name: /CONFIRM APPLY/i })).toBeDefined();
+    });
+
+    it('renders APPLIED ✓ on initial render when the upgrade is already applied', () => {
+      // Mirrors the case where mergeAppliedImprovements stamped applied
+      // = true onto a ProposedUpgrade before the card mounts (page
+      // reload after a previous APPLY).
+      const u = upgrade({ applied: true, appliedAt: 1_700_500_000_000 });
+      const p = pattern({ proposedUpgrades: [u] });
+      const onApply = vi.fn();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          onApply={onApply}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      expect(screen.getByText(/APPLIED ✓/)).toBeDefined();
+    });
+  });
+
+  describe('instance clickthrough', () => {
+    it('renders each instance as a clickable button when onSelectSession is provided', () => {
+      const onSelectSession = vi.fn();
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          onSelectSession={onSelectSession}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      // 3 instances × 1 pill each.
+      const pills = screen.getAllByRole('button', { name: /open session s-c/ });
+      expect(pills).toHaveLength(3);
+      fireEvent.click(pills[0]);
+      expect(onSelectSession).toHaveBeenCalledWith('s-c1');
+    });
+
+    it('renders instances as static (no buttons) when onSelectSession is omitted', () => {
+      const p = pattern();
+      render(
+        <CorrectionPatternCard pattern={p} instancesById={buildInstancesById(p.instanceIds)} />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      // Only the SHOW/HIDE-DETAILS toggle and (disabled) APPLY remain
+      // as buttons in this branch — no per-instance pill buttons.
+      expect(screen.queryAllByRole('button', { name: /open session/i })).toHaveLength(0);
+    });
+  });
 });

--- a/packages/viewer/src/components/CorrectionPatternCard.test.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.test.tsx
@@ -124,7 +124,9 @@ describe('CorrectionPatternCard', () => {
       });
     });
 
-    it('renders APPLY as disabled with an explanatory tooltip', () => {
+    it('renders APPLY as disabled when no onApply handler is provided', () => {
+      // Production static-build fallback: APPLY stays disabled with a
+      // copy-and-edit tooltip so users can still apply manually.
       const p = pattern();
       render(
         <CorrectionPatternCard pattern={p} instancesById={buildInstancesById(p.instanceIds)} />,
@@ -132,7 +134,7 @@ describe('CorrectionPatternCard', () => {
       fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
       const apply = screen.getByRole('button', { name: /^APPLY$/ });
       expect((apply as HTMLButtonElement).disabled).toBe(true);
-      expect(apply.getAttribute('title')).toMatch(/not yet implemented/i);
+      expect(apply.getAttribute('title')).toMatch(/copy/i);
     });
   });
 });

--- a/packages/viewer/src/components/CorrectionPatternCard.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.tsx
@@ -5,6 +5,7 @@ import type {
   ProposedUpgrade,
   UpgradeTarget,
 } from '@chat-arch/schema';
+import { formatRelative } from '../util/time.js';
 
 export interface CorrectionPatternCardProps {
   pattern: CorrectionPattern;
@@ -79,7 +80,18 @@ function formatConfidence(c: number): string {
   return `${pct}%`;
 }
 
+/**
+ * Render APPLIED ✓ timestamps as relative ("64d ago", "3h ago"). The
+ * raw ISO is kept in a `title=` attribute so the precise time is one
+ * hover away — relative numbers help "is this recent?" pattern-recall;
+ * the ISO is the audit trail.
+ */
 function formatAppliedAt(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  return formatRelative(ms);
+}
+
+function formatAppliedAtIso(ms: number): string {
   if (!Number.isFinite(ms) || ms <= 0) return '';
   try {
     return new Date(ms).toISOString().replace(/\.\d+Z$/, 'Z');
@@ -320,7 +332,10 @@ function UpgradeRow({
       ? { kind: 'applied', appliedAt: upgrade.appliedAt }
       : { kind: 'idle' },
   );
-  const [targetFilesInput, setTargetFilesInput] = useState('');
+  // Pre-fill with the upgrade's targetPath so the default CONFIRM click
+  // captures the obvious answer instead of an empty audit trail. Users
+  // can append other files (`CLAUDE.md, .claude/skills/foo/SKILL.md`).
+  const [targetFilesInput, setTargetFilesInput] = useState(upgrade.targetPath);
   const [notesInput, setNotesInput] = useState('');
 
   const submit = async () => {
@@ -390,7 +405,8 @@ function UpgradeRow({
         {state.kind === 'applied' && (
           <span
             className="lcars-correction-pattern__applied"
-            aria-label={`applied at ${formatAppliedAt(state.appliedAt)}`}
+            aria-label={`applied ${formatAppliedAt(state.appliedAt)} (${formatAppliedAtIso(state.appliedAt)})`}
+            title={formatAppliedAtIso(state.appliedAt)}
           >
             APPLIED ✓
             {formatAppliedAt(state.appliedAt) && (
@@ -460,10 +476,23 @@ function UpgradeRow({
             />
           </label>
           <div className="lcars-correction-pattern__confirm-actions">
+            {/*
+              Disable CONFIRM APPLY when a sibling row is mid-write
+              (busy && !isMe). Without this lock, the second click would
+              fly past the IDLE→CONFIRMING gate (we're already in
+              CONFIRMING) and trip the server's 409 race response —
+              cosmetic, but confusing.
+            */}
             <button
               type="button"
               className="lcars-correction-pattern__btn lcars-correction-pattern__btn--primary"
               onClick={() => void submit()}
+              disabled={busy && !isMe}
+              title={
+                busy && !isMe
+                  ? 'Another upgrade is being applied. Try again in a moment.'
+                  : undefined
+              }
               autoFocus
             >
               CONFIRM APPLY

--- a/packages/viewer/src/components/CorrectionPatternCard.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.tsx
@@ -376,7 +376,7 @@ function UpgradeRow({
         >
           {copied ? 'COPIED' : 'COPY PATCH'}
         </button>
-        {!onApply && (
+        {!onApply && state.kind !== 'applied' && (
           <button
             type="button"
             className="lcars-correction-pattern__btn lcars-correction-pattern__btn--primary"
@@ -386,6 +386,20 @@ function UpgradeRow({
           >
             APPLY
           </button>
+        )}
+        {state.kind === 'applied' && (
+          <span
+            className="lcars-correction-pattern__applied"
+            aria-label={`applied at ${formatAppliedAt(state.appliedAt)}`}
+          >
+            APPLIED ✓
+            {formatAppliedAt(state.appliedAt) && (
+              <span className="lcars-correction-pattern__applied-time">
+                {' '}
+                {formatAppliedAt(state.appliedAt)}
+              </span>
+            )}
+          </span>
         )}
         {onApply && state.kind === 'idle' && (
           <button
@@ -406,20 +420,6 @@ function UpgradeRow({
           >
             {isMe ? 'APPLYING…' : 'APPLY'}
           </button>
-        )}
-        {onApply && state.kind === 'applied' && (
-          <span
-            className="lcars-correction-pattern__applied"
-            aria-label={`applied at ${formatAppliedAt(state.appliedAt)}`}
-          >
-            APPLIED ✓
-            {formatAppliedAt(state.appliedAt) && (
-              <span className="lcars-correction-pattern__applied-time">
-                {' '}
-                {formatAppliedAt(state.appliedAt)}
-              </span>
-            )}
-          </span>
         )}
       </div>
       {onApply && state.kind === 'confirming' && (

--- a/packages/viewer/src/components/CorrectionPatternCard.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.tsx
@@ -14,6 +14,23 @@ export interface CorrectionPatternCardProps {
    * array. The caller (CorrectionsPanel) builds it once.
    */
   instancesById: Map<string, Correction>;
+  /**
+   * APPLY click handler. When omitted (production static build, or
+   * the dev endpoint hasn't been probed yet), APPLY renders disabled
+   * with the legacy "not yet implemented" tooltip — same fallback
+   * the v0.7 panel showed.
+   */
+  onApply?: (
+    upgrade: ProposedUpgrade,
+    extras: { targetFiles?: string[]; notes?: string },
+  ) => Promise<{ ok: boolean; error?: string }>;
+  /**
+   * Session-selection handler for the instance-pill clickthrough.
+   * Plumbed from CorrectionsPanel → BucketsView → here. When omitted
+   * (e.g. host that doesn't support detail view), the instance row
+   * renders as static text rather than as a button.
+   */
+  onSelectSession?: (sessionId: string) => void;
 }
 
 const CATEGORY: Array<{
@@ -62,12 +79,27 @@ function formatConfidence(c: number): string {
   return `${pct}%`;
 }
 
+function formatAppliedAt(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  try {
+    return new Date(ms).toISOString().replace(/\.\d+Z$/, 'Z');
+  } catch {
+    return '';
+  }
+}
+
 const INITIAL_INSTANCE_COUNT = 3;
 
-export function CorrectionPatternCard({ pattern, instancesById }: CorrectionPatternCardProps) {
+export function CorrectionPatternCard({
+  pattern,
+  instancesById,
+  onApply,
+  onSelectSession,
+}: CorrectionPatternCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [showAllInstances, setShowAllInstances] = useState(false);
   const [copiedIx, setCopiedIx] = useState<number | null>(null);
+  const [busyIx, setBusyIx] = useState<number | null>(null);
 
   const category = categoryFor(pattern);
   const categoryLabel =
@@ -161,22 +193,47 @@ export function CorrectionPatternCard({ pattern, instancesById }: CorrectionPatt
               </p>
             ) : (
               <ul className="lcars-correction-pattern__instance-list" role="list">
-                {visibleInstances.map((inst) => (
-                  <li key={inst.id} className="lcars-correction-pattern__instance">
-                    {inst.precedingAssistantExcerpt && (
-                      <p className="lcars-correction-pattern__instance-context">
-                        <span className="lcars-correction-pattern__instance-tag">
-                          ASSISTANT
-                        </span>
-                        <span>{inst.precedingAssistantExcerpt}</span>
+                {visibleInstances.map((inst) => {
+                  const body = (
+                    <>
+                      {inst.precedingAssistantExcerpt && (
+                        <p className="lcars-correction-pattern__instance-context">
+                          <span className="lcars-correction-pattern__instance-tag">
+                            ASSISTANT
+                          </span>
+                          <span>{inst.precedingAssistantExcerpt}</span>
+                        </p>
+                      )}
+                      <p className="lcars-correction-pattern__instance-body">
+                        <span className="lcars-correction-pattern__instance-tag">USER</span>
+                        <span>{inst.excerpt}</span>
                       </p>
-                    )}
-                    <p className="lcars-correction-pattern__instance-body">
-                      <span className="lcars-correction-pattern__instance-tag">USER</span>
-                      <span>{inst.excerpt}</span>
-                    </p>
-                  </li>
-                ))}
+                    </>
+                  );
+                  if (onSelectSession) {
+                    return (
+                      <li
+                        key={inst.id}
+                        className="lcars-correction-pattern__instance"
+                      >
+                        <button
+                          type="button"
+                          className="lcars-correction-pattern__instance-pill"
+                          onClick={() => onSelectSession(inst.sessionId)}
+                          aria-label={`open session ${inst.sessionId}`}
+                          title={`Open session ${inst.sessionId}`}
+                        >
+                          {body}
+                        </button>
+                      </li>
+                    );
+                  }
+                  return (
+                    <li key={inst.id} className="lcars-correction-pattern__instance">
+                      {body}
+                    </li>
+                  );
+                })}
               </ul>
             )}
             {hiddenInstanceCount > 0 && (
@@ -204,6 +261,14 @@ export function CorrectionPatternCard({ pattern, instancesById }: CorrectionPatt
                     upgrade={u}
                     copied={copiedIx === ix}
                     onCopy={() => void copyPatch(u.patch, ix)}
+                    {...(onApply
+                      ? {
+                          onApply: async (extras) => onApply(u, extras),
+                        }
+                      : {})}
+                    busy={busyIx !== null}
+                    isMe={busyIx === ix}
+                    onBusyChange={(busy) => setBusyIx(busy ? ix : null)}
                   />
                 ))}
               </ul>
@@ -219,10 +284,78 @@ interface UpgradeRowProps {
   upgrade: ProposedUpgrade;
   copied: boolean;
   onCopy: () => void;
+  /** Omit to render APPLY as the legacy disabled placeholder. */
+  onApply?: (
+    extras: { targetFiles?: string[]; notes?: string },
+  ) => Promise<{ ok: boolean; error?: string }>;
+  /** True while any sibling upgrade in the same card is mid-write. */
+  busy: boolean;
+  /** True when this row is the one writing — drives the APPLYING… label. */
+  isMe: boolean;
+  /** Toggle the card-level busy lock. Called on submit start / settle. */
+  onBusyChange: (busy: boolean) => void;
 }
 
-function UpgradeRow({ upgrade, copied, onCopy }: UpgradeRowProps) {
+type ApplyState =
+  | { kind: 'idle' }
+  | { kind: 'confirming' }
+  | { kind: 'submitting' }
+  | { kind: 'applied'; appliedAt: number }
+  | { kind: 'error'; message: string };
+
+function UpgradeRow({
+  upgrade,
+  copied,
+  onCopy,
+  onApply,
+  busy,
+  isMe,
+  onBusyChange,
+}: UpgradeRowProps) {
   const targetLabel = TARGET_LABEL[upgrade.target];
+  // Seed from the upgrade's persisted state so a reload after APPLY
+  // shows APPLIED ✓ without waiting for a re-click.
+  const [state, setState] = useState<ApplyState>(() =>
+    upgrade.applied && typeof upgrade.appliedAt === 'number'
+      ? { kind: 'applied', appliedAt: upgrade.appliedAt }
+      : { kind: 'idle' },
+  );
+  const [targetFilesInput, setTargetFilesInput] = useState('');
+  const [notesInput, setNotesInput] = useState('');
+
+  const submit = async () => {
+    if (!onApply) return;
+    setState({ kind: 'submitting' });
+    onBusyChange(true);
+    const targetFiles = targetFilesInput
+      .split(/[\n,]/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const notes = notesInput.trim();
+    let result: { ok: boolean; error?: string };
+    try {
+      result = await onApply({
+        ...(targetFiles.length > 0 ? { targetFiles } : {}),
+        ...(notes.length > 0 ? { notes } : {}),
+      });
+    } catch (err) {
+      result = {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    } finally {
+      onBusyChange(false);
+    }
+    if (result.ok) {
+      setState({ kind: 'applied', appliedAt: Date.now() });
+    } else {
+      setState({
+        kind: 'error',
+        message: result.error ?? 'apply failed',
+      });
+    }
+  };
+
   return (
     <li className="lcars-correction-pattern__upgrade">
       <header className="lcars-correction-pattern__upgrade-header">
@@ -243,16 +376,129 @@ function UpgradeRow({ upgrade, copied, onCopy }: UpgradeRowProps) {
         >
           {copied ? 'COPIED' : 'COPY PATCH'}
         </button>
-        <button
-          type="button"
-          className="lcars-correction-pattern__btn lcars-correction-pattern__btn--primary"
-          disabled
-          aria-disabled="true"
-          title="Apply flow not yet implemented — copy the patch and apply manually."
-        >
-          APPLY
-        </button>
+        {!onApply && (
+          <button
+            type="button"
+            className="lcars-correction-pattern__btn lcars-correction-pattern__btn--primary"
+            disabled
+            aria-disabled="true"
+            title="Apply flow not available — copy the patch and apply manually."
+          >
+            APPLY
+          </button>
+        )}
+        {onApply && state.kind === 'idle' && (
+          <button
+            type="button"
+            className="lcars-correction-pattern__btn lcars-correction-pattern__btn--primary"
+            onClick={() => setState({ kind: 'confirming' })}
+            disabled={busy}
+          >
+            APPLY
+          </button>
+        )}
+        {onApply && state.kind === 'submitting' && (
+          <button
+            type="button"
+            className="lcars-correction-pattern__btn lcars-correction-pattern__btn--primary"
+            disabled
+            aria-busy="true"
+          >
+            {isMe ? 'APPLYING…' : 'APPLY'}
+          </button>
+        )}
+        {onApply && state.kind === 'applied' && (
+          <span
+            className="lcars-correction-pattern__applied"
+            aria-label={`applied at ${formatAppliedAt(state.appliedAt)}`}
+          >
+            APPLIED ✓
+            {formatAppliedAt(state.appliedAt) && (
+              <span className="lcars-correction-pattern__applied-time">
+                {' '}
+                {formatAppliedAt(state.appliedAt)}
+              </span>
+            )}
+          </span>
+        )}
       </div>
+      {onApply && state.kind === 'confirming' && (
+        <div
+          className="lcars-correction-pattern__confirm"
+          role="dialog"
+          aria-label="confirm apply correction"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              setState({ kind: 'idle' });
+            }
+          }}
+        >
+          <p className="lcars-correction-pattern__confirm-blurb">
+            Record this upgrade as applied. The patch isn&apos;t written to
+            disk for you — copy it above, edit the target file, then confirm
+            so the loop closes.
+          </p>
+          <label className="lcars-correction-pattern__confirm-field">
+            <span>Files you edited (one per line, optional)</span>
+            <textarea
+              className="lcars-correction-pattern__confirm-textarea"
+              rows={2}
+              value={targetFilesInput}
+              onChange={(e) => setTargetFilesInput(e.target.value)}
+              placeholder={upgrade.targetPath}
+            />
+          </label>
+          <label className="lcars-correction-pattern__confirm-field">
+            <span>Notes (optional)</span>
+            <textarea
+              className="lcars-correction-pattern__confirm-textarea"
+              rows={2}
+              value={notesInput}
+              onChange={(e) => setNotesInput(e.target.value)}
+              placeholder="e.g. moved to PostToolUse hook"
+            />
+          </label>
+          <div className="lcars-correction-pattern__confirm-actions">
+            <button
+              type="button"
+              className="lcars-correction-pattern__btn lcars-correction-pattern__btn--primary"
+              onClick={() => void submit()}
+              autoFocus
+            >
+              CONFIRM APPLY
+            </button>
+            <button
+              type="button"
+              className="lcars-correction-pattern__btn lcars-correction-pattern__btn--ghost"
+              onClick={() => setState({ kind: 'idle' })}
+            >
+              CANCEL
+            </button>
+          </div>
+        </div>
+      )}
+      {onApply && state.kind === 'error' && (
+        <div className="lcars-correction-pattern__apply-error" role="alert">
+          <p>Apply failed: {state.message}</p>
+          <div className="lcars-correction-pattern__confirm-actions">
+            <button
+              type="button"
+              className="lcars-correction-pattern__btn lcars-correction-pattern__btn--secondary"
+              onClick={() => setState({ kind: 'confirming' })}
+            >
+              RETRY
+            </button>
+            <button
+              type="button"
+              className="lcars-correction-pattern__btn lcars-correction-pattern__btn--ghost"
+              onClick={() => setState({ kind: 'idle' })}
+            >
+              DISMISS
+            </button>
+          </div>
+        </div>
+      )}
     </li>
   );
 }

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
-import type { CorrectionPattern, CorrectionsFile } from '@chat-arch/schema';
+import type {
+  CorrectionPattern,
+  CorrectionsFile,
+  ProposedUpgrade,
+} from '@chat-arch/schema';
 import type * as CorrectionsLoaderModule from '../data/correctionsLoader.js';
 
 // Mock the loader module before importing the panel so the mocked
@@ -41,6 +45,7 @@ vi.mock('../data/mineCorrectionsClient.js', () => ({
 import {
   loadCorrectionsFile,
   loadCorrectionCandidatesFile,
+  loadAppliedImprovementsFile,
 } from '../data/correctionsLoader.js';
 import { CorrectionsPanel } from './CorrectionsPanel.js';
 
@@ -51,6 +56,7 @@ afterEach(() => {
 
 const mockedLoadCorrections = vi.mocked(loadCorrectionsFile);
 const mockedLoadCandidates = vi.mocked(loadCorrectionCandidatesFile);
+const mockedLoadApplied = vi.mocked(loadAppliedImprovementsFile);
 
 function pattern(overrides: Partial<CorrectionPattern> & { id: string }): CorrectionPattern {
   return {
@@ -86,6 +92,8 @@ describe('CorrectionsPanel', () => {
   beforeEach(() => {
     mockedLoadCorrections.mockReset();
     mockedLoadCandidates.mockReset();
+    mockedLoadApplied.mockReset();
+    mockedLoadApplied.mockResolvedValue(null);
   });
 
   it('renders the empty state when both fetches return null', async () => {
@@ -188,5 +196,96 @@ describe('CorrectionsPanel', () => {
     const encoded = screen.getByLabelText('ALREADY ENCODED BUT FAILING');
     expect(within(recurring).getByText('Nothing here — good.')).toBeDefined();
     expect(within(encoded).getByText('Nothing here — good.')).toBeDefined();
+  });
+
+  describe('applied-improvements merge', () => {
+    it('flips a NEW pattern into RECURRING when ledger entry has appliedAt < lastSeen', async () => {
+      // The pattern itself was emitted with recurringPostApplication =
+      // false, but the ledger says it was applied earlier; merge
+      // should re-categorize it.
+      const u: ProposedUpgrade = {
+        target: 'global-claude-md',
+        targetPath: '~/.claude/CLAUDE.md',
+        patch: '- rule X',
+        rationale: 'r',
+        applied: false,
+        appliedAt: null,
+      };
+      const p = pattern({
+        id: 'p-recurring',
+        canonicalRule: 'flips into recurring',
+        proposedUpgrades: [u],
+        recurringPostApplication: false,
+      });
+      mockedLoadCorrections.mockResolvedValue(file([p]));
+      mockedLoadCandidates.mockResolvedValue(null);
+      mockedLoadApplied.mockResolvedValue({
+        schemaVersion: 1,
+        generatedAt: 1_700_200_000_000,
+        entries: [
+          {
+            id: 'a-1',
+            patternId: 'p-recurring',
+            // lastSeen = 1_700_100_000_000 from the pattern factory.
+            appliedAt: 1_700_050_000_000,
+            ruleSummary: 'flips into recurring',
+            proposedUpgrade: { ...u, applied: true, appliedAt: 1_700_050_000_000 },
+          },
+        ],
+      });
+      render(<CorrectionsPanel dataDirBaseUrl="/x" />);
+      await waitFor(() => {
+        const recurring = screen.getByLabelText('RECURRING AFTER APPLIED');
+        expect(within(recurring).getByText('flips into recurring')).toBeDefined();
+      });
+      const fresh = screen.getByLabelText('NEW PATTERNS TO ENCODE');
+      expect(within(fresh).queryByText('flips into recurring')).toBeNull();
+    });
+
+    it('treats applied: true on the merged upgrade as initial APPLIED state', async () => {
+      const u: ProposedUpgrade = {
+        target: 'global-claude-md',
+        targetPath: '~/.claude/CLAUDE.md',
+        patch: '- rule Y',
+        rationale: 'r',
+        applied: false,
+        appliedAt: null,
+      };
+      const p = pattern({
+        id: 'p-applied',
+        canonicalRule: 'already applied via ledger',
+        proposedUpgrades: [u],
+        instanceIds: [],
+      });
+      mockedLoadCorrections.mockResolvedValue(file([p]));
+      mockedLoadCandidates.mockResolvedValue(null);
+      mockedLoadApplied.mockResolvedValue({
+        schemaVersion: 1,
+        generatedAt: 1_700_200_000_000,
+        entries: [
+          {
+            id: 'a-1',
+            patternId: 'p-applied',
+            appliedAt: 1_700_120_000_000,
+            ruleSummary: 'already applied',
+            proposedUpgrade: { ...u, applied: true, appliedAt: 1_700_120_000_000 },
+          },
+        ],
+      });
+      render(<CorrectionsPanel dataDirBaseUrl="/x" />);
+      await waitFor(() => {
+        expect(screen.getByText('already applied via ledger')).toBeDefined();
+      });
+      const toggles = screen.getAllByRole('button', { name: /SHOW DETAILS/i });
+      // Three buckets render their cards; the one we want is the one
+      // that surfaces our pattern, but all toggles are equivalent here.
+      // Click the first toggle that belongs to our pattern's card.
+      // Just clicking any toggle for this pattern is enough — there's only one.
+      for (const t of toggles) t.click();
+      // APPLIED ✓ should appear without any APPLY interaction.
+      await waitFor(() => {
+        expect(screen.getByText(/APPLIED ✓/)).toBeDefined();
+      });
+    });
   });
 });

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -1,13 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, waitFor, within } from '@testing-library/react';
 import type { CorrectionPattern, CorrectionsFile } from '@chat-arch/schema';
+import type * as CorrectionsLoaderModule from '../data/correctionsLoader.js';
 
 // Mock the loader module before importing the panel so the mocked
 // implementations are in place when the panel's effects fire.
-vi.mock('../data/correctionsLoader.js', () => ({
-  loadCorrectionsFile: vi.fn(),
-  loadCorrectionCandidatesFile: vi.fn(),
-}));
+vi.mock('../data/correctionsLoader.js', async () => {
+  // Pull the real `mergeAppliedImprovements` so panel-level merge
+  // assertions in the new tests below run against the production
+  // implementation; only the I/O entry points are stubbed.
+  const actual = await vi.importActual<typeof CorrectionsLoaderModule>(
+    '../data/correctionsLoader.js',
+  );
+  return {
+    loadCorrectionsFile: vi.fn(),
+    loadCorrectionCandidatesFile: vi.fn(),
+    loadAppliedImprovementsFile: vi.fn(async () => null),
+    mergeAppliedImprovements: actual.mergeAppliedImprovements,
+  };
+});
 vi.mock('../data/mineCorrectionsClient.js', () => ({
   startMineCorrections: vi.fn(),
   fetchCorrectionRunStatus: vi.fn(async () => null),

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -22,10 +22,22 @@ import {
   type MineEvent,
 } from '../data/mineCorrectionsClient.js';
 import { CorrectionPatternCard } from './CorrectionPatternCard.js';
+import {
+  applyCorrection,
+  probeApplyCorrection,
+  type ApplyCorrectionRequest,
+} from '../data/applyCorrectionClient.js';
+import type { ProposedUpgrade } from '@chat-arch/schema';
 
 export interface CorrectionsPanelProps {
   /** Same base URL the manifest was fetched from (e.g. "/chat-arch-data"). */
   dataDirBaseUrl: string;
+  /**
+   * Callback for opening a session in detail view. Plumbed from
+   * ChatArchViewer; when omitted, instance pills render as static
+   * (non-clickable) cards.
+   */
+  onSelectSession?: (sessionId: string) => void;
 }
 
 type LoadState =
@@ -115,13 +127,17 @@ type ClearState =
   | { status: 'busy' }
   | { status: 'error'; message: string };
 
-export function CorrectionsPanel({ dataDirBaseUrl }: CorrectionsPanelProps) {
+export function CorrectionsPanel({
+  dataDirBaseUrl,
+  onSelectSession,
+}: CorrectionsPanelProps) {
   const [load, setLoad] = useState<LoadState>({ status: 'loading' });
   const [mining, setMining] = useState<MiningState>({ status: 'idle' });
   const [autoWindow, setAutoWindow] = useState<AutoWindowResult | null>(null);
   const [runError, setRunError] = useState<string | null>(null);
   const [clearAvailable, setClearAvailable] = useState<boolean>(false);
   const [clearState, setClearState] = useState<ClearState>({ status: 'idle' });
+  const [applyAvailable, setApplyAvailable] = useState<boolean>(false);
 
   // Cancel in-flight loads cleanly on unmount.
   const aliveRef = useRef(true);
@@ -206,6 +222,47 @@ export function CorrectionsPanel({ dataDirBaseUrl }: CorrectionsPanelProps) {
       cancelled = true;
     };
   }, []);
+
+  // Probe the apply-correction endpoint once on mount. Same posture as
+  // the clear probe: APPLY hides on production static builds where the
+  // dev server isn't running, falling back to copy-and-edit-by-hand.
+  useEffect(() => {
+    let cancelled = false;
+    void probeApplyCorrection().then((available) => {
+      if (cancelled || !aliveRef.current) return;
+      setApplyAvailable(available);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleApply = useCallback(
+    async (
+      pattern: CorrectionPattern,
+      upgrade: ProposedUpgrade,
+      extras: { targetFiles?: string[]; notes?: string },
+    ): Promise<{ ok: boolean; error?: string }> => {
+      const req: ApplyCorrectionRequest = {
+        patternId: pattern.id,
+        proposedUpgrade: upgrade,
+        ruleSummary: pattern.canonicalRule,
+        ...extras,
+      };
+      const result = await applyCorrection(req);
+      // On success, reload the merged file so the bucket re-categorizes
+      // the pattern (RECURRING vs ENCODED vs NEW shifts when applied
+      // flips). The card itself already swapped to APPLIED ✓
+      // optimistically; the reload only affects bucket placement.
+      if (result.ok && aliveRef.current) {
+        await refresh();
+      }
+      return result.ok
+        ? { ok: true }
+        : { ok: false, ...(result.error ? { error: result.error } : {}) };
+    },
+    [refresh],
+  );
 
   const runClear = useCallback(async () => {
     setClearState({ status: 'busy' });
@@ -515,7 +572,11 @@ export function CorrectionsPanel({ dataDirBaseUrl }: CorrectionsPanelProps) {
           </p>
         )
       ) : (
-        <BucketsView corrections={corrections!} />
+        <BucketsView
+          corrections={corrections!}
+          {...(applyAvailable ? { onApply: handleApply } : {})}
+          {...(onSelectSession ? { onSelectSession } : {})}
+        />
       )}
 
       {clearAvailable && mining.status !== 'running' && (
@@ -1193,9 +1254,15 @@ function RunningBanner({ state, nowMs, onAbort }: RunningBannerProps) {
 
 interface BucketsViewProps {
   corrections: CorrectionsFile;
+  onApply?: (
+    pattern: CorrectionPattern,
+    upgrade: ProposedUpgrade,
+    extras: { targetFiles?: string[]; notes?: string },
+  ) => Promise<{ ok: boolean; error?: string }>;
+  onSelectSession?: (sessionId: string) => void;
 }
 
-function BucketsView({ corrections }: BucketsViewProps) {
+function BucketsView({ corrections, onApply, onSelectSession }: BucketsViewProps) {
   const instancesById = useMemo(() => {
     const m = new Map<string, Correction>();
     for (const c of corrections.corrections) m.set(c.id, c);
@@ -1243,7 +1310,16 @@ function BucketsView({ corrections }: BucketsViewProps) {
               <ul className="lcars-corrections__pattern-list" role="list">
                 {items.map((p) => (
                   <li key={p.id}>
-                    <CorrectionPatternCard pattern={p} instancesById={instancesById} />
+                    <CorrectionPatternCard
+                      pattern={p}
+                      instancesById={instancesById}
+                      {...(onApply
+                        ? {
+                            onApply: (upgrade, extras) => onApply(p, upgrade, extras),
+                          }
+                        : {})}
+                      {...(onSelectSession ? { onSelectSession } : {})}
+                    />
                   </li>
                 ))}
               </ul>

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -6,8 +6,10 @@ import type {
   ScanStats,
 } from '@chat-arch/schema';
 import {
+  loadAppliedImprovementsFile,
   loadCorrectionCandidatesFile,
   loadCorrectionsFile,
+  mergeAppliedImprovements,
 } from '../data/correctionsLoader.js';
 import {
   clearCorrections,
@@ -164,11 +166,19 @@ export function CorrectionsPanel({ dataDirBaseUrl }: CorrectionsPanelProps) {
   const refresh = useCallback(async () => {
     setLoad({ status: 'loading' });
     try {
-      const [corrections, candidates] = await Promise.all([
+      const [rawCorrections, candidates, applied] = await Promise.all([
         loadCorrectionsFile(dataDirBaseUrl),
         loadCorrectionCandidatesFile(dataDirBaseUrl),
+        loadAppliedImprovementsFile(dataDirBaseUrl),
       ]);
       if (!aliveRef.current) return;
+      // Merge the apply ledger over the canonical mining-pipeline
+      // output. corrections.json itself is never mutated — the
+      // merge runs at read time so a future re-mine never clobbers
+      // the user's apply history.
+      const corrections = rawCorrections
+        ? mergeAppliedImprovements(rawCorrections, applied)
+        : null;
       setLoad({ status: 'ready', corrections, candidates });
       void refreshAutoWindow();
     } catch (err) {

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -940,8 +940,10 @@ function Header({ generatedAt }: HeaderProps) {
       <h2 className="lcars-corrections__title">CORRECTIONS</h2>
       <p className="lcars-corrections__lead">
         Recurring instructions you keep giving the model — clustered, ranked, and paired with
-        proposed CLAUDE.md upgrades. Apply manually for now; the apply-to-disk flow ships in a
-        follow-up.
+        proposed CLAUDE.md upgrades. Click APPLY to log a CLAUDE.md edit you&apos;ve made; the
+        loop closes when the next mining pass shows the rule is no longer recurring. Apply
+        history is recorded in <code>applied-improvements.json</code> next to{' '}
+        <code>corrections.json</code>.
       </p>
       {typeof generatedAt === 'number' && (
         <p className="lcars-corrections__meta">

--- a/packages/viewer/src/components/LastIndexedChip.test.tsx
+++ b/packages/viewer/src/components/LastIndexedChip.test.tsx
@@ -44,6 +44,29 @@ describe('LastIndexedChip', () => {
     expect(chip!.hasAttribute('data-stale')).toBe(true);
   });
 
+  it('renders nothing when generatedAt is 0 (epoch zero treated as no real timestamp)', () => {
+    // A half-initialized manifest (or a parser bug) writing
+    // generatedAt: 0 would otherwise produce "INDEXED 20000d AGO" — a
+    // misleading staleness signal. Treat <=0 as "no timestamp" and
+    // hide the chip.
+    const { container } = render(<LastIndexedChip generatedAt={0} now={NOW} />);
+    expect(container.querySelector('.lcars-top-bar__indexed')).toBeNull();
+  });
+
+  it('clamps future generatedAt to INDEXED TODAY (clock-skew tolerance)', () => {
+    // A user whose clock is behind the build host's clock would see
+    // generatedAt > now. Without the clamp the chip would render
+    // "INDEXED -1d AGO" — a parsing artifact, not a real signal.
+    // Floor elapsed days at 0 and degrade gracefully to today.
+    const { container } = render(
+      <LastIndexedChip generatedAt={NOW + MS_PER_DAY} now={NOW} />,
+    );
+    const chip = container.querySelector('.lcars-top-bar__indexed');
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain('INDEXED TODAY');
+    expect(chip!.hasAttribute('data-stale')).toBe(false);
+  });
+
   it('tooltip contains the ISO timestamp and the UPDATE LOCAL CTA', () => {
     const generatedAt = NOW - 5 * MS_PER_DAY;
     const { container } = render(

--- a/packages/viewer/src/components/LastIndexedChip.test.tsx
+++ b/packages/viewer/src/components/LastIndexedChip.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { LastIndexedChip } from './LastIndexedChip.js';
+
+afterEach(() => cleanup());
+
+const MS_PER_DAY = 86_400_000;
+// Fixed "now" so the test isn't time-dependent. Picked an arbitrary
+// 2026-05-08 noon UTC.
+const NOW = Date.parse('2026-05-08T12:00:00Z');
+
+describe('LastIndexedChip', () => {
+  it('renders nothing when generatedAt is null', () => {
+    const { container } = render(<LastIndexedChip generatedAt={null} now={NOW} />);
+    expect(container.querySelector('.lcars-top-bar__indexed')).toBeNull();
+  });
+
+  it('shows INDEXED TODAY for a fresh manifest', () => {
+    const { container } = render(
+      <LastIndexedChip generatedAt={NOW - 2 * 60 * 60 * 1000} now={NOW} />,
+    );
+    const chip = container.querySelector('.lcars-top-bar__indexed');
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain('INDEXED TODAY');
+    // No stale attribute when fresh.
+    expect(chip!.hasAttribute('data-stale')).toBe(false);
+  });
+
+  it('shows day count and no stale flag at 5 days', () => {
+    const { container } = render(
+      <LastIndexedChip generatedAt={NOW - 5 * MS_PER_DAY} now={NOW} />,
+    );
+    const chip = container.querySelector('.lcars-top-bar__indexed');
+    expect(chip!.textContent).toContain('INDEXED 5d AGO');
+    expect(chip!.hasAttribute('data-stale')).toBe(false);
+  });
+
+  it('flips to stale at 31 days', () => {
+    const { container } = render(
+      <LastIndexedChip generatedAt={NOW - 31 * MS_PER_DAY} now={NOW} />,
+    );
+    const chip = container.querySelector('.lcars-top-bar__indexed');
+    expect(chip!.textContent).toContain('INDEXED 31d AGO');
+    expect(chip!.hasAttribute('data-stale')).toBe(true);
+  });
+
+  it('tooltip contains the ISO timestamp and the UPDATE LOCAL CTA', () => {
+    const generatedAt = NOW - 5 * MS_PER_DAY;
+    const { container } = render(
+      <LastIndexedChip generatedAt={generatedAt} now={NOW} />,
+    );
+    const chip = container.querySelector('.lcars-top-bar__indexed') as HTMLElement;
+    const title = chip.getAttribute('title') ?? '';
+    expect(title).toContain(new Date(generatedAt).toISOString());
+    expect(title).toContain('UPDATE LOCAL');
+  });
+});

--- a/packages/viewer/src/components/LastIndexedChip.tsx
+++ b/packages/viewer/src/components/LastIndexedChip.tsx
@@ -25,9 +25,16 @@ const MS_PER_DAY = 86_400_000;
 const STALE_DAYS_THRESHOLD = 30;
 
 export function LastIndexedChip({ generatedAt, now }: LastIndexedChipProps) {
-  if (generatedAt == null) return null;
+  // Treat null AND non-positive epoch values as "no real timestamp"
+  // so a `0` from a half-initialized manifest doesn't render a
+  // misleading "INDEXED 56 YEARS AGO" chip.
+  if (generatedAt == null || generatedAt <= 0) return null;
   const ref = now ?? Date.now();
-  const days = Math.floor((ref - generatedAt) / MS_PER_DAY);
+  // Clock-skew clamp: a future `generatedAt` (e.g. user's clock is
+  // behind the server's) would otherwise produce "INDEXED -1d AGO".
+  // Floor the elapsed days at 0 so the chip degrades gracefully to
+  // "INDEXED TODAY" instead of negatives.
+  const days = Math.max(0, Math.floor((ref - generatedAt) / MS_PER_DAY));
   const label = days < 1 ? 'INDEXED TODAY' : `INDEXED ${days}d AGO`;
   const isStale = days > STALE_DAYS_THRESHOLD;
   const iso = new Date(generatedAt).toISOString();

--- a/packages/viewer/src/components/LastIndexedChip.tsx
+++ b/packages/viewer/src/components/LastIndexedChip.tsx
@@ -1,0 +1,45 @@
+/**
+ * LastIndexedChip — TopBar info chip showing how stale the on-disk
+ * manifest is. Mirrors the EARTHDATE chip's visual treatment but is
+ * derived from `manifest.generatedAt` instead of "today" so a returning
+ * user can see at a glance whether they're looking at fresh data or a
+ * snapshot from weeks ago.
+ *
+ * Stale threshold (>30 days) flips the chip to the peach warning
+ * palette and surfaces a CTA in the tooltip that points at UPDATE
+ * LOCAL — the chip is informational only; the action lives in the
+ * DATA panel where rescans actually run.
+ *
+ * Returns null when `generatedAt` is null (no manifest yet) so the
+ * chip silently disappears in pre-data states rather than rendering
+ * a placeholder the user has to interpret.
+ */
+export interface LastIndexedChipProps {
+  /** ms-since-epoch from manifest.generatedAt; null → no chip. */
+  generatedAt: number | null;
+  /** Injectable "now" for deterministic tests; defaults to `Date.now()`. */
+  now?: number;
+}
+
+const MS_PER_DAY = 86_400_000;
+const STALE_DAYS_THRESHOLD = 30;
+
+export function LastIndexedChip({ generatedAt, now }: LastIndexedChipProps) {
+  if (generatedAt == null) return null;
+  const ref = now ?? Date.now();
+  const days = Math.floor((ref - generatedAt) / MS_PER_DAY);
+  const label = days < 1 ? 'INDEXED TODAY' : `INDEXED ${days}d AGO`;
+  const isStale = days > STALE_DAYS_THRESHOLD;
+  const iso = new Date(generatedAt).toISOString();
+  const tooltip = `${iso}\nRun UPDATE LOCAL to refresh`;
+  return (
+    <div
+      className="lcars-top-bar__indexed"
+      data-stale={isStale ? '' : undefined}
+      title={tooltip}
+      aria-label={`last indexed ${days < 1 ? 'today' : `${days} days ago`}`}
+    >
+      <span className="lcars-top-bar__indexed-value">{label}</span>
+    </div>
+  );
+}

--- a/packages/viewer/src/components/Sidebar.test.tsx
+++ b/packages/viewer/src/components/Sidebar.test.tsx
@@ -5,9 +5,9 @@ import { Sidebar } from './Sidebar.js';
 afterEach(() => cleanup());
 
 describe('Sidebar (vertical variant, default) — Phase 2a IA', () => {
-  it('renders WORKSHOP (CORRECTIONS+PRACTICE), BROWSE (SESSIONS), ANALYTICS (PROJECTS+TOPICS+COST+ANALYSIS)', () => {
+  it('renders FIX RULES (CORRECTIONS+PRACTICE), BROWSE (SESSIONS), ANALYTICS (PROJECTS+TOPICS+COST+ANALYSIS)', () => {
     render(<Sidebar mode="command" onSelectMode={() => {}} />);
-    // WORKSHOP — primary refocus surfaces lead.
+    // FIX RULES — primary refocus surfaces lead.
     expect(screen.getByRole('button', { name: /mode CORRECTIONS/i })).toBeDefined();
     expect(screen.getByRole('button', { name: /mode PRACTICE/i })).toBeDefined();
     // BROWSE — sessions only.
@@ -22,11 +22,11 @@ describe('Sidebar (vertical variant, default) — Phase 2a IA', () => {
     expect(screen.queryByRole('button', { name: /mode DETAIL/i })).toBeNull();
   });
 
-  it('groups the nav into WORKSHOP, BROWSE, ANALYTICS sections', () => {
+  it('groups the nav into FIX RULES, BROWSE, ANALYTICS sections', () => {
     const { container } = render(<Sidebar mode="command" onSelectMode={() => {}} />);
     const labels = container.querySelectorAll('.lcars-sidebar__group-label');
     expect(Array.from(labels).map((el) => el.textContent)).toEqual([
-      'WORKSHOP',
+      'FIX RULES',
       'BROWSE',
       'ANALYTICS',
     ]);
@@ -81,7 +81,7 @@ describe('Sidebar — ANALYTICS collapse (Phase 2a)', () => {
       />,
     );
     const groups = container.querySelectorAll('.lcars-sidebar__group');
-    // ANALYTICS is the third group (WORKSHOP, BROWSE, ANALYTICS).
+    // ANALYTICS is the third group (FIX RULES, BROWSE, ANALYTICS).
     const analytics = groups[2];
     expect(analytics.classList.contains('lcars-sidebar__group--collapsed')).toBe(true);
   });
@@ -160,7 +160,7 @@ describe('Sidebar — DATA panel trigger (v2 spec §6 / D4)', () => {
     );
     const labels = container.querySelectorAll('.lcars-sidebar__group-label');
     expect(Array.from(labels).map((el) => el.textContent)).toEqual([
-      'WORKSHOP',
+      'FIX RULES',
       'BROWSE',
       'ANALYTICS',
       'ACTIONS',

--- a/packages/viewer/src/components/Sidebar.test.tsx
+++ b/packages/viewer/src/components/Sidebar.test.tsx
@@ -4,29 +4,32 @@ import { Sidebar } from './Sidebar.js';
 
 afterEach(() => cleanup());
 
-describe('Sidebar (vertical variant, default)', () => {
-  it('renders PROJECTS + TOPICS + SESSIONS in BROWSE; PRACTICE + CORRECTIONS + ANALYSIS + COST in INSIGHTS', () => {
+describe('Sidebar (vertical variant, default) — Phase 2a IA', () => {
+  it('renders WORKSHOP (CORRECTIONS+PRACTICE), BROWSE (SESSIONS), ANALYTICS (PROJECTS+TOPICS+COST+ANALYSIS)', () => {
     render(<Sidebar mode="command" onSelectMode={() => {}} />);
-    // BROWSE
+    // WORKSHOP — primary refocus surfaces lead.
+    expect(screen.getByRole('button', { name: /mode CORRECTIONS/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /mode PRACTICE/i })).toBeDefined();
+    // BROWSE — sessions only.
+    expect(screen.getByRole('button', { name: /mode SESSIONS/i })).toBeDefined();
+    // ANALYTICS — descriptive surfaces.
     expect(screen.getByRole('button', { name: /mode PROJECTS/i })).toBeDefined();
     expect(screen.getByRole('button', { name: /mode TOPICS/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /mode SESSIONS/i })).toBeDefined();
-    // INSIGHTS — PRACTICE leads (D6b/D6c); CORRECTIONS sits between PRACTICE
-    // and ANALYSIS so the "audit → suggest upgrades → deep-dive" flow reads
-    // top-down.
-    expect(screen.getByRole('button', { name: /mode PRACTICE/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /mode CORRECTIONS/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /mode ANALYSIS/i })).toBeDefined();
     expect(screen.getByRole('button', { name: /mode COST/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /mode ANALYSIS/i })).toBeDefined();
     // Absent.
     expect(screen.queryByRole('button', { name: /mode TIMELINE/i })).toBeNull();
     expect(screen.queryByRole('button', { name: /mode DETAIL/i })).toBeNull();
   });
 
-  it('groups the nav into BROWSE and INSIGHTS sections (no DATA without onOpenDataPanel)', () => {
+  it('groups the nav into WORKSHOP, BROWSE, ANALYTICS sections', () => {
     const { container } = render(<Sidebar mode="command" onSelectMode={() => {}} />);
     const labels = container.querySelectorAll('.lcars-sidebar__group-label');
-    expect(Array.from(labels).map((el) => el.textContent)).toEqual(['BROWSE', 'INSIGHTS']);
+    expect(Array.from(labels).map((el) => el.textContent)).toEqual([
+      'WORKSHOP',
+      'BROWSE',
+      'ANALYTICS',
+    ]);
   });
 
   it('marks the active mode with aria-current=page', () => {
@@ -60,16 +63,93 @@ describe('Sidebar (vertical variant, default)', () => {
   });
 
   it('renders only the top elbow (left-edge-only frame, no bottom elbow)', () => {
-    // Spec §10 (amended 2026-05-07): the canonical design-system shape
-    // is the asymmetric one-corner-rounded rectangle (radius.elbow-lg);
-    // v2 keeps only the top elbow — bottom elbow is retired so the
-    // sidebar's lower edge stays bare. The earlier single-SVG concave-
-    // arc Elbow component diverged from the design system and has been
-    // removed.
     const { container } = render(<Sidebar mode="command" onSelectMode={() => {}} />);
     expect(container.querySelectorAll('.lcars-sidebar__elbow--top').length).toBe(1);
     expect(container.querySelectorAll('.lcars-sidebar__elbow--bottom').length).toBe(0);
     expect(container.querySelectorAll('.lcars-sidebar__l-frame').length).toBe(0);
+  });
+});
+
+describe('Sidebar — ANALYTICS collapse (Phase 2a)', () => {
+  it('hides the analytics list when analyticsCollapsed=true', () => {
+    const { container } = render(
+      <Sidebar
+        mode="command"
+        onSelectMode={() => {}}
+        analyticsCollapsed
+        onToggleAnalyticsCollapsed={() => {}}
+      />,
+    );
+    const groups = container.querySelectorAll('.lcars-sidebar__group');
+    // ANALYTICS is the third group (WORKSHOP, BROWSE, ANALYTICS).
+    const analytics = groups[2];
+    expect(analytics.classList.contains('lcars-sidebar__group--collapsed')).toBe(true);
+  });
+
+  it('marks the toggle label with aria-expanded=false when collapsed', () => {
+    render(
+      <Sidebar
+        mode="command"
+        onSelectMode={() => {}}
+        analyticsCollapsed
+        onToggleAnalyticsCollapsed={() => {}}
+      />,
+    );
+    const toggle = screen.getByRole('button', { name: /expand ANALYTICS/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('marks the toggle label with aria-expanded=true when expanded', () => {
+    render(
+      <Sidebar
+        mode="command"
+        onSelectMode={() => {}}
+        analyticsCollapsed={false}
+        onToggleAnalyticsCollapsed={() => {}}
+      />,
+    );
+    const toggle = screen.getByRole('button', { name: /collapse ANALYTICS/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('invokes onToggleAnalyticsCollapsed on click', () => {
+    const onToggle = vi.fn();
+    render(
+      <Sidebar
+        mode="command"
+        onSelectMode={() => {}}
+        analyticsCollapsed
+        onToggleAnalyticsCollapsed={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /expand ANALYTICS/i }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onToggleAnalyticsCollapsed on Enter key', () => {
+    const onToggle = vi.fn();
+    render(
+      <Sidebar
+        mode="command"
+        onSelectMode={() => {}}
+        analyticsCollapsed
+        onToggleAnalyticsCollapsed={onToggle}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole('button', { name: /expand ANALYTICS/i }), {
+      key: 'Enter',
+    });
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders ANALYTICS label as static (non-button) when no toggle handler is provided', () => {
+    // Falls back to plain label when host doesn't supply a toggle —
+    // safety for embeddings that don't manage collapse state.
+    const { container } = render(<Sidebar mode="command" onSelectMode={() => {}} />);
+    const labels = container.querySelectorAll('.lcars-sidebar__group-label');
+    const analyticsLabel = labels[2];
+    expect(analyticsLabel.getAttribute('role')).toBeNull();
+    expect(analyticsLabel.textContent).toBe('ANALYTICS');
   });
 });
 
@@ -80,8 +160,9 @@ describe('Sidebar — DATA panel trigger (v2 spec §6 / D4)', () => {
     );
     const labels = container.querySelectorAll('.lcars-sidebar__group-label');
     expect(Array.from(labels).map((el) => el.textContent)).toEqual([
+      'WORKSHOP',
       'BROWSE',
-      'INSIGHTS',
+      'ANALYTICS',
       'ACTIONS',
     ]);
     expect(screen.getByRole('button', { name: /open DATA panel/i })).toBeDefined();
@@ -122,24 +203,24 @@ describe('Sidebar — DATA panel trigger (v2 spec §6 / D4)', () => {
 });
 
 describe('Sidebar (horizontal variant)', () => {
-  it('renders a pill bar without chrome frame, DETAIL + TIMELINE dropped', () => {
+  it('renders a pill bar without chrome frame, in the Phase 2a refocus order', () => {
     const { container } = render(
       <Sidebar mode="command" onSelectMode={() => {}} variant="horizontal" />,
     );
     expect(container.querySelector('.lcars-sidebar--horizontal')).toBeTruthy();
     expect(container.querySelectorAll('.lcars-sidebar__elbow').length).toBe(0);
-    // 7 mode pills now: PRJ, TOP, SES, PRC, COR, ANL, CST.
+    // 7 mode pills now: COR, PRC, SES, PRJ, TOP, CST, ANL.
     expect(container.querySelectorAll('.lcars-sidebar__pill').length).toBe(7);
   });
 
-  it('shows only the short label in horizontal pills', () => {
+  it('shows only the short label in horizontal pills, in the new order', () => {
     const { container } = render(
       <Sidebar mode="command" onSelectMode={() => {}} variant="horizontal" />,
     );
     const pillShorts = container.querySelectorAll('.lcars-sidebar__pill-short');
     expect(pillShorts.length).toBe(7);
     const texts = Array.from(pillShorts).map((el) => el.textContent);
-    expect(texts).toEqual(['PRJ', 'TOP', 'SES', 'PRC', 'COR', 'ANL', 'CST']);
+    expect(texts).toEqual(['COR', 'PRC', 'SES', 'PRJ', 'TOP', 'CST', 'ANL']);
   });
 
   it('appends a DAT pill when onOpenDataPanel is provided', () => {
@@ -154,13 +235,13 @@ describe('Sidebar (horizontal variant)', () => {
     );
     const pillShorts = container.querySelectorAll('.lcars-sidebar__pill-short');
     expect(Array.from(pillShorts).map((el) => el.textContent)).toEqual([
+      'COR',
+      'PRC',
+      'SES',
       'PRJ',
       'TOP',
-      'SES',
-      'PRC',
-      'COR',
-      'ANL',
       'CST',
+      'ANL',
       'DAT',
     ]);
     fireEvent.click(screen.getByRole('button', { name: /open DATA panel/i }));
@@ -180,5 +261,18 @@ describe('Sidebar (horizontal variant)', () => {
     render(<Sidebar mode="command" onSelectMode={onSelectMode} variant="horizontal" />);
     fireEvent.click(screen.getByRole('button', { name: /mode ANALYSIS/i }));
     expect(onSelectMode).toHaveBeenCalledWith('constellation');
+  });
+
+  it('keeps all 7 pills visible regardless of analyticsCollapsed (collapse is vertical-only)', () => {
+    const { container } = render(
+      <Sidebar
+        mode="command"
+        onSelectMode={() => {}}
+        variant="horizontal"
+        analyticsCollapsed
+        onToggleAnalyticsCollapsed={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('.lcars-sidebar__pill').length).toBe(7);
   });
 });

--- a/packages/viewer/src/components/Sidebar.tsx
+++ b/packages/viewer/src/components/Sidebar.tsx
@@ -23,6 +23,14 @@ export interface SidebarProps {
    * over the sidebar role below 600px.
    */
   variant?: SidebarVariant;
+  /**
+   * Phase 2a: ANALYTICS is collapsible — defaults to collapsed so the
+   * primary refocus surfaces (CORRECTIONS / PRACTICE / SESSIONS) sit
+   * above the fold. Optional so embeddings without persisted state
+   * still render at default-collapsed.
+   */
+  analyticsCollapsed?: boolean;
+  onToggleAnalyticsCollapsed?: () => void;
 }
 
 interface NavItem {
@@ -32,18 +40,18 @@ interface NavItem {
 }
 
 interface NavGroup {
-  group: 'BROWSE' | 'INSIGHTS';
+  group: 'WORKSHOP' | 'BROWSE' | 'ANALYTICS';
   items: readonly NavItem[];
 }
 
-// Two-tier IA:
-//   BROWSE   → Sessions          (the v1 grid surface)
-//   INSIGHTS → Analysis, Cost    (aggregate / pattern surfaces)
-//
-// v2 spec §5.3 / decision D6a: TIMELINE is no longer a top-level surface;
-// it's absorbed into SESSIONS as an in-surface view toggle. The internal
-// `command` mode id is preserved for code stability — only the user-
-// facing label flips to SESSIONS so the sidebar matches the spec naming.
+// Phase 2a refocus IA: three-tier IA aligned to the new "audit your
+// practice" framing.
+//   WORKSHOP   → Corrections, Practice — where the user goes to act
+//                on their own behavior changes.
+//   BROWSE     → Sessions — the v1 grid surface, kept lightweight.
+//   ANALYTICS  → Projects, Topics, Cost, Analysis — descriptive
+//                surfaces that answer "what's in my corpus", collapsed
+//                by default so they don't crowd the workshop.
 //
 // `detail` is intentionally missing — it's a drill-in surface reached by
 // clicking a session card, not a top-level mode. `constellation` is the
@@ -51,39 +59,46 @@ interface NavGroup {
 // (keeping the internal mode id stable avoids a cross-codebase rename).
 const NAV: readonly NavGroup[] = [
   {
-    group: 'BROWSE',
+    group: 'WORKSHOP',
     items: [
-      // v2 spec §5.1: PROJECTS sits above SESSIONS in BROWSE — narratives
-      // live on projects, so PROJECTS is where users land for insights
-      // about how their work is going. SESSIONS is the v1 grid.
-      { mode: 'projects', label: 'PROJECTS', short: 'PRJ' },
-      { mode: 'topics', label: 'TOPICS', short: 'TOP' },
-      { mode: 'command', label: 'SESSIONS', short: 'SES' },
+      { mode: 'corrections', label: 'CORRECTIONS', short: 'COR' },
+      { mode: 'practice', label: 'PRACTICE', short: 'PRC' },
     ],
   },
   {
-    group: 'INSIGHTS',
+    group: 'BROWSE',
+    items: [{ mode: 'command', label: 'SESSIONS', short: 'SES' }],
+  },
+  {
+    group: 'ANALYTICS',
     items: [
-      // v2 spec §5.4 / D6b+D6c: PRACTICE leads INSIGHTS — it's the
-      // primary audit surface and absorbs CONSTELLATION's "value
-      // leaks" outputs + COST's outlier surfacing. The standalone
-      // CONSTELLATION + COST entries remain accessible for deep-dives
-      // until a follow-up phase consolidates their surfaces into
-      // PRACTICE / per-project panels.
-      { mode: 'practice', label: 'PRACTICE', short: 'PRC' },
-      { mode: 'corrections', label: 'CORRECTIONS', short: 'COR' },
-      { mode: 'constellation', label: 'ANALYSIS', short: 'ANL' },
+      { mode: 'projects', label: 'PROJECTS', short: 'PRJ' },
+      { mode: 'topics', label: 'TOPICS', short: 'TOP' },
       { mode: 'cost', label: 'COST', short: 'CST' },
+      { mode: 'constellation', label: 'ANALYSIS', short: 'ANL' },
     ],
   },
 ];
 
-const ALL_ITEMS: readonly NavItem[] = NAV.flatMap((g) => g.items);
+// Horizontal-variant pill order is independent of the vertical groups
+// so collapse-state never hides primary nav on mobile. Order mirrors
+// the WORKSHOP → BROWSE → ANALYTICS reading order from the vertical
+// rail so muscle memory carries across viewports.
+const HORIZONTAL_PILL_ORDER: readonly NavItem[] = [
+  { mode: 'corrections', label: 'CORRECTIONS', short: 'COR' },
+  { mode: 'practice', label: 'PRACTICE', short: 'PRC' },
+  { mode: 'command', label: 'SESSIONS', short: 'SES' },
+  { mode: 'projects', label: 'PROJECTS', short: 'PRJ' },
+  { mode: 'topics', label: 'TOPICS', short: 'TOP' },
+  { mode: 'cost', label: 'COST', short: 'CST' },
+  { mode: 'constellation', label: 'ANALYSIS', short: 'ANL' },
+];
 
 // DATA item is rendered separately from the mode-driven nav: it's a
 // panel trigger, not a content surface, so it doesn't slot into the
-// `Mode` enum or the BROWSE/INSIGHTS groupings. The accent borrows the
-// destructive peach used by the existing data-source chip cluster.
+// `Mode` enum or the WORKSHOP/BROWSE/ANALYTICS groupings. The accent
+// borrows the destructive peach used by the existing data-source chip
+// cluster.
 const DATA_ITEM_LABEL = 'DATA';
 const DATA_ITEM_SHORT = 'DAT';
 const DATA_ITEM_COLOR = 'var(--lcars-peach)';
@@ -94,12 +109,14 @@ export function Sidebar({
   onOpenDataPanel,
   dataPanelOpen = false,
   variant = 'vertical',
+  analyticsCollapsed = false,
+  onToggleAnalyticsCollapsed,
 }: SidebarProps) {
   if (variant === 'horizontal') {
     return (
       <nav className="lcars-sidebar lcars-sidebar--horizontal" aria-label="primary">
         <ul className="lcars-sidebar__pill-bar" role="tablist">
-          {ALL_ITEMS.map((item) => {
+          {HORIZONTAL_PILL_ORDER.map((item) => {
             const active = item.mode === mode;
             const style = {
               ['--mode-color' as string]: MODE_COLOR[item.mode],
@@ -166,44 +183,74 @@ export function Sidebar({
         divergence from the design system and has been retired.
       */}
       <div className="lcars-sidebar__elbow lcars-sidebar__elbow--top" aria-hidden="true" />
-      {NAV.map((g) => (
-        <div key={g.group} className="lcars-sidebar__group">
-          <div className="lcars-sidebar__group-label" aria-hidden="true">
-            {g.group}
+      {NAV.map((g) => {
+        const isAnalytics = g.group === 'ANALYTICS';
+        const collapsed = isAnalytics && analyticsCollapsed;
+        const groupClass =
+          'lcars-sidebar__group' +
+          (collapsed ? ' lcars-sidebar__group--collapsed' : '');
+        const labelClass =
+          'lcars-sidebar__group-label' +
+          (isAnalytics && onToggleAnalyticsCollapsed
+            ? ' lcars-sidebar__group-label--toggle'
+            : '');
+        return (
+          <div key={g.group} className={groupClass}>
+            {isAnalytics && onToggleAnalyticsCollapsed ? (
+              <div
+                className={labelClass}
+                role="button"
+                tabIndex={0}
+                aria-expanded={!collapsed}
+                aria-controls={`lcars-sidebar-list-${g.group.toLowerCase()}`}
+                aria-label={`${collapsed ? 'expand' : 'collapse'} ${g.group} group`}
+                onClick={onToggleAnalyticsCollapsed}
+                onKeyDown={(e) => onActivate(e, onToggleAnalyticsCollapsed)}
+              >
+                {g.group}
+              </div>
+            ) : (
+              <div className={labelClass} aria-hidden="true">
+                {g.group}
+              </div>
+            )}
+            <ul
+              className="lcars-sidebar__list"
+              id={`lcars-sidebar-list-${g.group.toLowerCase()}`}
+            >
+              {g.items.map((item) => {
+                const active = item.mode === mode;
+                const style = {
+                  ['--mode-color' as string]: MODE_COLOR[item.mode],
+                } as React.CSSProperties;
+                // Why role=button on a div here: v7 LCARS iteration found that native
+                // <button> UA styles (Firefox on Windows in particular) blew past
+                // our LCARS `background-color` and left gray-button chrome visible.
+                // The shared onActivate helper keeps keyboard parity with <button>.
+                return (
+                  <li key={item.mode}>
+                    <div
+                      className={`lcars-sidebar__item${active ? ' lcars-sidebar__item--active' : ''}`}
+                      role="button"
+                      tabIndex={0}
+                      aria-current={active ? 'page' : undefined}
+                      aria-label={`mode ${item.label}`}
+                      style={style}
+                      onClick={() => onSelectMode(item.mode)}
+                      onKeyDown={(e) => onActivate(e, () => onSelectMode(item.mode))}
+                    >
+                      <span className="lcars-sidebar__item-short" aria-hidden="true">
+                        {item.short}
+                      </span>
+                      <span className="lcars-sidebar__item-label">{item.label}</span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
-          <ul className="lcars-sidebar__list">
-            {g.items.map((item) => {
-              const active = item.mode === mode;
-              const style = {
-                ['--mode-color' as string]: MODE_COLOR[item.mode],
-              } as React.CSSProperties;
-              // Why role=button on a div here: v7 LCARS iteration found that native
-              // <button> UA styles (Firefox on Windows in particular) blew past
-              // our LCARS `background-color` and left gray-button chrome visible.
-              // The shared onActivate helper keeps keyboard parity with <button>.
-              return (
-                <li key={item.mode}>
-                  <div
-                    className={`lcars-sidebar__item${active ? ' lcars-sidebar__item--active' : ''}`}
-                    role="button"
-                    tabIndex={0}
-                    aria-current={active ? 'page' : undefined}
-                    aria-label={`mode ${item.label}`}
-                    style={style}
-                    onClick={() => onSelectMode(item.mode)}
-                    onKeyDown={(e) => onActivate(e, () => onSelectMode(item.mode))}
-                  >
-                    <span className="lcars-sidebar__item-short" aria-hidden="true">
-                      {item.short}
-                    </span>
-                    <span className="lcars-sidebar__item-label">{item.label}</span>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      ))}
+        );
+      })}
       {onOpenDataPanel && (
         <div className="lcars-sidebar__group lcars-sidebar__group--actions">
           <div className="lcars-sidebar__group-label" aria-hidden="true">

--- a/packages/viewer/src/components/Sidebar.tsx
+++ b/packages/viewer/src/components/Sidebar.tsx
@@ -40,14 +40,17 @@ interface NavItem {
 }
 
 interface NavGroup {
-  group: 'WORKSHOP' | 'BROWSE' | 'ANALYTICS';
+  group: 'FIX RULES' | 'BROWSE' | 'ANALYTICS';
   items: readonly NavItem[];
 }
 
 // Phase 2a refocus IA: three-tier IA aligned to the new "audit your
 // practice" framing.
-//   WORKSHOP   → Corrections, Practice — where the user goes to act
-//                on their own behavior changes.
+//   FIX RULES  → Corrections, Practice — where the user goes to act
+//                on their own behavior changes. (Earlier label was
+//                "WORKSHOP"; the eval flagged it as too abstract for
+//                first-time users — "FIX RULES" announces the loop's
+//                outcome verb-first.)
 //   BROWSE     → Sessions — the v1 grid surface, kept lightweight.
 //   ANALYTICS  → Projects, Topics, Cost, Analysis — descriptive
 //                surfaces that answer "what's in my corpus", collapsed
@@ -59,7 +62,7 @@ interface NavGroup {
 // (keeping the internal mode id stable avoids a cross-codebase rename).
 const NAV: readonly NavGroup[] = [
   {
-    group: 'WORKSHOP',
+    group: 'FIX RULES',
     items: [
       { mode: 'corrections', label: 'CORRECTIONS', short: 'COR' },
       { mode: 'practice', label: 'PRACTICE', short: 'PRC' },
@@ -82,7 +85,7 @@ const NAV: readonly NavGroup[] = [
 
 // Horizontal-variant pill order is independent of the vertical groups
 // so collapse-state never hides primary nav on mobile. Order mirrors
-// the WORKSHOP → BROWSE → ANALYTICS reading order from the vertical
+// the FIX RULES → BROWSE → ANALYTICS reading order from the vertical
 // rail so muscle memory carries across viewports.
 const HORIZONTAL_PILL_ORDER: readonly NavItem[] = [
   { mode: 'corrections', label: 'CORRECTIONS', short: 'COR' },
@@ -96,7 +99,7 @@ const HORIZONTAL_PILL_ORDER: readonly NavItem[] = [
 
 // DATA item is rendered separately from the mode-driven nav: it's a
 // panel trigger, not a content surface, so it doesn't slot into the
-// `Mode` enum or the WORKSHOP/BROWSE/ANALYTICS groupings. The accent
+// `Mode` enum or the FIX-RULES/BROWSE/ANALYTICS groupings. The accent
 // borrows the destructive peach used by the existing data-source chip
 // cluster.
 const DATA_ITEM_LABEL = 'DATA';

--- a/packages/viewer/src/components/TopBar.tsx
+++ b/packages/viewer/src/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import type { ViewportTier } from '../util/viewport.js';
 import { InfoPopover } from './InfoPopover.js';
+import { LastIndexedChip } from './LastIndexedChip.js';
 
 export type RescanStatus = 'idle' | 'running' | 'error' | 'ok';
 export type UploadStatus = 'idle' | 'running' | 'error' | 'ok';
@@ -52,6 +53,12 @@ export interface TopBarProps {
   };
   /** Click handler for the chip's ✕ dismiss button. */
   onDismissRescanDelta?: () => void;
+  /**
+   * Phase 2a: ms-since-epoch from `manifest.generatedAt`. Drives the
+   * INDEXED chip — null hides it. Optional so embeddings without a
+   * manifest still render the bar.
+   */
+  lastIndexed?: number | null;
 }
 
 function defaultEarthdate(): string {
@@ -78,6 +85,7 @@ export function TopBar({
   disabled = false,
   rescanDelta,
   onDismissRescanDelta,
+  lastIndexed,
 }: TopBarProps) {
   const placeholder = disabled
     ? 'exit detail view to search'
@@ -122,6 +130,7 @@ export function TopBar({
         <div className="lcars-top-bar__earthdate" aria-label={`earthdate ${dateText}`}>
           <span className="lcars-top-bar__earthdate-value">{dateText}</span>
         </div>
+        <LastIndexedChip generatedAt={lastIndexed ?? null} />
         {rescanDelta && (
           <div
             className="lcars-top-bar__rescan-chip"

--- a/packages/viewer/src/components/TopBar.tsx
+++ b/packages/viewer/src/components/TopBar.tsx
@@ -39,6 +39,19 @@ export interface TopBarProps {
    * underlying list the user returns to.
    */
   disabled?: boolean;
+  /**
+   * Rescan-delta breakdown chip. Persists between rescans (no auto-
+   * dismiss timer) so a user who walks away can see how many new
+   * sessions the latest scan picked up. Omit to hide the chip.
+   */
+  rescanDelta?: {
+    totalLocal: number;
+    cowork: number;
+    cli: number;
+    desktop: number;
+  };
+  /** Click handler for the chip's ✕ dismiss button. */
+  onDismissRescanDelta?: () => void;
 }
 
 function defaultEarthdate(): string {
@@ -49,6 +62,12 @@ function defaultEarthdate(): string {
   return `${yyyy}.${mm}.${dd}`;
 }
 
+function formatDelta(n: number): string {
+  if (n > 0) return `+${n}`;
+  if (n < 0) return `${n}`;
+  return '0';
+}
+
 export function TopBar({
   query,
   onQueryChange,
@@ -57,6 +76,8 @@ export function TopBar({
   earthdate,
   tier = 'desktop',
   disabled = false,
+  rescanDelta,
+  onDismissRescanDelta,
 }: TopBarProps) {
   const placeholder = disabled
     ? 'exit detail view to search'
@@ -101,6 +122,28 @@ export function TopBar({
         <div className="lcars-top-bar__earthdate" aria-label={`earthdate ${dateText}`}>
           <span className="lcars-top-bar__earthdate-value">{dateText}</span>
         </div>
+        {rescanDelta && (
+          <div
+            className="lcars-top-bar__rescan-chip"
+            aria-label={`last rescan added ${formatDelta(rescanDelta.totalLocal)} local sessions`}
+            title={`+${rescanDelta.cowork} cowork · +${rescanDelta.cli} CLI · +${rescanDelta.desktop} desktop`}
+          >
+            <span className="lcars-top-bar__rescan-chip-label">RESCAN</span>
+            <span className="lcars-top-bar__rescan-chip-value">
+              {formatDelta(rescanDelta.totalLocal)}
+            </span>
+            {onDismissRescanDelta && (
+              <button
+                type="button"
+                className="lcars-top-bar__rescan-chip-dismiss"
+                aria-label="dismiss rescan delta"
+                onClick={onDismissRescanDelta}
+              >
+                ✕
+              </button>
+            )}
+          </div>
+        )}
       </div>
       <div className="lcars-top-bar__right">
         <label

--- a/packages/viewer/src/components/TopBar.tsx
+++ b/packages/viewer/src/components/TopBar.tsx
@@ -127,10 +127,17 @@ export function TopBar({
             <span className="lcars-top-bar__location-label">{locationLabel}</span>
           </div>
         )}
+        {/*
+          INDEXED renders BEFORE EARTHDATE so the eye lands on the
+          data-freshness signal first. Earlier ordering had the
+          misleading "today" date leading and the corrective
+          INDEXED-N-days-ago chip trailing — readers anchored on
+          "today" and treated the trailing chip as supplementary.
+        */}
+        <LastIndexedChip generatedAt={lastIndexed ?? null} />
         <div className="lcars-top-bar__earthdate" aria-label={`earthdate ${dateText}`}>
           <span className="lcars-top-bar__earthdate-value">{dateText}</span>
         </div>
-        <LastIndexedChip generatedAt={lastIndexed ?? null} />
         {rescanDelta && (
           <div
             className="lcars-top-bar__rescan-chip"

--- a/packages/viewer/src/components/TrustStrip.tsx
+++ b/packages/viewer/src/components/TrustStrip.tsx
@@ -1,37 +1,51 @@
 import { RepoLink } from './RepoLink.js';
 
+export type TrustStripVariant = 'landing' | 'footer';
+
+export interface TrustStripProps {
+  /**
+   * `landing` (default) — full pre-load reassurance with the Hugging
+   * Face footnote. `footer` — Phase 2a leaner one-line variant that
+   * persists below the populated frame; drops the HF footnote because
+   * by that point the user has either already triggered the embedding
+   * download or never will.
+   */
+  variant?: TrustStripVariant;
+}
+
 /**
- * Landing trust strip. Renders directly under the TopBar on the empty
- * state so a first-time visitor sees the local-first pledge *before*
- * they decide whether to click SCAN LOCAL or UPLOAD CLOUD. Three
- * things get communicated:
+ * Trust strip. Two variants:
  *
- *   1. "Local-first" — the top-line promise.
- *   2. The proof — browser-only parsing, no telemetry, transcripts
- *      never leave the machine.
- *   3. A SOURCE ↗ link to the open-source repo so the claim is
- *      verifiable, not just asserted.
- *
- * A footnote discloses the one exception we *do* make a cross-origin
- * fetch for: the first Analyze Topics run downloads the BGE-small
- * embedding model from huggingface.co (cached after). This sends only
- * the model-file request — no transcript content is ever uploaded.
- * The disclosure lives here (and not only in the AnalysisLauncher
- * where the fetch actually triggers) so the "no servers" read of the
- * body copy can't be technically-true-but-misleading for a user who
- * hasn't clicked anything yet.
+ *   - `landing` (the original) renders directly under the TopBar on
+ *     the empty state so a first-time visitor sees the local-first
+ *     pledge *before* they decide whether to click SCAN LOCAL or
+ *     UPLOAD CLOUD. Includes the HF model-download footnote so the
+ *     "no servers" read can't be technically-true-but-misleading.
+ *   - `footer` renders inside the populated frame so the pledge stays
+ *     visible after the empty state is gone — Phase 2a's "trust as
+ *     ambient chrome" cue. Single row, no footnote, mobile-hidden.
  *
  * Kept intentionally lean (no icons, no graphics) so it reads as a
- * status-bar reassurance rather than an upsell banner. The strip
- * disappears once data is loaded — returning users don't need the
- * re-pitch every session.
+ * status-bar reassurance rather than an upsell banner.
  */
-export function TrustStrip() {
+export function TrustStrip({ variant = 'landing' }: TrustStripProps = {}) {
+  const className =
+    'lcars-trust-strip' + (variant === 'footer' ? ' lcars-trust-strip--footer' : '');
+  if (variant === 'footer') {
+    return (
+      <aside className={className} aria-label="local-first data handling">
+        <div className="lcars-trust-strip__row">
+          <span className="lcars-trust-strip__pledge">LOCAL-FIRST</span>
+          <span className="lcars-trust-strip__body">
+            Parsed in your browser. No telemetry, no analytics.
+          </span>
+          <RepoLink variant="inline" label="VIEW SOURCE" />
+        </div>
+      </aside>
+    );
+  }
   return (
-    <aside
-      className="lcars-trust-strip"
-      aria-label="local-first data handling"
-    >
+    <aside className={className} aria-label="local-first data handling">
       <div className="lcars-trust-strip__row">
         <span className="lcars-trust-strip__pledge">LOCAL-FIRST</span>
         <span className="lcars-trust-strip__body">

--- a/packages/viewer/src/data/activityLog.ts
+++ b/packages/viewer/src/data/activityLog.ts
@@ -33,7 +33,11 @@ export type LogSource =
   | 'discover'
   // Manifest fetch / merge composition. Populated by ChatArchViewer as
   // it resolves which sessions end up in the active view.
-  | 'manifest';
+  | 'manifest'
+  // Rescan deltas. Populated by ChatArchViewer.onRescan after a
+  // successful scan so the activity log keeps a record of the
+  // per-source breakdown beyond the lifetime of the success banner.
+  | 'rescan';
 
 export interface LogEntry {
   /** Monotonic id assigned at log time; stable across the entry's lifetime in the ring. */

--- a/packages/viewer/src/data/applyCorrectionClient.ts
+++ b/packages/viewer/src/data/applyCorrectionClient.ts
@@ -1,0 +1,104 @@
+/**
+ * Client for `POST /api/apply-correction`. Mirrors
+ * `mineCorrectionsClient.ts` for probe + error-handling shape so the
+ * panel can hide the APPLY action gracefully on production static
+ * builds where the dev-server endpoint isn't bundled.
+ */
+
+import type { ProposedUpgrade } from '@chat-arch/schema';
+
+const APPLY_PATH = '/api/apply-correction';
+const REQUIRED_HEADER_VALUE = 'chat-arch-apply-correction';
+
+export interface ApplyCorrectionRequest {
+  patternId: string;
+  proposedUpgrade: ProposedUpgrade;
+  ruleSummary: string;
+  targetFiles?: string[];
+  notes?: string;
+}
+
+export interface ApplyCorrectionResult {
+  ok: boolean;
+  /** Set when ok === true. */
+  appliedImprovementId?: string;
+  /** Set when ok === true. */
+  ledgerPath?: string;
+  /** Set when ok === true. */
+  entriesCount?: number;
+  /** Set when ok === false. */
+  error?: string;
+}
+
+/**
+ * GET probe. Returns true when the endpoint exists (dev server) and
+ * false otherwise (static production build). Networks failures also
+ * fall through to false — the panel hides APPLY in that case.
+ */
+export async function probeApplyCorrection(): Promise<boolean> {
+  try {
+    const res = await fetch(APPLY_PATH, { method: 'GET' });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * POST the apply request. Always resolves to a result object — never
+ * throws — so callers can drive a state machine without a try/catch.
+ */
+export async function applyCorrection(
+  req: ApplyCorrectionRequest,
+): Promise<ApplyCorrectionResult> {
+  let res: Response;
+  try {
+    res = await fetch(APPLY_PATH, {
+      method: 'POST',
+      headers: {
+        'X-Requested-With': REQUIRED_HEADER_VALUE,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(req),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  let parsed: unknown = null;
+  try {
+    parsed = await res.json();
+  } catch {
+    parsed = null;
+  }
+  if (!res.ok) {
+    const errMsg =
+      parsed && typeof parsed === 'object' && 'error' in parsed
+        ? String((parsed as { error?: unknown }).error)
+        : `apply-correction failed (status ${res.status})`;
+    return { ok: false, error: errMsg };
+  }
+  if (parsed && typeof parsed === 'object') {
+    const p = parsed as {
+      ok?: boolean;
+      appliedImprovementId?: string;
+      ledgerPath?: string;
+      entriesCount?: number;
+      error?: string;
+    };
+    if (p.ok === true && typeof p.appliedImprovementId === 'string') {
+      return {
+        ok: true,
+        appliedImprovementId: p.appliedImprovementId,
+        ...(typeof p.ledgerPath === 'string' ? { ledgerPath: p.ledgerPath } : {}),
+        ...(typeof p.entriesCount === 'number'
+          ? { entriesCount: p.entriesCount }
+          : {}),
+      };
+    }
+    return { ok: false, error: p.error ?? 'apply-correction returned unexpected body' };
+  }
+  return { ok: false, error: 'apply-correction returned no body' };
+}

--- a/packages/viewer/src/data/applyCorrectionClient.ts
+++ b/packages/viewer/src/data/applyCorrectionClient.ts
@@ -74,6 +74,15 @@ export async function applyCorrection(
     parsed = null;
   }
   if (!res.ok) {
+    // 409 is the "another apply is in flight" gate from the server.
+    // Surface a friendly message rather than the raw status string —
+    // UpgradeRow renders this verbatim in its error state.
+    if (res.status === 409) {
+      return {
+        ok: false,
+        error: 'Another apply is in flight. Try again in a moment.',
+      };
+    }
     const errMsg =
       parsed && typeof parsed === 'object' && 'error' in parsed
         ? String((parsed as { error?: unknown }).error)

--- a/packages/viewer/src/data/correctionsLoader.test.ts
+++ b/packages/viewer/src/data/correctionsLoader.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  AppliedImprovement,
+  AppliedImprovementsFile,
+  CorrectionPattern,
+  CorrectionsFile,
+  ProposedUpgrade,
+} from '@chat-arch/schema';
+import { mergeAppliedImprovements } from './correctionsLoader.js';
+
+function upgrade(overrides: Partial<ProposedUpgrade> = {}): ProposedUpgrade {
+  return {
+    target: 'global-claude-md',
+    targetPath: '~/.claude/CLAUDE.md',
+    patch: '- some rule',
+    rationale: 'because',
+    applied: false,
+    appliedAt: null,
+    ...overrides,
+  };
+}
+
+function pattern(overrides: Partial<CorrectionPattern> & { id: string }): CorrectionPattern {
+  return {
+    id: overrides.id,
+    canonicalRule: overrides.canonicalRule ?? `rule ${overrides.id}`,
+    instanceIds: overrides.instanceIds ?? [],
+    occurrenceCount: overrides.occurrenceCount ?? 3,
+    firstSeen: overrides.firstSeen ?? 1_700_000_000_000,
+    lastSeen: overrides.lastSeen ?? 1_700_100_000_000,
+    scope: overrides.scope ?? { kind: 'global' },
+    proposedUpgrades: overrides.proposedUpgrades ?? [upgrade()],
+    confidence: overrides.confidence ?? 0.7,
+    recurringPostApplication: overrides.recurringPostApplication ?? false,
+    alreadyEncoded: overrides.alreadyEncoded ?? false,
+  };
+}
+
+function file(patterns: readonly CorrectionPattern[]): CorrectionsFile {
+  return {
+    generatedAt: 1_700_000_000_000,
+    corrections: [],
+    patterns,
+    pipeline: {
+      heuristicRecall: true,
+      llmClassification: true,
+      embeddingClustering: true,
+      claudeMdCrossCheck: true,
+    },
+  };
+}
+
+function entry(overrides: Partial<AppliedImprovement> & { id: string; patternId: string }): AppliedImprovement {
+  return {
+    id: overrides.id,
+    patternId: overrides.patternId,
+    appliedAt: overrides.appliedAt ?? 1_700_050_000_000,
+    ruleSummary: overrides.ruleSummary ?? 'rule summary',
+    proposedUpgrade: overrides.proposedUpgrade ?? upgrade({ applied: true, appliedAt: 1_700_050_000_000 }),
+    ...(overrides.targetFiles ? { targetFiles: overrides.targetFiles } : {}),
+    ...(overrides.notes ? { notes: overrides.notes } : {}),
+  };
+}
+
+function ledger(entries: AppliedImprovement[]): AppliedImprovementsFile {
+  return { schemaVersion: 1, generatedAt: Date.now(), entries };
+}
+
+describe('mergeAppliedImprovements', () => {
+  it('returns the input unchanged when the ledger is null or empty', () => {
+    const corrections = file([pattern({ id: 'p1' })]);
+    expect(mergeAppliedImprovements(corrections, null)).toBe(corrections);
+    expect(
+      mergeAppliedImprovements(corrections, ledger([])),
+    ).toBe(corrections);
+  });
+
+  it('stamps applied/appliedAt onto the matching ProposedUpgrade by (target, targetPath)', () => {
+    const u = upgrade({
+      target: 'project-claude-md',
+      targetPath: '<repo>/CLAUDE.md',
+    });
+    const corrections = file([
+      pattern({ id: 'p1', proposedUpgrades: [u] }),
+    ]);
+    const e = entry({
+      id: 'a-1',
+      patternId: 'p1',
+      appliedAt: 1_700_080_000_000,
+      proposedUpgrade: {
+        ...u,
+        applied: true,
+        appliedAt: 1_700_080_000_000,
+      },
+    });
+    const merged = mergeAppliedImprovements(corrections, ledger([e]));
+    const mergedUpgrade = merged.patterns[0].proposedUpgrades[0];
+    expect(mergedUpgrade.applied).toBe(true);
+    expect(mergedUpgrade.appliedAt).toBe(1_700_080_000_000);
+    // Original ProposedUpgrade is left untouched (pure merge).
+    expect(u.applied).toBe(false);
+    expect(u.appliedAt).toBeNull();
+  });
+
+  it('does NOT match when only patternId matches but target/path differ', () => {
+    const u = upgrade({ target: 'global-claude-md', targetPath: '~/.claude/CLAUDE.md' });
+    const corrections = file([pattern({ id: 'p1', proposedUpgrades: [u] })]);
+    const ledgerEntry = entry({
+      id: 'a-1',
+      patternId: 'p1',
+      proposedUpgrade: upgrade({
+        target: 'skill',
+        targetPath: '~/.claude/skills/foo/SKILL.md',
+        applied: true,
+        appliedAt: 1_700_080_000_000,
+      }),
+    });
+    const merged = mergeAppliedImprovements(corrections, ledger([ledgerEntry]));
+    const mergedUpgrade = merged.patterns[0].proposedUpgrades[0];
+    // The live upgrade is unmodified — its (target, path) did not match.
+    expect(mergedUpgrade.applied).toBe(false);
+    expect(mergedUpgrade.appliedAt).toBeNull();
+  });
+
+  it('flips recurringPostApplication when pattern.lastSeen > maxAppliedAt', () => {
+    const u = upgrade();
+    const corrections = file([
+      pattern({
+        id: 'p1',
+        proposedUpgrades: [u],
+        // Applied earlier; the pattern recurred AFTER the apply.
+        lastSeen: 1_700_200_000_000,
+        recurringPostApplication: false,
+      }),
+    ]);
+    const e = entry({
+      id: 'a-1',
+      patternId: 'p1',
+      appliedAt: 1_700_100_000_000,
+    });
+    const merged = mergeAppliedImprovements(corrections, ledger([e]));
+    expect(merged.patterns[0].recurringPostApplication).toBe(true);
+  });
+
+  it('does NOT flip recurringPostApplication when pattern.lastSeen <= maxAppliedAt', () => {
+    const u = upgrade();
+    const corrections = file([
+      pattern({
+        id: 'p1',
+        proposedUpgrades: [u],
+        lastSeen: 1_700_050_000_000,
+        recurringPostApplication: false,
+      }),
+    ]);
+    const e = entry({
+      id: 'a-1',
+      patternId: 'p1',
+      appliedAt: 1_700_100_000_000, // applied AFTER lastSeen
+    });
+    const merged = mergeAppliedImprovements(corrections, ledger([e]));
+    expect(merged.patterns[0].recurringPostApplication).toBe(false);
+  });
+
+  it('preserves the original recurringPostApplication when no upgrade matches and no ledger entries land', () => {
+    const corrections = file([
+      pattern({
+        id: 'p1',
+        // pre-existing recurring flag from the mining pipeline
+        recurringPostApplication: true,
+      }),
+    ]);
+    // Ledger has no entry for p1.
+    const e = entry({ id: 'a-1', patternId: 'pZ' });
+    const merged = mergeAppliedImprovements(corrections, ledger([e]));
+    expect(merged.patterns[0].recurringPostApplication).toBe(true);
+  });
+
+  it('uses max appliedAt across multiple ledger entries for the same pattern', () => {
+    const u1 = upgrade({ target: 'global-claude-md', targetPath: '~/global.md' });
+    const u2 = upgrade({ target: 'project-claude-md', targetPath: '~/project.md' });
+    const corrections = file([
+      pattern({
+        id: 'p1',
+        proposedUpgrades: [u1, u2],
+        // lastSeen falls between the two appliedAt values.
+        lastSeen: 1_700_150_000_000,
+      }),
+    ]);
+    const merged = mergeAppliedImprovements(
+      corrections,
+      ledger([
+        entry({
+          id: 'e1',
+          patternId: 'p1',
+          appliedAt: 1_700_080_000_000,
+          proposedUpgrade: { ...u1, applied: true, appliedAt: 1_700_080_000_000 },
+        }),
+        entry({
+          id: 'e2',
+          patternId: 'p1',
+          appliedAt: 1_700_200_000_000, // after lastSeen
+          proposedUpgrade: { ...u2, applied: true, appliedAt: 1_700_200_000_000 },
+        }),
+      ]),
+    );
+    // lastSeen 1_700_150_000_000 is < max(1_700_080, 1_700_200) ⇒ NOT recurring.
+    expect(merged.patterns[0].recurringPostApplication).toBe(false);
+    // Both upgrades stamped applied.
+    expect(merged.patterns[0].proposedUpgrades[0].applied).toBe(true);
+    expect(merged.patterns[0].proposedUpgrades[1].applied).toBe(true);
+  });
+
+  it('ignores ledger entries whose patternId does not exist in corrections', () => {
+    const corrections = file([pattern({ id: 'p1' })]);
+    const merged = mergeAppliedImprovements(
+      corrections,
+      ledger([entry({ id: 'orphan', patternId: 'gone' })]),
+    );
+    expect(merged.patterns).toHaveLength(1);
+    expect(merged.patterns[0].id).toBe('p1');
+    expect(merged.patterns[0].recurringPostApplication).toBe(false);
+  });
+});

--- a/packages/viewer/src/data/correctionsLoader.test.ts
+++ b/packages/viewer/src/data/correctionsLoader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type {
   AppliedImprovement,
   AppliedImprovementsFile,
@@ -6,7 +6,10 @@ import type {
   CorrectionsFile,
   ProposedUpgrade,
 } from '@chat-arch/schema';
-import { mergeAppliedImprovements } from './correctionsLoader.js';
+import {
+  loadAppliedImprovementsFile,
+  mergeAppliedImprovements,
+} from './correctionsLoader.js';
 
 function upgrade(overrides: Partial<ProposedUpgrade> = {}): ProposedUpgrade {
   return {
@@ -219,5 +222,75 @@ describe('mergeAppliedImprovements', () => {
     expect(merged.patterns).toHaveLength(1);
     expect(merged.patterns[0].id).toBe('p1');
     expect(merged.patterns[0].recurringPostApplication).toBe(false);
+  });
+});
+
+describe('loadAppliedImprovementsFile', () => {
+  const originalFetch = globalThis.fetch;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    warnSpy.mockRestore();
+  });
+
+  it('returns the file when schemaVersion === 1', async () => {
+    const valid: AppliedImprovementsFile = {
+      schemaVersion: 1,
+      generatedAt: Date.now(),
+      entries: [],
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => valid,
+    })) as unknown as typeof fetch;
+    const result = await loadAppliedImprovementsFile('/chat-arch-data');
+    expect(result).toEqual(valid);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns null and logs a warning when schemaVersion is unsupported (P1.6)', async () => {
+    // A future writer bumps schemaVersion to 2 in a backwards-
+    // incompatible way. The loader must reject the file rather than
+    // silently shipping mismatched data into mergeAppliedImprovements.
+    const future = {
+      schemaVersion: 2,
+      generatedAt: Date.now(),
+      entries: [],
+    };
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => future,
+    })) as unknown as typeof fetch;
+    const result = await loadAppliedImprovementsFile('/chat-arch-data');
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toMatch(/schemaVersion=2/);
+  });
+
+  it('returns null when the body is missing entries', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ schemaVersion: 1, generatedAt: 0 }),
+    })) as unknown as typeof fetch;
+    const result = await loadAppliedImprovementsFile('/chat-arch-data');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on 404', async () => {
+    globalThis.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    const result = await loadAppliedImprovementsFile('/chat-arch-data');
+    expect(result).toBeNull();
   });
 });

--- a/packages/viewer/src/data/correctionsLoader.ts
+++ b/packages/viewer/src/data/correctionsLoader.ts
@@ -1,4 +1,10 @@
-import type { CorrectionsFile } from '@chat-arch/schema';
+import type {
+  AppliedImprovement,
+  AppliedImprovementsFile,
+  CorrectionPattern,
+  CorrectionsFile,
+  ProposedUpgrade,
+} from '@chat-arch/schema';
 
 /**
  * Load a JSON sidecar from the analysis/ directory. Returns `null` for
@@ -45,4 +51,110 @@ export async function loadCorrectionCandidatesFile(
   baseUrl: string,
 ): Promise<CorrectionsFile | null> {
   return fetchCorrectionsJson(joinAnalysisUrl(baseUrl, 'correction-candidates.json'));
+}
+
+/**
+ * Fetch `analysis/applied-improvements.json` — the user's APPLY-click
+ * ledger. Returns null on 404 (file doesn't exist yet, common case
+ * before the first apply) or any read failure; callers should treat
+ * that the same as "no entries".
+ */
+export async function loadAppliedImprovementsFile(
+  baseUrl: string,
+): Promise<AppliedImprovementsFile | null> {
+  const url = joinAnalysisUrl(baseUrl, 'applied-improvements.json');
+  let res: Response;
+  try {
+    res = await fetch(url, { cache: 'no-store' });
+  } catch {
+    return null;
+  }
+  if (res.status === 404) return null;
+  if (!res.ok) return null;
+  try {
+    const body = (await res.json()) as AppliedImprovementsFile;
+    if (!body || !Array.isArray(body.entries)) return null;
+    return body;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Idempotency key in the merge step: `(target, targetPath)` identifies
+ * a `ProposedUpgrade` within a `CorrectionPattern`. Same triple
+ * `(patternId, target, targetPath)` is the apply ledger's idempotency
+ * key — kept consistent so an apply ↔ live-pattern roundtrip survives.
+ */
+function matchesUpgrade(u: ProposedUpgrade, applied: AppliedImprovement): boolean {
+  return (
+    u.target === applied.proposedUpgrade.target &&
+    u.targetPath === applied.proposedUpgrade.targetPath
+  );
+}
+
+/**
+ * Merge the apply-ledger over a `CorrectionsFile` snapshot:
+ *
+ *   - For each `AppliedImprovement`, locate the matching pattern by
+ *     `patternId` and the matching `ProposedUpgrade` by
+ *     `(target, targetPath)`. Stamp `applied: true` and the ledger's
+ *     `appliedAt` onto a fresh copy.
+ *   - Recompute `recurringPostApplication` per pattern: if the
+ *     pattern's `lastSeen` is greater than the max `appliedAt` across
+ *     all applied upgrades, the rule is failing in practice and the
+ *     viewer surfaces it in the RECURRING bucket.
+ *
+ * Pure / non-mutating — returns a new `CorrectionsFile`. The input is
+ * not modified, so the caller can keep the raw `corrections.json`
+ * around for diff / debugging.
+ */
+export function mergeAppliedImprovements(
+  corrections: CorrectionsFile,
+  applied: AppliedImprovementsFile | null,
+): CorrectionsFile {
+  if (!applied || applied.entries.length === 0) return corrections;
+
+  // Bucket entries by patternId so each pattern is visited once.
+  const byPattern = new Map<string, AppliedImprovement[]>();
+  for (const entry of applied.entries) {
+    const arr = byPattern.get(entry.patternId);
+    if (arr) arr.push(entry);
+    else byPattern.set(entry.patternId, [entry]);
+  }
+
+  const nextPatterns: CorrectionPattern[] = corrections.patterns.map((p) => {
+    const ledgerForPattern = byPattern.get(p.id);
+    if (!ledgerForPattern || ledgerForPattern.length === 0) return p;
+
+    let maxAppliedAt = 0;
+    const nextUpgrades: ProposedUpgrade[] = p.proposedUpgrades.map((u) => {
+      const match = ledgerForPattern.find((entry) => matchesUpgrade(u, entry));
+      if (!match) return u;
+      if (match.appliedAt > maxAppliedAt) maxAppliedAt = match.appliedAt;
+      return { ...u, applied: true, appliedAt: match.appliedAt };
+    });
+
+    // Even when no live ProposedUpgrade matched (the upgrades list
+    // shifted between mining passes) the ledger still pins `applied`
+    // semantics for the pattern — fall back to the max ledger entry.
+    if (maxAppliedAt === 0) {
+      for (const entry of ledgerForPattern) {
+        if (entry.appliedAt > maxAppliedAt) maxAppliedAt = entry.appliedAt;
+      }
+    }
+
+    const recurringPostApplication =
+      maxAppliedAt > 0 && p.lastSeen > maxAppliedAt
+        ? true
+        : p.recurringPostApplication;
+
+    return {
+      ...p,
+      proposedUpgrades: nextUpgrades,
+      recurringPostApplication,
+    };
+  });
+
+  return { ...corrections, patterns: nextPatterns };
 }

--- a/packages/viewer/src/data/correctionsLoader.ts
+++ b/packages/viewer/src/data/correctionsLoader.ts
@@ -74,6 +74,21 @@ export async function loadAppliedImprovementsFile(
   try {
     const body = (await res.json()) as AppliedImprovementsFile;
     if (!body || !Array.isArray(body.entries)) return null;
+    // Reject unknown schema versions outright. A future writer may
+    // bump the schema in a backwards-incompatible way (e.g. rename
+    // `appliedAt` or change the proposedUpgrade shape); silently
+    // accepting it would let the merge step downstream produce
+    // misleading results. Treat unknown schema as "no ledger" — the
+    // viewer behaves the same as a fresh install. Logged so a user
+    // who notices their applies disappeared can find the cause.
+    if (body.schemaVersion !== 1) {
+      console.warn(
+        `[correctionsLoader] applied-improvements.json schemaVersion=${
+          (body as { schemaVersion?: unknown }).schemaVersion
+        } is unsupported (expected 1). Ignoring file.`,
+      );
+      return null;
+    }
     return body;
   } catch {
     return null;

--- a/packages/viewer/src/data/correctionsLoader.ts
+++ b/packages/viewer/src/data/correctionsLoader.ts
@@ -108,6 +108,22 @@ function matchesUpgrade(u: ProposedUpgrade, applied: AppliedImprovement): boolea
  * Pure / non-mutating — returns a new `CorrectionsFile`. The input is
  * not modified, so the caller can keep the raw `corrections.json`
  * around for diff / debugging.
+ *
+ * KNOWN FRAGILITY (`pattern.lastSeen > maxAppliedAt`):
+ *   This compares the pattern's last-seen timestamp (an attribute of
+ *   the underlying corpus, set during the most recent mining pass)
+ *   against the max APPLY timestamp. If the user APPLYs and then
+ *   immediately re-mines on a STALE window — i.e. a window that still
+ *   ends in correction instances older than the apply but newer than
+ *   the previous pattern.lastSeen — the pattern can flip to RECURRING
+ *   even though the user hasn't pushed back since the apply. The
+ *   long-term fix is to carry per-correction `detectedAtMs` and
+ *   compare apply vs the latest *correction-instance* time, not
+ *   pattern.lastSeen. Short-term this is acceptable because re-mines
+ *   are infrequent and the false-positive direction (a "still
+ *   recurring" badge that disappears on the next clean mine) is the
+ *   safer side of the error budget — it asks the user to look again,
+ *   it doesn't hide a regression.
  */
 export function mergeAppliedImprovements(
   corrections: CorrectionsFile,

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6332,6 +6332,49 @@
   padding-bottom: 2px;
   line-height: 1;
 }
+.lcars-top-bar__rescan-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 4px 0 12px;
+  border-radius: 14px;
+  background: var(--lcars-peach);
+  color: var(--lcars-bg);
+  font-family: var(--lcars-font-chrome);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  flex: 0 0 auto;
+  line-height: 1;
+}
+.lcars-top-bar__rescan-chip-label,
+.lcars-top-bar__rescan-chip-value {
+  padding-bottom: 2px;
+  line-height: 1;
+}
+.lcars-top-bar__rescan-chip-value {
+  font-variant-numeric: tabular-nums;
+}
+.lcars-top-bar__rescan-chip-dismiss {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--lcars-bg);
+  font-size: 10px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.lcars-top-bar__rescan-chip-dismiss:hover,
+.lcars-top-bar__rescan-chip-dismiss:focus-visible {
+  background: rgba(0, 0, 0, 0.5);
+  outline: none;
+}
 @media (max-width: 899px) {
   /* Mirror the source-btn mobile inversion — dark title bar needs
      light-on-dark chips. */

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6344,9 +6344,32 @@
   text-overflow: ellipsis;
   font-size: 12px;
 }
+/*
+  Mobile (< 600px) renders a leaner one-line variant instead of
+  hiding the strip entirely. Earlier the strip dropped on mobile so
+  the pill bar + content kept the limited vertical space, but that
+  removed the local-first reassurance from the surface where it
+  matters most (a first-time visitor on their phone). This restyle
+  drops the longer body copy + RepoLink wrapper and keeps just the
+  pledge + a compact VIEW SOURCE link, costing one row of vertical
+  space.
+*/
 @media (max-width: 600px) {
   .lcars-trust-strip--footer {
+    padding: 4px 12px;
+    font-size: 11px;
+    gap: 4px 10px;
+  }
+  .lcars-trust-strip--footer .lcars-trust-strip__row {
+    gap: 10px;
+  }
+  /* Hide the prose body — only the pledge + repo link survive on phones. */
+  .lcars-trust-strip--footer .lcars-trust-strip__body {
     display: none;
+  }
+  .lcars-trust-strip--footer .lcars-trust-strip__pledge {
+    font-size: 10px;
+    letter-spacing: 0.18em;
   }
 }
 

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -155,8 +155,10 @@
 .lcars-frame {
   display: grid;
   grid-template-columns: 1fr;
-  /* Tier C: top bar / pill sidebar / content column — content area flexes. */
-  grid-template-rows: auto auto 1fr;
+  /* Tier C: top bar / pill sidebar / content column / optional footer
+     trust strip. The footer row is `auto` so it collapses to zero when
+     no <TrustStrip variant="footer" /> is present. */
+  grid-template-rows: auto auto 1fr auto;
   gap: 6px;
 }
 /* Empty-state frame: keep the TopBar visible (SCAN LOCAL + UPLOAD CLOUD are
@@ -421,7 +423,7 @@
 @media (min-width: 600px) {
   .lcars-frame {
     grid-template-columns: 1fr;
-    grid-template-rows: 56px 1fr;
+    grid-template-rows: 56px 1fr auto;
     gap: 8px;
     /* No forced min-height — frame sizes to content. Populated layouts
        grow naturally from their session grid; empty state stays short
@@ -450,7 +452,7 @@
      the sidebar itself. */
   .lcars-frame {
     grid-template-columns: 160px 1fr;
-    grid-template-rows: 40px 1fr;
+    grid-template-rows: 40px 1fr auto;
     column-gap: 8px;
     row-gap: 0;
   }
@@ -6310,6 +6312,42 @@
 .lcars-empty-main .lcars-trust-strip {
   align-self: center;
   max-width: 640px;
+}
+
+/* Phase 2a footer variant: leaner persistent strip that lives below
+   the populated frame so the local-first pledge is visible when
+   returning users land on data. Single row, smaller padding, spans
+   the full grid; mobile drops it entirely so the pill bar + content
+   keep the limited vertical space. */
+.lcars-trust-strip--footer {
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+  padding: 6px 16px;
+  font-size: 12px;
+  border-left: none;
+  border-top: 2px solid var(--lcars-butterscotch-muted);
+  background: rgba(221, 153, 68, 0.04);
+  border-radius: 0;
+  grid-column: 1 / -1;
+}
+.lcars-trust-strip--footer .lcars-trust-strip__row {
+  flex-wrap: nowrap;
+  gap: 14px;
+  width: 100%;
+}
+.lcars-trust-strip--footer .lcars-trust-strip__body {
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+}
+@media (max-width: 600px) {
+  .lcars-trust-strip--footer {
+    display: none;
+  }
 }
 
 /* ---------------------------------------------------------------- *

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6328,9 +6328,38 @@
   line-height: 1;
 }
 .lcars-top-bar__location-label,
-.lcars-top-bar__earthdate-value {
+.lcars-top-bar__earthdate-value,
+.lcars-top-bar__indexed-value {
   padding-bottom: 2px;
   line-height: 1;
+}
+/* INDEXED chip — mirrors the EARTHDATE chip's chrome treatment but
+   slightly muted so the date stays the dominant time-anchor. The
+   stale variant flips to the peach warning palette so a >30-day-old
+   manifest reads as "needs attention" without being alarmist. */
+.lcars-top-bar__indexed {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.18);
+  border: 1.5px solid rgba(0, 0, 0, 0.4);
+  color: var(--lcars-bg);
+  font-family: var(--lcars-font-chrome);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  flex: 0 0 auto;
+  line-height: 1;
+  opacity: 0.85;
+}
+.lcars-top-bar__indexed[data-stale] {
+  background: var(--lcars-peach);
+  border-color: rgba(0, 0, 0, 0.4);
+  color: var(--lcars-bg);
+  opacity: 1;
 }
 .lcars-top-bar__rescan-chip {
   display: inline-flex;

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -1106,6 +1106,33 @@
 .lcars-sidebar__group:first-of-type > .lcars-sidebar__group-label {
   padding-top: 6px;
 }
+/* Phase 2a: ANALYTICS group is collapsible. The label becomes
+   interactive — focusable, with a chevron suffix that flips when
+   expanded. The collapsed list hides via display:none so it doesn't
+   steal scroll space. */
+.lcars-sidebar__group-label--toggle {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  outline: none;
+}
+.lcars-sidebar__group-label--toggle::after {
+  content: '▾';
+  font-size: 10px;
+  margin-left: 6px;
+  transition: transform 120ms ease-out;
+}
+.lcars-sidebar__group--collapsed .lcars-sidebar__group-label--toggle::after {
+  transform: rotate(-90deg);
+}
+.lcars-sidebar__group-label--toggle:focus-visible {
+  outline: 2px solid var(--lcars-sunflower);
+  outline-offset: 2px;
+}
+.lcars-sidebar__group--collapsed .lcars-sidebar__list {
+  display: none;
+}
 .lcars-sidebar__item {
   display: flex;
   align-items: center;

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -7219,3 +7219,80 @@
   font-size: 11.5px;
   color: color-mix(in srgb, var(--lcars-text) 78%, transparent);
 }
+.lcars-correction-pattern__btn--ghost {
+  border-color: color-mix(in srgb, var(--lcars-text) 30%, transparent);
+  color: color-mix(in srgb, var(--lcars-text) 80%, transparent);
+}
+.lcars-correction-pattern__instance-pill {
+  width: 100%;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.lcars-correction-pattern__instance-pill:hover,
+.lcars-correction-pattern__instance-pill:focus-visible {
+  border-color: color-mix(in srgb, var(--lcars-peach) 50%, transparent);
+  outline: none;
+}
+.lcars-correction-pattern__applied {
+  font-family: var(--lcars-font-chrome);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--lcars-peach) 20%, transparent);
+  color: var(--lcars-peach);
+}
+.lcars-correction-pattern__applied-time {
+  margin-left: 6px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+}
+.lcars-correction-pattern__confirm,
+.lcars-correction-pattern__apply-error {
+  margin-top: 8px;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 12px;
+}
+.lcars-correction-pattern__confirm-blurb {
+  margin: 0;
+  font-size: 11.5px;
+  color: color-mix(in srgb, var(--lcars-text) 88%, transparent);
+}
+.lcars-correction-pattern__confirm-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: color-mix(in srgb, var(--lcars-text) 80%, transparent);
+}
+.lcars-correction-pattern__confirm-textarea {
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 12px;
+  padding: 6px 8px;
+  border: 1px solid color-mix(in srgb, var(--lcars-text) 25%, transparent);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--lcars-text);
+  resize: vertical;
+}
+.lcars-correction-pattern__confirm-actions {
+  display: flex;
+  gap: 8px;
+}


### PR DESCRIPTION
## Summary

Phase 2a of the [refocus plan](../blob/feature/refocus-phase-0-pitch/research/refocus-plan.md). Restructures the chrome to surface the workshop framing without yet adding new modes (the new "Since you patched" mode is Phase 2b).

**Stacks on Phase 1** ([#25](https://github.com/BryceEWatson/chat-arch/pull/25)) — depends on the `applied-improvements.json` ledger schema for the default-mode reroute.

## What landed (6 commits)

1. `LastIndexedChip` in TopBar — surfaces `manifest.generatedAt` as `INDEXED Nd AGO`, peach-stale styling >30d (Sam's #1 friction point retired)
2. Sidebar IA: `FIX RULES` (Corrections, Practice) | `BROWSE` (Sessions) | `ANALYTICS` (Projects, Topics, Cost, Constellation — collapsed by default for fresh installs, expanded for returning users)
3. `TrustStrip` footer-pinned post-load — David's "TrustStrip vanishes when sharing matters most" complaint addressed
4. `ChatArchViewer` wiring — applied-improvements + corrections lifted to mount; default-mode reroute lands returning users + demo visitors on CORRECTIONS when there's content there
5. Reroute integration tests
6. `fix(phase-2a): address adversarial review findings (P0+P1)` — addresses the 4-agent adversarial review

## Adversarial review (4 agents: Sam, Maya, Priya, code-quality)

**P0 fixes (commit 8da16ac):**
- **HIGH**: `priorMode` BACK-flow was dead-on-arrival. The Phase 1 P0.4 fix wired the state but `onBack` returned early via `history.back()` before consuming it; hashchange listener then forced `'command'`. Moved consumption into the hashchange listener via a ref mirror. PracticeMode's clickthrough also wired so PRACTICE → DETAIL → BACK now restores PRACTICE. Regression test added (`ChatArchViewer.back.test.tsx`).
- ANALYTICS collapse default opted *existing* users in (the localStorage key never existed pre-Phase-2a). Now detects "returning user" via any `chat-arch:` localStorage key and defaults to expanded; renamed key to project-convention `chat-arch:analytics-collapsed`.
- LastIndexedChip: clamps `generatedAt <= 0` (no render) and future timestamps from clock skew (renders "INDEXED TODAY" not "-1d AGO").

**P1 fixes (same commit):**
- Swapped INDEXED before EARTHDATE in TopBar render order (Sam — eye lands on the corrective signal first, not the misleading TODAY)
- Default reroute now also fires when `corrections.json` has patterns (Priya — fixes demo-load bait-and-switch where the canvas is SESSIONS while the sidebar shouts WORKSHOP)
- WORKSHOP → FIX RULES (Priya — concrete value-prop language vs. metaphor)
- Footer TrustStrip hidden in detail-overlay mode (Maya — eats pixels in detail view)
- Mobile footer restyled as one-liner (LOCAL-FIRST + VIEW SOURCE) instead of fully hidden (Priya — phones least likely to trust an unfamiliar tool)
- `schemaVersion !== 1` rejected in `loadAppliedImprovementsFile` (code-quality)

**Deferred to Phase 4 (hosted refocus):**
- BROWSE single-item ghost group, jargon polish, demo `corrections.json` fixture, hide CORRECTIONS sidebar on hosted.

## Test plan

- [x] `pnpm test` — 775 passed (was 766; +9 new), 4 pre-existing skips
- [x] `pnpm lint` — clean (5 pre-existing warnings unchanged)
- [x] `pnpm build` — clean
- [ ] Visual: open viewer with stale manifest → INDEXED chip shows N days; CORRECTIONS sidebar item under FIX RULES group; ANALYTICS collapsed for new install / expanded for returning; instance-pill click → BACK preserves CORRECTIONS mode

## Verdict

The chrome now reflects the workshop framing without any new modes. Sam's staleness gap closed (with graduated-stale tiers as a future polish). Maya's daily rhythm respected — reroute lands her on CORRECTIONS, BACK preserves it through clickthroughs. Priya's bait-and-switch reduced — demo visitors with corrections now see the workshop landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)