### PR TITLE
fix(corrections): unblock MINE ALL — silent abort in headless mode

### DIFF
--- a/.claude/skills/mine-corrections/SKILL.md
+++ b/.claude/skills/mine-corrections/SKILL.md
@@ -39,7 +39,7 @@ You orchestrate six stages. Update the status file at every transition.
    ```
    If MISSING, tell the user: "Ollama is not running. Install from https://ollama.com, then `ollama pull mxbai-embed-large`." Stop.
 5. Estimate sub-agent count: `ceil(numCandidates / 20) + estimatedClusters` (estimate clusters as ~numCandidates/8 for a first pass; tighten on subsequent runs once you know the real cluster ratio). Log the estimate to status either way. All sub-agent calls run inside the parent Claude Code session — no separate billing, but each call counts against the user's plan usage.
-   - **When `--candidate-ids-file` is set**: skip the interactive cap-and-ask entirely. The viewer's `/api/mine-corrections` endpoint only writes that file *after* the user confirmed the count + window in the ArmedPreview dialog, so re-asking here is a) redundant and b) silently fatal in headless `claude -p` mode where there is no one to answer. Proceed regardless of `--max-sub-agents` and log "user pre-approved via API (NN candidates)".
+   - **When `--candidate-ids-file` is set** (the viewer wrote it): skip the interactive cap-and-ask entirely. The viewer's `/api/mine-corrections` endpoint only writes that file *after* the user confirmed the count + window in the ArmedPreview dialog, so re-asking here is a) redundant and b) silently fatal in headless `claude -p` mode where there is no one to answer. Proceed regardless of `--max-sub-agents` and log "viewer-confirmed run (NN candidates) — skipping sub-agent cap check".
    - **Else** (direct CLI invocation, no id file): if the estimate exceeds `--max-sub-agents`, ask the user before proceeding. This path has a human at the terminal who can answer.
 6. Write the initial status file.
 
@@ -303,7 +303,7 @@ Update on every stage transition. The viewer polls this for live progress.
 - Ollama down → stop, tell the user how to start.
 - Manifest missing → stop, tell the user to run the exporter first.
 - Sub-agent malformed JSON → retry once, then drop those candidates and continue.
-- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently. **Exception**: when `--candidate-ids-file` is set (API-driven run), the user already confirmed in the ArmedPreview UI; proceed regardless of the cap. Asking would silently abort the run.
+- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently. **Exception**: when `--candidate-ids-file` is set (viewer-confirmed run), the user already confirmed in the ArmedPreview dialog; proceed regardless of the cap. Asking would silently abort the run.
 - Any unrecoverable error → write `status: error` with message, exit.
 
 ## What you must NOT do

--- a/.claude/skills/mine-corrections/SKILL.md
+++ b/.claude/skills/mine-corrections/SKILL.md
@@ -38,7 +38,9 @@ You orchestrate six stages. Update the status file at every transition.
    curl -s -m 1 http://localhost:11434/api/tags > /dev/null && echo OK || echo MISSING
    ```
    If MISSING, tell the user: "Ollama is not running. Install from https://ollama.com, then `ollama pull mxbai-embed-large`." Stop.
-5. Estimate sub-agent count: `ceil(numCandidates / 20) + estimatedClusters` (estimate clusters as ~numCandidates/8 for a first pass; tighten on subsequent runs once you know the real cluster ratio). If estimate exceeds `--max-sub-agents`, tell the user the count and ask whether to proceed or narrow the window. All sub-agent calls run inside the parent Claude Code session — no separate billing, but each call counts against the user's plan usage.
+5. Estimate sub-agent count: `ceil(numCandidates / 20) + estimatedClusters` (estimate clusters as ~numCandidates/8 for a first pass; tighten on subsequent runs once you know the real cluster ratio). Log the estimate to status either way. All sub-agent calls run inside the parent Claude Code session — no separate billing, but each call counts against the user's plan usage.
+   - **When `--candidate-ids-file` is set**: skip the interactive cap-and-ask entirely. The viewer's `/api/mine-corrections` endpoint only writes that file *after* the user confirmed the count + window in the ArmedPreview dialog, so re-asking here is a) redundant and b) silently fatal in headless `claude -p` mode where there is no one to answer. Proceed regardless of `--max-sub-agents` and log "user pre-approved via API (NN candidates)".
+   - **Else** (direct CLI invocation, no id file): if the estimate exceeds `--max-sub-agents`, ask the user before proceeding. This path has a human at the terminal who can answer.
 6. Write the initial status file.
 
 ### Stage 1 — Classification
@@ -301,7 +303,7 @@ Update on every stage transition. The viewer polls this for live progress.
 - Ollama down → stop, tell the user how to start.
 - Manifest missing → stop, tell the user to run the exporter first.
 - Sub-agent malformed JSON → retry once, then drop those candidates and continue.
-- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently.
+- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently. **Exception**: when `--candidate-ids-file` is set (API-driven run), the user already confirmed in the ArmedPreview UI; proceed regardless of the cap. Asking would silently abort the run.
 - Any unrecoverable error → write `status: error` with message, exit.
 
 ## What you must NOT do

--- a/.claude/skills/mine-corrections/SKILL.md
+++ b/.claude/skills/mine-corrections/SKILL.md
@@ -173,6 +173,7 @@ PRODUCE: a JSON array of ProposedUpgrade objects, ranked best-first. Each object
 {
   "target": "global-claude-md" | "project-claude-md" | "settings-hook" | "skill" | "prompt-snippet" | "agent" | "command",
   "targetPath": "<concrete file path or settings.json key>",
+  "headline": "<one plain-English sentence — what the upgrade does and why it matters>",
   "patch": "<the literal text to add or the unified diff if replacing>",
   "rationale": "<one paragraph; cite at least 2 instance ids by '<corId>' format from above>",
   "applied": false,
@@ -181,6 +182,7 @@ PRODUCE: a JSON array of ProposedUpgrade objects, ranked best-first. Each object
 
 CONSTRAINTS — non-negotiable:
 - patch must be CONCRETE TEXT, not a description of what to add.
+- headline must be ≤15 words, plain English, and name BOTH the rule being changed AND the change itself. Good: "Widen 'adversarial review' rule to fire on plans/lists/decisions, not just experiment results." Bad: "Update CLAUDE.md." / "Improve the adversarial review rule." / "Add a hook for tests." (Last one would be fine if rewritten to name the rule: "Add PostToolUse hook so 'run tests before committing' enforces itself.")
 - If alreadyEncoded is true: the existing rule is failing. Your top-ranked proposal MUST be a reword (with the failure diagnosed: why is the model violating the existing rule?) OR an escalation to deterministic enforcement (hook). Do NOT propose adding a new rule when one already exists.
 - If projectsAffected is one project: prefer project-claude-md over global-claude-md.
 - If projectsAffected is many projects: prefer global-claude-md.
@@ -198,6 +200,7 @@ After all sub-agents return, validate each proposal:
 - `targetPath` non-empty
 - `rationale` cites at least 2 strings of the form `<corId>` that exist in the cluster's instanceIds
 - `target` is one of the allowed values
+- `headline` non-empty and ≤15 words (split on whitespace). If absent or too long, do NOT drop the proposal — instead, set `headline` to the first sentence of `rationale` truncated to 15 words. Headline is a UX-quality field, not a correctness gate; a long headline beats no headline beats dropping the proposal.
 
 Drop invalid proposals. If a pattern ends up with zero valid proposals, keep the pattern but with `proposedUpgrades: []` and note it in status.
 

--- a/apps/standalone/src/pages/api/mine-corrections.ts
+++ b/apps/standalone/src/pages/api/mine-corrections.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { spawn } from 'node:child_process';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -92,6 +92,103 @@ interface SpawnOutcome {
   stdout: string;
   stderr: string;
   spawnError: Error | null;
+}
+
+/**
+ * What we learn from probing the on-disk artifacts after the skill
+ * exits. Used by `classifyOutcome` to decide whether the run actually
+ * succeeded, independent of the CLI's exit code (which can be 0 even
+ * when the skill refused to proceed in headless mode — see below).
+ */
+export interface OutcomeProbe {
+  /** `generatedAt` from a corrections.json file present on disk, or
+   *  null if the file is missing / unreadable / lacks the field. */
+  correctionsGeneratedAt: number | null;
+  /** `status` from a `correction-status-<requestId>.json` file, or
+   *  null if absent. */
+  statusFileStatus: string | null;
+  /** `error` from the same status file (only set when status is
+   *  `'error'`), or null. */
+  statusFileError: string | null;
+}
+
+export interface MiningOutcomeVerdict {
+  ok: boolean;
+  reason: string | null;
+}
+
+/**
+ * Decide whether a mining run actually succeeded. The CLI's exit code
+ * isn't sufficient on its own: `claude -p` exits 0 when the skill
+ * decides not to proceed (e.g. it hits a documented "ask the user
+ * before proceeding" branch in headless mode where there's no one to
+ * answer). Without this check, the endpoint would emit `ok: true` for
+ * a run that wrote zero output, and the viewer's runMining would
+ * silently swap back to the idle state — the exact "MINE ALL fails
+ * silently" bug this helper exists to prevent.
+ *
+ * Definition of success: the skill wrote `corrections.json` (or
+ * refreshed an existing one) with `generatedAt >= startedAt`. If the
+ * status file says `status: error`, that's an explicit failure with a
+ * useful message to surface.
+ */
+export function classifyOutcome(
+  startedAt: number,
+  exitCode: number | null,
+  spawnError: Error | null,
+  probe: OutcomeProbe,
+): MiningOutcomeVerdict {
+  if (spawnError !== null) {
+    return { ok: false, reason: `spawn error: ${spawnError.message}` };
+  }
+  if (exitCode !== 0) {
+    return { ok: false, reason: `claude CLI exited with code ${exitCode}` };
+  }
+  if (probe.statusFileStatus === 'error') {
+    const msg = probe.statusFileError ?? '(no message in status file)';
+    return { ok: false, reason: `skill reported error: ${msg}` };
+  }
+  if (
+    probe.correctionsGeneratedAt === null ||
+    probe.correctionsGeneratedAt < startedAt
+  ) {
+    const detail =
+      probe.statusFileStatus !== null
+        ? ` (last skill status: ${probe.statusFileStatus})`
+        : ' (no skill status file written — skill likely aborted in Stage 0 before initializing, e.g. hit a cap-and-ask branch in headless mode or failed to verify Ollama)';
+    return {
+      ok: false,
+      reason:
+        `skill exited cleanly but did not write a fresh corrections.json${detail}. ` +
+        `This is the "silent abort" failure mode — the CLI returned exit 0 but no output was produced.`,
+    };
+  }
+  return { ok: true, reason: null };
+}
+
+async function probeOutcome(
+  rootAbs: string,
+  dataDir: string,
+  requestId: string,
+): Promise<OutcomeProbe> {
+  const dataDirAbs = resolve(rootAbs, dataDir);
+  const corrections = await readJsonOrNull<{ generatedAt?: unknown }>(
+    join(dataDirAbs, 'analysis', 'corrections.json'),
+  );
+  const status = await readJsonOrNull<{
+    status?: unknown;
+    error?: unknown;
+  }>(join(dataDirAbs, 'analysis', `correction-status-${requestId}.json`));
+  return {
+    correctionsGeneratedAt:
+      typeof corrections?.generatedAt === 'number'
+        ? corrections.generatedAt
+        : null,
+    statusFileStatus:
+      typeof status?.status === 'string' ? status.status : null,
+    statusFileError:
+      typeof status?.error === 'string' ? status.error : null,
+  };
 }
 
 interface MineParams {
@@ -677,15 +774,45 @@ async function streamMineCorrections(
     ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
     : '';
 
+  // Validate the on-disk outcome. The CLI's exit code alone isn't a
+  // reliable success signal: in headless `claude -p` mode, the skill
+  // can hit an "ask the user" branch (e.g. Stage 0 sub-agent cap),
+  // print a question, and exit cleanly with code 0 without writing
+  // anything. Reporting `ok: true` for that case is the silent
+  // failure path — the viewer would refresh, find no new corrections,
+  // and revert to idle without surfacing why.
+  const probe = await probeOutcome(repoRoot(), dataDir, requestId);
+  const verdict = classifyOutcome(
+    started,
+    outcome.exitCode,
+    outcome.spawnError,
+    probe,
+  );
+
+  // Skill cleans up the target-ids file on Stage 7 success. If the run
+  // failed, the file is now an orphan — sweep it ourselves so future
+  // diagnostics aren't cluttered (and so the user can re-arm MINE ALL
+  // without seeing a stale id file). Silent best-effort; an unreachable
+  // file is fine.
+  if (!verdict.ok && candidateIdsFile !== null) {
+    try {
+      await unlink(candidateIdsFile);
+    } catch {
+      // Already gone or unreadable — nothing to do.
+    }
+  }
+
+  const verdictNote = verdict.reason !== null ? '\n[outcome] ' + verdict.reason : '';
+
   send({
     type: 'done',
-    ok: outcome.exitCode === 0 && !outcome.spawnError,
+    ok: verdict.ok,
     exitCode: outcome.exitCode,
     durationMs: Date.now() - started,
     requestId,
     usedFallback,
     stdoutTail: tailBytes(outcome.stdout),
-    stderrTail: tailBytes(outcome.stderr + extraStderr),
+    stderrTail: tailBytes(outcome.stderr + extraStderr + verdictNote),
     command: usedFallback
       ? `claude -p "${fallbackPrompt}"`
       : `claude -p "${slashPrompt}"`,

--- a/apps/standalone/test/api/mine-corrections.test.ts
+++ b/apps/standalone/test/api/mine-corrections.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   REQUIRED_HEADER,
+  classifyOutcome,
   isLocalOrigin,
+  type OutcomeProbe,
 } from '../../src/pages/api/mine-corrections.js';
+
+const emptyProbe: OutcomeProbe = {
+  correctionsGeneratedAt: null,
+  statusFileStatus: null,
+  statusFileError: null,
+};
 
 describe('mine-corrections — CSRF gate', () => {
   it('accepts http://localhost:<any>', () => {
@@ -49,5 +57,102 @@ describe('mine-corrections — CSRF gate', () => {
     // Pinned so a refactor can't silently rename it and break the
     // viewer client that posts the same string.
     expect(REQUIRED_HEADER).toBe('chat-arch-mine-corrections');
+  });
+});
+
+describe('mine-corrections — classifyOutcome', () => {
+  const started = 1_000_000;
+
+  it('reports success when corrections.json is fresh and exit was clean', () => {
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started + 5_000,
+      statusFileStatus: 'complete',
+    });
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toBeNull();
+  });
+
+  it('reports success when corrections.json generatedAt equals startedAt', () => {
+    // Boundary: skill could write generatedAt = exact start ms. Don't
+    // false-negative on that edge.
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started,
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('flags the silent-abort path: exit 0 but no corrections.json written', () => {
+    // This is the bug that motivated the helper: claude -p exits clean
+    // because the skill printed a question and gave up, but nothing
+    // landed on disk. The verdict must surface that, not pass it
+    // through as success.
+    const verdict = classifyOutcome(started, 0, null, emptyProbe);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/did not write a fresh corrections\.json/);
+    expect(verdict.reason).toMatch(/no skill status file written/);
+  });
+
+  it('flags the silent-abort path even when corrections.json is stale', () => {
+    // Prior run's output still on disk from earlier mining. New run
+    // didn't refresh it. Must not credit the prior run.
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started - 60_000,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/did not write a fresh corrections\.json/);
+  });
+
+  it('surfaces the skill error message when status file says error', () => {
+    const verdict = classifyOutcome(started, 0, null, {
+      correctionsGeneratedAt: null,
+      statusFileStatus: 'error',
+      statusFileError: 'Ollama is not running',
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe('skill reported error: Ollama is not running');
+  });
+
+  it('falls back to a placeholder when status=error has no message', () => {
+    const verdict = classifyOutcome(started, 0, null, {
+      correctionsGeneratedAt: null,
+      statusFileStatus: 'error',
+      statusFileError: null,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/skill reported error/);
+  });
+
+  it('includes the last-known phase when corrections is missing but status was non-error', () => {
+    // Skill crashed mid-pipeline without writing status=error.
+    const verdict = classifyOutcome(started, 0, null, {
+      correctionsGeneratedAt: null,
+      statusFileStatus: 'classifying',
+      statusFileError: null,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/last skill status: classifying/);
+  });
+
+  it('reports spawn errors before checking output', () => {
+    const verdict = classifyOutcome(
+      started,
+      null,
+      new Error('ENOENT: claude not on PATH'),
+      emptyProbe,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/spawn error.*claude not on PATH/);
+  });
+
+  it('reports a non-zero exit code over the on-disk probe', () => {
+    const verdict = classifyOutcome(started, 1, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started + 1_000,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe('claude CLI exited with code 1');
   });
 });

--- a/packages/schema/src/correction.ts
+++ b/packages/schema/src/correction.ts
@@ -112,6 +112,17 @@ export interface ProposedUpgrade {
    *   prompt-snippet       → "(reusable, no fixed path)"
    */
   targetPath: string;
+  /**
+   * One-sentence plain-English summary of WHAT this upgrade does and
+   * WHY it matters — the punchline. The card surfaces it large above
+   * the rationale paragraph so users can decide whether to act in a
+   * glance. ≤15 words, names the rule + the change, no jargon. The
+   * `rationale` field below remains the long-form diagnosis for users
+   * who want the evidence. Optional for back-compat: patterns from
+   * mining runs before this field shipped fall back to showing the
+   * rationale alone (the card truncates it as a fallback headline).
+   */
+  headline?: string;
   /** The literal text to add. User reviews before applying. */
   patch: string;
   /** Why this target — cites the inference rule that fired. */

--- a/packages/viewer/src/ChatArchViewer.back.test.tsx
+++ b/packages/viewer/src/ChatArchViewer.back.test.tsx
@@ -155,8 +155,9 @@ describe('ChatArchViewer — BACK from detail restores prior surface (P0.1)', ()
       expect(locationLabel()).toBe('CORRECTIONS');
     });
 
-    // Pattern cards collapse instance pills behind a SHOW DETAILS
-    // toggle. Click that first, then the instance pill. The panel's
+    // Pattern cards collapse instance pills behind SHOW DETAILS, and
+    // after the proposals-first reordering EVIDENCE is collapsed too.
+    // Open both to reach the instance pill. The panel's
     // onSelectSession wrapper sets priorModeBeforeDetail and calls
     // onSelect, which pushes #session/a and flips mode.
     const showDetails = await waitFor(() =>
@@ -164,6 +165,12 @@ describe('ChatArchViewer — BACK from detail restores prior surface (P0.1)', ()
     );
     act(() => {
       fireEvent.click(showDetails);
+    });
+    const evidence = await waitFor(() =>
+      screen.getByRole('button', { name: /EVIDENCE/ }),
+    );
+    act(() => {
+      fireEvent.click(evidence);
     });
     const pill = await waitFor(() =>
       screen.getByRole('button', { name: /open session a/i }),

--- a/packages/viewer/src/components/CorrectionPatternCard.test.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.test.tsx
@@ -70,6 +70,118 @@ describe('CorrectionPatternCard', () => {
     expect(screen.getByText('×3')).toBeDefined();
   });
 
+  describe('upgrade headline (lead-with-the-punchline)', () => {
+    it('renders the upgrade.headline above the rationale when present', () => {
+      const u = upgrade({
+        headline: "Widen 'adversarial review' rule to fire on plans, not just experiment results.",
+      });
+      const p = pattern({ proposedUpgrades: [u] });
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      expect(
+        screen.getByText(
+          "Widen 'adversarial review' rule to fire on plans, not just experiment results.",
+        ),
+      ).toBeDefined();
+    });
+
+    it('falls back to a derived headline from rationale when the field is missing', () => {
+      // Legacy data path: corrections.json written before the headline
+      // field shipped. The card must still lead with a one-liner;
+      // long rationale alone is the bug the headline solves.
+      const u = upgrade({
+        rationale:
+          'Rule recurs in 5 sessions and 3 projects. Diagnose the trigger before reword.',
+      });
+      const p = pattern({ proposedUpgrades: [u] });
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      // First sentence (12 words, ≤15 cap — no truncation).
+      expect(
+        screen.getByText('Rule recurs in 5 sessions and 3 projects.'),
+      ).toBeDefined();
+    });
+
+    it('truncates a fallback headline to ~15 words with an ellipsis', () => {
+      const u = upgrade({
+        rationale:
+          'This is a deliberately long single sentence that runs well past fifteen words to verify the truncation branch kicks in and appends an ellipsis at the end',
+      });
+      const p = pattern({ proposedUpgrades: [u] });
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      // The first 15 words + ellipsis. Asserting on the ellipsis is
+      // enough; counting exact words is brittle.
+      const headlineText = screen.getByText(
+        /^This is a deliberately long single sentence that runs well past fifteen words to verify…$/,
+      );
+      expect(headlineText).toBeDefined();
+    });
+  });
+
+  describe('section ordering (proposals before evidence)', () => {
+    it('renders PROPOSED UPGRADES above EVIDENCE in the DOM', () => {
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      const proposals = screen.getByText('PROPOSED UPGRADES');
+      const evidence = screen.getByText('EVIDENCE');
+      // Both labels are in the document; compareDocumentPosition
+      // returns DOCUMENT_POSITION_FOLLOWING (4) when `evidence` follows
+      // `proposals`. Anything else means we regressed the ordering.
+      expect(
+        proposals.compareDocumentPosition(evidence) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
+    it('collapses EVIDENCE by default — instance bodies are hidden until the user opens them', () => {
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      // Header is visible; the conversation excerpts inside are not.
+      expect(screen.getByText('EVIDENCE')).toBeDefined();
+      expect(screen.queryByText(/please c1 stop using docstrings/)).toBeNull();
+    });
+
+    it('opens EVIDENCE when the toggle is clicked', () => {
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /EVIDENCE/ }));
+      expect(screen.getByText(/please c1 stop using docstrings/)).toBeDefined();
+    });
+  });
+
   it('shows the ALREADY ENCODED badge when alreadyEncoded is set', () => {
     const p = pattern({ alreadyEncoded: true });
     render(<CorrectionPatternCard pattern={p} instancesById={buildInstancesById(p.instanceIds)} />);
@@ -335,6 +447,9 @@ describe('CorrectionPatternCard', () => {
         />,
       );
       fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      // Evidence is collapsed by default after the proposals-first
+      // reordering; open it before asserting on the instance pills.
+      fireEvent.click(screen.getByRole('button', { name: /EVIDENCE/ }));
       // 3 instances × 1 pill each.
       const pills = screen.getAllByRole('button', { name: /open session s-c/ });
       expect(pills).toHaveLength(3);
@@ -348,8 +463,10 @@ describe('CorrectionPatternCard', () => {
         <CorrectionPatternCard pattern={p} instancesById={buildInstancesById(p.instanceIds)} />,
       );
       fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
-      // Only the SHOW/HIDE-DETAILS toggle and (disabled) APPLY remain
-      // as buttons in this branch — no per-instance pill buttons.
+      fireEvent.click(screen.getByRole('button', { name: /EVIDENCE/ }));
+      // Only the SHOW/HIDE-DETAILS toggle, EVIDENCE toggle, and
+      // (disabled) APPLY remain as buttons in this branch — no
+      // per-instance pill buttons.
       expect(screen.queryAllByRole('button', { name: /open session/i })).toHaveLength(0);
     });
   });

--- a/packages/viewer/src/components/CorrectionPatternCard.test.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.test.tsx
@@ -180,6 +180,37 @@ describe('CorrectionPatternCard', () => {
       fireEvent.click(screen.getByRole('button', { name: /EVIDENCE/ }));
       expect(screen.getByText(/please c1 stop using docstrings/)).toBeDefined();
     });
+
+    // a11y: PROPOSED UPGRADES is an <h4>, so EVIDENCE must announce as
+    // a heading at the same level — otherwise screen-reader heading-
+    // list navigation walks past it. The toggle button uses
+    // aria-expanded + aria-controls to pair with the disclosure region.
+    it('exposes EVIDENCE label as a level-4 heading paired to its region', () => {
+      const p = pattern();
+      const { container } = render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      const toggle = screen.getByRole('button', { name: /EVIDENCE/ });
+      const controlsId = toggle.getAttribute('aria-controls');
+      expect(controlsId).toBeTruthy();
+      // PROPOSED UPGRADES is a real <h4> — pin heading-level parity.
+      const proposalsHeading = screen.getByText('PROPOSED UPGRADES');
+      expect(proposalsHeading.tagName).toBe('H4');
+      // EVIDENCE span needs role=heading aria-level=4 to match in the
+      // SR heading list.
+      const evidenceLabel = screen.getByText('EVIDENCE');
+      expect(evidenceLabel.getAttribute('role')).toBe('heading');
+      expect(evidenceLabel.getAttribute('aria-level')).toBe('4');
+      // Region is mounted only after open — click and verify pairing.
+      fireEvent.click(toggle);
+      const region = container.querySelector(`#${controlsId}`);
+      expect(region).not.toBeNull();
+      expect(region?.getAttribute('role')).toBe('region');
+    });
   });
 
   it('shows the ALREADY ENCODED badge when alreadyEncoded is set', () => {

--- a/packages/viewer/src/components/CorrectionPatternCard.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.tsx
@@ -149,6 +149,7 @@ export function CorrectionPatternCard({
   const [showAllInstances, setShowAllInstances] = useState(false);
   const [copiedIx, setCopiedIx] = useState<number | null>(null);
   const [busyIx, setBusyIx] = useState<number | null>(null);
+  const evidenceRegionId = `lcars-correction-pattern-evidence-${pattern.id}`;
 
   const category = categoryFor(pattern);
   const categoryLabel =
@@ -274,9 +275,22 @@ export function CorrectionPatternCard({
               type="button"
               className="lcars-correction-pattern__evidence-toggle"
               aria-expanded={evidenceOpen}
+              aria-controls={evidenceRegionId}
               onClick={() => setEvidenceOpen((v) => !v)}
             >
-              <span className="lcars-correction-pattern__section-title">
+              {/*
+                role="heading" + aria-level on the visible label so a
+                screen-reader's heading-list navigation sees EVIDENCE at
+                the same level as the <h4>PROPOSED UPGRADES</h4> above.
+                Without this, the headings list would skip from h4 to
+                whatever sits below EVIDENCE — confusing for keyboard /
+                AT users walking the card by heading.
+              */}
+              <span
+                className="lcars-correction-pattern__section-title"
+                role="heading"
+                aria-level={4}
+              >
                 EVIDENCE
               </span>
               <span className="lcars-correction-pattern__evidence-toggle-hint">
@@ -284,7 +298,7 @@ export function CorrectionPatternCard({
               </span>
             </button>
             {evidenceOpen && (
-              <>
+              <div id={evidenceRegionId} role="region" aria-label="EVIDENCE">
                 {visibleInstances.length === 0 ? (
                   <p className="lcars-correction-pattern__empty">
                     No instance bodies available — the corrections file may be partial.
@@ -343,7 +357,7 @@ export function CorrectionPatternCard({
                     Show all ({instances.length})
                   </button>
                 )}
-              </>
+              </div>
             )}
           </section>
         </div>

--- a/packages/viewer/src/components/CorrectionPatternCard.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.tsx
@@ -110,6 +110,22 @@ function formatAppliedAtIso(ms: number): string {
 
 const INITIAL_INSTANCE_COUNT = 3;
 
+/**
+ * Back-compat fallback for upgrades produced by mining runs before the
+ * `headline` field shipped. Take the rationale's first sentence and
+ * truncate at ~15 words so the card still leads with a one-line summary
+ * instead of a wall of diagnosis prose. Re-mining the corpus produces
+ * proper headlines and this branch retires.
+ */
+function deriveHeadline(rationale: string): string {
+  const trimmed = rationale.trim();
+  if (trimmed.length === 0) return '';
+  const firstSentence = trimmed.split(/(?<=[.!?])\s/)[0] ?? trimmed;
+  const words = firstSentence.split(/\s+/);
+  if (words.length <= 15) return firstSentence;
+  return words.slice(0, 15).join(' ') + '…';
+}
+
 export function CorrectionPatternCard({
   pattern,
   instancesById,
@@ -125,6 +141,11 @@ export function CorrectionPatternCard({
   useEffect(() => {
     if (defaultExpanded) setExpanded(true);
   }, [defaultExpanded]);
+  // EVIDENCE section is collapsed by default — proposals are the
+  // value, instances are the supporting evidence. Users who want to
+  // verify before applying click SHOW EVIDENCE; everyone else
+  // doesn't pay the wall-of-conversation tax.
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
   const [showAllInstances, setShowAllInstances] = useState(false);
   const [copiedIx, setCopiedIx] = useState<number | null>(null);
   const [busyIx, setBusyIx] = useState<number | null>(null);
@@ -213,68 +234,13 @@ export function CorrectionPatternCard({
 
       {expanded && (
         <div className="lcars-correction-pattern__body">
-          <section className="lcars-correction-pattern__section">
-            <h4 className="lcars-correction-pattern__section-title">INSTANCES</h4>
-            {visibleInstances.length === 0 ? (
-              <p className="lcars-correction-pattern__empty">
-                No instance bodies available — the corrections file may be partial.
-              </p>
-            ) : (
-              <ul className="lcars-correction-pattern__instance-list" role="list">
-                {visibleInstances.map((inst) => {
-                  const body = (
-                    <>
-                      {inst.precedingAssistantExcerpt && (
-                        <p className="lcars-correction-pattern__instance-context">
-                          <span className="lcars-correction-pattern__instance-tag">
-                            ASSISTANT
-                          </span>
-                          <span>{inst.precedingAssistantExcerpt}</span>
-                        </p>
-                      )}
-                      <p className="lcars-correction-pattern__instance-body">
-                        <span className="lcars-correction-pattern__instance-tag">USER</span>
-                        <span>{inst.excerpt}</span>
-                      </p>
-                    </>
-                  );
-                  if (onSelectSession) {
-                    return (
-                      <li
-                        key={inst.id}
-                        className="lcars-correction-pattern__instance"
-                      >
-                        <button
-                          type="button"
-                          className="lcars-correction-pattern__instance-pill"
-                          onClick={() => onSelectSession(inst.sessionId)}
-                          aria-label={`open session ${inst.sessionId}`}
-                          title={`Open session ${inst.sessionId}`}
-                        >
-                          {body}
-                        </button>
-                      </li>
-                    );
-                  }
-                  return (
-                    <li key={inst.id} className="lcars-correction-pattern__instance">
-                      {body}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {hiddenInstanceCount > 0 && (
-              <button
-                type="button"
-                className="lcars-correction-pattern__more"
-                onClick={() => setShowAllInstances(true)}
-              >
-                Show all ({instances.length})
-              </button>
-            )}
-          </section>
-
+          {/*
+            PROPOSED UPGRADES first: the action is the product. EVIDENCE
+            (instances) used to render above and pushed proposals
+            below-the-fold — see the UX feedback in PR #34's review
+            thread. Section headers are restyled for stronger visual
+            hierarchy.
+          */}
           <section className="lcars-correction-pattern__section">
             <h4 className="lcars-correction-pattern__section-title">PROPOSED UPGRADES</h4>
             {pattern.proposedUpgrades.length === 0 ? (
@@ -300,6 +266,84 @@ export function CorrectionPatternCard({
                   />
                 ))}
               </ul>
+            )}
+          </section>
+
+          <section className="lcars-correction-pattern__section">
+            <button
+              type="button"
+              className="lcars-correction-pattern__evidence-toggle"
+              aria-expanded={evidenceOpen}
+              onClick={() => setEvidenceOpen((v) => !v)}
+            >
+              <span className="lcars-correction-pattern__section-title">
+                EVIDENCE
+              </span>
+              <span className="lcars-correction-pattern__evidence-toggle-hint">
+                {evidenceOpen ? '▾ hide' : `▸ show ${instances.length} ${instances.length === 1 ? 'instance' : 'instances'}`}
+              </span>
+            </button>
+            {evidenceOpen && (
+              <>
+                {visibleInstances.length === 0 ? (
+                  <p className="lcars-correction-pattern__empty">
+                    No instance bodies available — the corrections file may be partial.
+                  </p>
+                ) : (
+                  <ul className="lcars-correction-pattern__instance-list" role="list">
+                    {visibleInstances.map((inst) => {
+                      const body = (
+                        <>
+                          {inst.precedingAssistantExcerpt && (
+                            <p className="lcars-correction-pattern__instance-context">
+                              <span className="lcars-correction-pattern__instance-tag">
+                                ASSISTANT
+                              </span>
+                              <span>{inst.precedingAssistantExcerpt}</span>
+                            </p>
+                          )}
+                          <p className="lcars-correction-pattern__instance-body">
+                            <span className="lcars-correction-pattern__instance-tag">USER</span>
+                            <span>{inst.excerpt}</span>
+                          </p>
+                        </>
+                      );
+                      if (onSelectSession) {
+                        return (
+                          <li
+                            key={inst.id}
+                            className="lcars-correction-pattern__instance"
+                          >
+                            <button
+                              type="button"
+                              className="lcars-correction-pattern__instance-pill"
+                              onClick={() => onSelectSession(inst.sessionId)}
+                              aria-label={`open session ${inst.sessionId}`}
+                              title={`Open session ${inst.sessionId}`}
+                            >
+                              {body}
+                            </button>
+                          </li>
+                        );
+                      }
+                      return (
+                        <li key={inst.id} className="lcars-correction-pattern__instance">
+                          {body}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+                {hiddenInstanceCount > 0 && (
+                  <button
+                    type="button"
+                    className="lcars-correction-pattern__more"
+                    onClick={() => setShowAllInstances(true)}
+                  >
+                    Show all ({instances.length})
+                  </button>
+                )}
+              </>
             )}
           </section>
         </div>
@@ -387,8 +431,19 @@ function UpgradeRow({
     }
   };
 
+  // Headline = the punchline. Skill writes it directly; legacy
+  // upgrades without it get a derived headline from rationale so the
+  // card still leads with a one-liner.
+  const headline =
+    typeof upgrade.headline === 'string' && upgrade.headline.trim().length > 0
+      ? upgrade.headline.trim()
+      : deriveHeadline(upgrade.rationale);
+
   return (
     <li className="lcars-correction-pattern__upgrade">
+      {headline.length > 0 && (
+        <p className="lcars-correction-pattern__upgrade-headline">{headline}</p>
+      )}
       <header className="lcars-correction-pattern__upgrade-header">
         <span
           className={`lcars-correction-pattern__target lcars-correction-pattern__target--${upgrade.target}`}

--- a/packages/viewer/src/data/demoUpload.ts
+++ b/packages/viewer/src/data/demoUpload.ts
@@ -563,11 +563,13 @@ function buildDemoCorrections(now: number): {
   const upgrade = (
     target: ProposedUpgrade['target'],
     targetPath: string,
+    headline: string,
     patch: string,
     rationale: string,
   ): ProposedUpgrade => ({
     target,
     targetPath,
+    headline,
     patch,
     rationale,
     applied: false,
@@ -578,12 +580,14 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Add a Bash Tool Use section forbidding `cd <dir> &&` chains.',
       '## Bash Tool Use\n- Always pass absolute paths to the Bash tool. Never chain `cd <dir> && command` — the working directory resets between calls.',
       'Recurs across 4 sessions, 3 projects. Path-prefix problem; canonical fix is a global rule under Bash usage.',
     ),
     upgrade(
       'settings-hook',
       'settings.json :: hooks.PreToolUse',
+      'Escalate `cd &&` ban to a PreToolUse hook — soft rule is being ignored.',
       '{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "node scripts/reject-cd-chain.js" }] }',
       'Soft rule was already shipped (see applied-improvements ledger) and the model still violates it. Promote to a hook so the violation is rejected before it executes.',
     ),
@@ -593,6 +597,7 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Replace soft "clean code" guidance with an explicit no-docstrings rule.',
       '## Documentation\n- Do not add docstrings, JSDoc, or inline comments unless the user explicitly asks for them. Removing unrequested documentation is part of the cleanup pass.',
       'Recurs across 3 sessions; existing rule is too soft ("clean code") and the model defaults to documenting.',
     ),
@@ -602,12 +607,14 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'project-claude-md',
       '<repo>/CLAUDE.md',
+      'Promote ripgrep preference from "Tooling" footnote to a top-level section.',
       '## Search Conventions\n- Use `rg` (ripgrep), not `grep`, for content search. The repo is a pnpm monorepo — `rg` is configured to skip `node_modules`/`dist` automatically.',
       'Already-encoded under "Tooling" but the model bypasses it. Move to a top-level Search Conventions section so it lands in the model\'s default attention.',
     ),
     upgrade(
       'prompt-snippet',
       '(reusable, no fixed path)',
+      'Reusable mid-conversation reminder to use `rg` over `grep -r`.',
       'When searching: prefer `rg <pattern>` over `grep -r`. `rg` is faster, respects `.gitignore`, and is the project default.',
       'Reusable snippet for direct paste into a fresh conversation when the rule is being violated mid-task.',
     ),
@@ -617,6 +624,7 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Hoist the "strip debug output" rule out of a buried list into its own section.',
       '## Quality Gates\n- Remove all debug output (`console.log`, `print`, `dbg!`) before presenting a patch. Debug statements are scaffolding, not deliverable code.',
       'Encoded under Quality Gates; recurs because the rule is buried mid-list. Promote it or split Quality Gates into two sections (security + cleanup).',
     ),
@@ -626,12 +634,14 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Add a new global Workflow rule mandating test-first when adding behavior.',
       '## Workflow\n- Test-first: when adding behavior, write the failing test before the implementation. Show the failing test output, then the implementation, then the passing test.',
       'No matching rule found. Recurs across 4 sessions and projects — strong candidate for a new global directive.',
     ),
     upgrade(
       'skill',
       '~/.claude/skills/test-first/SKILL.md',
+      'Package the test-first procedure as a skill so it auto-triggers on "add a function".',
       '# test-first\n\nWhen the user asks for a new function / endpoint / component, default to:\n1. Draft the failing test.\n2. Run it (show red).\n3. Implement minimal code to pass.\n4. Run tests (show green).\n5. Refactor if needed.',
       'Workflow rule with a clear procedure — packageable as a skill so it triggers automatically on "add a function" requests.',
     ),
@@ -641,6 +651,7 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'project-claude-md',
       '<repo>/CLAUDE.md',
+      'Encode conventional-commits subject-line format as a project Git Conventions rule.',
       '## Git Conventions\n- Commit messages: conventional-commits format. Subject line is ≤72 chars, lowercase verb-first, no trailing period. Example: `fix: drop trailing period from commit subjects`.',
       'No matching rule in the project file; format expectations live only in PR descriptions. Encode as a Git Conventions section so the model picks it up at commit-suggestion time.',
     ),

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -7032,10 +7032,64 @@ button.lcars-applied-summary__stale--button:focus-visible {
 .lcars-correction-pattern__section-title {
   margin: 0;
   font-family: var(--lcars-font-chrome);
-  font-size: 10.5px;
-  letter-spacing: 0.18em;
-  color: color-mix(in srgb, var(--lcars-text) 88%, transparent);
+  /* Bumped from 10.5px → 13px after UX feedback: the old size read as
+     a chip label and the eye skipped right past it, making it hard to
+     find the section breaks inside a dense card. */
+  font-size: 13px;
+  letter-spacing: 0.22em;
+  color: var(--lcars-peach);
   font-weight: 700;
+  /* Subtle left accent so the header is found by both shape and
+     color, not color alone. Matches the LCARS chrome elsewhere in
+     the viewer where section labels live next to a colored bar. */
+  padding-left: 8px;
+  border-left: 3px solid var(--lcars-peach);
+  line-height: 1.2;
+}
+
+/* EVIDENCE toggle: header sits inside a button so the whole row is
+   clickable. Reset the button chrome so it reads as a header with a
+   hint to its right, not a generic button. */
+.lcars-correction-pattern__evidence-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+}
+.lcars-correction-pattern__evidence-toggle:focus-visible {
+  outline: 2px solid var(--lcars-peach);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+.lcars-correction-pattern__evidence-toggle-hint {
+  font-family: var(--lcars-font-chrome);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
+.lcars-correction-pattern__evidence-toggle:hover .lcars-correction-pattern__evidence-toggle-hint {
+  color: var(--lcars-peach);
+}
+
+/* Upgrade headline: the punchline. Sits above the target chip + path
+   so the user reads "what changes and why" in one glance before any
+   diagnosis prose or diff. Larger + brighter than rationale, which
+   stays as supporting detail below. */
+.lcars-correction-pattern__upgrade-headline {
+  margin: 0 0 2px 0;
+  font-size: 14px;
+  line-height: 1.45;
+  font-weight: 600;
+  color: var(--lcars-text);
+  max-width: 78ch;
 }
 .lcars-correction-pattern__instance-list,
 .lcars-correction-pattern__upgrade-list {


### PR DESCRIPTION
## Root cause

`SKILL.md` Stage 0 estimates `ceil(N/20) + N/8` sub-agents and asks the user before proceeding when the estimate exceeds `--max-sub-agents` (default 40). MINE ALL on 582 candidates lands at ~103 → hits the cap-and-ask branch. In headless `claude -p` mode (how the viewer invokes the skill) there's no human to answer — Claude prints the question, the CLI exits with code 0, and nothing reaches disk. The endpoint's outcome check was `exitCode === 0`, so it reported `ok: true`, the viewer refreshed, found no corrections.json, and reverted to "0 / 582 mined" with no error banner.

**Evidence**: two orphan `_correction-target-ids-*.json` files (582 ids each = two retries) with no companion `correction-status-*.json` or `_corrections-classified.json`. Proves the skill bailed at Stage 0 step 5, *before* reaching step 6 (status-file write) or Stage 1 (classification).

## Fix

**Layer 1 — `SKILL.md`**: scope the cap-and-ask to direct CLI invocations only. When `--candidate-ids-file` is set (always the case for API-driven runs) the user already confirmed in the ArmedPreview dialog before the endpoint wrote the id file; re-asking is redundant and silently fatal in headless mode. Skill proceeds regardless of the cap and logs "user pre-approved via API".

**Layer 2 — `mine-corrections.ts`**: defense in depth. A new pure `classifyOutcome` helper validates the on-disk artifacts (`corrections.json` freshly generated and/or status file says `complete`) rather than trusting the CLI's exit code alone. If the skill exits cleanly but produced no output, the endpoint now reports `ok: false` with a descriptive reason in `stderrTail` so the viewer surfaces a real error instead of swapping back to idle. Also sweeps the orphan target-ids file on failure so re-trying MINE ALL starts from a clean state.

## Test plan

- [x] `pnpm --filter @chat-arch/standalone test` — 51 tests pass (9 new for `classifyOutcome` covering silent-abort, stale corrections, status-file error, spawn error, non-zero exit)
- [x] `pnpm --filter @chat-arch/standalone build` — clean
- [x] `pnpm --filter @chat-arch/standalone lint` — clean
- [ ] **Manual**: run MINE ALL against the 582-candidate corpus and confirm patterns land in `corrections.json` + the SCANNED breakdown populates. If the run fails for any other reason, the viewer should now show a real error banner with the reason in `stderrTail` instead of silently reverting.

## Note on base branch

Branched off `feature/corrections-ux-simplification` rather than `main` because PR #32 (the Stage 6 tag-topics work, where the cap-and-ask branch became reachable on every `selection: 'all'` run) merged into that branch, not main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)