### PR TITLE
feat(corrections): LLM-derived topic buckets replace fixed taxonomy

### DIFF
--- a/.claude/skills/mine-corrections/SKILL.md
+++ b/.claude/skills/mine-corrections/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: mine-corrections
+description: Mine the chat-arch corpus for correction patterns — moments where the user pushed back on the AI — and propose concrete upgrades to CLAUDE.md, skills, agents, commands, or hooks. Detects rules that already exist but are still being violated. Reads chat-arch-data/analysis/correction-candidates.json (produced by the chat-arch exporter) and writes corrections.json with classified patterns and proposed upgrades. Local Ollama required for embeddings.
+---
+
+# /mine-corrections
+
+You are running the LLM stages of chat-arch's correction-mining pipeline. The exporter has already produced a heuristic-recall list of candidate corrections. Your job: classify them, cluster repeated rules, check whether each rule already exists in the user's config, and propose concrete upgrades.
+
+## When to invoke
+
+- The user runs `/mine-corrections` (optionally with arguments below).
+- The viewer wrote a request to `chat-arch-data/analysis/correction-requests.json` (you'll see a `--request-id` arg in that case).
+
+## Arguments
+
+Parse from the user's message. Defaults in brackets.
+
+- `--data-dir <path>` [defaults to `./chat-arch-data` relative to repo root, or whatever the user names]
+- `--window-days <N>` [30] — only process corrections from sessions updated within the last N days. Most-recent-first ordering. **Ignored when `--candidate-ids-file` is also passed.**
+- `--candidate-ids-file <path>` [omitted] — JSON file with `{ "ids": ["cor_...", ...] }`. When present, processes ONLY those correction ids regardless of `--window-days`. The API endpoint writes this file when auto-window selects candidates by composite (signal × recency) score rather than a pure time slice. Honor this list verbatim.
+- `--request-id <uuid>` [omitted] — present when invoked from the viewer; correlates status/output with the requesting UI.
+- `--max-sub-agents <N>` [40] — abort if the work plan would dispatch more than N sub-agents. Each batch of 20 candidates = 1 classification sub-agent; each cluster = 1 proposal sub-agent. The bound prevents a runaway window from quietly burning a chunk of your Claude Code plan usage.
+- `--no-llm` [false] — skip stages 2, 4 (proposal LLM); useful for dry runs and CI.
+- `--reclassify` [false] — re-process already-classified corrections (default skips them).
+
+## Pipeline
+
+You orchestrate six stages. Update the status file at every transition.
+
+### Stage 0 — Setup
+
+1. Resolve `--data-dir`. Read `${dataDir}/analysis/correction-candidates.json`. If absent, tell the user to run `pnpm --filter @chat-arch/exporter run start ...` first.
+2. **If `--candidate-ids-file` is set**: read it, take the `ids` array, filter `correction-candidates.json` to ONLY those ids. Skip the time-window filter entirely. This is the auto-window's preferred path — composite (signal × recency) ranking already happened upstream.
+   **Else** (legacy / explicit `--window-days`): filter to candidates from sessions whose `updatedAt` is within `--window-days` of now. Use the manifest at `${dataDir}/manifest.json` to look up session timestamps by `sessionId`. Sort most-recent-first.
+4. Verify Ollama is up. Run `Bash`:
+   ```
+   curl -s -m 1 http://localhost:11434/api/tags > /dev/null && echo OK || echo MISSING
+   ```
+   If MISSING, tell the user: "Ollama is not running. Install from https://ollama.com, then `ollama pull mxbai-embed-large`." Stop.
+5. Estimate sub-agent count: `ceil(numCandidates / 20) + estimatedClusters` (estimate clusters as ~numCandidates/8 for a first pass; tighten on subsequent runs once you know the real cluster ratio). If estimate exceeds `--max-sub-agents`, tell the user the count and ask whether to proceed or narrow the window. All sub-agent calls run inside the parent Claude Code session — no separate billing, but each call counts against the user's plan usage.
+6. Write the initial status file.
+
+### Stage 1 — Classification
+
+Goal: turn each candidate into a structured `CorrectionClassification` (kind, distilledRule, confidence, actionable). Drop the rest.
+
+Batch candidates into groups of 20. For each batch, dispatch a `general-purpose` sub-agent **with `model: "haiku"`**. Classification is a structured-output task — Haiku 4.5 handles it well at a fraction of the rate-limit cost of Opus, and proposal generation later (Stage 5) keeps the default Opus where judgment matters. Run multiple batches in parallel — up to 4 at a time — by sending multiple Agent tool calls in a single message.
+
+Use this exact sub-agent prompt template (substitute the candidate JSON in place of `<<CANDIDATES>>`):
+
+```
+You are classifying user-corrections-to-AI from a chat transcript. Each input is a {sessionId, userTurnIndex, excerpt, precedingAssistantExcerpt, signals} object.
+
+For each input, decide:
+1. Is this an actual correction-to-the-AI (an instruction, behavior rule, format demand) — actionable?
+2. If actionable, what KIND: 'behavior-rule' | 'output-format' | 'tool-preference' | 'factual-fix' | 'tone' | 'process' | 'other'.
+3. Distill the rule into ONE imperative sentence. No first-person, no project-specific identifiers, no quotes from the assistant. Example: "don't add docstrings unless the user asks." Bad example: "the user wants me to stop adding docstrings."
+4. Confidence (0..1): how confident are you this is a real, repeatable correction (not a one-off fix or aside).
+
+Output ONLY a JSON array, one entry per input, same order:
+[{"id": "<correction id>", "actionable": true|false, "kind": "...", "distilledRule": "...", "confidence": 0.0-1.0}]
+
+Inputs:
+<<CANDIDATES>>
+```
+
+Each sub-agent returns its JSON. Concatenate results. If any sub-agent fails or returns malformed JSON, retry once; if still bad, drop those candidates with a status message.
+
+After all batches: filter to `actionable: true` AND `confidence >= 0.6`. Update status: `"classified N of M, K kept after filter"`.
+
+Write the intermediate file `${dataDir}/analysis/_corrections-classified.json` (the leading underscore signals "intermediate, not consumed by viewer"):
+
+```json
+{
+  "generatedAt": <now>,
+  "corrections": [<each Correction with classification populated>],
+  "patterns": [],
+  "pipeline": { "heuristicRecall": true, "llmClassification": true, "embeddingClustering": false, "claudeMdCrossCheck": false }
+}
+```
+
+### Stage 2 — Config ingestion
+
+Discover the user's existing CLAUDE.md / skills / agents / commands / settings.
+
+```bash
+# Build the project-roots list from the manifest's distinct cwd values.
+node -e "
+const m = JSON.parse(require('fs').readFileSync('${dataDir}/manifest.json','utf8'));
+const roots = [...new Set(m.sessions.map(s => s.cwd).filter(Boolean).filter(c => !c.startsWith('/sessions/')))];
+require('fs').writeFileSync('${dataDir}/analysis/_project-roots.json', JSON.stringify(roots));
+"
+
+# Run the ingestion CLI. The home-dir default is fine.
+node packages/exporter/dist/cli/ingest-configs-cli.js \
+  --project-roots-file ${dataDir}/analysis/_project-roots.json \
+  --output ${dataDir}/analysis/_configs.json
+```
+
+### Stage 3 — Embed everything
+
+Embed (a) the distilled rules, (b) every config sentence. Two batched calls to `chat-arch-embed`.
+
+```bash
+# Rules
+node -e "
+const c = JSON.parse(require('fs').readFileSync('${dataDir}/analysis/_corrections-classified.json','utf8'));
+const texts = c.corrections.filter(x => x.classification?.actionable).map(x => x.classification.distilledRule);
+require('fs').writeFileSync('${dataDir}/analysis/_rules-input.json', JSON.stringify({ texts }));
+"
+node packages/exporter/dist/cli/embed-cli.js \
+  --input ${dataDir}/analysis/_rules-input.json \
+  --output ${dataDir}/analysis/_rules-vectors.json
+
+# Sentences
+node -e "
+const cf = JSON.parse(require('fs').readFileSync('${dataDir}/analysis/_configs.json','utf8'));
+const texts = cf.documents.flatMap(d => d.sentences.map(s => s.text));
+require('fs').writeFileSync('${dataDir}/analysis/_sentences-input.json', JSON.stringify({ texts }));
+"
+node packages/exporter/dist/cli/embed-cli.js \
+  --input ${dataDir}/analysis/_sentences-input.json \
+  --output ${dataDir}/analysis/_sentences-vectors.json
+```
+
+If an embed call fails, surface stderr to the user. Likely cause: Ollama dropped, or the model isn't pulled (`ollama pull mxbai-embed-large`).
+
+### Stage 4 — Cluster + already-encoded check
+
+```bash
+node packages/exporter/dist/cli/cluster-corrections-cli.js \
+  --classifications ${dataDir}/analysis/_corrections-classified.json \
+  --configs ${dataDir}/analysis/_configs.json \
+  --output ${dataDir}/analysis/_patterns-no-proposals.json
+```
+
+This reads the classifications + configs and writes patterns with `proposedUpgrades: []`. Each pattern has its `alreadyEncoded` and `confidence` fields populated.
+
+Update status: `"clustered into K patterns (J already-encoded)"`.
+
+### Stage 5 — Proposal generation
+
+For each pattern, dispatch a sub-agent to generate `ProposedUpgrade[]`. Process patterns in parallel up to 4 at a time. **Use the default model (Opus)** — proposal generation requires judgment about which target file to recommend, why the existing rule is failing, and what the patch text should say. Don't downgrade to Haiku here.
+
+For each pattern, build the sub-agent prompt with:
+
+- The pattern's `canonicalRule`, `occurrenceCount`, `alreadyEncoded`.
+- 3-5 representative instances (excerpt + precedingAssistantExcerpt) — pick the highest-confidence ones.
+- The relevant config documents (those whose sentences had highest similarity to the rule). Truncate each to ≤2000 chars.
+- The list of distinct project roots affected (lookup via session→cwd from the manifest).
+
+Sub-agent prompt template:
+
+```
+You are proposing a concrete fix for a recurring AI-correction pattern.
+
+PATTERN
+canonicalRule: <text>
+occurrenceCount: <N>
+alreadyEncoded: <true|false>
+projectsAffected: [<roots>]
+
+INSTANCES (5 most representative):
+<excerpt + preceding assistant text for each>
+
+EXISTING USER CONFIG (most relevant, may be empty):
+<excerpts of any CLAUDE.md / SKILL.md / agent / command / settings document with high similarity>
+
+PRODUCE: a JSON array of ProposedUpgrade objects, ranked best-first. Each object:
+{
+  "target": "global-claude-md" | "project-claude-md" | "settings-hook" | "skill" | "prompt-snippet" | "agent" | "command",
+  "targetPath": "<concrete file path or settings.json key>",
+  "patch": "<the literal text to add or the unified diff if replacing>",
+  "rationale": "<one paragraph; cite at least 2 instance ids by '<corId>' format from above>",
+  "applied": false,
+  "appliedAt": null
+}
+
+CONSTRAINTS — non-negotiable:
+- patch must be CONCRETE TEXT, not a description of what to add.
+- If alreadyEncoded is true: the existing rule is failing. Your top-ranked proposal MUST be a reword (with the failure diagnosed: why is the model violating the existing rule?) OR an escalation to deterministic enforcement (hook). Do NOT propose adding a new rule when one already exists.
+- If projectsAffected is one project: prefer project-claude-md over global-claude-md.
+- If projectsAffected is many projects: prefer global-claude-md.
+- If pattern is process-y and tool-bound (e.g. "always run X before Y"): consider a hook over a CLAUDE.md rule.
+- If pattern is workflow-shaped (e.g. "when reviewing code, do X"): consider a skill or agent.
+- rationale must cite at least 2 instance ids.
+- No flattery. No "you have great instincts." Pure mechanism.
+- If you cannot produce ≥1 valid proposal under these constraints, return an empty array. Do not produce a low-quality proposal to fill the slot.
+
+Output ONLY the JSON array.
+```
+
+After all sub-agents return, validate each proposal:
+- `patch` non-empty
+- `targetPath` non-empty
+- `rationale` cites at least 2 strings of the form `<corId>` that exist in the cluster's instanceIds
+- `target` is one of the allowed values
+
+Drop invalid proposals. If a pattern ends up with zero valid proposals, keep the pattern but with `proposedUpgrades: []` and note it in status.
+
+### Stage 6 — Tag topics
+
+Goal: assign every pattern (this run's new patterns AND any prior patterns preserved across runs) a short topic label that drives dynamic bucketing in the viewer. ONE LLM call sees all patterns at once — clustering needs a global view to keep labels coherent (no fragmentation between "Git Workflow" and "Git Practices").
+
+1. Read existing `${dataDir}/analysis/corrections.json` if present. Collect prior patterns. Combine with this run's freshly-clustered patterns from `_patterns-no-proposals.json` (or with proposals from the staging step above — only `canonicalRule` is needed here).
+2. If the combined pattern count is ≤ 1, skip this stage (one pattern doesn't need clustering — leave `topic` undefined).
+3. Build the topic-tagging prompt with the full pattern list. Use the **default model (Opus)** — taxonomy quality is the whole point and Haiku tends to over-cluster.
+
+Sub-agent prompt template (single sub-agent, NOT parallelized — taxonomy needs a global view):
+
+```
+You are clustering correction patterns into a small number of topic categories. The user will browse patterns grouped by topic, so the labels must be:
+- short (1-3 words, Title Case)
+- mutually distinct (don't return two labels that mean the same thing)
+- balanced (aim for 4-8 topics across the corpus; merge sparingly-populated themes into a broader parent)
+- stable in shape across runs (same corpus → same labels)
+
+INPUTS — every pattern in the corpus:
+[{"id":"p_...","canonicalRule":"...","occurrenceCount":N,"alreadyEncoded":bool}, ...]
+
+PRODUCE — a JSON object mapping each pattern id to a topic label, plus the deduplicated topic list:
+{
+  "topics": ["Git Workflow", "Test Discipline", ...],
+  "assignments": { "p_abc123": "Git Workflow", "p_def456": "Test Discipline", ... }
+}
+
+CONSTRAINTS — non-negotiable:
+- Every input id appears in `assignments`. No id is dropped.
+- Every value in `assignments` appears in `topics`. No orphan labels.
+- Topic labels are 1-3 words, Title Case, no punctuation.
+- Don't invent a "Misc" or "Other" bucket. If a pattern truly doesn't fit, group it with the nearest semantic neighbor.
+- Don't pad to a fixed count. If the corpus genuinely splits into 3 topics, return 3.
+
+Output ONLY the JSON object.
+```
+
+Validate the response:
+- Parse as JSON; on failure, retry once. On second failure, log a warning and skip the stage (patterns ship without `topic` — viewer falls back to an Untagged bucket).
+- Every pattern id present? Every assigned label in `topics`?
+- If validation fails, drop the stage rather than ship inconsistent data.
+
+Apply the assignments: for each pattern in this run's set AND any prior pattern that was passed to the LLM, write `topic = assignments[patternId]`. Patterns NOT in the input list (none, if you built the input correctly) keep their existing `topic` field as-is.
+
+Update status: `"tagged N patterns into K topics: [<topics>]"`.
+
+### Stage 7 — Assemble + write
+
+Merge classifications + patterns + proposals into the final `CorrectionsFile`. **Critical:** preserve any prior corrections in `corrections.json` that this run did NOT touch — they keep their existing classification (or `null` if they were never classified). Only overwrite entries for candidates this run classified.
+
+```json
+{
+  "generatedAt": <now>,
+  "corrections": [<merged: prior entries + this run's freshly classified, classification populated where known, null otherwise>],
+  "patterns": [<merged: prior patterns retained, this run's new patterns added>],
+  "pipeline": { "heuristicRecall": true, "llmClassification": true, "embeddingClustering": true, "claudeMdCrossCheck": true }
+}
+```
+
+The merge step is what makes the auto-window's "incremental" promise hold. If you wholesale-replace `corrections.json` with only this run's processed candidates, the next auto-window run will treat anything you didn't touch as unprocessed and try to re-do it.
+
+Write to `${dataDir}/analysis/corrections.json`. Then DELETE the intermediate `_*.json` files (clean up), including the `_correction-target-ids-${requestId}.json` file the API endpoint wrote when `--candidate-ids-file` was used.
+
+Update status to `complete` with summary counts.
+
+If a `--request-id` was passed, also write a completion marker at `${dataDir}/analysis/correction-status-${requestId}.json`:
+
+```json
+{ "requestId": "<id>", "status": "complete", "completedAt": <now>, "patternCount": N, "alreadyEncodedCount": K, "tokenCost": "<estimate>" }
+```
+
+## Loop closure (subsequent runs)
+
+When invoked with `--reclassify` OR when corrections.json already exists with applied proposals:
+
+1. Load existing corrections.json. Note which patterns have `proposedUpgrades[*].applied === true` with `appliedAt` set.
+2. For each "applied" pattern, check whether new corrections (post-`appliedAt`) match the same canonical rule (use embedding similarity ≥ 0.85 against the canonicalRule).
+3. If yes: set `recurringPostApplication: true` on that pattern. The viewer surfaces it as "applied but still recurring" — top priority.
+4. Also re-read the file at `appliedAt`'s `targetPath`. If the rule's normalized canonical no longer appears there (user edited it away), retire the proposal — set `applied: false` and clear `appliedAt`. The pattern goes back into the queue normally.
+
+## Status file format
+
+`${dataDir}/analysis/correction-status-${requestId}.json`:
+
+```json
+{
+  "requestId": "<id or 'manual'>",
+  "status": "starting" | "classifying" | "ingesting-configs" | "embedding" | "clustering" | "proposing" | "tagging-topics" | "writing" | "complete" | "error",
+  "progress": { "phase": "<current>", "current": N, "total": M },
+  "startedAt": <ms>,
+  "updatedAt": <ms>,
+  "log": ["<recent message>", "..."],
+  "error": "<message if status=error>"
+}
+```
+
+Update on every stage transition. The viewer polls this for live progress.
+
+## Error handling
+
+- Ollama down → stop, tell the user how to start.
+- Manifest missing → stop, tell the user to run the exporter first.
+- Sub-agent malformed JSON → retry once, then drop those candidates and continue.
+- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently.
+- Any unrecoverable error → write `status: error` with message, exit.
+
+## What you must NOT do
+
+- Don't auto-apply proposals. Writing to `~/.claude/CLAUDE.md` or settings.json without explicit per-proposal user approval is out of scope. Propose only.
+- Don't post-process or re-rank proposals from sub-agents. They produce ranked lists; preserve order.
+- Don't invent instance ids in citations. The validator drops proposals citing nonexistent ids.
+- Don't write to corrections.json until stage 6. Use `_` prefix for all intermediate files.
+- Don't re-classify already-classified corrections unless `--reclassify` was passed.
+- Don't proceed if cost estimate exceeds the cap; ask first.

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,20 @@ out/
 .claude/settings.local.json
 .claude/launch.json
 .claude/scheduled_tasks.lock
-.claude/skills/
 .claude/worktrees/
 .claude/projects/
+# Skills folder: un-ignore the directory itself so git descends, then
+# re-ignore everything inside it via `/*` so file-level negations
+# below can take effect. Same trick as `.claude/*` above. Ships the
+# project's own mining-pipeline skill (README references it as "the
+# project's .claude/skills/mine-corrections/" and the viewer's
+# dynamic topic buckets only work when the skill runs the tag-topics
+# stage on every mining pass) while leaving other per-developer
+# skills inside the folder ignored.
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/mine-corrections/
+!.claude/skills/mine-corrections/SKILL.md
 # …except (1) test fixtures, which legitimately contain a `.claude/`
 # subtree that mimics what a real Cowork session directory looks
 # like on disk. These are synthetic (redacted), vital for the

--- a/apps/standalone/src/pages/api/mine-corrections.ts
+++ b/apps/standalone/src/pages/api/mine-corrections.ts
@@ -164,8 +164,9 @@ export interface AutoWindowResult {
   /** 'first-run' on cold start; 'incremental' when prior corrections exist;
    *  'idle' when nothing new since last run; 'unavailable' when the data
    *  files aren't readable yet; 'backfill' when explicitly running an
-   *  oldest-first selection. */
-  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill';
+   *  oldest-first selection; 'all' when the caller asked to mine every
+   *  unprocessed candidate in one pass (no cost cap). */
+  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill' | 'all';
   /** Diagnostic for outcome-aware sizing. Null on first run. */
   patternYield: { patterns: number; classified: number; ratio: number } | null;
   /** Present when there are unprocessed candidates older than the picked
@@ -283,7 +284,7 @@ function outcomeAwareTarget(
 export async function computeAutoWindow(
   rootAbs: string,
   dataDir: string,
-  selection: 'recent' | 'backfill' = 'recent',
+  selection: 'recent' | 'backfill' | 'all' = 'recent',
 ): Promise<{ result: AutoWindowResult; targetIds: string[] }> {
   const empty = (result: AutoWindowResult): { result: AutoWindowResult; targetIds: string[] } => ({
     result,
@@ -393,10 +394,12 @@ export async function computeAutoWindow(
     });
   }
 
-  // Order: composite score desc for 'recent' selection. For 'backfill',
-  // re-score with INVERTED recency so older high-signal candidates win.
+  // Order: composite score desc for 'recent' AND 'all' (the user picks
+  // everything; ranking just controls which items the skill processes
+  // first within the batch). For 'backfill', re-score with INVERTED
+  // recency so older high-signal candidates win.
   const ordered = [...fresh].sort((a, b) => {
-    if (selection === 'recent') return b.composite - a.composite;
+    if (selection === 'recent' || selection === 'all') return b.composite - a.composite;
     const invA = a.signalScore + (a.updatedAt > 0 ? 0 : 0); // pure signal weight
     const invB = b.signalScore + (b.updatedAt > 0 ? 0 : 0);
     if (invB !== invA) return invB - invA;
@@ -404,11 +407,14 @@ export async function computeAutoWindow(
   });
 
   // Outcome-aware sizing — falls back to FIRST_RUN_TARGET_CANDIDATES on
-  // first run or zero-yield runs.
+  // first run or zero-yield runs. 'all' bypasses the cap entirely:
+  // the user explicitly opted into mining every unprocessed candidate
+  // in one pass and accepted the cost in the ArmedPreview confirmation.
   const baseTarget = hasPriorRun
     ? outcomeAwareTarget(priorPatterns, priorClassified)
     : FIRST_RUN_TARGET_CANDIDATES;
-  const target = Math.min(baseTarget, ordered.length);
+  const target =
+    selection === 'all' ? ordered.length : Math.min(baseTarget, ordered.length);
   const picked = ordered.slice(0, target);
   const targetIds = picked.map((p) => p.id);
 
@@ -459,7 +465,10 @@ export async function computeAutoWindow(
 
   let mode: AutoWindowResult['mode'];
   let reasoning: string;
-  if (selection === 'backfill') {
+  if (selection === 'all') {
+    mode = 'all';
+    reasoning = `All: targeting every unprocessed candidate (${target} of ${ranked.length} total). Composite-ranked so high-signal items run first within the batch. Covers ~${windowDays} day${windowDays === 1 ? '' : 's'}.`;
+  } else if (selection === 'backfill') {
     mode = 'backfill';
     reasoning = `Backfill: targeting ${target} oldest unprocessed candidate${target === 1 ? '' : 's'} of ${fresh.length} total (~${windowDays} day${windowDays === 1 ? '' : 's'} span). High-signal items prioritized.`;
   } else if (hasPriorRun) {
@@ -692,7 +701,8 @@ async function streamMineCorrections(
 interface MineRequestBody {
   windowDays?: unknown;
   dataDir?: unknown;
-  /** 'recent' (default) or 'backfill' to flip auto-window selection. */
+  /** 'recent' (default), 'backfill', or 'all' (mine every unprocessed
+   *  candidate in one pass — bypasses the cost cap). */
   selection?: unknown;
 }
 
@@ -720,8 +730,12 @@ async function parseParams(body: MineRequestBody): Promise<MineParams> {
     };
   }
 
-  const selection: 'recent' | 'backfill' =
-    body.selection === 'backfill' ? 'backfill' : 'recent';
+  const selection: 'recent' | 'backfill' | 'all' =
+    body.selection === 'all'
+      ? 'all'
+      : body.selection === 'backfill'
+        ? 'backfill'
+        : 'recent';
   const { result: auto, targetIds } = await computeAutoWindow(
     repoRoot(),
     dataDir,
@@ -885,8 +899,13 @@ export const GET: APIRoute = async ({ url }) => {
     typeof dirParam === 'string' && dirParam.trim().length > 0
       ? dirParam
       : DEFAULT_DATA_DIR;
-  const selection: 'recent' | 'backfill' =
-    url.searchParams.get('selection') === 'backfill' ? 'backfill' : 'recent';
+  const selParam = url.searchParams.get('selection');
+  const selection: 'recent' | 'backfill' | 'all' =
+    selParam === 'all'
+      ? 'all'
+      : selParam === 'backfill'
+        ? 'backfill'
+        : 'recent';
   let autoWindow: AutoWindowResult | null = null;
   try {
     const out = await computeAutoWindow(repoRoot(), dataDir, selection);

--- a/packages/schema/src/correction.ts
+++ b/packages/schema/src/correction.ts
@@ -180,6 +180,18 @@ export interface CorrectionPattern {
    * finding, surfaced separately in the viewer.
    */
   alreadyEncoded: boolean;
+  /**
+   * Short LLM-derived topic label (1-3 words, Title Case) shared
+   * across all patterns in the same theme — drives dynamic bucketing
+   * in the viewer instead of the predefined RECURRING/ENCODED/NEW
+   * taxonomy. Set by the mine-corrections skill's `tag-topics` stage,
+   * which sees ALL patterns in one LLM call so labels stay coherent
+   * across the corpus (no fragmentation between "Git Workflow" and
+   * "Git Practices"). Optional for back-compat: patterns from prior
+   * mining runs without this field render in an "Untagged" bucket
+   * until re-mined.
+   */
+  topic?: string;
 }
 
 export interface CorrectionsFile {

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -125,7 +125,13 @@ describe('CorrectionsPanel', () => {
     await waitFor(() => {
       expect(screen.getByText(/4 candidates ready to mine/i)).toBeDefined();
     });
-    expect(screen.getByRole('button', { name: /MINE CORRECTIONS/i })).toBeDefined();
+    // The mocked autoWindow probe returns count=12, so the single
+    // primary CTA renders "MINE ALL 12".
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /MINE ALL 12/ }),
+      ).toBeDefined();
+    });
   });
 
   it('sorts patterns into the three buckets correctly', async () => {
@@ -445,6 +451,119 @@ describe('CorrectionsPanel', () => {
       });
       // Hosted-only label must not be present.
       expect(screen.queryByLabelText('TOLD NOT TO, STILL DOES IT')).toBeNull();
+    });
+  });
+
+  // Header-row redesign: "Generated <iso>" was demoted from a row of
+  // its own to a "Last mined …" chip in the title row. Verify the chip
+  // renders relative time and keeps the absolute ISO in `title=` for
+  // debugging without polluting the layout.
+  describe('Header timestamp chip', () => {
+    it('renders the chip in the title row when corrections.json has generatedAt', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([pattern({ id: 'n1', canonicalRule: 'rule one' })]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByText(/Last mined/i)).toBeDefined();
+      });
+      const chip = screen.getByText(/Last mined/i);
+      // Absolute ISO survives in `title=` for tooltip / debugging.
+      expect(chip.getAttribute('title')).toMatch(/Generated 20\d\d-/);
+      // Demoted row that used to read "Generated 20...Z" should be gone.
+      expect(screen.queryByText(/^Generated 20\d\d-/)).toBeNull();
+    });
+  });
+
+  // First-principles simplification (Tight): CoverageMeter shows just
+  // the bar + one figure ("271 / 581 mined"). The label, funnel
+  // sentence, actionable %, and pattern count are gone — diagnostic
+  // info now lives only behind the "details ▸" chevron.
+  describe('CoverageMeter — Tight layout', () => {
+    it('renders just the bar + "N / M mined" figure (no label, no funnel sentence)', async () => {
+      const c: CorrectionsFile = {
+        generatedAt: 1_700_000_000_000,
+        corrections: [
+          { id: 'c1', classification: { actionable: true, ruleSummary: 'r' } },
+          { id: 'c2', classification: { actionable: false, ruleSummary: 'r' } },
+          { id: 'c3', classification: { actionable: true, ruleSummary: 'r' } },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+        patterns: [pattern({ id: 'p1', canonicalRule: 'pat one' })],
+        pipeline: {
+          heuristicRecall: true,
+          llmClassification: true,
+          embeddingClustering: true,
+          claudeMdCrossCheck: true,
+        },
+      };
+      const cands = {
+        ...c,
+        corrections: [
+          { id: 'c1' },
+          { id: 'c2' },
+          { id: 'c3' },
+          { id: 'c4' },
+          { id: 'c5' },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+      };
+      mockedLoadCorrections.mockResolvedValue(c);
+      mockedLoadCandidates.mockResolvedValue(cands);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      await waitFor(() => {
+        const figure = container.querySelector(
+          '.lcars-corrections__coverage-figure',
+        );
+        expect(figure?.textContent ?? '').toMatch(/3\s*\/\s*5\s*mined/);
+      });
+      // Cut by the simplification — these strings should be absent.
+      expect(screen.queryByText('MINING PROGRESS')).toBeNull();
+      expect(screen.queryByText('ANALYSIS COVERAGE')).toBeNull();
+      expect(screen.queryByText(/Of the .* mined/)).toBeNull();
+      expect(screen.queryByText(/became actionable corrections/)).toBeNull();
+      expect(screen.queryByText(/still to mine/)).toBeNull();
+    });
+  });
+
+  // MINE ALL collapse: the recent/older split was killed in favor of a
+  // single CTA that mines every unprocessed candidate in one pass.
+  // Verify the trigger renders one status + one button, and that all
+  // the historical jargon (recent/older/backfill/auto-window) is gone.
+  describe('MiningTrigger — single MINE ALL CTA', () => {
+    it('renders one status sentence + one primary CTA with the total count', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([pattern({ id: 'p1', canonicalRule: 'rule' })]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      // Mocked autoWindow probe returns candidateCount=12; with
+      // selection='all' on the wire, that's the full unprocessed set.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /MINE ALL 12/ }),
+        ).toBeDefined();
+      });
+      const status = container.querySelector(
+        '.lcars-corrections__trigger-status',
+      );
+      expect(status?.textContent ?? '').toMatch(/12 ready to mine/);
+      const cta = screen.getByRole('button', { name: /MINE ALL 12/ });
+      expect(cta.getAttribute('title')).toMatch(/Mine all 12 unprocessed candidates/);
+      // Killed copy — no recent/older split, no backfill jargon, no
+      // auto-window chip, no kicker label.
+      expect(screen.queryByText('NEXT MINING PASS')).toBeNull();
+      expect(screen.queryByText('AUTO WINDOW')).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+RECENT/)).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+OLDER/)).toBeNull();
+      expect(screen.queryByText(/^BACKFILL OLDER/)).toBeNull();
+      expect(screen.queryByText(/← back to recent/i)).toBeNull();
+      expect(screen.queryByText(/RE-MINE CORRECTIONS/i)).toBeNull();
     });
   });
 });

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -71,6 +71,7 @@ function pattern(overrides: Partial<CorrectionPattern> & { id: string }): Correc
     confidence: overrides.confidence ?? 0.5,
     recurringPostApplication: overrides.recurringPostApplication ?? false,
     alreadyEncoded: overrides.alreadyEncoded ?? false,
+    ...(overrides.topic !== undefined ? { topic: overrides.topic } : {}),
   };
 }
 
@@ -134,74 +135,135 @@ describe('CorrectionsPanel', () => {
     });
   });
 
-  it('sorts patterns into the three buckets correctly', async () => {
+  it('groups patterns into buckets by topic, label uppercased', async () => {
     const patterns = [
-      pattern({ id: 'r1', canonicalRule: 'recurring rule', recurringPostApplication: true }),
-      pattern({ id: 'e1', canonicalRule: 'encoded rule', alreadyEncoded: true }),
-      pattern({ id: 'n1', canonicalRule: 'new rule' }),
-      // recurring + alreadyEncoded → still RECURRING (it's the stronger signal).
+      pattern({ id: 'g1', canonicalRule: 'git rule a', topic: 'Git Workflow' }),
+      pattern({ id: 't1', canonicalRule: 'test rule a', topic: 'Test Discipline' }),
+      pattern({ id: 'g2', canonicalRule: 'git rule b', topic: 'Git Workflow' }),
+    ];
+    mockedLoadCorrections.mockResolvedValue(file(patterns));
+    mockedLoadCandidates.mockResolvedValue(null);
+    render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('GIT WORKFLOW')).toBeDefined();
+    });
+    const git = screen.getByLabelText('GIT WORKFLOW');
+    const test = screen.getByLabelText('TEST DISCIPLINE');
+
+    expect(within(git).getByText('git rule a')).toBeDefined();
+    expect(within(git).getByText('git rule b')).toBeDefined();
+    expect(within(test).getByText('test rule a')).toBeDefined();
+    // No leakage across topics.
+    expect(within(git).queryByText('test rule a')).toBeNull();
+    expect(within(test).queryByText('git rule a')).toBeNull();
+  });
+
+  it('falls back to an UNTAGGED bucket for patterns without a topic field', async () => {
+    const patterns = [
+      pattern({ id: 'a', canonicalRule: 'pre-topic-stage rule' }),
+      pattern({ id: 'b', canonicalRule: 'another untagged', topic: '' }),
+      pattern({ id: 'c', canonicalRule: 'tagged rule', topic: 'Tool Usage' }),
+    ];
+    mockedLoadCorrections.mockResolvedValue(file(patterns));
+    mockedLoadCandidates.mockResolvedValue(null);
+    render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
+    });
+    const untagged = screen.getByLabelText('UNTAGGED');
+    const tool = screen.getByLabelText('TOOL USAGE');
+    expect(within(untagged).getByText('pre-topic-stage rule')).toBeDefined();
+    expect(within(untagged).getByText('another untagged')).toBeDefined();
+    expect(within(tool).getByText('tagged rule')).toBeDefined();
+  });
+
+  it('orders buckets: topics with recurring patterns first, then by total weight desc', async () => {
+    const patterns = [
+      // Heavy non-recurring bucket — would win on weight alone.
+      pattern({ id: 'h1', topic: 'Heavy', canonicalRule: 'heavy 1', occurrenceCount: 20 }),
+      pattern({ id: 'h2', topic: 'Heavy', canonicalRule: 'heavy 2', occurrenceCount: 20 }),
+      // Light bucket with a single RECURRING pattern — must hoist above Heavy.
       pattern({
-        id: 'r2',
-        canonicalRule: 'recurring and encoded',
+        id: 'r1',
+        topic: 'Recurring Topic',
+        canonicalRule: 'recurring',
         recurringPostApplication: true,
-        alreadyEncoded: true,
+        occurrenceCount: 3,
+      }),
+      // Medium-weight bucket between them.
+      pattern({ id: 'm1', topic: 'Medium', canonicalRule: 'medium', occurrenceCount: 10 }),
+    ];
+    mockedLoadCorrections.mockResolvedValue(file(patterns));
+    mockedLoadCandidates.mockResolvedValue(null);
+    const { container } = render(
+      <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText('RECURRING TOPIC')).toBeDefined();
+    });
+    const sections = Array.from(
+      container.querySelectorAll('.lcars-corrections__buckets > section'),
+    ).map((s) => s.getAttribute('aria-label'));
+    expect(sections).toEqual(['RECURRING TOPIC', 'HEAVY', 'MEDIUM']);
+  });
+
+  it('within a bucket: recurring sorts first, then by confidence desc', async () => {
+    const patterns = [
+      pattern({
+        id: 'low',
+        topic: 'T',
+        canonicalRule: 'low confidence',
+        confidence: 0.2,
+        occurrenceCount: 9,
+      }),
+      pattern({
+        id: 'hi',
+        topic: 'T',
+        canonicalRule: 'high confidence',
+        confidence: 0.95,
+        occurrenceCount: 3,
+      }),
+      pattern({
+        id: 'rec',
+        topic: 'T',
+        canonicalRule: 'recurring even with low confidence',
+        confidence: 0.3,
+        occurrenceCount: 4,
+        recurringPostApplication: true,
       }),
     ];
     mockedLoadCorrections.mockResolvedValue(file(patterns));
     mockedLoadCandidates.mockResolvedValue(null);
     render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
     await waitFor(() => {
-      expect(screen.getByLabelText('RECURRING AFTER APPLIED')).toBeDefined();
+      expect(screen.getByLabelText('T')).toBeDefined();
     });
-    const recurring = screen.getByLabelText('RECURRING AFTER APPLIED');
-    const encoded = screen.getByLabelText('ALREADY ENCODED BUT FAILING');
-    const fresh = screen.getByLabelText('NEW PATTERNS TO ENCODE');
-
-    expect(within(recurring).getByText('recurring rule')).toBeDefined();
-    expect(within(recurring).getByText('recurring and encoded')).toBeDefined();
-    expect(within(encoded).getByText('encoded rule')).toBeDefined();
-    expect(within(fresh).getByText('new rule')).toBeDefined();
-
-    // No leakage between buckets.
-    expect(within(recurring).queryByText('encoded rule')).toBeNull();
-    expect(within(encoded).queryByText('recurring rule')).toBeNull();
-    expect(within(fresh).queryByText('encoded rule')).toBeNull();
-  });
-
-  it('sorts patterns within a bucket by confidence desc, then occurrenceCount desc', async () => {
-    const patterns = [
-      pattern({ id: 'low', canonicalRule: 'low confidence', confidence: 0.2, occurrenceCount: 9 }),
-      pattern({ id: 'hi', canonicalRule: 'high confidence', confidence: 0.95, occurrenceCount: 3 }),
-      pattern({ id: 'mid-a', canonicalRule: 'mid a', confidence: 0.5, occurrenceCount: 5 }),
-      pattern({ id: 'mid-b', canonicalRule: 'mid b', confidence: 0.5, occurrenceCount: 8 }),
-    ];
-    mockedLoadCorrections.mockResolvedValue(file(patterns));
-    mockedLoadCandidates.mockResolvedValue(null);
-    render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
-    await waitFor(() => {
-      expect(screen.getByText('NEW PATTERNS TO ENCODE')).toBeDefined();
-    });
-    const fresh = screen.getByLabelText('NEW PATTERNS TO ENCODE');
+    const bucket = screen.getByLabelText('T');
     const titles = Array.from(
-      fresh.querySelectorAll('.lcars-correction-pattern__rule'),
+      bucket.querySelectorAll('.lcars-correction-pattern__rule'),
     ).map((el) => el.textContent);
-    // confidence: 0.95, 0.5 (count 8), 0.5 (count 5), 0.2.
-    expect(titles).toEqual(['high confidence', 'mid b', 'mid a', 'low confidence']);
+    // recurring → first; rest by confidence desc.
+    expect(titles).toEqual([
+      'recurring even with low confidence',
+      'high confidence',
+      'low confidence',
+    ]);
   });
 
-  it('renders the "Nothing here — good." placeholder for empty buckets', async () => {
+  it('does not render empty-bucket placeholders (no Nothing here — good.)', async () => {
     mockedLoadCorrections.mockResolvedValue(
-      file([pattern({ id: 'n1', canonicalRule: 'only a new pattern' })]),
+      file([pattern({ id: 'n1', canonicalRule: 'only one', topic: 'Solo' })]),
     );
     mockedLoadCandidates.mockResolvedValue(null);
     render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
     await waitFor(() => {
-      expect(screen.getByText('NEW PATTERNS TO ENCODE')).toBeDefined();
+      expect(screen.getByLabelText('SOLO')).toBeDefined();
     });
-    const recurring = screen.getByLabelText('RECURRING AFTER APPLIED');
-    const encoded = screen.getByLabelText('ALREADY ENCODED BUT FAILING');
-    expect(within(recurring).getByText('Nothing here — good.')).toBeDefined();
-    expect(within(encoded).getByText('Nothing here — good.')).toBeDefined();
+    // Only one section renders; the old empty-bucket placeholder is gone.
+    expect(screen.queryByText(/Nothing here/i)).toBeNull();
+    expect(screen.queryByLabelText('RECURRING AFTER APPLIED')).toBeNull();
+    expect(screen.queryByLabelText('ALREADY ENCODED BUT FAILING')).toBeNull();
+    expect(screen.queryByLabelText('NEW PATTERNS TO ENCODE')).toBeNull();
   });
 
   describe('AppliedImprovementsSummary mount (Phase 2b)', () => {
@@ -212,8 +274,9 @@ describe('CorrectionsPanel', () => {
       mockedLoadCandidates.mockResolvedValue(null);
       mockedLoadApplied.mockResolvedValue(null);
       render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      // Untagged bucket renders (pattern has no topic field); summary does not.
       await waitFor(() => {
-        expect(screen.getByText('NEW PATTERNS TO ENCODE')).toBeDefined();
+        expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
       });
       expect(screen.queryByLabelText('since you patched')).toBeNull();
     });
@@ -341,12 +404,15 @@ describe('CorrectionsPanel', () => {
         ],
       });
       render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      // The pattern lands in the UNTAGGED bucket (no topic) but should now
+      // bear the recurring signal — the merge layer flipped
+      // recurringPostApplication=true based on the ledger entry. Verify the
+      // bucket sort puts it first (recurring sorts to top within a bucket).
       await waitFor(() => {
-        const recurring = screen.getByLabelText('RECURRING AFTER APPLIED');
-        expect(within(recurring).getByText('flips into recurring')).toBeDefined();
+        expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
       });
-      const fresh = screen.getByLabelText('NEW PATTERNS TO ENCODE');
-      expect(within(fresh).queryByText('flips into recurring')).toBeNull();
+      const bucket = screen.getByLabelText('UNTAGGED');
+      expect(within(bucket).getByText('flips into recurring')).toBeDefined();
     });
 
     it('treats applied: true on the merged upgrade as initial APPLIED state', async () => {
@@ -396,63 +462,11 @@ describe('CorrectionsPanel', () => {
     });
   });
 
-  // Phase 4 — when CorrectionsPanel renders on a hosted static build
-  // (rescanAvailable=false), the bucket header copy explicitly
-  // referencing CLAUDE.md / "ship it" is meaningless to a non-developer
-  // visitor on chat-arch.dev. Verify the reframed labels + blurbs land.
-  describe('Phase 4 — hosted demo blurbs (rescanAvailable=false)', () => {
-    it('reframes the encoded bucket label + blurb to avoid CLAUDE.md jargon', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([
-          pattern({ id: 'e1', canonicalRule: 'demo encoded', alreadyEncoded: true }),
-        ]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
-      // No rescanAvailable → defaults to false → hosted-demo blurbs.
-      render(<CorrectionsPanel dataDirBaseUrl="/x" />);
-      await waitFor(() => {
-        expect(screen.getByLabelText('TOLD NOT TO, STILL DOES IT')).toBeDefined();
-      });
-      const bucket = screen.getByLabelText('TOLD NOT TO, STILL DOES IT');
-      // Multiple elements may match (the title + the blurb both
-      // contain the phrase); presence of any is enough.
-      expect(within(bucket).getAllByText(/told not to/i).length).toBeGreaterThan(0);
-      // Canonical CLAUDE.md jargon must not leak into the demo copy.
-      expect(within(bucket).queryByText(/already exists in CLAUDE\.md/i)).toBeNull();
-    });
-
-    it('reframes the recurring bucket label to "STILL FAILING AFTER A FIX"', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([
-          pattern({
-            id: 'r1',
-            canonicalRule: 'demo recurring',
-            recurringPostApplication: true,
-          }),
-        ]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
-      render(<CorrectionsPanel dataDirBaseUrl="/x" />);
-      await waitFor(() => {
-        expect(screen.getByLabelText('STILL FAILING AFTER A FIX')).toBeDefined();
-      });
-    });
-
-    it('keeps the canonical labels when rescanAvailable=true (local dev)', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([
-          pattern({ id: 'e1', canonicalRule: 'local encoded', alreadyEncoded: true }),
-        ]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
-      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
-      await waitFor(() => {
-        expect(screen.getByLabelText('ALREADY ENCODED BUT FAILING')).toBeDefined();
-      });
-      // Hosted-only label must not be present.
-      expect(screen.queryByLabelText('TOLD NOT TO, STILL DOES IT')).toBeNull();
-    });
-  });
+  // The Phase 4 hosted-demo blurb relabeling is gone — fixed taxonomy
+  // (RECURRING / ENCODED / NEW) was replaced with LLM-derived dynamic
+  // topic buckets, so there's no per-host bucket copy to reframe.
+  // The hosted demo fixture in `demoUpload.ts` now ships its own
+  // topic assignments and renders identically to local mining output.
 
   // Header-row redesign: "Generated <iso>" was demoted from a row of
   // its own to a "Last mined …" chip in the title row. Verify the chip

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -250,6 +250,102 @@ describe('CorrectionsPanel', () => {
     ]);
   });
 
+  // Codex review feedback on PR #32: the dropped `--recurring|encoded|new`
+  // modifier classes used to drive bucket border + background + title
+  // color (signal-based urgency). With dynamic topics those hardcodes
+  // don't fit, but the urgency signal still lives on every pattern as
+  // `recurringPostApplication` / `alreadyEncoded`. The replacement is
+  // `data-has-recurring` / `data-has-encoded` attribute hooks that the
+  // stylesheet now keys off. These tests lock the contract.
+  describe('bucket urgency attributes', () => {
+    it('flags data-has-recurring=true when the bucket contains a recurring pattern', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'r1',
+            topic: 'Git Workflow',
+            canonicalRule: 'a recurring rule',
+            recurringPostApplication: true,
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('GIT WORKFLOW')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('GIT WORKFLOW');
+      expect(bucket.getAttribute('data-has-recurring')).toBe('true');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('false');
+    });
+
+    it('flags data-has-encoded=true when the bucket has an encoded-but-not-recurring pattern', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'e1',
+            topic: 'Tool Usage',
+            canonicalRule: 'encoded',
+            alreadyEncoded: true,
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('TOOL USAGE')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('TOOL USAGE');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('true');
+      expect(bucket.getAttribute('data-has-recurring')).toBe('false');
+    });
+
+    it('prefers data-has-recurring when a bucket has both signals (recurring wins)', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'r-and-e',
+            topic: 'Mixed',
+            canonicalRule: 'recurring + encoded',
+            recurringPostApplication: true,
+            alreadyEncoded: true,
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('MIXED')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('MIXED');
+      // Builder records `recurring` and skips the `encoded` branch
+      // (else-if). CSS rule order also ensures the recurring style
+      // wins when both attributes are 'true' on the same element.
+      expect(bucket.getAttribute('data-has-recurring')).toBe('true');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('false');
+    });
+
+    it('flags both attributes as false for plain non-urgent buckets', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'plain',
+            topic: 'New Stuff',
+            canonicalRule: 'just a new pattern',
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('NEW STUFF')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('NEW STUFF');
+      expect(bucket.getAttribute('data-has-recurring')).toBe('false');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('false');
+    });
+  });
+
   it('does not render empty-bucket placeholders (no Nothing here — good.)', async () => {
     mockedLoadCorrections.mockResolvedValue(
       file([pattern({ id: 'n1', canonicalRule: 'only one', topic: 'Solo' })]),

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -131,8 +131,14 @@ interface TopicBucket {
   weight: number;
   /** True when ≥1 pattern is recurring after applied. Hoists the bucket
    *  toward the top regardless of weight (recurring is the highest-
-   *  signal finding the user can act on). */
+   *  signal finding the user can act on), AND drives the bucket's
+   *  visual urgency via the `data-has-recurring` style hook so the
+   *  user can scan the page for hot spots at a glance. */
   hasRecurring: boolean;
+  /** True when ≥1 pattern is alreadyEncoded but not recurring — a
+   *  weaker urgency signal than `hasRecurring`. Drives the bucket's
+   *  visual treatment when `hasRecurring` is false. */
+  hasEncoded: boolean;
 }
 
 /**
@@ -161,9 +167,11 @@ function buildTopicBuckets(
     group.sort(sortPatterns);
     let weight = 0;
     let hasRecurring = false;
+    let hasEncoded = false;
     for (const p of group) {
       weight += p.occurrenceCount;
       if (p.recurringPostApplication) hasRecurring = true;
+      else if (p.alreadyEncoded) hasEncoded = true;
     }
     buckets.push({
       key: topic,
@@ -171,6 +179,7 @@ function buildTopicBuckets(
       patterns: group,
       weight,
       hasRecurring,
+      hasEncoded,
     });
   }
   buckets.sort((a, b) => {
@@ -1478,6 +1487,13 @@ function BucketsView({
           className="lcars-corrections__bucket"
           aria-label={bucket.label}
           data-topic={bucket.key}
+          // Signal-based urgency hooks — restore the visual
+          // differentiation the dropped --recurring/--encoded/--new
+          // modifier classes used to provide. Recurring wins over
+          // encoded (the CSS uses attribute selectors, last rule
+          // wins) so a bucket with both signals reads as urgent.
+          data-has-recurring={bucket.hasRecurring ? 'true' : 'false'}
+          data-has-encoded={bucket.hasEncoded ? 'true' : 'false'}
         >
           <header className="lcars-corrections__bucket-header">
             <h3 className="lcars-corrections__bucket-title">{bucket.label}</h3>

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -30,6 +30,7 @@ import {
   type ApplyCorrectionRequest,
 } from '../data/applyCorrectionClient.js';
 import type { ProposedUpgrade } from '@chat-arch/schema';
+import { formatRelative } from '../util/time.js';
 
 export interface CorrectionsPanelProps {
   /** Same base URL the manifest was fetched from (e.g. "/chat-arch-data"). */
@@ -188,6 +189,16 @@ function formatGenerated(ms: number): string {
   }
 }
 
+/**
+ * Header timestamp formatter. Uses the shared relative-time util so
+ * the chip reads "2d ago" instead of an ISO blob; the absolute ISO
+ * survives in the surrounding `title=` tooltip for debug use.
+ */
+function relativeGenerated(ms: number): string {
+  if (!Number.isFinite(ms)) return 'unknown';
+  return formatRelative(ms);
+}
+
 type ClearState =
   | { status: 'idle' }
   | { status: 'armed' }
@@ -231,10 +242,13 @@ export function CorrectionsPanel({
     };
   }, []);
 
-  const [selection, setSelection] = useState<'recent' | 'backfill'>('recent');
+  // Single-CTA mining (per the "MINE ALL" UX): selection is always 'all'.
+  // The backend's recent/backfill split still exists for future power-user
+  // surfaces but is no longer driven by this panel.
+  const [selection] = useState<'recent' | 'backfill' | 'all'>('all');
 
   const refreshAutoWindow = useCallback(
-    async (sel: 'recent' | 'backfill' = selection) => {
+    async (sel: 'recent' | 'backfill' | 'all' = selection) => {
       const probe = await probeMineCorrections(undefined, sel);
       if (!aliveRef.current) return;
       setAutoWindow(probe?.autoWindow ?? null);
@@ -517,14 +531,13 @@ export function CorrectionsPanel({
       return;
     }
     setMining({ status: 'idle' });
-    setSelection('recent');
     await refresh();
   }, [refresh, selection]);
 
   if (load.status === 'loading') {
     return (
       <section className="lcars-corrections" aria-label="corrections">
-        <Header hostedDemo={!rescanAvailable} />
+        <Header />
         <p className="lcars-corrections__lead">Loading corrections…</p>
       </section>
     );
@@ -533,7 +546,7 @@ export function CorrectionsPanel({
   if (load.status === 'error') {
     return (
       <section className="lcars-corrections" aria-label="corrections">
-        <Header hostedDemo={!rescanAvailable} />
+        <Header />
         <div className="lcars-corrections__error" role="alert">
           <p>Could not load corrections: {load.message}</p>
           <button
@@ -584,7 +597,6 @@ export function CorrectionsPanel({
   return (
     <section className="lcars-corrections" aria-label="corrections">
       <Header
-        hostedDemo={!rescanAvailable}
         {...(typeof corrections?.generatedAt === 'number'
           ? { generatedAt: corrections.generatedAt }
           : {})}
@@ -707,17 +719,8 @@ export function CorrectionsPanel({
           hasCorrections={hasCorrections}
           candidateCount={candidateCount}
           autoWindow={autoWindow}
-          selection={selection}
           onArm={() => setMining({ status: 'armed' })}
           onRefreshAutoWindow={() => void refreshAutoWindow()}
-          onSwitchToBackfill={() => {
-            setSelection('backfill');
-            void refreshAutoWindow('backfill');
-          }}
-          onSwitchToRecent={() => {
-            setSelection('recent');
-            void refreshAutoWindow('recent');
-          }}
           rescanAvailable={rescanAvailable}
         />
       )}
@@ -801,53 +804,31 @@ function CoverageMeter({ coverage }: CoverageMeterProps) {
   const { total, classified, actionable, patterns, scanStats } = coverage;
   const [expanded, setExpanded] = useState(false);
   const pct = total === 0 ? 0 : Math.round((classified / total) * 100);
-  const remaining = Math.max(0, total - classified);
-  const actionablePct =
-    classified === 0 ? 0 : Math.round((actionable / classified) * 100);
 
   return (
     <div
       className="lcars-corrections__coverage"
       role="group"
-      aria-label="analysis coverage"
+      aria-label="mining progress"
     >
-      <div className="lcars-corrections__coverage-row">
-        <span className="lcars-corrections__coverage-label">
-          ANALYSIS COVERAGE
-        </span>
-        <span className="lcars-corrections__coverage-figure">
-          <strong>{fmt(classified)}</strong> / {fmt(total)} candidates
-          classified · {pct}%
-        </span>
-      </div>
       <div
         className="lcars-corrections__coverage-bar"
         role="progressbar"
         aria-valuenow={pct}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuetext={`${classified} of ${total} candidates classified`}
+        aria-valuetext={`${classified} of ${total} candidates mined`}
       >
         <span
           className="lcars-corrections__coverage-fill"
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="lcars-corrections__coverage-funnel">
-        {classified > 0 ? (
-          <>
-            <strong>{fmt(actionable)}</strong> actionable ({actionablePct}% of
-            classified) · <strong>{fmt(patterns)}</strong>{' '}
-            {patterns === 1 ? 'pattern' : 'patterns'} surfaced ·{' '}
-            <strong>{fmt(remaining)}</strong> unmined
-          </>
-        ) : (
-          <>
-            <strong>{fmt(remaining)}</strong> candidate
-            {remaining === 1 ? '' : 's'} unmined — no LLM pass run yet.
-          </>
-        )}
-      </p>
+      <div className="lcars-corrections__coverage-row">
+        <span className="lcars-corrections__coverage-figure">
+          <strong>{fmt(classified)}</strong> / {fmt(total)} mined
+        </span>
+      </div>
       {scanStats !== null && (
         <button
           type="button"
@@ -855,18 +836,9 @@ function CoverageMeter({ coverage }: CoverageMeterProps) {
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
           aria-controls="lcars-corrections-pipeline-detail"
-          aria-label={`pipeline funnel: ${fmt(scanStats.sessionsScanned)} transcripts produced ${fmt(scanStats.survivingTurns)} prompts producing ${fmt(total)} candidates. ${expanded ? 'Hide' : 'Show'} details.`}
+          aria-label={`${expanded ? 'Hide' : 'Show'} mining details`}
         >
-          <span aria-hidden="true">
-            {fmt(scanStats.sessionsScanned)} transcripts →{' '}
-            {fmt(scanStats.survivingTurns)} prompts → {fmt(total)} candidates
-          </span>
-          <span
-            className="lcars-corrections__coverage-chevron"
-            aria-hidden="true"
-          >
-            {expanded ? '▾' : '▸'}
-          </span>
+          <span aria-hidden="true">{expanded ? '▾' : '▸'} details</span>
         </button>
       )}
       {scanStats !== null && expanded && (
@@ -902,40 +874,48 @@ function CoverageDetail({
     'cowork',
     'cloud',
   ];
-  const absent: string[] = [];
-  for (const s of knownSources) {
-    if ((scanStats.sessionsBySource[s] ?? 0) === 0) absent.push(s);
-  }
 
   return (
     <div
       id="lcars-corrections-pipeline-detail"
       className="lcars-corrections__coverage-detail"
     >
-      {(scanStats.sessionsMissing > 0 || absent.length > 0) && (
-        <div className="lcars-corrections__pipeline">
-          <span className="lcars-corrections__pipeline-label">NOT SCANNED</span>
-          <ul className="lcars-corrections__pipeline-list">
-            {Object.entries(scanStats.sessionsMissingBySource).map(
-              ([source, n]) => (
-                <li key={`miss-${source}`}>
-                  <strong>{fmt(n)}</strong> {SOURCE_LABEL[source] ?? source}{' '}
-                  sessions — no transcript file on disk (stub entries from
-                  aborted/deleted sessions)
-                </li>
-              ),
-            )}
-            {absent.map((source) => (
-              <li key={`absent-${source}`}>
-                <strong>0</strong> {SOURCE_LABEL[source] ?? source} sessions —
-                {source === 'cloud'
-                  ? ' no claude.ai export loaded'
-                  : ' source not present in this corpus'}
+      <div className="lcars-corrections__pipeline">
+        <span className="lcars-corrections__pipeline-label">SCANNED</span>
+        <span className="lcars-corrections__pipeline-sublabel">
+          transcripts read · indexed in manifest
+        </span>
+        <ul className="lcars-corrections__pipeline-list">
+          {knownSources.map((source) => {
+            const total = scanStats.sessionsBySource[source] ?? 0;
+            const missing = scanStats.sessionsMissingBySource[source] ?? 0;
+            const scanned = Math.max(0, total - missing);
+            const note =
+              total === 0
+                ? source === 'cloud'
+                  ? 'no claude.ai export loaded'
+                  : 'not present in this corpus'
+                : missing > 0
+                  ? `${fmt(missing)} indexed but transcript file not on disk — usually deleted or aborted sessions`
+                  : null;
+            return (
+              <li key={`scan-${source}`}>
+                <span className="lcars-corrections__pipeline-source">
+                  {SOURCE_LABEL[source] ?? source}
+                </span>{' '}
+                <strong>
+                  {fmt(scanned)} / {fmt(total)}
+                </strong>
+                {note && (
+                  <span className="lcars-corrections__pipeline-note">
+                    {note}
+                  </span>
+                )}
               </li>
-            ))}
-          </ul>
-        </div>
-      )}
+            );
+          })}
+        </ul>
+      </div>
       <div className="lcars-corrections__pipeline">
         <span className="lcars-corrections__pipeline-label">PIPELINE</span>
         <ul className="lcars-corrections__pipeline-list">
@@ -1103,43 +1083,23 @@ function DangerZone({
 
 interface HeaderProps {
   generatedAt?: number;
-  /**
-   * Phase 4 P0.3: when true, the panel is showing demo data on a
-   * hosted static build (no `/api/mine-corrections`, no apply ledger
-   * back end). Swap the developer-y lead copy ("log a CLAUDE.md edit",
-   * "next mining pass", "applied-improvements.json") for plain
-   * language that explains what corrections ARE — matching the
-   * hosted-demo bucket blurbs above.
-   */
-  hostedDemo?: boolean;
 }
 
-function Header({ generatedAt, hostedDemo = false }: HeaderProps) {
+function Header({ generatedAt }: HeaderProps) {
+  const hasTime = typeof generatedAt === 'number';
   return (
     <header className="lcars-corrections__header">
-      <h2 className="lcars-corrections__title">CORRECTIONS</h2>
-      <p className="lcars-corrections__lead">
-        {hostedDemo ? (
-          <>
-            These are corrections — moments where Claude broke a rule you set, clustered into
-            patterns. Patterns marked <strong>RECURRING</strong> came back even after you patched
-            them; those are the strongest signal that the rule needs reshaping.
-          </>
-        ) : (
-          <>
-            Recurring instructions you keep giving the model — clustered, ranked, and paired with
-            proposed CLAUDE.md upgrades. Click APPLY to log a CLAUDE.md edit you&apos;ve made; the
-            loop closes when the next mining pass shows the rule is no longer recurring. Apply
-            history is recorded in <code>applied-improvements.json</code> next to{' '}
-            <code>corrections.json</code>.
-          </>
+      <div className="lcars-corrections__title-row">
+        <h2 className="lcars-corrections__title">CORRECTIONS</h2>
+        {hasTime && (
+          <span
+            className="lcars-corrections__time"
+            title={`Generated ${formatGenerated(generatedAt!)}`}
+          >
+            Last mined {relativeGenerated(generatedAt!)}
+          </span>
         )}
-      </p>
-      {typeof generatedAt === 'number' && (
-        <p className="lcars-corrections__meta">
-          Generated {formatGenerated(generatedAt)}
-        </p>
-      )}
+      </div>
     </header>
   );
 }
@@ -1148,11 +1108,8 @@ interface MiningTriggerProps {
   hasCorrections: boolean;
   candidateCount: number;
   autoWindow: AutoWindowResult | null;
-  selection: 'recent' | 'backfill';
   onArm: () => void;
   onRefreshAutoWindow: () => void;
-  onSwitchToBackfill: () => void;
-  onSwitchToRecent: () => void;
   /**
    * Phase 4 — when `false`, the host is the hosted static build with
    * no `/api/mine-corrections` endpoint. Mining can never run there;
@@ -1166,14 +1123,10 @@ function MiningTrigger({
   hasCorrections,
   candidateCount,
   autoWindow,
-  selection,
   onArm,
   onRefreshAutoWindow,
-  onSwitchToBackfill,
-  onSwitchToRecent,
   rescanAvailable = true,
 }: MiningTriggerProps) {
-  const ctaLabel = hasCorrections ? 'RE-MINE CORRECTIONS' : 'MINE CORRECTIONS';
   const isIdle = autoWindow?.mode === 'idle';
   const isUnavailable = autoWindow?.mode === 'unavailable';
   // Phase 4 — when the local server is unreachable AND the auto-window
@@ -1183,51 +1136,68 @@ function MiningTrigger({
   const localOnly = !rescanAvailable && autoWindow === null;
   const disabled =
     isIdle || isUnavailable || localOnly || (candidateCount === 0 && !hasCorrections);
-  const modeLabel = selection === 'backfill' ? 'BACKFILL' : 'AUTO WINDOW';
-  const backfill = autoWindow?.backfillAvailable ?? null;
+
+  // With selection='all' the autoWindow result already carries the
+  // entire unprocessed set — no separate "older" count to add.
+  const totalReady = autoWindow?.candidateCount ?? 0;
+  const windowDays = autoWindow?.windowDays ?? null;
+  const hasReady = totalReady > 0 && !isIdle && !isUnavailable;
+
+  const ctaLabel = isIdle
+    ? 'NO NEW CANDIDATES'
+    : isUnavailable
+      ? 'NO DATA'
+      : hasReady
+        ? `MINE ALL ${totalReady}`
+        : hasCorrections
+          ? 'RE-MINE CORRECTIONS'
+          : 'MINE CORRECTIONS';
+
+  const ctaTitle = localOnly
+    ? 'Mining is local-only — install chat-arch on your machine to mine your own corpus.'
+    : isIdle
+      ? 'No new candidates since the last mining run.'
+      : isUnavailable
+        ? 'Run the chat-arch exporter first to produce candidates.'
+        : hasReady && windowDays !== null
+          ? `Mine all ${totalReady} unprocessed candidates (~${windowDays} day span).`
+          : undefined;
+
+  const status = localOnly
+    ? 'Mining is local-only.'
+    : autoWindow === null
+      ? 'Computing…'
+      : isUnavailable
+        ? 'No candidates yet.'
+        : isIdle
+          ? 'Nothing new to mine.'
+          : `${totalReady} ready to mine`;
 
   return (
     <div className="lcars-corrections__trigger">
-      <div className="lcars-corrections__auto">
-        <span className="lcars-corrections__auto-label">{modeLabel}</span>
-        <span className="lcars-corrections__auto-value">
-          {localOnly
-            ? 'mining is local-only'
-            : autoWindow === null
-              ? 'computing…'
-              : autoWindow.mode === 'idle'
-                ? 'no new candidates'
-                : autoWindow.mode === 'unavailable'
-                  ? 'no data'
-                  : `${autoWindow.windowDays}d · ${autoWindow.candidateCount} candidate${autoWindow.candidateCount === 1 ? '' : 's'}`}
-        </span>
+      <div className="lcars-corrections__trigger-status-row">
+        <span className="lcars-corrections__trigger-status">{status}</span>
         <button
           type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--ghost"
+          className="lcars-corrections__btn lcars-corrections__btn--ghost lcars-corrections__btn--icon"
           onClick={onRefreshAutoWindow}
-          aria-label="refresh auto window"
-          title="Recompute auto-window"
+          aria-label="refresh"
+          title="Recompute the candidate count"
         >
           ↻
         </button>
       </div>
-      <button
-        type="button"
-        className="lcars-corrections__btn lcars-corrections__btn--primary"
-        onClick={onArm}
-        disabled={disabled}
-        title={
-          localOnly
-            ? 'Mining is local-only — install chat-arch on your machine to mine your own corpus.'
-            : isIdle
-              ? 'No new candidates since the last mining run.'
-              : isUnavailable
-                ? 'Run the chat-arch exporter first to produce candidates.'
-                : undefined
-        }
-      >
-        ▶ {ctaLabel}
-      </button>
+      <div className="lcars-corrections__trigger-row">
+        <button
+          type="button"
+          className="lcars-corrections__btn lcars-corrections__btn--primary"
+          onClick={onArm}
+          disabled={disabled}
+          {...(ctaTitle ? { title: ctaTitle } : {})}
+        >
+          ▶ {ctaLabel}
+        </button>
+      </div>
       {localOnly && (
         <p className="lcars-corrections__auto-hint">
           Mining is local-only — these demo patterns ship with the bundled fixture.{' '}
@@ -1240,25 +1210,6 @@ function MiningTrigger({
           </a>{' '}
           to mine your own corpus.
         </p>
-      )}
-      {selection === 'recent' && backfill !== null && (
-        <button
-          type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--secondary"
-          onClick={onSwitchToBackfill}
-          title={`${backfill.count} unprocessed older than the recent set, oldest from ${backfill.oldestDate}`}
-        >
-          BACKFILL OLDER ({backfill.count})
-        </button>
-      )}
-      {selection === 'backfill' && (
-        <button
-          type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--ghost"
-          onClick={onSwitchToRecent}
-        >
-          ← RECENT
-        </button>
       )}
     </div>
   );
@@ -1292,8 +1243,11 @@ function ArmedPreview({ autoWindow, onRun, onCancel }: ArmedPreviewProps) {
         {windowDays === 1 ? 'day' : 'days'}. Estimated work:{' '}
         ~{Math.max(1, Math.ceil(candidateCount / 20))} classification batch
         {Math.ceil(candidateCount / 20) === 1 ? '' : 'es'} plus
-        one proposal call per cluster, ~3-8 min wall-clock. Counts against your
-        Claude Code plan usage; no separate billing.
+        one proposal call per cluster,{' '}
+        ~{Math.max(3, Math.ceil(Math.ceil(candidateCount / 20) * 0.75))}-
+        {Math.max(8, Math.ceil(Math.ceil(candidateCount / 20) * 2))} min
+        wall-clock. Counts against your Claude Code plan usage; no separate
+        billing.
       </p>
       <p className="lcars-corrections__armed-reasoning">{reasoning}</p>
       <div className="lcars-corrections__armed-actions">

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -109,73 +109,85 @@ const RUNNING_LINE_TAIL = 8;
 const STATUS_POLL_MS = 1500;
 const STATUS_LOG_TAIL = 6;
 
-type BucketDef = {
-  key: 'recurring' | 'encoded' | 'new';
+/**
+ * Sentinel topic for patterns emitted by mining runs that predate the
+ * `tag-topics` skill stage. Acts as a graceful fallback so the viewer
+ * doesn't break on legacy `corrections.json` files; re-mining assigns a
+ * real topic and the bucket disappears.
+ */
+const UNTAGGED_TOPIC = 'Untagged';
+
+function topicOf(p: CorrectionPattern): string {
+  return typeof p.topic === 'string' && p.topic.trim().length > 0
+    ? p.topic.trim()
+    : UNTAGGED_TOPIC;
+}
+
+interface TopicBucket {
+  key: string;
   label: string;
-  blurb: string;
-  match: (p: CorrectionPattern) => boolean;
-};
+  patterns: CorrectionPattern[];
+  /** Sum of occurrenceCount across all patterns — drives bucket order. */
+  weight: number;
+  /** True when ≥1 pattern is recurring after applied. Hoists the bucket
+   *  toward the top regardless of weight (recurring is the highest-
+   *  signal finding the user can act on). */
+  hasRecurring: boolean;
+}
 
-const BUCKET_DEFS: ReadonlyArray<BucketDef> = [
-  {
-    key: 'recurring',
-    label: 'RECURRING AFTER APPLIED',
-    blurb:
-      'You wrote a rule, the model still gets it wrong. The encoded correction is failing in practice — reword it, add an example, or move it to a hook.',
-    match: (p) => p.recurringPostApplication,
-  },
-  {
-    key: 'encoded',
-    label: 'ALREADY ENCODED BUT FAILING',
-    blurb:
-      'The rule already exists in CLAUDE.md but the model is still being corrected on it — same finding, weaker signal than recurring-after-applied.',
-    match: (p) => p.alreadyEncoded && !p.recurringPostApplication,
-  },
-  {
-    key: 'new',
-    label: 'NEW PATTERNS TO ENCODE',
-    blurb:
-      'Recurring corrections that aren’t encoded anywhere. Pick a target file, paste the patch, and ship it.',
-    match: () => true,
-  },
-];
-
-// Phase 4 — hosted demo blurbs avoid CLAUDE.md / "ship it" language
-// that doesn't apply to a non-developer visitor on chat-arch.dev.
-// Same key ordering and matchers as BUCKET_DEFS so bucketFor() and
-// the bucket grid stay in sync.
-const BUCKET_DEFS_HOSTED_DEMO: ReadonlyArray<BucketDef> = [
-  {
-    key: 'recurring',
-    label: 'STILL FAILING AFTER A FIX',
-    blurb:
-      'You patched this — the timestamp shows when — and the model is still making the same mistake. The rule is too soft, too buried, or the wrong shape.',
-    match: (p) => p.recurringPostApplication,
-  },
-  {
-    key: 'encoded',
-    label: 'TOLD NOT TO, STILL DOES IT',
-    blurb:
-      'The model keeps making this mistake even though it has been told not to. The rule exists somewhere in your config but is being ignored in practice.',
-    match: (p) => p.alreadyEncoded && !p.recurringPostApplication,
-  },
-  {
-    key: 'new',
-    label: 'NEW PATTERNS TO ENCODE',
-    blurb:
-      'Recurring corrections that aren’t written down anywhere. These are good candidates for the next round of rules.',
-    match: () => true,
-  },
-];
-
-function bucketFor(p: CorrectionPattern): 'recurring' | 'encoded' | 'new' {
-  for (const b of BUCKET_DEFS) {
-    if (b.match(p)) return b.key;
+/**
+ * Group patterns by their LLM-derived topic. Buckets are ordered by:
+ *   1. has-recurring desc (recurring topics surface first)
+ *   2. weight desc (larger topics before smaller)
+ *   3. label asc (stable tiebreak)
+ * Within a bucket, recurring patterns sort to the top so the highest-
+ * signal items inside a topic are visible without scrolling.
+ */
+function buildTopicBuckets(
+  patterns: ReadonlyArray<CorrectionPattern>,
+): TopicBucket[] {
+  const seen = new Set<string>();
+  const byTopic = new Map<string, CorrectionPattern[]>();
+  for (const p of patterns) {
+    if (seen.has(p.id)) continue;
+    seen.add(p.id);
+    const topic = topicOf(p);
+    const arr = byTopic.get(topic);
+    if (arr) arr.push(p);
+    else byTopic.set(topic, [p]);
   }
-  return 'new';
+  const buckets: TopicBucket[] = [];
+  for (const [topic, group] of byTopic) {
+    group.sort(sortPatterns);
+    let weight = 0;
+    let hasRecurring = false;
+    for (const p of group) {
+      weight += p.occurrenceCount;
+      if (p.recurringPostApplication) hasRecurring = true;
+    }
+    buckets.push({
+      key: topic,
+      label: topic.toUpperCase(),
+      patterns: group,
+      weight,
+      hasRecurring,
+    });
+  }
+  buckets.sort((a, b) => {
+    if (a.hasRecurring !== b.hasRecurring) return a.hasRecurring ? -1 : 1;
+    if (b.weight !== a.weight) return b.weight - a.weight;
+    return a.label.localeCompare(b.label);
+  });
+  return buckets;
 }
 
 function sortPatterns(a: CorrectionPattern, b: CorrectionPattern): number {
+  // Recurring-after-applied sorts to the top within a bucket — the
+  // strongest "your rule is failing in practice" signal beats raw
+  // confidence.
+  if (a.recurringPostApplication !== b.recurringPostApplication) {
+    return a.recurringPostApplication ? -1 : 1;
+  }
   if (b.confidence !== a.confidence) return b.confidence - a.confidence;
   return b.occurrenceCount - a.occurrenceCount;
 }
@@ -744,10 +756,6 @@ export function CorrectionsPanel({
         <BucketsView
           corrections={corrections!}
           highlightedPatternId={highlightedPatternId}
-          // Phase 4 — when corrections are showing on a host with no
-          // local server (the hosted demo path), reframe the bucket
-          // header copy to avoid CLAUDE.md / "paste the patch" jargon.
-          hostedDemo={!rescanAvailable}
           {...(applyAvailable ? { onApply: handleApply } : {})}
           {...(onSelectSession ? { onSelectSession } : {})}
         />
@@ -1284,6 +1292,7 @@ const STATUS_LABELS: Record<CorrectionRunStatus['status'], string> = {
   embedding: 'embedding',
   clustering: 'clustering',
   proposing: 'generating proposals',
+  'tagging-topics': 'tagging topics',
   writing: 'writing output',
   complete: 'complete',
   error: 'error',
@@ -1442,17 +1451,6 @@ interface BucketsViewProps {
    * AppliedImprovementsSummary scrolls it into view.
    */
   highlightedPatternId?: string | null;
-  /**
-   * Phase 4 — when true, the panel is rendering demo corrections on
-   * the hosted static build (no `/api/rescan` reachable, no
-   * mining endpoint, no actual CLAUDE.md the user owns). The default
-   * blurb copy explicitly references "the rule already exists in
-   * CLAUDE.md", which is meaningless on a hosted demo. Reframe it
-   * to "the model keeps making this mistake even though it's been
-   * told not to" so the demo reads cleanly to a non-developer
-   * visitor.
-   */
-  hostedDemo?: boolean;
 }
 
 function BucketsView({
@@ -1460,82 +1458,61 @@ function BucketsView({
   onApply,
   onSelectSession,
   highlightedPatternId,
-  hostedDemo = false,
 }: BucketsViewProps) {
-  const bucketDefs = hostedDemo ? BUCKET_DEFS_HOSTED_DEMO : BUCKET_DEFS;
   const instancesById = useMemo(() => {
     const m = new Map<string, Correction>();
     for (const c of corrections.corrections) m.set(c.id, c);
     return m;
   }, [corrections.corrections]);
 
-  const buckets = useMemo(() => {
-    const seen = new Set<string>();
-    const grouped: Record<'recurring' | 'encoded' | 'new', CorrectionPattern[]> = {
-      recurring: [],
-      encoded: [],
-      new: [],
-    };
-    for (const p of corrections.patterns) {
-      if (seen.has(p.id)) continue;
-      seen.add(p.id);
-      grouped[bucketFor(p)].push(p);
-    }
-    for (const k of Object.keys(grouped) as Array<keyof typeof grouped>) {
-      grouped[k].sort(sortPatterns);
-    }
-    return grouped;
-  }, [corrections.patterns]);
+  const buckets = useMemo(
+    () => buildTopicBuckets(corrections.patterns),
+    [corrections.patterns],
+  );
 
   return (
     <div className="lcars-corrections__buckets">
-      {bucketDefs.map((def) => {
-        const items = buckets[def.key];
-        return (
-          <section
-            key={def.key}
-            className={`lcars-corrections__bucket lcars-corrections__bucket--${def.key}`}
-            aria-label={def.label}
-          >
-            <header className="lcars-corrections__bucket-header">
-              <h3 className="lcars-corrections__bucket-title">{def.label}</h3>
-              <span className="lcars-corrections__bucket-count">
-                {items.length} {items.length === 1 ? 'pattern' : 'patterns'}
-              </span>
-            </header>
-            <p className="lcars-corrections__bucket-blurb">{def.blurb}</p>
-            {items.length === 0 ? (
-              <p className="lcars-corrections__bucket-empty">Nothing here — good.</p>
-            ) : (
-              <ul className="lcars-corrections__pattern-list" role="list">
-                {items.map((p) => {
-                  const isHighlighted = highlightedPatternId === p.id;
-                  return (
-                    <li
-                      key={p.id}
-                      data-pattern-id={p.id}
-                      {...(isHighlighted ? { 'data-highlighted': 'true' } : {})}
-                      className="lcars-corrections__pattern-item"
-                    >
-                      <CorrectionPatternCard
-                        pattern={p}
-                        instancesById={instancesById}
-                        defaultExpanded={isHighlighted}
-                        {...(onApply
-                          ? {
-                              onApply: (upgrade, extras) => onApply(p, upgrade, extras),
-                            }
-                          : {})}
-                        {...(onSelectSession ? { onSelectSession } : {})}
-                      />
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </section>
-        );
-      })}
+      {buckets.map((bucket) => (
+        <section
+          key={bucket.key}
+          className="lcars-corrections__bucket"
+          aria-label={bucket.label}
+          data-topic={bucket.key}
+        >
+          <header className="lcars-corrections__bucket-header">
+            <h3 className="lcars-corrections__bucket-title">{bucket.label}</h3>
+            <span className="lcars-corrections__bucket-count">
+              {bucket.patterns.length}{' '}
+              {bucket.patterns.length === 1 ? 'pattern' : 'patterns'}
+            </span>
+          </header>
+          <ul className="lcars-corrections__pattern-list" role="list">
+            {bucket.patterns.map((p) => {
+              const isHighlighted = highlightedPatternId === p.id;
+              return (
+                <li
+                  key={p.id}
+                  data-pattern-id={p.id}
+                  {...(isHighlighted ? { 'data-highlighted': 'true' } : {})}
+                  className="lcars-corrections__pattern-item"
+                >
+                  <CorrectionPatternCard
+                    pattern={p}
+                    instancesById={instancesById}
+                    defaultExpanded={isHighlighted}
+                    {...(onApply
+                      ? {
+                          onApply: (upgrade, extras) => onApply(p, upgrade, extras),
+                        }
+                      : {})}
+                    {...(onSelectSession ? { onSelectSession } : {})}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
     </div>
   );
 }

--- a/packages/viewer/src/data/demoUpload.ts
+++ b/packages/viewer/src/data/demoUpload.ts
@@ -658,6 +658,7 @@ function buildDemoCorrections(now: number): {
     confidence: number,
     recurringPostApplication: boolean,
     alreadyEncoded: boolean,
+    topic: string,
     scopeKind: 'global' | 'project' | 'tool' | 'request-shape' = 'global',
   ): CorrectionPattern => ({
     id,
@@ -671,10 +672,10 @@ function buildDemoCorrections(now: number): {
     confidence,
     recurringPostApplication,
     alreadyEncoded,
+    topic,
   });
 
   const patterns: CorrectionPattern[] = [
-    // RED — recurring after applied
     pattern(
       'demo-pat-1',
       'Use absolute paths in Bash tool calls; do not chain `cd <dir> &&`.',
@@ -683,6 +684,7 @@ function buildDemoCorrections(now: number): {
       0.92,
       true,
       true,
+      'Tool Usage',
     ),
     pattern(
       'demo-pat-2',
@@ -692,8 +694,8 @@ function buildDemoCorrections(now: number): {
       0.81,
       true,
       false,
+      'Output Discipline',
     ),
-    // YELLOW — already encoded but failing
     pattern(
       'demo-pat-3',
       'Use ripgrep (rg) instead of grep for content search.',
@@ -702,6 +704,7 @@ function buildDemoCorrections(now: number): {
       0.78,
       false,
       true,
+      'Tool Usage',
       'tool',
     ),
     pattern(
@@ -712,8 +715,8 @@ function buildDemoCorrections(now: number): {
       0.74,
       false,
       true,
+      'Output Discipline',
     ),
-    // NEW — candidates to encode
     pattern(
       'demo-pat-5',
       'Test-first: write the failing test before the implementation.',
@@ -722,6 +725,7 @@ function buildDemoCorrections(now: number): {
       0.69,
       false,
       false,
+      'Test Discipline',
       'request-shape',
     ),
     pattern(
@@ -732,6 +736,7 @@ function buildDemoCorrections(now: number): {
       0.66,
       false,
       false,
+      'Git Workflow',
       'project',
     ),
   ];

--- a/packages/viewer/src/data/mineCorrectionsClient.ts
+++ b/packages/viewer/src/data/mineCorrectionsClient.ts
@@ -60,6 +60,7 @@ export interface CorrectionRunStatus {
     | 'embedding'
     | 'clustering'
     | 'proposing'
+    | 'tagging-topics'
     | 'writing'
     | 'complete'
     | 'error';

--- a/packages/viewer/src/data/mineCorrectionsClient.ts
+++ b/packages/viewer/src/data/mineCorrectionsClient.ts
@@ -25,7 +25,7 @@ export interface AutoWindowResult {
   windowDays: number;
   candidateCount: number;
   reasoning: string;
-  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill';
+  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill' | 'all';
   patternYield: { patterns: number; classified: number; ratio: number } | null;
   backfillAvailable: BackfillInfo | null;
 }
@@ -96,9 +96,9 @@ export interface MineCorrectionsOptions {
   /** Omit to use server-side auto-window selection. */
   windowDays?: number;
   dataDir?: string;
-  /** 'recent' (default) or 'backfill' — flips auto-window selection
-   *  to oldest-unprocessed-first so historical patterns surface. */
-  selection?: 'recent' | 'backfill';
+  /** 'recent' (default), 'backfill', or 'all' — 'all' bypasses the
+   *  cost cap and processes every unprocessed candidate in one pass. */
+  selection?: 'recent' | 'backfill' | 'all';
 }
 
 /**
@@ -108,11 +108,13 @@ export interface MineCorrectionsOptions {
  */
 export async function probeMineCorrections(
   dataDir?: string,
-  selection?: 'recent' | 'backfill',
+  selection?: 'recent' | 'backfill' | 'all',
 ): Promise<MineProbe | null> {
   const params = new URLSearchParams();
   if (dataDir !== undefined && dataDir.length > 0) params.set('dataDir', dataDir);
-  if (selection === 'backfill') params.set('selection', 'backfill');
+  if (selection === 'backfill' || selection === 'all') {
+    params.set('selection', selection);
+  }
   const qs = params.toString();
   const url = qs.length > 0 ? `${MINE_CORRECTIONS_PATH}?${qs}` : MINE_CORRECTIONS_PATH;
   try {

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6851,18 +6851,27 @@ button.lcars-applied-summary__stale--button:focus-visible {
   gap: 8px;
   padding: 12px 14px;
   border-radius: 0 8px 8px 0;
+  /* Default neutral treatment — applies to every bucket; the
+   * urgency-attribute selectors below override for buckets containing
+   * recurring / already-encoded patterns. Same visual that the
+   * dropped `--new` modifier class used to render. */
+  border-left: 3px solid color-mix(in srgb, var(--lcars-text) 30%, transparent);
+  background: rgba(0, 0, 0, 0.18);
 }
-.lcars-corrections__bucket--recurring {
-  border-left: 3px solid var(--lcars-peach);
-  background: rgba(255, 153, 51, 0.05);
-}
-.lcars-corrections__bucket--encoded {
+/* Encoded-but-failing signal (weaker urgency, sunflower accent) —
+ * applied when a bucket contains ≥1 alreadyEncoded pattern AND
+ * no recurring patterns. */
+.lcars-corrections__bucket[data-has-encoded='true'] {
   border-left: 3px solid var(--lcars-sunflower);
   background: rgba(255, 204, 102, 0.05);
 }
-.lcars-corrections__bucket--new {
-  border-left: 3px solid color-mix(in srgb, var(--lcars-text) 30%, transparent);
-  background: rgba(0, 0, 0, 0.18);
+/* Recurring-after-applied signal (highest urgency, peach accent) —
+ * declared last so it wins over the encoded rule when a bucket
+ * carries both signals. Same intent as the dropped `--recurring`
+ * modifier class: scan the page for these first. */
+.lcars-corrections__bucket[data-has-recurring='true'] {
+  border-left: 3px solid var(--lcars-peach);
+  background: rgba(255, 153, 51, 0.05);
 }
 .lcars-corrections__bucket-header {
   display: flex;
@@ -6876,10 +6885,17 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-size: 12.5px;
   letter-spacing: 0.18em;
   font-weight: 700;
+  /* Default neutral title color — matches the dropped `--new` modifier.
+   * Urgency selectors below override per signal. */
+  color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
 }
-.lcars-corrections__bucket--recurring .lcars-corrections__bucket-title { color: var(--lcars-peach); }
-.lcars-corrections__bucket--encoded   .lcars-corrections__bucket-title { color: var(--lcars-sunflower); }
-.lcars-corrections__bucket--new       .lcars-corrections__bucket-title { color: color-mix(in srgb, var(--lcars-text) 92%, transparent); }
+.lcars-corrections__bucket[data-has-encoded='true'] .lcars-corrections__bucket-title {
+  color: var(--lcars-sunflower);
+}
+/* Recurring last so it wins when both signals are present. */
+.lcars-corrections__bucket[data-has-recurring='true'] .lcars-corrections__bucket-title {
+  color: var(--lcars-peach);
+}
 .lcars-corrections__bucket-count {
   font-family: var(--lcars-font-chrome);
   font-size: 10.5px;

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6134,6 +6134,13 @@
   flex-direction: column;
   gap: 4px;
 }
+.lcars-corrections__title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
 .lcars-corrections__title {
   font-family: var(--lcars-font-chrome);
   font-size: 18px;
@@ -6142,19 +6149,19 @@
   color: var(--lcars-peach);
   margin: 0;
 }
+.lcars-corrections__time {
+  font-family: var(--lcars-font-chrome);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
 .lcars-corrections__lead {
   margin: 0;
   max-width: 78ch;
   font-size: 13px;
   line-height: 1.5;
   color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
-}
-.lcars-corrections__meta {
-  margin: 0;
-  font-size: 11px;
-  font-family: var(--lcars-font-chrome);
-  letter-spacing: 0.12em;
-  color: color-mix(in srgb, var(--lcars-text) 85%, transparent);
 }
 .lcars-corrections__empty {
   margin: 0;
@@ -6197,29 +6204,28 @@
 }
 .lcars-corrections__trigger {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 6px;
 }
-.lcars-corrections__auto {
-  display: inline-flex;
+.lcars-corrections__trigger-status-row {
+  display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 10px 4px 12px;
-  border: 1px solid color-mix(in srgb, var(--lcars-peach) 35%, transparent);
-  border-radius: 999px;
-  background: rgba(0, 0, 0, 0.25);
 }
-.lcars-corrections__auto-label {
-  font-family: var(--lcars-font-chrome);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  color: color-mix(in srgb, var(--lcars-text) 80%, transparent);
+.lcars-corrections__trigger-status {
+  font-size: 13px;
+  color: color-mix(in srgb, var(--lcars-text) 90%, transparent);
 }
-.lcars-corrections__auto-value {
-  font-family: var(--lcars-font-mono, monospace);
-  font-size: 12px;
-  color: var(--lcars-text);
+.lcars-corrections__trigger-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.lcars-corrections__btn--icon {
+  padding: 2px 8px;
+  font-size: 14px;
+  letter-spacing: 0;
 }
 .lcars-corrections__armed-reasoning {
   margin: 0;
@@ -6559,13 +6565,6 @@ button.lcars-applied-summary__stale--button:focus-visible {
   gap: 12px;
   flex-wrap: wrap;
 }
-.lcars-corrections__coverage-label {
-  font-family: var(--lcars-font-chrome);
-  font-size: 10px;
-  letter-spacing: 0.22em;
-  color: var(--lcars-sunflower);
-  font-weight: 700;
-}
 .lcars-corrections__coverage-figure {
   font-size: 12.5px;
   color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
@@ -6591,16 +6590,6 @@ button.lcars-applied-summary__stale--button:focus-visible {
     var(--lcars-peach)
   );
   transition: width 240ms ease-out;
-}
-.lcars-corrections__coverage-funnel {
-  margin: 2px 0 0 0;
-  font-size: 12px;
-  line-height: 1.5;
-  color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
-}
-.lcars-corrections__coverage-funnel strong {
-  color: var(--lcars-text);
-  font-variant-numeric: tabular-nums;
 }
 .lcars-corrections__coverage-provenance {
   display: flex;
@@ -6674,6 +6663,22 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-size: 11.5px;
   font-style: italic;
   color: color-mix(in srgb, var(--lcars-text) 85%, transparent);
+}
+.lcars-corrections__pipeline-source {
+  display: inline-block;
+  min-width: 9ch;
+  font-family: var(--lcars-font-chrome);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--lcars-text) 75%, transparent);
+}
+.lcars-corrections__pipeline-sublabel {
+  margin-top: -2px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+  font-style: italic;
+  color: color-mix(in srgb, var(--lcars-text) 60%, transparent);
 }
 .lcars-corrections__danger {
   display: flex;


### PR DESCRIPTION
## Summary

Replaces the predefined `RECURRING / ENCODED / NEW` bucket taxonomy with **dynamic buckets keyed by an LLM-derived `pattern.topic` field**. Categories now reflect what's actually in the user's corpus instead of forcing every pattern into one of three behavioral slots.

**Stacked on top of #31** — base branch is `feature/corrections-ux-simplification`. Merge #31 first, then this.

## Why

Bryce flagged: *"I don't like how we have these predefined categories. I'd rather the categories be dynamic based on what is encountered."* The fixed taxonomy was forcing patterns into slots that didn't reflect their actual themes (everything ending up in ENCODED, empty RECURRING bucket showing marketing copy, etc.).

## How

**One LLM call sees all patterns at once** (clustering needs a global view to keep labels coherent — no fragmentation between "Git Workflow" and "Git Practices"). Re-clusters every mining run so the taxonomy evolves with the corpus instead of pinning bad early labels forever.

### Schema
- `CorrectionPattern.topic?: string` (1-3 words, Title Case). Optional for back-compat — patterns from prior runs land in an `UNTAGGED` bucket until re-mined.

### Skill (`mine-corrections/SKILL.md`)
- New **Stage 6 — Tag topics**: single LLM call with the full pattern list, returns `{ topics: [...], assignments: { patternId: topic } }`.
- Renumber existing Stage 6 (Assemble + write) → Stage 7.
- New `tagging-topics` value in the status enum.
- **Now tracked in git** — un-ignored via `.gitignore` negation. The README references the skill as "the project's `.claude/skills/mine-corrections/`", so it should ship with the repo. Other files inside `.claude/skills/` stay ignored as per-developer state.

### Frontend (`CorrectionsPanel.tsx`)
- Drops `BUCKET_DEFS` + hosted-demo variant + `bucketFor`.
- New `buildTopicBuckets`: groups by topic; orders buckets so recurring-bearing topics surface first, then by total weight desc; within a bucket, recurring patterns sort to top, then by confidence desc.
- No empty-bucket placeholders (`Nothing here — good.` removed).
- Drops `BucketsView.hostedDemo` prop — there's no per-host bucket copy to reframe anymore.

### Demo fixture
- Six demo patterns now carry topics: Tool Usage, Output Discipline, Test Discipline, Git Workflow.

## Test plan

- [ ] 806 tests pass (3 fewer than before — Phase 4 hosted-demo blurb tests deleted)
- [ ] Lint clean (5 pre-existing warnings unrelated)
- [ ] Monorepo build clean
- [ ] Visual: re-mine on local corpus → patterns get topics → CORRECTIONS page shows dynamic buckets matching actual themes
- [ ] Visual: load demo upload → 4 topic buckets render (Tool Usage, Output Discipline, Test Discipline, Git Workflow)
- [ ] Backwards compat: existing `corrections.json` from a pre-topic-stage run renders patterns in an UNTAGGED bucket without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)