### PR TITLE
feat(viewer): simplify CORRECTIONS header + collapse to single MINE ALL CTA

### DIFF
--- a/apps/standalone/src/pages/api/mine-corrections.ts
+++ b/apps/standalone/src/pages/api/mine-corrections.ts
@@ -164,8 +164,9 @@ export interface AutoWindowResult {
   /** 'first-run' on cold start; 'incremental' when prior corrections exist;
    *  'idle' when nothing new since last run; 'unavailable' when the data
    *  files aren't readable yet; 'backfill' when explicitly running an
-   *  oldest-first selection. */
-  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill';
+   *  oldest-first selection; 'all' when the caller asked to mine every
+   *  unprocessed candidate in one pass (no cost cap). */
+  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill' | 'all';
   /** Diagnostic for outcome-aware sizing. Null on first run. */
   patternYield: { patterns: number; classified: number; ratio: number } | null;
   /** Present when there are unprocessed candidates older than the picked
@@ -283,7 +284,7 @@ function outcomeAwareTarget(
 export async function computeAutoWindow(
   rootAbs: string,
   dataDir: string,
-  selection: 'recent' | 'backfill' = 'recent',
+  selection: 'recent' | 'backfill' | 'all' = 'recent',
 ): Promise<{ result: AutoWindowResult; targetIds: string[] }> {
   const empty = (result: AutoWindowResult): { result: AutoWindowResult; targetIds: string[] } => ({
     result,
@@ -393,10 +394,12 @@ export async function computeAutoWindow(
     });
   }
 
-  // Order: composite score desc for 'recent' selection. For 'backfill',
-  // re-score with INVERTED recency so older high-signal candidates win.
+  // Order: composite score desc for 'recent' AND 'all' (the user picks
+  // everything; ranking just controls which items the skill processes
+  // first within the batch). For 'backfill', re-score with INVERTED
+  // recency so older high-signal candidates win.
   const ordered = [...fresh].sort((a, b) => {
-    if (selection === 'recent') return b.composite - a.composite;
+    if (selection === 'recent' || selection === 'all') return b.composite - a.composite;
     const invA = a.signalScore + (a.updatedAt > 0 ? 0 : 0); // pure signal weight
     const invB = b.signalScore + (b.updatedAt > 0 ? 0 : 0);
     if (invB !== invA) return invB - invA;
@@ -404,11 +407,14 @@ export async function computeAutoWindow(
   });
 
   // Outcome-aware sizing — falls back to FIRST_RUN_TARGET_CANDIDATES on
-  // first run or zero-yield runs.
+  // first run or zero-yield runs. 'all' bypasses the cap entirely:
+  // the user explicitly opted into mining every unprocessed candidate
+  // in one pass and accepted the cost in the ArmedPreview confirmation.
   const baseTarget = hasPriorRun
     ? outcomeAwareTarget(priorPatterns, priorClassified)
     : FIRST_RUN_TARGET_CANDIDATES;
-  const target = Math.min(baseTarget, ordered.length);
+  const target =
+    selection === 'all' ? ordered.length : Math.min(baseTarget, ordered.length);
   const picked = ordered.slice(0, target);
   const targetIds = picked.map((p) => p.id);
 
@@ -459,7 +465,10 @@ export async function computeAutoWindow(
 
   let mode: AutoWindowResult['mode'];
   let reasoning: string;
-  if (selection === 'backfill') {
+  if (selection === 'all') {
+    mode = 'all';
+    reasoning = `All: targeting every unprocessed candidate (${target} of ${ranked.length} total). Composite-ranked so high-signal items run first within the batch. Covers ~${windowDays} day${windowDays === 1 ? '' : 's'}.`;
+  } else if (selection === 'backfill') {
     mode = 'backfill';
     reasoning = `Backfill: targeting ${target} oldest unprocessed candidate${target === 1 ? '' : 's'} of ${fresh.length} total (~${windowDays} day${windowDays === 1 ? '' : 's'} span). High-signal items prioritized.`;
   } else if (hasPriorRun) {
@@ -692,7 +701,8 @@ async function streamMineCorrections(
 interface MineRequestBody {
   windowDays?: unknown;
   dataDir?: unknown;
-  /** 'recent' (default) or 'backfill' to flip auto-window selection. */
+  /** 'recent' (default), 'backfill', or 'all' (mine every unprocessed
+   *  candidate in one pass — bypasses the cost cap). */
   selection?: unknown;
 }
 
@@ -720,8 +730,12 @@ async function parseParams(body: MineRequestBody): Promise<MineParams> {
     };
   }
 
-  const selection: 'recent' | 'backfill' =
-    body.selection === 'backfill' ? 'backfill' : 'recent';
+  const selection: 'recent' | 'backfill' | 'all' =
+    body.selection === 'all'
+      ? 'all'
+      : body.selection === 'backfill'
+        ? 'backfill'
+        : 'recent';
   const { result: auto, targetIds } = await computeAutoWindow(
     repoRoot(),
     dataDir,
@@ -885,8 +899,13 @@ export const GET: APIRoute = async ({ url }) => {
     typeof dirParam === 'string' && dirParam.trim().length > 0
       ? dirParam
       : DEFAULT_DATA_DIR;
-  const selection: 'recent' | 'backfill' =
-    url.searchParams.get('selection') === 'backfill' ? 'backfill' : 'recent';
+  const selParam = url.searchParams.get('selection');
+  const selection: 'recent' | 'backfill' | 'all' =
+    selParam === 'all'
+      ? 'all'
+      : selParam === 'backfill'
+        ? 'backfill'
+        : 'recent';
   let autoWindow: AutoWindowResult | null = null;
   try {
     const out = await computeAutoWindow(repoRoot(), dataDir, selection);

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -125,7 +125,13 @@ describe('CorrectionsPanel', () => {
     await waitFor(() => {
       expect(screen.getByText(/4 candidates ready to mine/i)).toBeDefined();
     });
-    expect(screen.getByRole('button', { name: /MINE CORRECTIONS/i })).toBeDefined();
+    // The mocked autoWindow probe returns count=12, so the single
+    // primary CTA renders "MINE ALL 12".
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /MINE ALL 12/ }),
+      ).toBeDefined();
+    });
   });
 
   it('sorts patterns into the three buckets correctly', async () => {
@@ -445,6 +451,119 @@ describe('CorrectionsPanel', () => {
       });
       // Hosted-only label must not be present.
       expect(screen.queryByLabelText('TOLD NOT TO, STILL DOES IT')).toBeNull();
+    });
+  });
+
+  // Header-row redesign: "Generated <iso>" was demoted from a row of
+  // its own to a "Last mined …" chip in the title row. Verify the chip
+  // renders relative time and keeps the absolute ISO in `title=` for
+  // debugging without polluting the layout.
+  describe('Header timestamp chip', () => {
+    it('renders the chip in the title row when corrections.json has generatedAt', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([pattern({ id: 'n1', canonicalRule: 'rule one' })]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByText(/Last mined/i)).toBeDefined();
+      });
+      const chip = screen.getByText(/Last mined/i);
+      // Absolute ISO survives in `title=` for tooltip / debugging.
+      expect(chip.getAttribute('title')).toMatch(/Generated 20\d\d-/);
+      // Demoted row that used to read "Generated 20...Z" should be gone.
+      expect(screen.queryByText(/^Generated 20\d\d-/)).toBeNull();
+    });
+  });
+
+  // First-principles simplification (Tight): CoverageMeter shows just
+  // the bar + one figure ("271 / 581 mined"). The label, funnel
+  // sentence, actionable %, and pattern count are gone — diagnostic
+  // info now lives only behind the "details ▸" chevron.
+  describe('CoverageMeter — Tight layout', () => {
+    it('renders just the bar + "N / M mined" figure (no label, no funnel sentence)', async () => {
+      const c: CorrectionsFile = {
+        generatedAt: 1_700_000_000_000,
+        corrections: [
+          { id: 'c1', classification: { actionable: true, ruleSummary: 'r' } },
+          { id: 'c2', classification: { actionable: false, ruleSummary: 'r' } },
+          { id: 'c3', classification: { actionable: true, ruleSummary: 'r' } },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+        patterns: [pattern({ id: 'p1', canonicalRule: 'pat one' })],
+        pipeline: {
+          heuristicRecall: true,
+          llmClassification: true,
+          embeddingClustering: true,
+          claudeMdCrossCheck: true,
+        },
+      };
+      const cands = {
+        ...c,
+        corrections: [
+          { id: 'c1' },
+          { id: 'c2' },
+          { id: 'c3' },
+          { id: 'c4' },
+          { id: 'c5' },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+      };
+      mockedLoadCorrections.mockResolvedValue(c);
+      mockedLoadCandidates.mockResolvedValue(cands);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      await waitFor(() => {
+        const figure = container.querySelector(
+          '.lcars-corrections__coverage-figure',
+        );
+        expect(figure?.textContent ?? '').toMatch(/3\s*\/\s*5\s*mined/);
+      });
+      // Cut by the simplification — these strings should be absent.
+      expect(screen.queryByText('MINING PROGRESS')).toBeNull();
+      expect(screen.queryByText('ANALYSIS COVERAGE')).toBeNull();
+      expect(screen.queryByText(/Of the .* mined/)).toBeNull();
+      expect(screen.queryByText(/became actionable corrections/)).toBeNull();
+      expect(screen.queryByText(/still to mine/)).toBeNull();
+    });
+  });
+
+  // MINE ALL collapse: the recent/older split was killed in favor of a
+  // single CTA that mines every unprocessed candidate in one pass.
+  // Verify the trigger renders one status + one button, and that all
+  // the historical jargon (recent/older/backfill/auto-window) is gone.
+  describe('MiningTrigger — single MINE ALL CTA', () => {
+    it('renders one status sentence + one primary CTA with the total count', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([pattern({ id: 'p1', canonicalRule: 'rule' })]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      // Mocked autoWindow probe returns candidateCount=12; with
+      // selection='all' on the wire, that's the full unprocessed set.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /MINE ALL 12/ }),
+        ).toBeDefined();
+      });
+      const status = container.querySelector(
+        '.lcars-corrections__trigger-status',
+      );
+      expect(status?.textContent ?? '').toMatch(/12 ready to mine/);
+      const cta = screen.getByRole('button', { name: /MINE ALL 12/ });
+      expect(cta.getAttribute('title')).toMatch(/Mine all 12 unprocessed candidates/);
+      // Killed copy — no recent/older split, no backfill jargon, no
+      // auto-window chip, no kicker label.
+      expect(screen.queryByText('NEXT MINING PASS')).toBeNull();
+      expect(screen.queryByText('AUTO WINDOW')).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+RECENT/)).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+OLDER/)).toBeNull();
+      expect(screen.queryByText(/^BACKFILL OLDER/)).toBeNull();
+      expect(screen.queryByText(/← back to recent/i)).toBeNull();
+      expect(screen.queryByText(/RE-MINE CORRECTIONS/i)).toBeNull();
     });
   });
 });

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -30,6 +30,7 @@ import {
   type ApplyCorrectionRequest,
 } from '../data/applyCorrectionClient.js';
 import type { ProposedUpgrade } from '@chat-arch/schema';
+import { formatRelative } from '../util/time.js';
 
 export interface CorrectionsPanelProps {
   /** Same base URL the manifest was fetched from (e.g. "/chat-arch-data"). */
@@ -188,6 +189,16 @@ function formatGenerated(ms: number): string {
   }
 }
 
+/**
+ * Header timestamp formatter. Uses the shared relative-time util so
+ * the chip reads "2d ago" instead of an ISO blob; the absolute ISO
+ * survives in the surrounding `title=` tooltip for debug use.
+ */
+function relativeGenerated(ms: number): string {
+  if (!Number.isFinite(ms)) return 'unknown';
+  return formatRelative(ms);
+}
+
 type ClearState =
   | { status: 'idle' }
   | { status: 'armed' }
@@ -231,10 +242,13 @@ export function CorrectionsPanel({
     };
   }, []);
 
-  const [selection, setSelection] = useState<'recent' | 'backfill'>('recent');
+  // Single-CTA mining (per the "MINE ALL" UX): selection is always 'all'.
+  // The backend's recent/backfill split still exists for future power-user
+  // surfaces but is no longer driven by this panel.
+  const [selection] = useState<'recent' | 'backfill' | 'all'>('all');
 
   const refreshAutoWindow = useCallback(
-    async (sel: 'recent' | 'backfill' = selection) => {
+    async (sel: 'recent' | 'backfill' | 'all' = selection) => {
       const probe = await probeMineCorrections(undefined, sel);
       if (!aliveRef.current) return;
       setAutoWindow(probe?.autoWindow ?? null);
@@ -517,14 +531,13 @@ export function CorrectionsPanel({
       return;
     }
     setMining({ status: 'idle' });
-    setSelection('recent');
     await refresh();
   }, [refresh, selection]);
 
   if (load.status === 'loading') {
     return (
       <section className="lcars-corrections" aria-label="corrections">
-        <Header hostedDemo={!rescanAvailable} />
+        <Header />
         <p className="lcars-corrections__lead">Loading corrections…</p>
       </section>
     );
@@ -533,7 +546,7 @@ export function CorrectionsPanel({
   if (load.status === 'error') {
     return (
       <section className="lcars-corrections" aria-label="corrections">
-        <Header hostedDemo={!rescanAvailable} />
+        <Header />
         <div className="lcars-corrections__error" role="alert">
           <p>Could not load corrections: {load.message}</p>
           <button
@@ -584,7 +597,6 @@ export function CorrectionsPanel({
   return (
     <section className="lcars-corrections" aria-label="corrections">
       <Header
-        hostedDemo={!rescanAvailable}
         {...(typeof corrections?.generatedAt === 'number'
           ? { generatedAt: corrections.generatedAt }
           : {})}
@@ -707,17 +719,8 @@ export function CorrectionsPanel({
           hasCorrections={hasCorrections}
           candidateCount={candidateCount}
           autoWindow={autoWindow}
-          selection={selection}
           onArm={() => setMining({ status: 'armed' })}
           onRefreshAutoWindow={() => void refreshAutoWindow()}
-          onSwitchToBackfill={() => {
-            setSelection('backfill');
-            void refreshAutoWindow('backfill');
-          }}
-          onSwitchToRecent={() => {
-            setSelection('recent');
-            void refreshAutoWindow('recent');
-          }}
           rescanAvailable={rescanAvailable}
         />
       )}
@@ -801,53 +804,31 @@ function CoverageMeter({ coverage }: CoverageMeterProps) {
   const { total, classified, actionable, patterns, scanStats } = coverage;
   const [expanded, setExpanded] = useState(false);
   const pct = total === 0 ? 0 : Math.round((classified / total) * 100);
-  const remaining = Math.max(0, total - classified);
-  const actionablePct =
-    classified === 0 ? 0 : Math.round((actionable / classified) * 100);
 
   return (
     <div
       className="lcars-corrections__coverage"
       role="group"
-      aria-label="analysis coverage"
+      aria-label="mining progress"
     >
-      <div className="lcars-corrections__coverage-row">
-        <span className="lcars-corrections__coverage-label">
-          ANALYSIS COVERAGE
-        </span>
-        <span className="lcars-corrections__coverage-figure">
-          <strong>{fmt(classified)}</strong> / {fmt(total)} candidates
-          classified · {pct}%
-        </span>
-      </div>
       <div
         className="lcars-corrections__coverage-bar"
         role="progressbar"
         aria-valuenow={pct}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuetext={`${classified} of ${total} candidates classified`}
+        aria-valuetext={`${classified} of ${total} candidates mined`}
       >
         <span
           className="lcars-corrections__coverage-fill"
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="lcars-corrections__coverage-funnel">
-        {classified > 0 ? (
-          <>
-            <strong>{fmt(actionable)}</strong> actionable ({actionablePct}% of
-            classified) · <strong>{fmt(patterns)}</strong>{' '}
-            {patterns === 1 ? 'pattern' : 'patterns'} surfaced ·{' '}
-            <strong>{fmt(remaining)}</strong> unmined
-          </>
-        ) : (
-          <>
-            <strong>{fmt(remaining)}</strong> candidate
-            {remaining === 1 ? '' : 's'} unmined — no LLM pass run yet.
-          </>
-        )}
-      </p>
+      <div className="lcars-corrections__coverage-row">
+        <span className="lcars-corrections__coverage-figure">
+          <strong>{fmt(classified)}</strong> / {fmt(total)} mined
+        </span>
+      </div>
       {scanStats !== null && (
         <button
           type="button"
@@ -855,18 +836,9 @@ function CoverageMeter({ coverage }: CoverageMeterProps) {
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
           aria-controls="lcars-corrections-pipeline-detail"
-          aria-label={`pipeline funnel: ${fmt(scanStats.sessionsScanned)} transcripts produced ${fmt(scanStats.survivingTurns)} prompts producing ${fmt(total)} candidates. ${expanded ? 'Hide' : 'Show'} details.`}
+          aria-label={`${expanded ? 'Hide' : 'Show'} mining details`}
         >
-          <span aria-hidden="true">
-            {fmt(scanStats.sessionsScanned)} transcripts →{' '}
-            {fmt(scanStats.survivingTurns)} prompts → {fmt(total)} candidates
-          </span>
-          <span
-            className="lcars-corrections__coverage-chevron"
-            aria-hidden="true"
-          >
-            {expanded ? '▾' : '▸'}
-          </span>
+          <span aria-hidden="true">{expanded ? '▾' : '▸'} details</span>
         </button>
       )}
       {scanStats !== null && expanded && (
@@ -902,40 +874,48 @@ function CoverageDetail({
     'cowork',
     'cloud',
   ];
-  const absent: string[] = [];
-  for (const s of knownSources) {
-    if ((scanStats.sessionsBySource[s] ?? 0) === 0) absent.push(s);
-  }
 
   return (
     <div
       id="lcars-corrections-pipeline-detail"
       className="lcars-corrections__coverage-detail"
     >
-      {(scanStats.sessionsMissing > 0 || absent.length > 0) && (
-        <div className="lcars-corrections__pipeline">
-          <span className="lcars-corrections__pipeline-label">NOT SCANNED</span>
-          <ul className="lcars-corrections__pipeline-list">
-            {Object.entries(scanStats.sessionsMissingBySource).map(
-              ([source, n]) => (
-                <li key={`miss-${source}`}>
-                  <strong>{fmt(n)}</strong> {SOURCE_LABEL[source] ?? source}{' '}
-                  sessions — no transcript file on disk (stub entries from
-                  aborted/deleted sessions)
-                </li>
-              ),
-            )}
-            {absent.map((source) => (
-              <li key={`absent-${source}`}>
-                <strong>0</strong> {SOURCE_LABEL[source] ?? source} sessions —
-                {source === 'cloud'
-                  ? ' no claude.ai export loaded'
-                  : ' source not present in this corpus'}
+      <div className="lcars-corrections__pipeline">
+        <span className="lcars-corrections__pipeline-label">SCANNED</span>
+        <span className="lcars-corrections__pipeline-sublabel">
+          transcripts read · indexed in manifest
+        </span>
+        <ul className="lcars-corrections__pipeline-list">
+          {knownSources.map((source) => {
+            const total = scanStats.sessionsBySource[source] ?? 0;
+            const missing = scanStats.sessionsMissingBySource[source] ?? 0;
+            const scanned = Math.max(0, total - missing);
+            const note =
+              total === 0
+                ? source === 'cloud'
+                  ? 'no claude.ai export loaded'
+                  : 'not present in this corpus'
+                : missing > 0
+                  ? `${fmt(missing)} indexed but transcript file not on disk — usually deleted or aborted sessions`
+                  : null;
+            return (
+              <li key={`scan-${source}`}>
+                <span className="lcars-corrections__pipeline-source">
+                  {SOURCE_LABEL[source] ?? source}
+                </span>{' '}
+                <strong>
+                  {fmt(scanned)} / {fmt(total)}
+                </strong>
+                {note && (
+                  <span className="lcars-corrections__pipeline-note">
+                    {note}
+                  </span>
+                )}
               </li>
-            ))}
-          </ul>
-        </div>
-      )}
+            );
+          })}
+        </ul>
+      </div>
       <div className="lcars-corrections__pipeline">
         <span className="lcars-corrections__pipeline-label">PIPELINE</span>
         <ul className="lcars-corrections__pipeline-list">
@@ -1103,43 +1083,23 @@ function DangerZone({
 
 interface HeaderProps {
   generatedAt?: number;
-  /**
-   * Phase 4 P0.3: when true, the panel is showing demo data on a
-   * hosted static build (no `/api/mine-corrections`, no apply ledger
-   * back end). Swap the developer-y lead copy ("log a CLAUDE.md edit",
-   * "next mining pass", "applied-improvements.json") for plain
-   * language that explains what corrections ARE — matching the
-   * hosted-demo bucket blurbs above.
-   */
-  hostedDemo?: boolean;
 }
 
-function Header({ generatedAt, hostedDemo = false }: HeaderProps) {
+function Header({ generatedAt }: HeaderProps) {
+  const hasTime = typeof generatedAt === 'number';
   return (
     <header className="lcars-corrections__header">
-      <h2 className="lcars-corrections__title">CORRECTIONS</h2>
-      <p className="lcars-corrections__lead">
-        {hostedDemo ? (
-          <>
-            These are corrections — moments where Claude broke a rule you set, clustered into
-            patterns. Patterns marked <strong>RECURRING</strong> came back even after you patched
-            them; those are the strongest signal that the rule needs reshaping.
-          </>
-        ) : (
-          <>
-            Recurring instructions you keep giving the model — clustered, ranked, and paired with
-            proposed CLAUDE.md upgrades. Click APPLY to log a CLAUDE.md edit you&apos;ve made; the
-            loop closes when the next mining pass shows the rule is no longer recurring. Apply
-            history is recorded in <code>applied-improvements.json</code> next to{' '}
-            <code>corrections.json</code>.
-          </>
+      <div className="lcars-corrections__title-row">
+        <h2 className="lcars-corrections__title">CORRECTIONS</h2>
+        {hasTime && (
+          <span
+            className="lcars-corrections__time"
+            title={`Generated ${formatGenerated(generatedAt!)}`}
+          >
+            Last mined {relativeGenerated(generatedAt!)}
+          </span>
         )}
-      </p>
-      {typeof generatedAt === 'number' && (
-        <p className="lcars-corrections__meta">
-          Generated {formatGenerated(generatedAt)}
-        </p>
-      )}
+      </div>
     </header>
   );
 }
@@ -1148,11 +1108,8 @@ interface MiningTriggerProps {
   hasCorrections: boolean;
   candidateCount: number;
   autoWindow: AutoWindowResult | null;
-  selection: 'recent' | 'backfill';
   onArm: () => void;
   onRefreshAutoWindow: () => void;
-  onSwitchToBackfill: () => void;
-  onSwitchToRecent: () => void;
   /**
    * Phase 4 — when `false`, the host is the hosted static build with
    * no `/api/mine-corrections` endpoint. Mining can never run there;
@@ -1166,14 +1123,10 @@ function MiningTrigger({
   hasCorrections,
   candidateCount,
   autoWindow,
-  selection,
   onArm,
   onRefreshAutoWindow,
-  onSwitchToBackfill,
-  onSwitchToRecent,
   rescanAvailable = true,
 }: MiningTriggerProps) {
-  const ctaLabel = hasCorrections ? 'RE-MINE CORRECTIONS' : 'MINE CORRECTIONS';
   const isIdle = autoWindow?.mode === 'idle';
   const isUnavailable = autoWindow?.mode === 'unavailable';
   // Phase 4 — when the local server is unreachable AND the auto-window
@@ -1183,51 +1136,68 @@ function MiningTrigger({
   const localOnly = !rescanAvailable && autoWindow === null;
   const disabled =
     isIdle || isUnavailable || localOnly || (candidateCount === 0 && !hasCorrections);
-  const modeLabel = selection === 'backfill' ? 'BACKFILL' : 'AUTO WINDOW';
-  const backfill = autoWindow?.backfillAvailable ?? null;
+
+  // With selection='all' the autoWindow result already carries the
+  // entire unprocessed set — no separate "older" count to add.
+  const totalReady = autoWindow?.candidateCount ?? 0;
+  const windowDays = autoWindow?.windowDays ?? null;
+  const hasReady = totalReady > 0 && !isIdle && !isUnavailable;
+
+  const ctaLabel = isIdle
+    ? 'NO NEW CANDIDATES'
+    : isUnavailable
+      ? 'NO DATA'
+      : hasReady
+        ? `MINE ALL ${totalReady}`
+        : hasCorrections
+          ? 'RE-MINE CORRECTIONS'
+          : 'MINE CORRECTIONS';
+
+  const ctaTitle = localOnly
+    ? 'Mining is local-only — install chat-arch on your machine to mine your own corpus.'
+    : isIdle
+      ? 'No new candidates since the last mining run.'
+      : isUnavailable
+        ? 'Run the chat-arch exporter first to produce candidates.'
+        : hasReady && windowDays !== null
+          ? `Mine all ${totalReady} unprocessed candidates (~${windowDays} day span).`
+          : undefined;
+
+  const status = localOnly
+    ? 'Mining is local-only.'
+    : autoWindow === null
+      ? 'Computing…'
+      : isUnavailable
+        ? 'No candidates yet.'
+        : isIdle
+          ? 'Nothing new to mine.'
+          : `${totalReady} ready to mine`;
 
   return (
     <div className="lcars-corrections__trigger">
-      <div className="lcars-corrections__auto">
-        <span className="lcars-corrections__auto-label">{modeLabel}</span>
-        <span className="lcars-corrections__auto-value">
-          {localOnly
-            ? 'mining is local-only'
-            : autoWindow === null
-              ? 'computing…'
-              : autoWindow.mode === 'idle'
-                ? 'no new candidates'
-                : autoWindow.mode === 'unavailable'
-                  ? 'no data'
-                  : `${autoWindow.windowDays}d · ${autoWindow.candidateCount} candidate${autoWindow.candidateCount === 1 ? '' : 's'}`}
-        </span>
+      <div className="lcars-corrections__trigger-status-row">
+        <span className="lcars-corrections__trigger-status">{status}</span>
         <button
           type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--ghost"
+          className="lcars-corrections__btn lcars-corrections__btn--ghost lcars-corrections__btn--icon"
           onClick={onRefreshAutoWindow}
-          aria-label="refresh auto window"
-          title="Recompute auto-window"
+          aria-label="refresh"
+          title="Recompute the candidate count"
         >
           ↻
         </button>
       </div>
-      <button
-        type="button"
-        className="lcars-corrections__btn lcars-corrections__btn--primary"
-        onClick={onArm}
-        disabled={disabled}
-        title={
-          localOnly
-            ? 'Mining is local-only — install chat-arch on your machine to mine your own corpus.'
-            : isIdle
-              ? 'No new candidates since the last mining run.'
-              : isUnavailable
-                ? 'Run the chat-arch exporter first to produce candidates.'
-                : undefined
-        }
-      >
-        ▶ {ctaLabel}
-      </button>
+      <div className="lcars-corrections__trigger-row">
+        <button
+          type="button"
+          className="lcars-corrections__btn lcars-corrections__btn--primary"
+          onClick={onArm}
+          disabled={disabled}
+          {...(ctaTitle ? { title: ctaTitle } : {})}
+        >
+          ▶ {ctaLabel}
+        </button>
+      </div>
       {localOnly && (
         <p className="lcars-corrections__auto-hint">
           Mining is local-only — these demo patterns ship with the bundled fixture.{' '}
@@ -1240,25 +1210,6 @@ function MiningTrigger({
           </a>{' '}
           to mine your own corpus.
         </p>
-      )}
-      {selection === 'recent' && backfill !== null && (
-        <button
-          type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--secondary"
-          onClick={onSwitchToBackfill}
-          title={`${backfill.count} unprocessed older than the recent set, oldest from ${backfill.oldestDate}`}
-        >
-          BACKFILL OLDER ({backfill.count})
-        </button>
-      )}
-      {selection === 'backfill' && (
-        <button
-          type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--ghost"
-          onClick={onSwitchToRecent}
-        >
-          ← RECENT
-        </button>
       )}
     </div>
   );
@@ -1292,8 +1243,11 @@ function ArmedPreview({ autoWindow, onRun, onCancel }: ArmedPreviewProps) {
         {windowDays === 1 ? 'day' : 'days'}. Estimated work:{' '}
         ~{Math.max(1, Math.ceil(candidateCount / 20))} classification batch
         {Math.ceil(candidateCount / 20) === 1 ? '' : 'es'} plus
-        one proposal call per cluster, ~3-8 min wall-clock. Counts against your
-        Claude Code plan usage; no separate billing.
+        one proposal call per cluster,{' '}
+        ~{Math.max(3, Math.ceil(Math.ceil(candidateCount / 20) * 0.75))}-
+        {Math.max(8, Math.ceil(Math.ceil(candidateCount / 20) * 2))} min
+        wall-clock. Counts against your Claude Code plan usage; no separate
+        billing.
       </p>
       <p className="lcars-corrections__armed-reasoning">{reasoning}</p>
       <div className="lcars-corrections__armed-actions">

--- a/packages/viewer/src/data/mineCorrectionsClient.ts
+++ b/packages/viewer/src/data/mineCorrectionsClient.ts
@@ -25,7 +25,7 @@ export interface AutoWindowResult {
   windowDays: number;
   candidateCount: number;
   reasoning: string;
-  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill';
+  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill' | 'all';
   patternYield: { patterns: number; classified: number; ratio: number } | null;
   backfillAvailable: BackfillInfo | null;
 }
@@ -96,9 +96,9 @@ export interface MineCorrectionsOptions {
   /** Omit to use server-side auto-window selection. */
   windowDays?: number;
   dataDir?: string;
-  /** 'recent' (default) or 'backfill' — flips auto-window selection
-   *  to oldest-unprocessed-first so historical patterns surface. */
-  selection?: 'recent' | 'backfill';
+  /** 'recent' (default), 'backfill', or 'all' — 'all' bypasses the
+   *  cost cap and processes every unprocessed candidate in one pass. */
+  selection?: 'recent' | 'backfill' | 'all';
 }
 
 /**
@@ -108,11 +108,13 @@ export interface MineCorrectionsOptions {
  */
 export async function probeMineCorrections(
   dataDir?: string,
-  selection?: 'recent' | 'backfill',
+  selection?: 'recent' | 'backfill' | 'all',
 ): Promise<MineProbe | null> {
   const params = new URLSearchParams();
   if (dataDir !== undefined && dataDir.length > 0) params.set('dataDir', dataDir);
-  if (selection === 'backfill') params.set('selection', 'backfill');
+  if (selection === 'backfill' || selection === 'all') {
+    params.set('selection', selection);
+  }
   const qs = params.toString();
   const url = qs.length > 0 ? `${MINE_CORRECTIONS_PATH}?${qs}` : MINE_CORRECTIONS_PATH;
   try {

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6134,6 +6134,13 @@
   flex-direction: column;
   gap: 4px;
 }
+.lcars-corrections__title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
 .lcars-corrections__title {
   font-family: var(--lcars-font-chrome);
   font-size: 18px;
@@ -6142,19 +6149,19 @@
   color: var(--lcars-peach);
   margin: 0;
 }
+.lcars-corrections__time {
+  font-family: var(--lcars-font-chrome);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
 .lcars-corrections__lead {
   margin: 0;
   max-width: 78ch;
   font-size: 13px;
   line-height: 1.5;
   color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
-}
-.lcars-corrections__meta {
-  margin: 0;
-  font-size: 11px;
-  font-family: var(--lcars-font-chrome);
-  letter-spacing: 0.12em;
-  color: color-mix(in srgb, var(--lcars-text) 85%, transparent);
 }
 .lcars-corrections__empty {
   margin: 0;
@@ -6197,29 +6204,28 @@
 }
 .lcars-corrections__trigger {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 6px;
 }
-.lcars-corrections__auto {
-  display: inline-flex;
+.lcars-corrections__trigger-status-row {
+  display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 10px 4px 12px;
-  border: 1px solid color-mix(in srgb, var(--lcars-peach) 35%, transparent);
-  border-radius: 999px;
-  background: rgba(0, 0, 0, 0.25);
 }
-.lcars-corrections__auto-label {
-  font-family: var(--lcars-font-chrome);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  color: color-mix(in srgb, var(--lcars-text) 80%, transparent);
+.lcars-corrections__trigger-status {
+  font-size: 13px;
+  color: color-mix(in srgb, var(--lcars-text) 90%, transparent);
 }
-.lcars-corrections__auto-value {
-  font-family: var(--lcars-font-mono, monospace);
-  font-size: 12px;
-  color: var(--lcars-text);
+.lcars-corrections__trigger-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.lcars-corrections__btn--icon {
+  padding: 2px 8px;
+  font-size: 14px;
+  letter-spacing: 0;
 }
 .lcars-corrections__armed-reasoning {
   margin: 0;
@@ -6559,13 +6565,6 @@ button.lcars-applied-summary__stale--button:focus-visible {
   gap: 12px;
   flex-wrap: wrap;
 }
-.lcars-corrections__coverage-label {
-  font-family: var(--lcars-font-chrome);
-  font-size: 10px;
-  letter-spacing: 0.22em;
-  color: var(--lcars-sunflower);
-  font-weight: 700;
-}
 .lcars-corrections__coverage-figure {
   font-size: 12.5px;
   color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
@@ -6591,16 +6590,6 @@ button.lcars-applied-summary__stale--button:focus-visible {
     var(--lcars-peach)
   );
   transition: width 240ms ease-out;
-}
-.lcars-corrections__coverage-funnel {
-  margin: 2px 0 0 0;
-  font-size: 12px;
-  line-height: 1.5;
-  color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
-}
-.lcars-corrections__coverage-funnel strong {
-  color: var(--lcars-text);
-  font-variant-numeric: tabular-nums;
 }
 .lcars-corrections__coverage-provenance {
   display: flex;
@@ -6674,6 +6663,22 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-size: 11.5px;
   font-style: italic;
   color: color-mix(in srgb, var(--lcars-text) 85%, transparent);
+}
+.lcars-corrections__pipeline-source {
+  display: inline-block;
+  min-width: 9ch;
+  font-family: var(--lcars-font-chrome);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--lcars-text) 75%, transparent);
+}
+.lcars-corrections__pipeline-sublabel {
+  margin-top: -2px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+  font-style: italic;
+  color: color-mix(in srgb, var(--lcars-text) 60%, transparent);
 }
 .lcars-corrections__danger {
   display: flex;


### PR DESCRIPTION
## Summary

First-principles UX pass on the `CORRECTIONS` page header, plus a backend `'all'` selection mode that lets one button mine everything unprocessed.

**Header** — dropped the 5-line developer-jargon lead. Title row now carries a `Last mined 2d ago` chip (ISO in title= tooltip).

**CoverageMeter** — collapsed to bar + `271 / 581 mined` only. Chevron renamed `details ▸`. Expanded panel reworked from a "NOT SCANNED" callout into a per-source `<scanned> / <total>` SCANNED panel with inline notes for missing transcripts / absent sources.

**MiningTrigger** — killed the RECENT/OLDER split (no user-meaningful reason to choose between them), the AUTO WINDOW chip, the BACKFILL jargon, and the back-button. One status sentence (`309 ready to mine`) + one CTA (`▶ MINE ALL 309`).

**Backend** — `computeAutoWindow` now accepts `'recent' | 'backfill' | 'all'`. `'all'` bypasses the cost cap and returns every unprocessed candidate in one pass. ArmedPreview's time estimate scales with batch count (`~12-32 min` for 309 candidates instead of hardcoded `~3-8 min`).

## Test plan

- [ ] Visual: `localhost:4323` → CORRECTIONS page reads cleaner; one button instead of three
- [ ] Click `details ▸` → SCANNED panel shows per-source counts + inline notes when relevant
- [ ] Click `▶ MINE ALL N` → ArmedPreview shows full count + scaled wall-clock estimate
- [ ] 807 tests pass, lint clean (5 pre-existing warnings unrelated), monorepo build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)