### PR TITLE
feat(corrections): bridge PR #32 + #33 + #34 onto main

### DIFF
--- a/.claude/skills/mine-corrections/SKILL.md
+++ b/.claude/skills/mine-corrections/SKILL.md
@@ -1,0 +1,314 @@
+---
+name: mine-corrections
+description: Mine the chat-arch corpus for correction patterns — moments where the user pushed back on the AI — and propose concrete upgrades to CLAUDE.md, skills, agents, commands, or hooks. Detects rules that already exist but are still being violated. Reads chat-arch-data/analysis/correction-candidates.json (produced by the chat-arch exporter) and writes corrections.json with classified patterns and proposed upgrades. Local Ollama required for embeddings.
+---
+
+# /mine-corrections
+
+You are running the LLM stages of chat-arch's correction-mining pipeline. The exporter has already produced a heuristic-recall list of candidate corrections. Your job: classify them, cluster repeated rules, check whether each rule already exists in the user's config, and propose concrete upgrades.
+
+## When to invoke
+
+- The user runs `/mine-corrections` (optionally with arguments below).
+- The viewer wrote a request to `chat-arch-data/analysis/correction-requests.json` (you'll see a `--request-id` arg in that case).
+
+## Arguments
+
+Parse from the user's message. Defaults in brackets.
+
+- `--data-dir <path>` [defaults to `./chat-arch-data` relative to repo root, or whatever the user names]
+- `--window-days <N>` [30] — only process corrections from sessions updated within the last N days. Most-recent-first ordering. **Ignored when `--candidate-ids-file` is also passed.**
+- `--candidate-ids-file <path>` [omitted] — JSON file with `{ "ids": ["cor_...", ...] }`. When present, processes ONLY those correction ids regardless of `--window-days`. The API endpoint writes this file when auto-window selects candidates by composite (signal × recency) score rather than a pure time slice. Honor this list verbatim.
+- `--request-id <uuid>` [omitted] — present when invoked from the viewer; correlates status/output with the requesting UI.
+- `--max-sub-agents <N>` [40] — abort if the work plan would dispatch more than N sub-agents. Each batch of 20 candidates = 1 classification sub-agent; each cluster = 1 proposal sub-agent. The bound prevents a runaway window from quietly burning a chunk of your Claude Code plan usage.
+- `--no-llm` [false] — skip stages 2, 4 (proposal LLM); useful for dry runs and CI.
+- `--reclassify` [false] — re-process already-classified corrections (default skips them).
+
+## Pipeline
+
+You orchestrate six stages. Update the status file at every transition.
+
+### Stage 0 — Setup
+
+1. Resolve `--data-dir`. Read `${dataDir}/analysis/correction-candidates.json`. If absent, tell the user to run `pnpm --filter @chat-arch/exporter run start ...` first.
+2. **If `--candidate-ids-file` is set**: read it, take the `ids` array, filter `correction-candidates.json` to ONLY those ids. Skip the time-window filter entirely. This is the auto-window's preferred path — composite (signal × recency) ranking already happened upstream.
+   **Else** (legacy / explicit `--window-days`): filter to candidates from sessions whose `updatedAt` is within `--window-days` of now. Use the manifest at `${dataDir}/manifest.json` to look up session timestamps by `sessionId`. Sort most-recent-first.
+4. Verify Ollama is up. Run `Bash`:
+   ```
+   curl -s -m 1 http://localhost:11434/api/tags > /dev/null && echo OK || echo MISSING
+   ```
+   If MISSING, tell the user: "Ollama is not running. Install from https://ollama.com, then `ollama pull mxbai-embed-large`." Stop.
+5. Estimate sub-agent count: `ceil(numCandidates / 20) + estimatedClusters` (estimate clusters as ~numCandidates/8 for a first pass; tighten on subsequent runs once you know the real cluster ratio). If estimate exceeds `--max-sub-agents`, tell the user the count and ask whether to proceed or narrow the window. All sub-agent calls run inside the parent Claude Code session — no separate billing, but each call counts against the user's plan usage.
+6. Write the initial status file.
+
+### Stage 1 — Classification
+
+Goal: turn each candidate into a structured `CorrectionClassification` (kind, distilledRule, confidence, actionable). Drop the rest.
+
+Batch candidates into groups of 20. For each batch, dispatch a `general-purpose` sub-agent **with `model: "haiku"`**. Classification is a structured-output task — Haiku 4.5 handles it well at a fraction of the rate-limit cost of Opus, and proposal generation later (Stage 5) keeps the default Opus where judgment matters. Run multiple batches in parallel — up to 4 at a time — by sending multiple Agent tool calls in a single message.
+
+Use this exact sub-agent prompt template (substitute the candidate JSON in place of `<<CANDIDATES>>`):
+
+```
+You are classifying user-corrections-to-AI from a chat transcript. Each input is a {sessionId, userTurnIndex, excerpt, precedingAssistantExcerpt, signals} object.
+
+For each input, decide:
+1. Is this an actual correction-to-the-AI (an instruction, behavior rule, format demand) — actionable?
+2. If actionable, what KIND: 'behavior-rule' | 'output-format' | 'tool-preference' | 'factual-fix' | 'tone' | 'process' | 'other'.
+3. Distill the rule into ONE imperative sentence. No first-person, no project-specific identifiers, no quotes from the assistant. Example: "don't add docstrings unless the user asks." Bad example: "the user wants me to stop adding docstrings."
+4. Confidence (0..1): how confident are you this is a real, repeatable correction (not a one-off fix or aside).
+
+Output ONLY a JSON array, one entry per input, same order:
+[{"id": "<correction id>", "actionable": true|false, "kind": "...", "distilledRule": "...", "confidence": 0.0-1.0}]
+
+Inputs:
+<<CANDIDATES>>
+```
+
+Each sub-agent returns its JSON. Concatenate results. If any sub-agent fails or returns malformed JSON, retry once; if still bad, drop those candidates with a status message.
+
+After all batches: filter to `actionable: true` AND `confidence >= 0.6`. Update status: `"classified N of M, K kept after filter"`.
+
+Write the intermediate file `${dataDir}/analysis/_corrections-classified.json` (the leading underscore signals "intermediate, not consumed by viewer"):
+
+```json
+{
+  "generatedAt": <now>,
+  "corrections": [<each Correction with classification populated>],
+  "patterns": [],
+  "pipeline": { "heuristicRecall": true, "llmClassification": true, "embeddingClustering": false, "claudeMdCrossCheck": false }
+}
+```
+
+### Stage 2 — Config ingestion
+
+Discover the user's existing CLAUDE.md / skills / agents / commands / settings.
+
+```bash
+# Build the project-roots list from the manifest's distinct cwd values.
+node -e "
+const m = JSON.parse(require('fs').readFileSync('${dataDir}/manifest.json','utf8'));
+const roots = [...new Set(m.sessions.map(s => s.cwd).filter(Boolean).filter(c => !c.startsWith('/sessions/')))];
+require('fs').writeFileSync('${dataDir}/analysis/_project-roots.json', JSON.stringify(roots));
+"
+
+# Run the ingestion CLI. The home-dir default is fine.
+node packages/exporter/dist/cli/ingest-configs-cli.js \
+  --project-roots-file ${dataDir}/analysis/_project-roots.json \
+  --output ${dataDir}/analysis/_configs.json
+```
+
+### Stage 3 — Embed everything
+
+Embed (a) the distilled rules, (b) every config sentence. Two batched calls to `chat-arch-embed`.
+
+```bash
+# Rules
+node -e "
+const c = JSON.parse(require('fs').readFileSync('${dataDir}/analysis/_corrections-classified.json','utf8'));
+const texts = c.corrections.filter(x => x.classification?.actionable).map(x => x.classification.distilledRule);
+require('fs').writeFileSync('${dataDir}/analysis/_rules-input.json', JSON.stringify({ texts }));
+"
+node packages/exporter/dist/cli/embed-cli.js \
+  --input ${dataDir}/analysis/_rules-input.json \
+  --output ${dataDir}/analysis/_rules-vectors.json
+
+# Sentences
+node -e "
+const cf = JSON.parse(require('fs').readFileSync('${dataDir}/analysis/_configs.json','utf8'));
+const texts = cf.documents.flatMap(d => d.sentences.map(s => s.text));
+require('fs').writeFileSync('${dataDir}/analysis/_sentences-input.json', JSON.stringify({ texts }));
+"
+node packages/exporter/dist/cli/embed-cli.js \
+  --input ${dataDir}/analysis/_sentences-input.json \
+  --output ${dataDir}/analysis/_sentences-vectors.json
+```
+
+If an embed call fails, surface stderr to the user. Likely cause: Ollama dropped, or the model isn't pulled (`ollama pull mxbai-embed-large`).
+
+### Stage 4 — Cluster + already-encoded check
+
+```bash
+node packages/exporter/dist/cli/cluster-corrections-cli.js \
+  --classifications ${dataDir}/analysis/_corrections-classified.json \
+  --configs ${dataDir}/analysis/_configs.json \
+  --output ${dataDir}/analysis/_patterns-no-proposals.json
+```
+
+This reads the classifications + configs and writes patterns with `proposedUpgrades: []`. Each pattern has its `alreadyEncoded` and `confidence` fields populated.
+
+Update status: `"clustered into K patterns (J already-encoded)"`.
+
+### Stage 5 — Proposal generation
+
+For each pattern, dispatch a sub-agent to generate `ProposedUpgrade[]`. Process patterns in parallel up to 4 at a time. **Use the default model (Opus)** — proposal generation requires judgment about which target file to recommend, why the existing rule is failing, and what the patch text should say. Don't downgrade to Haiku here.
+
+For each pattern, build the sub-agent prompt with:
+
+- The pattern's `canonicalRule`, `occurrenceCount`, `alreadyEncoded`.
+- 3-5 representative instances (excerpt + precedingAssistantExcerpt) — pick the highest-confidence ones.
+- The relevant config documents (those whose sentences had highest similarity to the rule). Truncate each to ≤2000 chars.
+- The list of distinct project roots affected (lookup via session→cwd from the manifest).
+
+Sub-agent prompt template:
+
+```
+You are proposing a concrete fix for a recurring AI-correction pattern.
+
+PATTERN
+canonicalRule: <text>
+occurrenceCount: <N>
+alreadyEncoded: <true|false>
+projectsAffected: [<roots>]
+
+INSTANCES (5 most representative):
+<excerpt + preceding assistant text for each>
+
+EXISTING USER CONFIG (most relevant, may be empty):
+<excerpts of any CLAUDE.md / SKILL.md / agent / command / settings document with high similarity>
+
+PRODUCE: a JSON array of ProposedUpgrade objects, ranked best-first. Each object:
+{
+  "target": "global-claude-md" | "project-claude-md" | "settings-hook" | "skill" | "prompt-snippet" | "agent" | "command",
+  "targetPath": "<concrete file path or settings.json key>",
+  "patch": "<the literal text to add or the unified diff if replacing>",
+  "rationale": "<one paragraph; cite at least 2 instance ids by '<corId>' format from above>",
+  "applied": false,
+  "appliedAt": null
+}
+
+CONSTRAINTS — non-negotiable:
+- patch must be CONCRETE TEXT, not a description of what to add.
+- If alreadyEncoded is true: the existing rule is failing. Your top-ranked proposal MUST be a reword (with the failure diagnosed: why is the model violating the existing rule?) OR an escalation to deterministic enforcement (hook). Do NOT propose adding a new rule when one already exists.
+- If projectsAffected is one project: prefer project-claude-md over global-claude-md.
+- If projectsAffected is many projects: prefer global-claude-md.
+- If pattern is process-y and tool-bound (e.g. "always run X before Y"): consider a hook over a CLAUDE.md rule.
+- If pattern is workflow-shaped (e.g. "when reviewing code, do X"): consider a skill or agent.
+- rationale must cite at least 2 instance ids.
+- No flattery. No "you have great instincts." Pure mechanism.
+- If you cannot produce ≥1 valid proposal under these constraints, return an empty array. Do not produce a low-quality proposal to fill the slot.
+
+Output ONLY the JSON array.
+```
+
+After all sub-agents return, validate each proposal:
+- `patch` non-empty
+- `targetPath` non-empty
+- `rationale` cites at least 2 strings of the form `<corId>` that exist in the cluster's instanceIds
+- `target` is one of the allowed values
+
+Drop invalid proposals. If a pattern ends up with zero valid proposals, keep the pattern but with `proposedUpgrades: []` and note it in status.
+
+### Stage 6 — Tag topics
+
+Goal: assign every pattern (this run's new patterns AND any prior patterns preserved across runs) a short topic label that drives dynamic bucketing in the viewer. ONE LLM call sees all patterns at once — clustering needs a global view to keep labels coherent (no fragmentation between "Git Workflow" and "Git Practices").
+
+1. Read existing `${dataDir}/analysis/corrections.json` if present. Collect prior patterns. Combine with this run's freshly-clustered patterns from `_patterns-no-proposals.json` (or with proposals from the staging step above — only `canonicalRule` is needed here).
+2. If the combined pattern count is ≤ 1, skip this stage (one pattern doesn't need clustering — leave `topic` undefined).
+3. Build the topic-tagging prompt with the full pattern list. Use the **default model (Opus)** — taxonomy quality is the whole point and Haiku tends to over-cluster.
+
+Sub-agent prompt template (single sub-agent, NOT parallelized — taxonomy needs a global view):
+
+```
+You are clustering correction patterns into a small number of topic categories. The user will browse patterns grouped by topic, so the labels must be:
+- short (1-3 words, Title Case)
+- mutually distinct (don't return two labels that mean the same thing)
+- balanced (aim for 4-8 topics across the corpus; merge sparingly-populated themes into a broader parent)
+- stable in shape across runs (same corpus → same labels)
+
+INPUTS — every pattern in the corpus:
+[{"id":"p_...","canonicalRule":"...","occurrenceCount":N,"alreadyEncoded":bool}, ...]
+
+PRODUCE — a JSON object mapping each pattern id to a topic label, plus the deduplicated topic list:
+{
+  "topics": ["Git Workflow", "Test Discipline", ...],
+  "assignments": { "p_abc123": "Git Workflow", "p_def456": "Test Discipline", ... }
+}
+
+CONSTRAINTS — non-negotiable:
+- Every input id appears in `assignments`. No id is dropped.
+- Every value in `assignments` appears in `topics`. No orphan labels.
+- Topic labels are 1-3 words, Title Case, no punctuation.
+- Don't invent a "Misc" or "Other" bucket. If a pattern truly doesn't fit, group it with the nearest semantic neighbor.
+- Don't pad to a fixed count. If the corpus genuinely splits into 3 topics, return 3.
+
+Output ONLY the JSON object.
+```
+
+Validate the response:
+- Parse as JSON; on failure, retry once. On second failure, log a warning and skip the stage (patterns ship without `topic` — viewer falls back to an Untagged bucket).
+- Every pattern id present? Every assigned label in `topics`?
+- If validation fails, drop the stage rather than ship inconsistent data.
+
+Apply the assignments: for each pattern in this run's set AND any prior pattern that was passed to the LLM, write `topic = assignments[patternId]`. Patterns NOT in the input list (none, if you built the input correctly) keep their existing `topic` field as-is.
+
+Update status: `"tagged N patterns into K topics: [<topics>]"`.
+
+### Stage 7 — Assemble + write
+
+Merge classifications + patterns + proposals into the final `CorrectionsFile`. **Critical:** preserve any prior corrections in `corrections.json` that this run did NOT touch — they keep their existing classification (or `null` if they were never classified). Only overwrite entries for candidates this run classified.
+
+```json
+{
+  "generatedAt": <now>,
+  "corrections": [<merged: prior entries + this run's freshly classified, classification populated where known, null otherwise>],
+  "patterns": [<merged: prior patterns retained, this run's new patterns added>],
+  "pipeline": { "heuristicRecall": true, "llmClassification": true, "embeddingClustering": true, "claudeMdCrossCheck": true }
+}
+```
+
+The merge step is what makes the auto-window's "incremental" promise hold. If you wholesale-replace `corrections.json` with only this run's processed candidates, the next auto-window run will treat anything you didn't touch as unprocessed and try to re-do it.
+
+Write to `${dataDir}/analysis/corrections.json`. Then DELETE the intermediate `_*.json` files (clean up), including the `_correction-target-ids-${requestId}.json` file the API endpoint wrote when `--candidate-ids-file` was used.
+
+Update status to `complete` with summary counts.
+
+If a `--request-id` was passed, also write a completion marker at `${dataDir}/analysis/correction-status-${requestId}.json`:
+
+```json
+{ "requestId": "<id>", "status": "complete", "completedAt": <now>, "patternCount": N, "alreadyEncodedCount": K, "tokenCost": "<estimate>" }
+```
+
+## Loop closure (subsequent runs)
+
+When invoked with `--reclassify` OR when corrections.json already exists with applied proposals:
+
+1. Load existing corrections.json. Note which patterns have `proposedUpgrades[*].applied === true` with `appliedAt` set.
+2. For each "applied" pattern, check whether new corrections (post-`appliedAt`) match the same canonical rule (use embedding similarity ≥ 0.85 against the canonicalRule).
+3. If yes: set `recurringPostApplication: true` on that pattern. The viewer surfaces it as "applied but still recurring" — top priority.
+4. Also re-read the file at `appliedAt`'s `targetPath`. If the rule's normalized canonical no longer appears there (user edited it away), retire the proposal — set `applied: false` and clear `appliedAt`. The pattern goes back into the queue normally.
+
+## Status file format
+
+`${dataDir}/analysis/correction-status-${requestId}.json`:
+
+```json
+{
+  "requestId": "<id or 'manual'>",
+  "status": "starting" | "classifying" | "ingesting-configs" | "embedding" | "clustering" | "proposing" | "tagging-topics" | "writing" | "complete" | "error",
+  "progress": { "phase": "<current>", "current": N, "total": M },
+  "startedAt": <ms>,
+  "updatedAt": <ms>,
+  "log": ["<recent message>", "..."],
+  "error": "<message if status=error>"
+}
+```
+
+Update on every stage transition. The viewer polls this for live progress.
+
+## Error handling
+
+- Ollama down → stop, tell the user how to start.
+- Manifest missing → stop, tell the user to run the exporter first.
+- Sub-agent malformed JSON → retry once, then drop those candidates and continue.
+- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently.
+- Any unrecoverable error → write `status: error` with message, exit.
+
+## What you must NOT do
+
+- Don't auto-apply proposals. Writing to `~/.claude/CLAUDE.md` or settings.json without explicit per-proposal user approval is out of scope. Propose only.
+- Don't post-process or re-rank proposals from sub-agents. They produce ranked lists; preserve order.
+- Don't invent instance ids in citations. The validator drops proposals citing nonexistent ids.
+- Don't write to corrections.json until stage 6. Use `_` prefix for all intermediate files.
+- Don't re-classify already-classified corrections unless `--reclassify` was passed.
+- Don't proceed if cost estimate exceeds the cap; ask first.

--- a/.claude/skills/mine-corrections/SKILL.md
+++ b/.claude/skills/mine-corrections/SKILL.md
@@ -38,7 +38,9 @@ You orchestrate six stages. Update the status file at every transition.
    curl -s -m 1 http://localhost:11434/api/tags > /dev/null && echo OK || echo MISSING
    ```
    If MISSING, tell the user: "Ollama is not running. Install from https://ollama.com, then `ollama pull mxbai-embed-large`." Stop.
-5. Estimate sub-agent count: `ceil(numCandidates / 20) + estimatedClusters` (estimate clusters as ~numCandidates/8 for a first pass; tighten on subsequent runs once you know the real cluster ratio). If estimate exceeds `--max-sub-agents`, tell the user the count and ask whether to proceed or narrow the window. All sub-agent calls run inside the parent Claude Code session — no separate billing, but each call counts against the user's plan usage.
+5. Estimate sub-agent count: `ceil(numCandidates / 20) + estimatedClusters` (estimate clusters as ~numCandidates/8 for a first pass; tighten on subsequent runs once you know the real cluster ratio). Log the estimate to status either way. All sub-agent calls run inside the parent Claude Code session — no separate billing, but each call counts against the user's plan usage.
+   - **When `--candidate-ids-file` is set** (the viewer wrote it): skip the interactive cap-and-ask entirely. The viewer's `/api/mine-corrections` endpoint only writes that file *after* the user confirmed the count + window in the ArmedPreview dialog, so re-asking here is a) redundant and b) silently fatal in headless `claude -p` mode where there is no one to answer. Proceed regardless of `--max-sub-agents` and log "viewer-confirmed run (NN candidates) — skipping sub-agent cap check".
+   - **Else** (direct CLI invocation, no id file): if the estimate exceeds `--max-sub-agents`, ask the user before proceeding. This path has a human at the terminal who can answer.
 6. Write the initial status file.
 
 ### Stage 1 — Classification
@@ -171,6 +173,7 @@ PRODUCE: a JSON array of ProposedUpgrade objects, ranked best-first. Each object
 {
   "target": "global-claude-md" | "project-claude-md" | "settings-hook" | "skill" | "prompt-snippet" | "agent" | "command",
   "targetPath": "<concrete file path or settings.json key>",
+  "headline": "<one plain-English sentence — what the upgrade does and why it matters>",
   "patch": "<the literal text to add or the unified diff if replacing>",
   "rationale": "<one paragraph; cite at least 2 instance ids by '<corId>' format from above>",
   "applied": false,
@@ -179,6 +182,7 @@ PRODUCE: a JSON array of ProposedUpgrade objects, ranked best-first. Each object
 
 CONSTRAINTS — non-negotiable:
 - patch must be CONCRETE TEXT, not a description of what to add.
+- headline must be ≤15 words, plain English, and name BOTH the rule being changed AND the change itself. Good: "Widen 'adversarial review' rule to fire on plans/lists/decisions, not just experiment results." Bad: "Update CLAUDE.md." / "Improve the adversarial review rule." / "Add a hook for tests." (Last one would be fine if rewritten to name the rule: "Add PostToolUse hook so 'run tests before committing' enforces itself.")
 - If alreadyEncoded is true: the existing rule is failing. Your top-ranked proposal MUST be a reword (with the failure diagnosed: why is the model violating the existing rule?) OR an escalation to deterministic enforcement (hook). Do NOT propose adding a new rule when one already exists.
 - If projectsAffected is one project: prefer project-claude-md over global-claude-md.
 - If projectsAffected is many projects: prefer global-claude-md.
@@ -196,6 +200,7 @@ After all sub-agents return, validate each proposal:
 - `targetPath` non-empty
 - `rationale` cites at least 2 strings of the form `<corId>` that exist in the cluster's instanceIds
 - `target` is one of the allowed values
+- `headline` non-empty and ≤15 words (split on whitespace). If absent or too long, do NOT drop the proposal — instead, set `headline` to the first sentence of `rationale` truncated to 15 words. Headline is a UX-quality field, not a correctness gate; a long headline beats no headline beats dropping the proposal.
 
 Drop invalid proposals. If a pattern ends up with zero valid proposals, keep the pattern but with `proposedUpgrades: []` and note it in status.
 
@@ -301,7 +306,7 @@ Update on every stage transition. The viewer polls this for live progress.
 - Ollama down → stop, tell the user how to start.
 - Manifest missing → stop, tell the user to run the exporter first.
 - Sub-agent malformed JSON → retry once, then drop those candidates and continue.
-- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently.
+- Sub-agent count over `--max-sub-agents` → ask, don't proceed silently. **Exception**: when `--candidate-ids-file` is set (viewer-confirmed run), the user already confirmed in the ArmedPreview dialog; proceed regardless of the cap. Asking would silently abort the run.
 - Any unrecoverable error → write `status: error` with message, exit.
 
 ## What you must NOT do

--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,20 @@ out/
 .claude/settings.local.json
 .claude/launch.json
 .claude/scheduled_tasks.lock
-.claude/skills/
 .claude/worktrees/
 .claude/projects/
+# Skills folder: un-ignore the directory itself so git descends, then
+# re-ignore everything inside it via `/*` so file-level negations
+# below can take effect. Same trick as `.claude/*` above. Ships the
+# project's own mining-pipeline skill (README references it as "the
+# project's .claude/skills/mine-corrections/" and the viewer's
+# dynamic topic buckets only work when the skill runs the tag-topics
+# stage on every mining pass) while leaving other per-developer
+# skills inside the folder ignored.
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/mine-corrections/
+!.claude/skills/mine-corrections/SKILL.md
 # …except (1) test fixtures, which legitimately contain a `.claude/`
 # subtree that mimics what a real Cowork session directory looks
 # like on disk. These are synthetic (redacted), vital for the

--- a/apps/standalone/src/pages/api/mine-corrections.ts
+++ b/apps/standalone/src/pages/api/mine-corrections.ts
@@ -164,8 +164,9 @@ export interface AutoWindowResult {
   /** 'first-run' on cold start; 'incremental' when prior corrections exist;
    *  'idle' when nothing new since last run; 'unavailable' when the data
    *  files aren't readable yet; 'backfill' when explicitly running an
-   *  oldest-first selection. */
-  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill';
+   *  oldest-first selection; 'all' when the caller asked to mine every
+   *  unprocessed candidate in one pass (no cost cap). */
+  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill' | 'all';
   /** Diagnostic for outcome-aware sizing. Null on first run. */
   patternYield: { patterns: number; classified: number; ratio: number } | null;
   /** Present when there are unprocessed candidates older than the picked
@@ -283,7 +284,7 @@ function outcomeAwareTarget(
 export async function computeAutoWindow(
   rootAbs: string,
   dataDir: string,
-  selection: 'recent' | 'backfill' = 'recent',
+  selection: 'recent' | 'backfill' | 'all' = 'recent',
 ): Promise<{ result: AutoWindowResult; targetIds: string[] }> {
   const empty = (result: AutoWindowResult): { result: AutoWindowResult; targetIds: string[] } => ({
     result,
@@ -393,10 +394,12 @@ export async function computeAutoWindow(
     });
   }
 
-  // Order: composite score desc for 'recent' selection. For 'backfill',
-  // re-score with INVERTED recency so older high-signal candidates win.
+  // Order: composite score desc for 'recent' AND 'all' (the user picks
+  // everything; ranking just controls which items the skill processes
+  // first within the batch). For 'backfill', re-score with INVERTED
+  // recency so older high-signal candidates win.
   const ordered = [...fresh].sort((a, b) => {
-    if (selection === 'recent') return b.composite - a.composite;
+    if (selection === 'recent' || selection === 'all') return b.composite - a.composite;
     const invA = a.signalScore + (a.updatedAt > 0 ? 0 : 0); // pure signal weight
     const invB = b.signalScore + (b.updatedAt > 0 ? 0 : 0);
     if (invB !== invA) return invB - invA;
@@ -404,11 +407,14 @@ export async function computeAutoWindow(
   });
 
   // Outcome-aware sizing — falls back to FIRST_RUN_TARGET_CANDIDATES on
-  // first run or zero-yield runs.
+  // first run or zero-yield runs. 'all' bypasses the cap entirely:
+  // the user explicitly opted into mining every unprocessed candidate
+  // in one pass and accepted the cost in the ArmedPreview confirmation.
   const baseTarget = hasPriorRun
     ? outcomeAwareTarget(priorPatterns, priorClassified)
     : FIRST_RUN_TARGET_CANDIDATES;
-  const target = Math.min(baseTarget, ordered.length);
+  const target =
+    selection === 'all' ? ordered.length : Math.min(baseTarget, ordered.length);
   const picked = ordered.slice(0, target);
   const targetIds = picked.map((p) => p.id);
 
@@ -459,7 +465,10 @@ export async function computeAutoWindow(
 
   let mode: AutoWindowResult['mode'];
   let reasoning: string;
-  if (selection === 'backfill') {
+  if (selection === 'all') {
+    mode = 'all';
+    reasoning = `All: targeting every unprocessed candidate (${target} of ${ranked.length} total). Composite-ranked so high-signal items run first within the batch. Covers ~${windowDays} day${windowDays === 1 ? '' : 's'}.`;
+  } else if (selection === 'backfill') {
     mode = 'backfill';
     reasoning = `Backfill: targeting ${target} oldest unprocessed candidate${target === 1 ? '' : 's'} of ${fresh.length} total (~${windowDays} day${windowDays === 1 ? '' : 's'} span). High-signal items prioritized.`;
   } else if (hasPriorRun) {
@@ -692,7 +701,8 @@ async function streamMineCorrections(
 interface MineRequestBody {
   windowDays?: unknown;
   dataDir?: unknown;
-  /** 'recent' (default) or 'backfill' to flip auto-window selection. */
+  /** 'recent' (default), 'backfill', or 'all' (mine every unprocessed
+   *  candidate in one pass — bypasses the cost cap). */
   selection?: unknown;
 }
 
@@ -720,8 +730,12 @@ async function parseParams(body: MineRequestBody): Promise<MineParams> {
     };
   }
 
-  const selection: 'recent' | 'backfill' =
-    body.selection === 'backfill' ? 'backfill' : 'recent';
+  const selection: 'recent' | 'backfill' | 'all' =
+    body.selection === 'all'
+      ? 'all'
+      : body.selection === 'backfill'
+        ? 'backfill'
+        : 'recent';
   const { result: auto, targetIds } = await computeAutoWindow(
     repoRoot(),
     dataDir,
@@ -885,8 +899,13 @@ export const GET: APIRoute = async ({ url }) => {
     typeof dirParam === 'string' && dirParam.trim().length > 0
       ? dirParam
       : DEFAULT_DATA_DIR;
-  const selection: 'recent' | 'backfill' =
-    url.searchParams.get('selection') === 'backfill' ? 'backfill' : 'recent';
+  const selParam = url.searchParams.get('selection');
+  const selection: 'recent' | 'backfill' | 'all' =
+    selParam === 'all'
+      ? 'all'
+      : selParam === 'backfill'
+        ? 'backfill'
+        : 'recent';
   let autoWindow: AutoWindowResult | null = null;
   try {
     const out = await computeAutoWindow(repoRoot(), dataDir, selection);

--- a/apps/standalone/src/pages/api/mine-corrections.ts
+++ b/apps/standalone/src/pages/api/mine-corrections.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { spawn } from 'node:child_process';
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -92,6 +92,103 @@ interface SpawnOutcome {
   stdout: string;
   stderr: string;
   spawnError: Error | null;
+}
+
+/**
+ * What we learn from probing the on-disk artifacts after the skill
+ * exits. Used by `classifyOutcome` to decide whether the run actually
+ * succeeded, independent of the CLI's exit code (which can be 0 even
+ * when the skill refused to proceed in headless mode — see below).
+ */
+export interface OutcomeProbe {
+  /** `generatedAt` from a corrections.json file present on disk, or
+   *  null if the file is missing / unreadable / lacks the field. */
+  correctionsGeneratedAt: number | null;
+  /** `status` from a `correction-status-<requestId>.json` file, or
+   *  null if absent. */
+  statusFileStatus: string | null;
+  /** `error` from the same status file (only set when status is
+   *  `'error'`), or null. */
+  statusFileError: string | null;
+}
+
+export interface MiningOutcomeVerdict {
+  ok: boolean;
+  reason: string | null;
+}
+
+/**
+ * Decide whether a mining run actually succeeded. The CLI's exit code
+ * isn't sufficient on its own: `claude -p` exits 0 when the skill
+ * decides not to proceed (e.g. it hits a documented "ask the user
+ * before proceeding" branch in headless mode where there's no one to
+ * answer). Without this check, the endpoint would emit `ok: true` for
+ * a run that wrote zero output, and the viewer's runMining would
+ * silently swap back to the idle state — the exact "MINE ALL fails
+ * silently" bug this helper exists to prevent.
+ *
+ * Definition of success: the skill wrote `corrections.json` (or
+ * refreshed an existing one) with `generatedAt >= startedAt`. If the
+ * status file says `status: error`, that's an explicit failure with a
+ * useful message to surface.
+ */
+export function classifyOutcome(
+  startedAt: number,
+  exitCode: number | null,
+  spawnError: Error | null,
+  probe: OutcomeProbe,
+): MiningOutcomeVerdict {
+  if (spawnError !== null) {
+    return { ok: false, reason: `spawn error: ${spawnError.message}` };
+  }
+  if (exitCode !== 0) {
+    return { ok: false, reason: `claude CLI exited with code ${exitCode}` };
+  }
+  if (probe.statusFileStatus === 'error') {
+    const msg = probe.statusFileError ?? '(no message in status file)';
+    return { ok: false, reason: `skill reported error: ${msg}` };
+  }
+  if (
+    probe.correctionsGeneratedAt === null ||
+    probe.correctionsGeneratedAt < startedAt
+  ) {
+    const detail =
+      probe.statusFileStatus !== null
+        ? ` (last skill status: ${probe.statusFileStatus})`
+        : ' (no skill status file written — skill likely aborted in Stage 0 before initializing, e.g. hit a cap-and-ask branch in headless mode or failed to verify Ollama)';
+    return {
+      ok: false,
+      reason:
+        `skill exited cleanly but did not write a fresh corrections.json${detail}. ` +
+        `This is the "silent abort" failure mode — the CLI returned exit 0 but no output was produced.`,
+    };
+  }
+  return { ok: true, reason: null };
+}
+
+async function probeOutcome(
+  rootAbs: string,
+  dataDir: string,
+  requestId: string,
+): Promise<OutcomeProbe> {
+  const dataDirAbs = resolve(rootAbs, dataDir);
+  const corrections = await readJsonOrNull<{ generatedAt?: unknown }>(
+    join(dataDirAbs, 'analysis', 'corrections.json'),
+  );
+  const status = await readJsonOrNull<{
+    status?: unknown;
+    error?: unknown;
+  }>(join(dataDirAbs, 'analysis', `correction-status-${requestId}.json`));
+  return {
+    correctionsGeneratedAt:
+      typeof corrections?.generatedAt === 'number'
+        ? corrections.generatedAt
+        : null,
+    statusFileStatus:
+      typeof status?.status === 'string' ? status.status : null,
+    statusFileError:
+      typeof status?.error === 'string' ? status.error : null,
+  };
 }
 
 interface MineParams {
@@ -677,15 +774,45 @@ async function streamMineCorrections(
     ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
     : '';
 
+  // Validate the on-disk outcome. The CLI's exit code alone isn't a
+  // reliable success signal: in headless `claude -p` mode, the skill
+  // can hit an "ask the user" branch (e.g. Stage 0 sub-agent cap),
+  // print a question, and exit cleanly with code 0 without writing
+  // anything. Reporting `ok: true` for that case is the silent
+  // failure path — the viewer would refresh, find no new corrections,
+  // and revert to idle without surfacing why.
+  const probe = await probeOutcome(repoRoot(), dataDir, requestId);
+  const verdict = classifyOutcome(
+    started,
+    outcome.exitCode,
+    outcome.spawnError,
+    probe,
+  );
+
+  // Skill cleans up the target-ids file on Stage 7 success. If the run
+  // failed, the file is now an orphan — sweep it ourselves so future
+  // diagnostics aren't cluttered (and so the user can re-arm MINE ALL
+  // without seeing a stale id file). Silent best-effort; an unreachable
+  // file is fine.
+  if (!verdict.ok && candidateIdsFile !== null) {
+    try {
+      await unlink(candidateIdsFile);
+    } catch {
+      // Already gone or unreadable — nothing to do.
+    }
+  }
+
+  const verdictNote = verdict.reason !== null ? '\n[outcome] ' + verdict.reason : '';
+
   send({
     type: 'done',
-    ok: outcome.exitCode === 0 && !outcome.spawnError,
+    ok: verdict.ok,
     exitCode: outcome.exitCode,
     durationMs: Date.now() - started,
     requestId,
     usedFallback,
     stdoutTail: tailBytes(outcome.stdout),
-    stderrTail: tailBytes(outcome.stderr + extraStderr),
+    stderrTail: tailBytes(outcome.stderr + extraStderr + verdictNote),
     command: usedFallback
       ? `claude -p "${fallbackPrompt}"`
       : `claude -p "${slashPrompt}"`,

--- a/apps/standalone/test/api/mine-corrections.test.ts
+++ b/apps/standalone/test/api/mine-corrections.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   REQUIRED_HEADER,
+  classifyOutcome,
   isLocalOrigin,
+  type OutcomeProbe,
 } from '../../src/pages/api/mine-corrections.js';
+
+const emptyProbe: OutcomeProbe = {
+  correctionsGeneratedAt: null,
+  statusFileStatus: null,
+  statusFileError: null,
+};
 
 describe('mine-corrections — CSRF gate', () => {
   it('accepts http://localhost:<any>', () => {
@@ -49,5 +57,102 @@ describe('mine-corrections — CSRF gate', () => {
     // Pinned so a refactor can't silently rename it and break the
     // viewer client that posts the same string.
     expect(REQUIRED_HEADER).toBe('chat-arch-mine-corrections');
+  });
+});
+
+describe('mine-corrections — classifyOutcome', () => {
+  const started = 1_000_000;
+
+  it('reports success when corrections.json is fresh and exit was clean', () => {
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started + 5_000,
+      statusFileStatus: 'complete',
+    });
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toBeNull();
+  });
+
+  it('reports success when corrections.json generatedAt equals startedAt', () => {
+    // Boundary: skill could write generatedAt = exact start ms. Don't
+    // false-negative on that edge.
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started,
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('flags the silent-abort path: exit 0 but no corrections.json written', () => {
+    // This is the bug that motivated the helper: claude -p exits clean
+    // because the skill printed a question and gave up, but nothing
+    // landed on disk. The verdict must surface that, not pass it
+    // through as success.
+    const verdict = classifyOutcome(started, 0, null, emptyProbe);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/did not write a fresh corrections\.json/);
+    expect(verdict.reason).toMatch(/no skill status file written/);
+  });
+
+  it('flags the silent-abort path even when corrections.json is stale', () => {
+    // Prior run's output still on disk from earlier mining. New run
+    // didn't refresh it. Must not credit the prior run.
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started - 60_000,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/did not write a fresh corrections\.json/);
+  });
+
+  it('surfaces the skill error message when status file says error', () => {
+    const verdict = classifyOutcome(started, 0, null, {
+      correctionsGeneratedAt: null,
+      statusFileStatus: 'error',
+      statusFileError: 'Ollama is not running',
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe('skill reported error: Ollama is not running');
+  });
+
+  it('falls back to a placeholder when status=error has no message', () => {
+    const verdict = classifyOutcome(started, 0, null, {
+      correctionsGeneratedAt: null,
+      statusFileStatus: 'error',
+      statusFileError: null,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/skill reported error/);
+  });
+
+  it('includes the last-known phase when corrections is missing but status was non-error', () => {
+    // Skill crashed mid-pipeline without writing status=error.
+    const verdict = classifyOutcome(started, 0, null, {
+      correctionsGeneratedAt: null,
+      statusFileStatus: 'classifying',
+      statusFileError: null,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/last skill status: classifying/);
+  });
+
+  it('reports spawn errors before checking output', () => {
+    const verdict = classifyOutcome(
+      started,
+      null,
+      new Error('ENOENT: claude not on PATH'),
+      emptyProbe,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/spawn error.*claude not on PATH/);
+  });
+
+  it('reports a non-zero exit code over the on-disk probe', () => {
+    const verdict = classifyOutcome(started, 1, null, {
+      ...emptyProbe,
+      correctionsGeneratedAt: started + 1_000,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe('claude CLI exited with code 1');
   });
 });

--- a/packages/exporter/src/analysis/corrections.ts
+++ b/packages/exporter/src/analysis/corrections.ts
@@ -213,6 +213,12 @@ export async function buildCorrectionsCandidatesFile(
   const scanStatsBySession: Record<string, readonly [number, number, number]> = {};
   const sessionsBySource: Record<string, number> = {};
   const sessionsMissingBySource: Record<string, number> = {};
+  // Sub-count of `sessionsMissingBySource`: missing entries whose
+  // `transcriptStatus === 'crashed'` (upstream tool crashed before a
+  // transcript was written — Cowork CLI handoff failures today). The
+  // viewer renders these as a separate sub-note so the user can tell
+  // apart "transcript file deleted" from "session never produced one".
+  const sessionsCrashedBySource: Record<string, number> = {};
   let scanned = 0;
   let reused = 0;
   let missing = 0;
@@ -229,6 +235,12 @@ export async function buildCorrectionsCandidatesFile(
     if (r.kind === 'missing') {
       missing += 1;
       sessionsMissingBySource[src] = (sessionsMissingBySource[src] ?? 0) + 1;
+      // Sub-count crashed entries (CLI handoff failures, etc.). Older
+      // entries without the field fall through and count as plain
+      // missing — same as today's behavior.
+      if (entry.transcriptStatus === 'crashed') {
+        sessionsCrashedBySource[src] = (sessionsCrashedBySource[src] ?? 0) + 1;
+      }
       continue;
     }
     allCorrections.push(...r.corrections);
@@ -267,6 +279,13 @@ export async function buildCorrectionsCandidatesFile(
     sessionsMissing: missing,
     sessionsBySource,
     sessionsMissingBySource,
+    // Omit the field entirely when no crashes were detected so older
+    // tooling reading the file doesn't see an empty object and assume
+    // the writer was newer than it is. Present-and-non-empty is the
+    // viewer's signal to render the split note.
+    ...(Object.keys(sessionsCrashedBySource).length > 0
+      ? { sessionsCrashedBySource }
+      : {}),
     rawUserTurns: aggRaw,
     wrapperFiltered: aggWrapper,
     tooLongFiltered: aggTooLong,

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -412,6 +412,21 @@ async function processCoworkManifest(
     );
   }
 
+  // Decide transcriptStatus — drives the viewer's SCANNED-panel split
+  // between "transcript file missing on disk" and "Cowork CLI crashed
+  // before writing a transcript". The diagnostic distinguishing the
+  // two cases is whether the upstream manifest ever allocated a
+  // `cliSessionId` (the CLI side never came up if not — these almost
+  // always carry an `error` field too). Both states are no-transcript
+  // from chat-arch's POV but they have different remediation paths:
+  // crashes are recoverable from `audit.jsonl` in a future pass;
+  // missing-from-disk files are genuinely gone.
+  const transcriptStatus: 'ok' | 'crashed' | 'missing' = transcriptCopied
+    ? 'ok'
+    : typeof manifest.cliSessionId !== 'string' || manifest.cliSessionId.length === 0
+      ? 'crashed'
+      : 'missing';
+
   // Tool-use histogram — mined from the copied transcript (same content-
   // block shape as cli-direct / cloud). audit.jsonl does not carry tool
   // names (only `tool_use_summary` lines with ids), so we have to read
@@ -456,6 +471,7 @@ async function processCoworkManifest(
     ...(transcriptCopied && transcriptOutRel !== undefined
       ? { transcriptPath: toPosixRelative(path.join(outDir, transcriptOutRel), outDir) }
       : {}),
+    transcriptStatus,
     manifestPath: toPosixRelative(manifestOutAbs, outDir),
     // auditPath: omitted (Q1)
   };

--- a/packages/schema/src/correction.ts
+++ b/packages/schema/src/correction.ts
@@ -112,6 +112,17 @@ export interface ProposedUpgrade {
    *   prompt-snippet       → "(reusable, no fixed path)"
    */
   targetPath: string;
+  /**
+   * One-sentence plain-English summary of WHAT this upgrade does and
+   * WHY it matters — the punchline. The card surfaces it large above
+   * the rationale paragraph so users can decide whether to act in a
+   * glance. ≤15 words, names the rule + the change, no jargon. The
+   * `rationale` field below remains the long-form diagnosis for users
+   * who want the evidence. Optional for back-compat: patterns from
+   * mining runs before this field shipped fall back to showing the
+   * rationale alone (the card truncates it as a fallback headline).
+   */
+  headline?: string;
   /** The literal text to add. User reviews before applying. */
   patch: string;
   /** Why this target — cites the inference rule that fired. */

--- a/packages/schema/src/correction.ts
+++ b/packages/schema/src/correction.ts
@@ -260,8 +260,22 @@ export interface ScanStats {
    *  `cli-desktop`, `cloud`). */
   sessionsBySource: Record<string, number>;
   /** Missing-transcript sessions broken out by source. Useful for
-   *  diagnosing whether all the gaps are concentrated in one ingester. */
+   *  diagnosing whether all the gaps are concentrated in one ingester.
+   *
+   *  Includes BOTH `transcriptStatus: 'missing'` (file gone from disk)
+   *  AND `transcriptStatus: 'crashed'` (upstream tool crashed before a
+   *  transcript was written). The `sessionsCrashedBySource` sub-count
+   *  below splits out the crashed sub-share so the SCANNED panel can
+   *  show them separately. */
   sessionsMissingBySource: Record<string, number>;
+  /** Crashed-session sub-count by source — a subset of
+   *  `sessionsMissingBySource`. Populated by `transcriptStatus: 'crashed'`
+   *  entries; in practice today only cowork emits these (CLI handoff
+   *  failures where `cliSessionId` is missing and an `error` field is
+   *  set on the source manifest). Optional for back-compat: older
+   *  candidate files predating this field render the legacy single-
+   *  number "missing" note. */
+  sessionsCrashedBySource?: Record<string, number>;
   /** Total user-role turns across all scanned transcripts, BEFORE the
    *  wrapper / length filter. */
   rawUserTurns: number;

--- a/packages/schema/src/correction.ts
+++ b/packages/schema/src/correction.ts
@@ -180,6 +180,18 @@ export interface CorrectionPattern {
    * finding, surfaced separately in the viewer.
    */
   alreadyEncoded: boolean;
+  /**
+   * Short LLM-derived topic label (1-3 words, Title Case) shared
+   * across all patterns in the same theme — drives dynamic bucketing
+   * in the viewer instead of the predefined RECURRING/ENCODED/NEW
+   * taxonomy. Set by the mine-corrections skill's `tag-topics` stage,
+   * which sees ALL patterns in one LLM call so labels stay coherent
+   * across the corpus (no fragmentation between "Git Workflow" and
+   * "Git Practices"). Optional for back-compat: patterns from prior
+   * mining runs without this field render in an "Untagged" bucket
+   * until re-mined.
+   */
+  topic?: string;
 }
 
 export interface CorrectionsFile {

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -288,6 +288,29 @@ export interface UnifiedSessionEntry {
    */
   transcriptPath?: string;
 
+  /**
+   * Why `transcriptPath` is absent, when it is. Optional for back-compat
+   * (older manifests don't carry this and the correction analyzer falls
+   * back to the legacy "any-missing-is-missing" classification). New
+   * values:
+   *
+   *   - 'ok'      — transcript was copied (transcriptPath present).
+   *   - 'crashed' — upstream session metadata was incomplete (e.g.
+   *                 Cowork CLI handoff failed: no `cliSessionId`, often
+   *                 with an `error` field set on the source manifest).
+   *                 User-side prompts may still exist in audit.jsonl —
+   *                 future recovery work can mine those.
+   *   - 'missing' — pointers were complete but the transcript file
+   *                 wasn't on disk at scan time (deleted, aborted, or
+   *                 cleaned up by the upstream tool between session end
+   *                 and exporter scan).
+   *
+   * Drives the SCANNED panel's split note ("X missing on disk · Y CLI
+   * crashed") so the user can tell apart recoverable-but-not-recovered
+   * errors from genuinely-gone transcripts.
+   */
+  transcriptStatus?: 'ok' | 'crashed' | 'missing';
+
   /** Output-relative path to the source manifest (Cowork, Desktop-CLI only). */
   manifestPath?: string;
 

--- a/packages/viewer/src/ChatArchViewer.back.test.tsx
+++ b/packages/viewer/src/ChatArchViewer.back.test.tsx
@@ -155,8 +155,9 @@ describe('ChatArchViewer — BACK from detail restores prior surface (P0.1)', ()
       expect(locationLabel()).toBe('CORRECTIONS');
     });
 
-    // Pattern cards collapse instance pills behind a SHOW DETAILS
-    // toggle. Click that first, then the instance pill. The panel's
+    // Pattern cards collapse instance pills behind SHOW DETAILS, and
+    // after the proposals-first reordering EVIDENCE is collapsed too.
+    // Open both to reach the instance pill. The panel's
     // onSelectSession wrapper sets priorModeBeforeDetail and calls
     // onSelect, which pushes #session/a and flips mode.
     const showDetails = await waitFor(() =>
@@ -164,6 +165,12 @@ describe('ChatArchViewer — BACK from detail restores prior surface (P0.1)', ()
     );
     act(() => {
       fireEvent.click(showDetails);
+    });
+    const evidence = await waitFor(() =>
+      screen.getByRole('button', { name: /EVIDENCE/ }),
+    );
+    act(() => {
+      fireEvent.click(evidence);
     });
     const pill = await waitFor(() =>
       screen.getByRole('button', { name: /open session a/i }),

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -2616,6 +2616,12 @@ export function ChatArchViewer({
                         {...(uploadedData?.appliedImprovements
                           ? { overrideApplied: uploadedData.appliedImprovements }
                           : {})}
+                        {...(uploadedData?.correctionCandidates
+                          ? {
+                              overrideCandidates:
+                                uploadedData.correctionCandidates,
+                            }
+                          : {})}
                         onSelectSession={(id) => {
                           // Stash the source mode so BACK restores
                           // CORRECTIONS instead of falling to SESSIONS

--- a/packages/viewer/src/components/CorrectionPatternCard.test.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.test.tsx
@@ -70,6 +70,149 @@ describe('CorrectionPatternCard', () => {
     expect(screen.getByText('×3')).toBeDefined();
   });
 
+  describe('upgrade headline (lead-with-the-punchline)', () => {
+    it('renders the upgrade.headline above the rationale when present', () => {
+      const u = upgrade({
+        headline: "Widen 'adversarial review' rule to fire on plans, not just experiment results.",
+      });
+      const p = pattern({ proposedUpgrades: [u] });
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      expect(
+        screen.getByText(
+          "Widen 'adversarial review' rule to fire on plans, not just experiment results.",
+        ),
+      ).toBeDefined();
+    });
+
+    it('falls back to a derived headline from rationale when the field is missing', () => {
+      // Legacy data path: corrections.json written before the headline
+      // field shipped. The card must still lead with a one-liner;
+      // long rationale alone is the bug the headline solves.
+      const u = upgrade({
+        rationale:
+          'Rule recurs in 5 sessions and 3 projects. Diagnose the trigger before reword.',
+      });
+      const p = pattern({ proposedUpgrades: [u] });
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      // First sentence (12 words, ≤15 cap — no truncation).
+      expect(
+        screen.getByText('Rule recurs in 5 sessions and 3 projects.'),
+      ).toBeDefined();
+    });
+
+    it('truncates a fallback headline to ~15 words with an ellipsis', () => {
+      const u = upgrade({
+        rationale:
+          'This is a deliberately long single sentence that runs well past fifteen words to verify the truncation branch kicks in and appends an ellipsis at the end',
+      });
+      const p = pattern({ proposedUpgrades: [u] });
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      // The first 15 words + ellipsis. Asserting on the ellipsis is
+      // enough; counting exact words is brittle.
+      const headlineText = screen.getByText(
+        /^This is a deliberately long single sentence that runs well past fifteen words to verify…$/,
+      );
+      expect(headlineText).toBeDefined();
+    });
+  });
+
+  describe('section ordering (proposals before evidence)', () => {
+    it('renders PROPOSED UPGRADES above EVIDENCE in the DOM', () => {
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      const proposals = screen.getByText('PROPOSED UPGRADES');
+      const evidence = screen.getByText('EVIDENCE');
+      // Both labels are in the document; compareDocumentPosition
+      // returns DOCUMENT_POSITION_FOLLOWING (4) when `evidence` follows
+      // `proposals`. Anything else means we regressed the ordering.
+      expect(
+        proposals.compareDocumentPosition(evidence) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBeTruthy();
+    });
+
+    it('collapses EVIDENCE by default — instance bodies are hidden until the user opens them', () => {
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      // Header is visible; the conversation excerpts inside are not.
+      expect(screen.getByText('EVIDENCE')).toBeDefined();
+      expect(screen.queryByText(/please c1 stop using docstrings/)).toBeNull();
+    });
+
+    it('opens EVIDENCE when the toggle is clicked', () => {
+      const p = pattern();
+      render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /EVIDENCE/ }));
+      expect(screen.getByText(/please c1 stop using docstrings/)).toBeDefined();
+    });
+
+    // a11y: PROPOSED UPGRADES is an <h4>, so EVIDENCE must announce as
+    // a heading at the same level — otherwise screen-reader heading-
+    // list navigation walks past it. The toggle button uses
+    // aria-expanded + aria-controls to pair with the disclosure region.
+    it('exposes EVIDENCE label as a level-4 heading paired to its region', () => {
+      const p = pattern();
+      const { container } = render(
+        <CorrectionPatternCard
+          pattern={p}
+          instancesById={buildInstancesById(p.instanceIds)}
+          defaultExpanded
+        />,
+      );
+      const toggle = screen.getByRole('button', { name: /EVIDENCE/ });
+      const controlsId = toggle.getAttribute('aria-controls');
+      expect(controlsId).toBeTruthy();
+      // PROPOSED UPGRADES is a real <h4> — pin heading-level parity.
+      const proposalsHeading = screen.getByText('PROPOSED UPGRADES');
+      expect(proposalsHeading.tagName).toBe('H4');
+      // EVIDENCE span needs role=heading aria-level=4 to match in the
+      // SR heading list.
+      const evidenceLabel = screen.getByText('EVIDENCE');
+      expect(evidenceLabel.getAttribute('role')).toBe('heading');
+      expect(evidenceLabel.getAttribute('aria-level')).toBe('4');
+      // Region is mounted only after open — click and verify pairing.
+      fireEvent.click(toggle);
+      const region = container.querySelector(`#${controlsId}`);
+      expect(region).not.toBeNull();
+      expect(region?.getAttribute('role')).toBe('region');
+    });
+  });
+
   it('shows the ALREADY ENCODED badge when alreadyEncoded is set', () => {
     const p = pattern({ alreadyEncoded: true });
     render(<CorrectionPatternCard pattern={p} instancesById={buildInstancesById(p.instanceIds)} />);
@@ -335,6 +478,9 @@ describe('CorrectionPatternCard', () => {
         />,
       );
       fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
+      // Evidence is collapsed by default after the proposals-first
+      // reordering; open it before asserting on the instance pills.
+      fireEvent.click(screen.getByRole('button', { name: /EVIDENCE/ }));
       // 3 instances × 1 pill each.
       const pills = screen.getAllByRole('button', { name: /open session s-c/ });
       expect(pills).toHaveLength(3);
@@ -348,8 +494,10 @@ describe('CorrectionPatternCard', () => {
         <CorrectionPatternCard pattern={p} instancesById={buildInstancesById(p.instanceIds)} />,
       );
       fireEvent.click(screen.getByRole('button', { name: /SHOW DETAILS/i }));
-      // Only the SHOW/HIDE-DETAILS toggle and (disabled) APPLY remain
-      // as buttons in this branch — no per-instance pill buttons.
+      fireEvent.click(screen.getByRole('button', { name: /EVIDENCE/ }));
+      // Only the SHOW/HIDE-DETAILS toggle, EVIDENCE toggle, and
+      // (disabled) APPLY remain as buttons in this branch — no
+      // per-instance pill buttons.
       expect(screen.queryAllByRole('button', { name: /open session/i })).toHaveLength(0);
     });
   });

--- a/packages/viewer/src/components/CorrectionPatternCard.tsx
+++ b/packages/viewer/src/components/CorrectionPatternCard.tsx
@@ -110,6 +110,22 @@ function formatAppliedAtIso(ms: number): string {
 
 const INITIAL_INSTANCE_COUNT = 3;
 
+/**
+ * Back-compat fallback for upgrades produced by mining runs before the
+ * `headline` field shipped. Take the rationale's first sentence and
+ * truncate at ~15 words so the card still leads with a one-line summary
+ * instead of a wall of diagnosis prose. Re-mining the corpus produces
+ * proper headlines and this branch retires.
+ */
+function deriveHeadline(rationale: string): string {
+  const trimmed = rationale.trim();
+  if (trimmed.length === 0) return '';
+  const firstSentence = trimmed.split(/(?<=[.!?])\s/)[0] ?? trimmed;
+  const words = firstSentence.split(/\s+/);
+  if (words.length <= 15) return firstSentence;
+  return words.slice(0, 15).join(' ') + '…';
+}
+
 export function CorrectionPatternCard({
   pattern,
   instancesById,
@@ -125,9 +141,15 @@ export function CorrectionPatternCard({
   useEffect(() => {
     if (defaultExpanded) setExpanded(true);
   }, [defaultExpanded]);
+  // EVIDENCE section is collapsed by default — proposals are the
+  // value, instances are the supporting evidence. Users who want to
+  // verify before applying click SHOW EVIDENCE; everyone else
+  // doesn't pay the wall-of-conversation tax.
+  const [evidenceOpen, setEvidenceOpen] = useState(false);
   const [showAllInstances, setShowAllInstances] = useState(false);
   const [copiedIx, setCopiedIx] = useState<number | null>(null);
   const [busyIx, setBusyIx] = useState<number | null>(null);
+  const evidenceRegionId = `lcars-correction-pattern-evidence-${pattern.id}`;
 
   const category = categoryFor(pattern);
   const categoryLabel =
@@ -213,68 +235,13 @@ export function CorrectionPatternCard({
 
       {expanded && (
         <div className="lcars-correction-pattern__body">
-          <section className="lcars-correction-pattern__section">
-            <h4 className="lcars-correction-pattern__section-title">INSTANCES</h4>
-            {visibleInstances.length === 0 ? (
-              <p className="lcars-correction-pattern__empty">
-                No instance bodies available — the corrections file may be partial.
-              </p>
-            ) : (
-              <ul className="lcars-correction-pattern__instance-list" role="list">
-                {visibleInstances.map((inst) => {
-                  const body = (
-                    <>
-                      {inst.precedingAssistantExcerpt && (
-                        <p className="lcars-correction-pattern__instance-context">
-                          <span className="lcars-correction-pattern__instance-tag">
-                            ASSISTANT
-                          </span>
-                          <span>{inst.precedingAssistantExcerpt}</span>
-                        </p>
-                      )}
-                      <p className="lcars-correction-pattern__instance-body">
-                        <span className="lcars-correction-pattern__instance-tag">USER</span>
-                        <span>{inst.excerpt}</span>
-                      </p>
-                    </>
-                  );
-                  if (onSelectSession) {
-                    return (
-                      <li
-                        key={inst.id}
-                        className="lcars-correction-pattern__instance"
-                      >
-                        <button
-                          type="button"
-                          className="lcars-correction-pattern__instance-pill"
-                          onClick={() => onSelectSession(inst.sessionId)}
-                          aria-label={`open session ${inst.sessionId}`}
-                          title={`Open session ${inst.sessionId}`}
-                        >
-                          {body}
-                        </button>
-                      </li>
-                    );
-                  }
-                  return (
-                    <li key={inst.id} className="lcars-correction-pattern__instance">
-                      {body}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-            {hiddenInstanceCount > 0 && (
-              <button
-                type="button"
-                className="lcars-correction-pattern__more"
-                onClick={() => setShowAllInstances(true)}
-              >
-                Show all ({instances.length})
-              </button>
-            )}
-          </section>
-
+          {/*
+            PROPOSED UPGRADES first: the action is the product. EVIDENCE
+            (instances) used to render above and pushed proposals
+            below-the-fold — see the UX feedback in PR #34's review
+            thread. Section headers are restyled for stronger visual
+            hierarchy.
+          */}
           <section className="lcars-correction-pattern__section">
             <h4 className="lcars-correction-pattern__section-title">PROPOSED UPGRADES</h4>
             {pattern.proposedUpgrades.length === 0 ? (
@@ -300,6 +267,97 @@ export function CorrectionPatternCard({
                   />
                 ))}
               </ul>
+            )}
+          </section>
+
+          <section className="lcars-correction-pattern__section">
+            <button
+              type="button"
+              className="lcars-correction-pattern__evidence-toggle"
+              aria-expanded={evidenceOpen}
+              aria-controls={evidenceRegionId}
+              onClick={() => setEvidenceOpen((v) => !v)}
+            >
+              {/*
+                role="heading" + aria-level on the visible label so a
+                screen-reader's heading-list navigation sees EVIDENCE at
+                the same level as the <h4>PROPOSED UPGRADES</h4> above.
+                Without this, the headings list would skip from h4 to
+                whatever sits below EVIDENCE — confusing for keyboard /
+                AT users walking the card by heading.
+              */}
+              <span
+                className="lcars-correction-pattern__section-title"
+                role="heading"
+                aria-level={4}
+              >
+                EVIDENCE
+              </span>
+              <span className="lcars-correction-pattern__evidence-toggle-hint">
+                {evidenceOpen ? '▾ hide' : `▸ show ${instances.length} ${instances.length === 1 ? 'instance' : 'instances'}`}
+              </span>
+            </button>
+            {evidenceOpen && (
+              <div id={evidenceRegionId} role="region" aria-label="EVIDENCE">
+                {visibleInstances.length === 0 ? (
+                  <p className="lcars-correction-pattern__empty">
+                    No instance bodies available — the corrections file may be partial.
+                  </p>
+                ) : (
+                  <ul className="lcars-correction-pattern__instance-list" role="list">
+                    {visibleInstances.map((inst) => {
+                      const body = (
+                        <>
+                          {inst.precedingAssistantExcerpt && (
+                            <p className="lcars-correction-pattern__instance-context">
+                              <span className="lcars-correction-pattern__instance-tag">
+                                ASSISTANT
+                              </span>
+                              <span>{inst.precedingAssistantExcerpt}</span>
+                            </p>
+                          )}
+                          <p className="lcars-correction-pattern__instance-body">
+                            <span className="lcars-correction-pattern__instance-tag">USER</span>
+                            <span>{inst.excerpt}</span>
+                          </p>
+                        </>
+                      );
+                      if (onSelectSession) {
+                        return (
+                          <li
+                            key={inst.id}
+                            className="lcars-correction-pattern__instance"
+                          >
+                            <button
+                              type="button"
+                              className="lcars-correction-pattern__instance-pill"
+                              onClick={() => onSelectSession(inst.sessionId)}
+                              aria-label={`open session ${inst.sessionId}`}
+                              title={`Open session ${inst.sessionId}`}
+                            >
+                              {body}
+                            </button>
+                          </li>
+                        );
+                      }
+                      return (
+                        <li key={inst.id} className="lcars-correction-pattern__instance">
+                          {body}
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+                {hiddenInstanceCount > 0 && (
+                  <button
+                    type="button"
+                    className="lcars-correction-pattern__more"
+                    onClick={() => setShowAllInstances(true)}
+                  >
+                    Show all ({instances.length})
+                  </button>
+                )}
+              </div>
             )}
           </section>
         </div>
@@ -387,8 +445,19 @@ function UpgradeRow({
     }
   };
 
+  // Headline = the punchline. Skill writes it directly; legacy
+  // upgrades without it get a derived headline from rationale so the
+  // card still leads with a one-liner.
+  const headline =
+    typeof upgrade.headline === 'string' && upgrade.headline.trim().length > 0
+      ? upgrade.headline.trim()
+      : deriveHeadline(upgrade.rationale);
+
   return (
     <li className="lcars-correction-pattern__upgrade">
+      {headline.length > 0 && (
+        <p className="lcars-correction-pattern__upgrade-headline">{headline}</p>
+      )}
       <header className="lcars-correction-pattern__upgrade-header">
         <span
           className={`lcars-correction-pattern__target lcars-correction-pattern__target--${upgrade.target}`}

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -677,42 +677,219 @@ describe('CorrectionsPanel', () => {
     });
   });
 
-  // Header-row redesign: "Generated <iso>" was demoted from a row of
-  // its own to a "Last mined …" chip in the title row. Verify the chip
-  // renders relative time and keeps the absolute ISO in `title=` for
-  // debugging without polluting the layout.
-  describe('Header timestamp chip', () => {
-    it('renders the chip in the title row when corrections.json has generatedAt', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([pattern({ id: 'n1', canonicalRule: 'rule one' })]),
+  // SCANNED panel: the per-source missing note now splits "transcript
+  // file missing on disk" from "CLI crashed before writing one"
+  // (Cowork's case). The split makes it explicit that the user's data
+  // *is* there in audit.jsonl for the crashed cases — different
+  // remediation path than the genuinely-gone files.
+  describe('SCANNED panel — crashed vs missing split', () => {
+    function fileWithScanStats(args: {
+      sessionsBySource: Record<string, number>;
+      sessionsMissingBySource: Record<string, number>;
+      sessionsCrashedBySource?: Record<string, number>;
+    }): CorrectionsFile {
+      return {
+        generatedAt: 1_700_000_000_000,
+        // At least one candidate is required for the CoverageMeter to
+        // mount (it gates on total > 0). The bucketing logic only cares
+        // about the `id` field for the headline; classification stays
+        // null so notRun=true in the LLM MINE stage.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        corrections: [{ id: 'cand-1' }, { id: 'cand-2' }] as any,
+        patterns: [],
+        pipeline: {
+          heuristicRecall: true,
+          llmClassification: false,
+          embeddingClustering: false,
+          claudeMdCrossCheck: false,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        scanStats: {
+          sessionsInManifest: 0,
+          sessionsScanned: 0,
+          sessionsMissing: 0,
+          sessionsBySource: args.sessionsBySource,
+          sessionsMissingBySource: args.sessionsMissingBySource,
+          ...(args.sessionsCrashedBySource
+            ? { sessionsCrashedBySource: args.sessionsCrashedBySource }
+            : {}),
+          rawUserTurns: 0,
+          wrapperFiltered: 0,
+          tooLongFiltered: 0,
+          survivingTurns: 0,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      };
+    }
+
+    it('renders split note when both crashed and true-missing exist', async () => {
+      mockedLoadCorrections.mockResolvedValue(null);
+      mockedLoadCandidates.mockResolvedValue(
+        fileWithScanStats({
+          sessionsBySource: { cowork: 323 },
+          sessionsMissingBySource: { cowork: 51 },
+          sessionsCrashedBySource: { cowork: 14 },
+        }),
       );
-      mockedLoadCandidates.mockResolvedValue(null);
-      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
-      await waitFor(() => {
-        expect(screen.getByText(/Last mined/i)).toBeDefined();
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      // Open the details disclosure so CoverageDetail renders.
+      const detailsBtn = await screen.findByRole('button', {
+        name: /details/i,
       });
-      const chip = screen.getByText(/Last mined/i);
-      // Absolute ISO survives in `title=` for tooltip / debugging.
-      expect(chip.getAttribute('title')).toMatch(/Generated 20\d\d-/);
-      // Demoted row that used to read "Generated 20...Z" should be gone.
-      expect(screen.queryByText(/^Generated 20\d\d-/)).toBeNull();
+      fireEvent.click(detailsBtn);
+      await waitFor(() => {
+        expect(
+          container.querySelector(
+            '[aria-label^="EXPORTER SCAN stage"]',
+          ),
+        ).not.toBeNull();
+      });
+      // 51 missing total - 14 crashed = 37 true-missing. The note
+      // should mention both numbers explicitly.
+      const cowork = container.querySelector(
+        '[aria-label^="EXPORTER SCAN stage"] li:nth-child(3)',
+      );
+      expect(cowork?.textContent ?? '').toMatch(/272\s*\/\s*323/);
+      expect(cowork?.textContent ?? '').toMatch(/37 transcript file missing on disk/);
+      expect(cowork?.textContent ?? '').toMatch(/14 CLI crashed/);
+    });
+
+    it('renders crashed-only note when all missing are crashes', async () => {
+      mockedLoadCorrections.mockResolvedValue(null);
+      mockedLoadCandidates.mockResolvedValue(
+        fileWithScanStats({
+          sessionsBySource: { cowork: 20 },
+          sessionsMissingBySource: { cowork: 5 },
+          sessionsCrashedBySource: { cowork: 5 },
+        }),
+      );
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      fireEvent.click(
+        await screen.findByRole('button', { name: /details/i }),
+      );
+      await waitFor(() => {
+        expect(
+          container.querySelector('[aria-label^="EXPORTER SCAN stage"]'),
+        ).not.toBeNull();
+      });
+      const cowork = container.querySelector(
+        '[aria-label^="EXPORTER SCAN stage"] li:nth-child(3)',
+      );
+      expect(cowork?.textContent ?? '').toMatch(/5 CLI crashed/);
+      expect(cowork?.textContent ?? '').not.toMatch(/missing on disk/);
+    });
+
+    it('falls back to legacy "missing on disk" note when no crashed sub-count is reported', async () => {
+      mockedLoadCorrections.mockResolvedValue(null);
+      mockedLoadCandidates.mockResolvedValue(
+        fileWithScanStats({
+          sessionsBySource: { cowork: 100 },
+          sessionsMissingBySource: { cowork: 10 },
+          // No sessionsCrashedBySource — older candidates file shape.
+        }),
+      );
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      fireEvent.click(
+        await screen.findByRole('button', { name: /details/i }),
+      );
+      await waitFor(() => {
+        expect(
+          container.querySelector('[aria-label^="EXPORTER SCAN stage"]'),
+        ).not.toBeNull();
+      });
+      const cowork = container.querySelector(
+        '[aria-label^="EXPORTER SCAN stage"] li:nth-child(3)',
+      );
+      expect(cowork?.textContent ?? '').toMatch(/10 transcript file missing on disk/);
+      expect(cowork?.textContent ?? '').not.toMatch(/CLI crashed/);
     });
   });
 
-  // First-principles simplification (Tight): CoverageMeter shows just
-  // the bar + one figure ("271 / 581 mined"). The label, funnel
-  // sentence, actionable %, and pattern count are gone — diagnostic
-  // info now lives only behind the "details ▸" chevron.
-  describe('CoverageMeter — Tight layout', () => {
-    it('renders just the bar + "N / M mined" figure (no label, no funnel sentence)', async () => {
-      const c: CorrectionsFile = {
+  // Pipeline-stage markers: the EXPORTER SCAN vs LLM MINE boundary
+  // resolves the user's "the headline says 0 mined but the detail
+  // shows non-zero counts" confusion. Verify both stages render with
+  // the right done/pending status badges and copy.
+  describe('pipeline-stage markers', () => {
+    function emptyScanStats() {
+      return {
+        sessionsInManifest: 0,
+        sessionsScanned: 0,
+        sessionsMissing: 0,
+        sessionsBySource: {},
+        sessionsMissingBySource: {},
+        rawUserTurns: 0,
+        wrapperFiltered: 0,
+        tooLongFiltered: 0,
+        survivingTurns: 0,
+      };
+    }
+
+    it('marks EXPORTER SCAN as done and LLM MINE as pending when no classifications run yet', async () => {
+      mockedLoadCorrections.mockResolvedValue(null);
+      mockedLoadCandidates.mockResolvedValue({
         generatedAt: 1_700_000_000_000,
-        corrections: [
-          { id: 'c1', classification: { actionable: true, ruleSummary: 'r' } },
-          { id: 'c2', classification: { actionable: false, ruleSummary: 'r' } },
-          { id: 'c3', classification: { actionable: true, ruleSummary: 'r' } },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ] as any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        corrections: [{ id: 'cand-1' }] as any,
+        patterns: [],
+        pipeline: {
+          heuristicRecall: true,
+          llmClassification: false,
+          embeddingClustering: false,
+          claudeMdCrossCheck: false,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        scanStats: emptyScanStats() as any,
+      });
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      fireEvent.click(
+        await screen.findByRole('button', { name: /details/i }),
+      );
+      await waitFor(() => {
+        expect(
+          container.querySelector('[aria-label^="EXPORTER SCAN stage"]'),
+        ).not.toBeNull();
+      });
+      const scanStage = container.querySelector(
+        '[aria-label^="EXPORTER SCAN stage"]',
+      );
+      const mineStage = container.querySelector(
+        '[aria-label^="LLM MINE stage"]',
+      );
+      expect(scanStage?.getAttribute('data-stage-status')).toBe('done');
+      expect(mineStage?.getAttribute('data-stage-status')).toBe('pending');
+      // Status echoed into aria-label so screen readers announce
+      // done/pending without having to walk into the body.
+      expect(scanStage?.getAttribute('aria-label')).toBe(
+        'EXPORTER SCAN stage — done',
+      );
+      expect(mineStage?.getAttribute('aria-label')).toBe(
+        'LLM MINE stage — pending',
+      );
+      expect(scanStage?.textContent ?? '').toMatch(/EXPORTER SCAN/);
+      expect(scanStage?.textContent ?? '').toMatch(/done · re-runs on SCAN LOCAL/);
+      expect(mineStage?.textContent ?? '').toMatch(/LLM MINE/);
+      expect(mineStage?.textContent ?? '').toMatch(/pending · click RE-MINE CORRECTIONS/);
+    });
+
+    // Regression: after a HEURISTIC_RECALL_VERSION bump retires every
+    // prior candidate, `classified` collapses to 0 (corrections live in
+    // corrections.json but their ids no longer intersect candidates).
+    // LLM MINE badge must still read "done" when patterns exist, or
+    // the panel lies "pending · click RE-MINE CORRECTIONS" while the
+    // Last-mined chip and pattern list contradict it.
+    it('marks LLM MINE as done when patterns exist even if classified count is 0', async () => {
+      mockedLoadCorrections.mockResolvedValue({
+        generatedAt: 1_700_000_000_000,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        corrections: [{ id: 'old-id', classification: { actionable: true, ruleSummary: 'r' } }] as any,
         patterns: [pattern({ id: 'p1', canonicalRule: 'pat one' })],
         pipeline: {
           heuristicRecall: true,
@@ -720,73 +897,45 @@ describe('CorrectionsPanel', () => {
           embeddingClustering: true,
           claudeMdCrossCheck: true,
         },
-      };
-      const cands = {
-        ...c,
-        corrections: [
-          { id: 'c1' },
-          { id: 'c2' },
-          { id: 'c3' },
-          { id: 'c4' },
-          { id: 'c5' },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ] as any,
-      };
-      mockedLoadCorrections.mockResolvedValue(c);
-      mockedLoadCandidates.mockResolvedValue(cands);
-      const { container } = render(
-        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
-      );
-      await waitFor(() => {
-        const figure = container.querySelector(
-          '.lcars-corrections__coverage-figure',
-        );
-        expect(figure?.textContent ?? '').toMatch(/3\s*\/\s*5\s*mined/);
       });
-      // Cut by the simplification — these strings should be absent.
-      expect(screen.queryByText('MINING PROGRESS')).toBeNull();
-      expect(screen.queryByText('ANALYSIS COVERAGE')).toBeNull();
-      expect(screen.queryByText(/Of the .* mined/)).toBeNull();
-      expect(screen.queryByText(/became actionable corrections/)).toBeNull();
-      expect(screen.queryByText(/still to mine/)).toBeNull();
-    });
-  });
-
-  // MINE ALL collapse: the recent/older split was killed in favor of a
-  // single CTA that mines every unprocessed candidate in one pass.
-  // Verify the trigger renders one status + one button, and that all
-  // the historical jargon (recent/older/backfill/auto-window) is gone.
-  describe('MiningTrigger — single MINE ALL CTA', () => {
-    it('renders one status sentence + one primary CTA with the total count', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([pattern({ id: 'p1', canonicalRule: 'rule' })]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
+      mockedLoadCandidates.mockResolvedValue({
+        generatedAt: 1_700_000_000_001,
+        // Candidates set is disjoint from corrections (retired ids).
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        corrections: [{ id: 'fresh-id' }] as any,
+        patterns: [],
+        pipeline: {
+          heuristicRecall: true,
+          llmClassification: false,
+          embeddingClustering: false,
+          claudeMdCrossCheck: false,
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        scanStats: emptyScanStats() as any,
+      });
       const { container } = render(
         <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
       );
-      // Mocked autoWindow probe returns candidateCount=12; with
-      // selection='all' on the wire, that's the full unprocessed set.
+      // Use the CoverageMeter's specific aria-label rather than a
+      // `/details/i` name match — when corrections has patterns,
+      // each card also exposes a "SHOW DETAILS" button which would
+      // shadow the meter's toggle.
+      fireEvent.click(
+        await screen.findByRole('button', { name: /show mining details/i }),
+      );
       await waitFor(() => {
         expect(
-          screen.getByRole('button', { name: /MINE ALL 12/ }),
-        ).toBeDefined();
+          container.querySelector('[aria-label^="LLM MINE stage"]'),
+        ).not.toBeNull();
       });
-      const status = container.querySelector(
-        '.lcars-corrections__trigger-status',
+      const mineStage = container.querySelector(
+        '[aria-label^="LLM MINE stage"]',
       );
-      expect(status?.textContent ?? '').toMatch(/12 ready to mine/);
-      const cta = screen.getByRole('button', { name: /MINE ALL 12/ });
-      expect(cta.getAttribute('title')).toMatch(/Mine all 12 unprocessed candidates/);
-      // Killed copy — no recent/older split, no backfill jargon, no
-      // auto-window chip, no kicker label.
-      expect(screen.queryByText('NEXT MINING PASS')).toBeNull();
-      expect(screen.queryByText('AUTO WINDOW')).toBeNull();
-      expect(screen.queryByText(/MINE\s+\d+\s+RECENT/)).toBeNull();
-      expect(screen.queryByText(/MINE\s+\d+\s+OLDER/)).toBeNull();
-      expect(screen.queryByText(/^BACKFILL OLDER/)).toBeNull();
-      expect(screen.queryByText(/← back to recent/i)).toBeNull();
-      expect(screen.queryByText(/RE-MINE CORRECTIONS/i)).toBeNull();
+      expect(mineStage?.getAttribute('data-stage-status')).toBe('done');
+      expect(mineStage?.getAttribute('aria-label')).toBe(
+        'LLM MINE stage — done',
+      );
+      expect(mineStage?.textContent ?? '').not.toMatch(/pending/);
     });
   });
 });

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -168,9 +168,9 @@ describe('CorrectionsPanel', () => {
     mockedLoadCandidates.mockResolvedValue(null);
     render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
     await waitFor(() => {
-      expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
+      expect(screen.getByLabelText(/^UNTAGGED/)).toBeDefined();
     });
-    const untagged = screen.getByLabelText('UNTAGGED');
+    const untagged = screen.getByLabelText(/^UNTAGGED/);
     const tool = screen.getByLabelText('TOOL USAGE');
     expect(within(untagged).getByText('pre-topic-stage rule')).toBeDefined();
     expect(within(untagged).getByText('another untagged')).toBeDefined();
@@ -372,7 +372,7 @@ describe('CorrectionsPanel', () => {
       render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
       // Untagged bucket renders (pattern has no topic field); summary does not.
       await waitFor(() => {
-        expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
+        expect(screen.getByLabelText(/^UNTAGGED/)).toBeDefined();
       });
       expect(screen.queryByLabelText('since you patched')).toBeNull();
     });
@@ -505,9 +505,9 @@ describe('CorrectionsPanel', () => {
       // recurringPostApplication=true based on the ledger entry. Verify the
       // bucket sort puts it first (recurring sorts to top within a bucket).
       await waitFor(() => {
-        expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
+        expect(screen.getByLabelText(/^UNTAGGED/)).toBeDefined();
       });
-      const bucket = screen.getByLabelText('UNTAGGED');
+      const bucket = screen.getByLabelText(/^UNTAGGED/);
       expect(within(bucket).getByText('flips into recurring')).toBeDefined();
     });
 
@@ -876,14 +876,14 @@ describe('CorrectionsPanel', () => {
       expect(scanStage?.textContent ?? '').toMatch(/EXPORTER SCAN/);
       expect(scanStage?.textContent ?? '').toMatch(/done · re-runs on SCAN LOCAL/);
       expect(mineStage?.textContent ?? '').toMatch(/LLM MINE/);
-      expect(mineStage?.textContent ?? '').toMatch(/pending · click RE-MINE CORRECTIONS/);
+      expect(mineStage?.textContent ?? '').toMatch(/pending · click MINE ALL/);
     });
 
     // Regression: after a HEURISTIC_RECALL_VERSION bump retires every
     // prior candidate, `classified` collapses to 0 (corrections live in
     // corrections.json but their ids no longer intersect candidates).
     // LLM MINE badge must still read "done" when patterns exist, or
-    // the panel lies "pending · click RE-MINE CORRECTIONS" while the
+    // the panel lies "pending · click MINE ALL to run" while the
     // Last-mined chip and pattern list contradict it.
     it('marks LLM MINE as done when patterns exist even if classified count is 0', async () => {
       mockedLoadCorrections.mockResolvedValue({
@@ -939,116 +939,4 @@ describe('CorrectionsPanel', () => {
     });
   });
 
-  // Header-row redesign: "Generated <iso>" was demoted from a row of
-  // its own to a "Last mined …" chip in the title row. Verify the chip
-  // renders relative time and keeps the absolute ISO in `title=` for
-  // debugging without polluting the layout.
-  describe('Header timestamp chip', () => {
-    it('renders the chip in the title row when corrections.json has generatedAt', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([pattern({ id: 'n1', canonicalRule: 'rule one' })]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
-      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
-      await waitFor(() => {
-        expect(screen.getByText(/Last mined/i)).toBeDefined();
-      });
-      const chip = screen.getByText(/Last mined/i);
-      // Absolute ISO survives in `title=` for tooltip / debugging.
-      expect(chip.getAttribute('title')).toMatch(/Generated 20\d\d-/);
-      // Demoted row that used to read "Generated 20...Z" should be gone.
-      expect(screen.queryByText(/^Generated 20\d\d-/)).toBeNull();
-    });
-  });
-
-  // First-principles simplification (Tight): CoverageMeter shows just
-  // the bar + one figure ("271 / 581 mined"). The label, funnel
-  // sentence, actionable %, and pattern count are gone — diagnostic
-  // info now lives only behind the "details ▸" chevron.
-  describe('CoverageMeter — Tight layout', () => {
-    it('renders just the bar + "N / M mined" figure (no label, no funnel sentence)', async () => {
-      const c: CorrectionsFile = {
-        generatedAt: 1_700_000_000_000,
-        corrections: [
-          { id: 'c1', classification: { actionable: true, ruleSummary: 'r' } },
-          { id: 'c2', classification: { actionable: false, ruleSummary: 'r' } },
-          { id: 'c3', classification: { actionable: true, ruleSummary: 'r' } },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ] as any,
-        patterns: [pattern({ id: 'p1', canonicalRule: 'pat one' })],
-        pipeline: {
-          heuristicRecall: true,
-          llmClassification: true,
-          embeddingClustering: true,
-          claudeMdCrossCheck: true,
-        },
-      };
-      const cands = {
-        ...c,
-        corrections: [
-          { id: 'c1' },
-          { id: 'c2' },
-          { id: 'c3' },
-          { id: 'c4' },
-          { id: 'c5' },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ] as any,
-      };
-      mockedLoadCorrections.mockResolvedValue(c);
-      mockedLoadCandidates.mockResolvedValue(cands);
-      const { container } = render(
-        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
-      );
-      await waitFor(() => {
-        const figure = container.querySelector(
-          '.lcars-corrections__coverage-figure',
-        );
-        expect(figure?.textContent ?? '').toMatch(/3\s*\/\s*5\s*mined/);
-      });
-      // Cut by the simplification — these strings should be absent.
-      expect(screen.queryByText('MINING PROGRESS')).toBeNull();
-      expect(screen.queryByText('ANALYSIS COVERAGE')).toBeNull();
-      expect(screen.queryByText(/Of the .* mined/)).toBeNull();
-      expect(screen.queryByText(/became actionable corrections/)).toBeNull();
-      expect(screen.queryByText(/still to mine/)).toBeNull();
-    });
-  });
-
-  // MINE ALL collapse: the recent/older split was killed in favor of a
-  // single CTA that mines every unprocessed candidate in one pass.
-  // Verify the trigger renders one status + one button, and that all
-  // the historical jargon (recent/older/backfill/auto-window) is gone.
-  describe('MiningTrigger — single MINE ALL CTA', () => {
-    it('renders one status sentence + one primary CTA with the total count', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([pattern({ id: 'p1', canonicalRule: 'rule' })]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
-      const { container } = render(
-        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
-      );
-      // Mocked autoWindow probe returns candidateCount=12; with
-      // selection='all' on the wire, that's the full unprocessed set.
-      await waitFor(() => {
-        expect(
-          screen.getByRole('button', { name: /MINE ALL 12/ }),
-        ).toBeDefined();
-      });
-      const status = container.querySelector(
-        '.lcars-corrections__trigger-status',
-      );
-      expect(status?.textContent ?? '').toMatch(/12 ready to mine/);
-      const cta = screen.getByRole('button', { name: /MINE ALL 12/ });
-      expect(cta.getAttribute('title')).toMatch(/Mine all 12 unprocessed candidates/);
-      // Killed copy — no recent/older split, no backfill jargon, no
-      // auto-window chip, no kicker label.
-      expect(screen.queryByText('NEXT MINING PASS')).toBeNull();
-      expect(screen.queryByText('AUTO WINDOW')).toBeNull();
-      expect(screen.queryByText(/MINE\s+\d+\s+RECENT/)).toBeNull();
-      expect(screen.queryByText(/MINE\s+\d+\s+OLDER/)).toBeNull();
-      expect(screen.queryByText(/^BACKFILL OLDER/)).toBeNull();
-      expect(screen.queryByText(/← back to recent/i)).toBeNull();
-      expect(screen.queryByText(/RE-MINE CORRECTIONS/i)).toBeNull();
-    });
-  });
 });

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -125,7 +125,13 @@ describe('CorrectionsPanel', () => {
     await waitFor(() => {
       expect(screen.getByText(/4 candidates ready to mine/i)).toBeDefined();
     });
-    expect(screen.getByRole('button', { name: /MINE CORRECTIONS/i })).toBeDefined();
+    // The mocked autoWindow probe returns count=12, so the single
+    // primary CTA renders "MINE ALL 12".
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /MINE ALL 12/ }),
+      ).toBeDefined();
+    });
   });
 
   it('sorts patterns into the three buckets correctly', async () => {
@@ -445,6 +451,119 @@ describe('CorrectionsPanel', () => {
       });
       // Hosted-only label must not be present.
       expect(screen.queryByLabelText('TOLD NOT TO, STILL DOES IT')).toBeNull();
+    });
+  });
+
+  // Header-row redesign: "Generated <iso>" was demoted from a row of
+  // its own to a "Last mined …" chip in the title row. Verify the chip
+  // renders relative time and keeps the absolute ISO in `title=` for
+  // debugging without polluting the layout.
+  describe('Header timestamp chip', () => {
+    it('renders the chip in the title row when corrections.json has generatedAt', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([pattern({ id: 'n1', canonicalRule: 'rule one' })]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByText(/Last mined/i)).toBeDefined();
+      });
+      const chip = screen.getByText(/Last mined/i);
+      // Absolute ISO survives in `title=` for tooltip / debugging.
+      expect(chip.getAttribute('title')).toMatch(/Generated 20\d\d-/);
+      // Demoted row that used to read "Generated 20...Z" should be gone.
+      expect(screen.queryByText(/^Generated 20\d\d-/)).toBeNull();
+    });
+  });
+
+  // First-principles simplification (Tight): CoverageMeter shows just
+  // the bar + one figure ("271 / 581 mined"). The label, funnel
+  // sentence, actionable %, and pattern count are gone — diagnostic
+  // info now lives only behind the "details ▸" chevron.
+  describe('CoverageMeter — Tight layout', () => {
+    it('renders just the bar + "N / M mined" figure (no label, no funnel sentence)', async () => {
+      const c: CorrectionsFile = {
+        generatedAt: 1_700_000_000_000,
+        corrections: [
+          { id: 'c1', classification: { actionable: true, ruleSummary: 'r' } },
+          { id: 'c2', classification: { actionable: false, ruleSummary: 'r' } },
+          { id: 'c3', classification: { actionable: true, ruleSummary: 'r' } },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+        patterns: [pattern({ id: 'p1', canonicalRule: 'pat one' })],
+        pipeline: {
+          heuristicRecall: true,
+          llmClassification: true,
+          embeddingClustering: true,
+          claudeMdCrossCheck: true,
+        },
+      };
+      const cands = {
+        ...c,
+        corrections: [
+          { id: 'c1' },
+          { id: 'c2' },
+          { id: 'c3' },
+          { id: 'c4' },
+          { id: 'c5' },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+      };
+      mockedLoadCorrections.mockResolvedValue(c);
+      mockedLoadCandidates.mockResolvedValue(cands);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      await waitFor(() => {
+        const figure = container.querySelector(
+          '.lcars-corrections__coverage-figure',
+        );
+        expect(figure?.textContent ?? '').toMatch(/3\s*\/\s*5\s*mined/);
+      });
+      // Cut by the simplification — these strings should be absent.
+      expect(screen.queryByText('MINING PROGRESS')).toBeNull();
+      expect(screen.queryByText('ANALYSIS COVERAGE')).toBeNull();
+      expect(screen.queryByText(/Of the .* mined/)).toBeNull();
+      expect(screen.queryByText(/became actionable corrections/)).toBeNull();
+      expect(screen.queryByText(/still to mine/)).toBeNull();
+    });
+  });
+
+  // MINE ALL collapse: the recent/older split was killed in favor of a
+  // single CTA that mines every unprocessed candidate in one pass.
+  // Verify the trigger renders one status + one button, and that all
+  // the historical jargon (recent/older/backfill/auto-window) is gone.
+  describe('MiningTrigger — single MINE ALL CTA', () => {
+    it('renders one status sentence + one primary CTA with the total count', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([pattern({ id: 'p1', canonicalRule: 'rule' })]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      // Mocked autoWindow probe returns candidateCount=12; with
+      // selection='all' on the wire, that's the full unprocessed set.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /MINE ALL 12/ }),
+        ).toBeDefined();
+      });
+      const status = container.querySelector(
+        '.lcars-corrections__trigger-status',
+      );
+      expect(status?.textContent ?? '').toMatch(/12 ready to mine/);
+      const cta = screen.getByRole('button', { name: /MINE ALL 12/ });
+      expect(cta.getAttribute('title')).toMatch(/Mine all 12 unprocessed candidates/);
+      // Killed copy — no recent/older split, no backfill jargon, no
+      // auto-window chip, no kicker label.
+      expect(screen.queryByText('NEXT MINING PASS')).toBeNull();
+      expect(screen.queryByText('AUTO WINDOW')).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+RECENT/)).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+OLDER/)).toBeNull();
+      expect(screen.queryByText(/^BACKFILL OLDER/)).toBeNull();
+      expect(screen.queryByText(/← back to recent/i)).toBeNull();
+      expect(screen.queryByText(/RE-MINE CORRECTIONS/i)).toBeNull();
     });
   });
 });

--- a/packages/viewer/src/components/CorrectionsPanel.test.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.test.tsx
@@ -71,6 +71,7 @@ function pattern(overrides: Partial<CorrectionPattern> & { id: string }): Correc
     confidence: overrides.confidence ?? 0.5,
     recurringPostApplication: overrides.recurringPostApplication ?? false,
     alreadyEncoded: overrides.alreadyEncoded ?? false,
+    ...(overrides.topic !== undefined ? { topic: overrides.topic } : {}),
   };
 }
 
@@ -134,74 +135,231 @@ describe('CorrectionsPanel', () => {
     });
   });
 
-  it('sorts patterns into the three buckets correctly', async () => {
+  it('groups patterns into buckets by topic, label uppercased', async () => {
     const patterns = [
-      pattern({ id: 'r1', canonicalRule: 'recurring rule', recurringPostApplication: true }),
-      pattern({ id: 'e1', canonicalRule: 'encoded rule', alreadyEncoded: true }),
-      pattern({ id: 'n1', canonicalRule: 'new rule' }),
-      // recurring + alreadyEncoded → still RECURRING (it's the stronger signal).
+      pattern({ id: 'g1', canonicalRule: 'git rule a', topic: 'Git Workflow' }),
+      pattern({ id: 't1', canonicalRule: 'test rule a', topic: 'Test Discipline' }),
+      pattern({ id: 'g2', canonicalRule: 'git rule b', topic: 'Git Workflow' }),
+    ];
+    mockedLoadCorrections.mockResolvedValue(file(patterns));
+    mockedLoadCandidates.mockResolvedValue(null);
+    render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('GIT WORKFLOW')).toBeDefined();
+    });
+    const git = screen.getByLabelText('GIT WORKFLOW');
+    const test = screen.getByLabelText('TEST DISCIPLINE');
+
+    expect(within(git).getByText('git rule a')).toBeDefined();
+    expect(within(git).getByText('git rule b')).toBeDefined();
+    expect(within(test).getByText('test rule a')).toBeDefined();
+    // No leakage across topics.
+    expect(within(git).queryByText('test rule a')).toBeNull();
+    expect(within(test).queryByText('git rule a')).toBeNull();
+  });
+
+  it('falls back to an UNTAGGED bucket for patterns without a topic field', async () => {
+    const patterns = [
+      pattern({ id: 'a', canonicalRule: 'pre-topic-stage rule' }),
+      pattern({ id: 'b', canonicalRule: 'another untagged', topic: '' }),
+      pattern({ id: 'c', canonicalRule: 'tagged rule', topic: 'Tool Usage' }),
+    ];
+    mockedLoadCorrections.mockResolvedValue(file(patterns));
+    mockedLoadCandidates.mockResolvedValue(null);
+    render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+    await waitFor(() => {
+      expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
+    });
+    const untagged = screen.getByLabelText('UNTAGGED');
+    const tool = screen.getByLabelText('TOOL USAGE');
+    expect(within(untagged).getByText('pre-topic-stage rule')).toBeDefined();
+    expect(within(untagged).getByText('another untagged')).toBeDefined();
+    expect(within(tool).getByText('tagged rule')).toBeDefined();
+  });
+
+  it('orders buckets: topics with recurring patterns first, then by total weight desc', async () => {
+    const patterns = [
+      // Heavy non-recurring bucket — would win on weight alone.
+      pattern({ id: 'h1', topic: 'Heavy', canonicalRule: 'heavy 1', occurrenceCount: 20 }),
+      pattern({ id: 'h2', topic: 'Heavy', canonicalRule: 'heavy 2', occurrenceCount: 20 }),
+      // Light bucket with a single RECURRING pattern — must hoist above Heavy.
       pattern({
-        id: 'r2',
-        canonicalRule: 'recurring and encoded',
+        id: 'r1',
+        topic: 'Recurring Topic',
+        canonicalRule: 'recurring',
         recurringPostApplication: true,
-        alreadyEncoded: true,
+        occurrenceCount: 3,
+      }),
+      // Medium-weight bucket between them.
+      pattern({ id: 'm1', topic: 'Medium', canonicalRule: 'medium', occurrenceCount: 10 }),
+    ];
+    mockedLoadCorrections.mockResolvedValue(file(patterns));
+    mockedLoadCandidates.mockResolvedValue(null);
+    const { container } = render(
+      <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+    );
+    await waitFor(() => {
+      expect(screen.getByLabelText('RECURRING TOPIC')).toBeDefined();
+    });
+    const sections = Array.from(
+      container.querySelectorAll('.lcars-corrections__buckets > section'),
+    ).map((s) => s.getAttribute('aria-label'));
+    expect(sections).toEqual(['RECURRING TOPIC', 'HEAVY', 'MEDIUM']);
+  });
+
+  it('within a bucket: recurring sorts first, then by confidence desc', async () => {
+    const patterns = [
+      pattern({
+        id: 'low',
+        topic: 'T',
+        canonicalRule: 'low confidence',
+        confidence: 0.2,
+        occurrenceCount: 9,
+      }),
+      pattern({
+        id: 'hi',
+        topic: 'T',
+        canonicalRule: 'high confidence',
+        confidence: 0.95,
+        occurrenceCount: 3,
+      }),
+      pattern({
+        id: 'rec',
+        topic: 'T',
+        canonicalRule: 'recurring even with low confidence',
+        confidence: 0.3,
+        occurrenceCount: 4,
+        recurringPostApplication: true,
       }),
     ];
     mockedLoadCorrections.mockResolvedValue(file(patterns));
     mockedLoadCandidates.mockResolvedValue(null);
     render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
     await waitFor(() => {
-      expect(screen.getByLabelText('RECURRING AFTER APPLIED')).toBeDefined();
+      expect(screen.getByLabelText('T')).toBeDefined();
     });
-    const recurring = screen.getByLabelText('RECURRING AFTER APPLIED');
-    const encoded = screen.getByLabelText('ALREADY ENCODED BUT FAILING');
-    const fresh = screen.getByLabelText('NEW PATTERNS TO ENCODE');
-
-    expect(within(recurring).getByText('recurring rule')).toBeDefined();
-    expect(within(recurring).getByText('recurring and encoded')).toBeDefined();
-    expect(within(encoded).getByText('encoded rule')).toBeDefined();
-    expect(within(fresh).getByText('new rule')).toBeDefined();
-
-    // No leakage between buckets.
-    expect(within(recurring).queryByText('encoded rule')).toBeNull();
-    expect(within(encoded).queryByText('recurring rule')).toBeNull();
-    expect(within(fresh).queryByText('encoded rule')).toBeNull();
-  });
-
-  it('sorts patterns within a bucket by confidence desc, then occurrenceCount desc', async () => {
-    const patterns = [
-      pattern({ id: 'low', canonicalRule: 'low confidence', confidence: 0.2, occurrenceCount: 9 }),
-      pattern({ id: 'hi', canonicalRule: 'high confidence', confidence: 0.95, occurrenceCount: 3 }),
-      pattern({ id: 'mid-a', canonicalRule: 'mid a', confidence: 0.5, occurrenceCount: 5 }),
-      pattern({ id: 'mid-b', canonicalRule: 'mid b', confidence: 0.5, occurrenceCount: 8 }),
-    ];
-    mockedLoadCorrections.mockResolvedValue(file(patterns));
-    mockedLoadCandidates.mockResolvedValue(null);
-    render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
-    await waitFor(() => {
-      expect(screen.getByText('NEW PATTERNS TO ENCODE')).toBeDefined();
-    });
-    const fresh = screen.getByLabelText('NEW PATTERNS TO ENCODE');
+    const bucket = screen.getByLabelText('T');
     const titles = Array.from(
-      fresh.querySelectorAll('.lcars-correction-pattern__rule'),
+      bucket.querySelectorAll('.lcars-correction-pattern__rule'),
     ).map((el) => el.textContent);
-    // confidence: 0.95, 0.5 (count 8), 0.5 (count 5), 0.2.
-    expect(titles).toEqual(['high confidence', 'mid b', 'mid a', 'low confidence']);
+    // recurring → first; rest by confidence desc.
+    expect(titles).toEqual([
+      'recurring even with low confidence',
+      'high confidence',
+      'low confidence',
+    ]);
   });
 
-  it('renders the "Nothing here — good." placeholder for empty buckets', async () => {
+  // Codex review feedback on PR #32: the dropped `--recurring|encoded|new`
+  // modifier classes used to drive bucket border + background + title
+  // color (signal-based urgency). With dynamic topics those hardcodes
+  // don't fit, but the urgency signal still lives on every pattern as
+  // `recurringPostApplication` / `alreadyEncoded`. The replacement is
+  // `data-has-recurring` / `data-has-encoded` attribute hooks that the
+  // stylesheet now keys off. These tests lock the contract.
+  describe('bucket urgency attributes', () => {
+    it('flags data-has-recurring=true when the bucket contains a recurring pattern', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'r1',
+            topic: 'Git Workflow',
+            canonicalRule: 'a recurring rule',
+            recurringPostApplication: true,
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('GIT WORKFLOW')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('GIT WORKFLOW');
+      expect(bucket.getAttribute('data-has-recurring')).toBe('true');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('false');
+    });
+
+    it('flags data-has-encoded=true when the bucket has an encoded-but-not-recurring pattern', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'e1',
+            topic: 'Tool Usage',
+            canonicalRule: 'encoded',
+            alreadyEncoded: true,
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('TOOL USAGE')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('TOOL USAGE');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('true');
+      expect(bucket.getAttribute('data-has-recurring')).toBe('false');
+    });
+
+    it('prefers data-has-recurring when a bucket has both signals (recurring wins)', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'r-and-e',
+            topic: 'Mixed',
+            canonicalRule: 'recurring + encoded',
+            recurringPostApplication: true,
+            alreadyEncoded: true,
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('MIXED')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('MIXED');
+      // Builder records `recurring` and skips the `encoded` branch
+      // (else-if). CSS rule order also ensures the recurring style
+      // wins when both attributes are 'true' on the same element.
+      expect(bucket.getAttribute('data-has-recurring')).toBe('true');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('false');
+    });
+
+    it('flags both attributes as false for plain non-urgent buckets', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([
+          pattern({
+            id: 'plain',
+            topic: 'New Stuff',
+            canonicalRule: 'just a new pattern',
+          }),
+        ]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('NEW STUFF')).toBeDefined();
+      });
+      const bucket = screen.getByLabelText('NEW STUFF');
+      expect(bucket.getAttribute('data-has-recurring')).toBe('false');
+      expect(bucket.getAttribute('data-has-encoded')).toBe('false');
+    });
+  });
+
+  it('does not render empty-bucket placeholders (no Nothing here — good.)', async () => {
     mockedLoadCorrections.mockResolvedValue(
-      file([pattern({ id: 'n1', canonicalRule: 'only a new pattern' })]),
+      file([pattern({ id: 'n1', canonicalRule: 'only one', topic: 'Solo' })]),
     );
     mockedLoadCandidates.mockResolvedValue(null);
     render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
     await waitFor(() => {
-      expect(screen.getByText('NEW PATTERNS TO ENCODE')).toBeDefined();
+      expect(screen.getByLabelText('SOLO')).toBeDefined();
     });
-    const recurring = screen.getByLabelText('RECURRING AFTER APPLIED');
-    const encoded = screen.getByLabelText('ALREADY ENCODED BUT FAILING');
-    expect(within(recurring).getByText('Nothing here — good.')).toBeDefined();
-    expect(within(encoded).getByText('Nothing here — good.')).toBeDefined();
+    // Only one section renders; the old empty-bucket placeholder is gone.
+    expect(screen.queryByText(/Nothing here/i)).toBeNull();
+    expect(screen.queryByLabelText('RECURRING AFTER APPLIED')).toBeNull();
+    expect(screen.queryByLabelText('ALREADY ENCODED BUT FAILING')).toBeNull();
+    expect(screen.queryByLabelText('NEW PATTERNS TO ENCODE')).toBeNull();
   });
 
   describe('AppliedImprovementsSummary mount (Phase 2b)', () => {
@@ -212,8 +370,9 @@ describe('CorrectionsPanel', () => {
       mockedLoadCandidates.mockResolvedValue(null);
       mockedLoadApplied.mockResolvedValue(null);
       render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      // Untagged bucket renders (pattern has no topic field); summary does not.
       await waitFor(() => {
-        expect(screen.getByText('NEW PATTERNS TO ENCODE')).toBeDefined();
+        expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
       });
       expect(screen.queryByLabelText('since you patched')).toBeNull();
     });
@@ -341,12 +500,15 @@ describe('CorrectionsPanel', () => {
         ],
       });
       render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
+      // The pattern lands in the UNTAGGED bucket (no topic) but should now
+      // bear the recurring signal — the merge layer flipped
+      // recurringPostApplication=true based on the ledger entry. Verify the
+      // bucket sort puts it first (recurring sorts to top within a bucket).
       await waitFor(() => {
-        const recurring = screen.getByLabelText('RECURRING AFTER APPLIED');
-        expect(within(recurring).getByText('flips into recurring')).toBeDefined();
+        expect(screen.getByLabelText('UNTAGGED')).toBeDefined();
       });
-      const fresh = screen.getByLabelText('NEW PATTERNS TO ENCODE');
-      expect(within(fresh).queryByText('flips into recurring')).toBeNull();
+      const bucket = screen.getByLabelText('UNTAGGED');
+      expect(within(bucket).getByText('flips into recurring')).toBeDefined();
     });
 
     it('treats applied: true on the merged upgrade as initial APPLIED state', async () => {
@@ -396,61 +558,122 @@ describe('CorrectionsPanel', () => {
     });
   });
 
-  // Phase 4 — when CorrectionsPanel renders on a hosted static build
-  // (rescanAvailable=false), the bucket header copy explicitly
-  // referencing CLAUDE.md / "ship it" is meaningless to a non-developer
-  // visitor on chat-arch.dev. Verify the reframed labels + blurbs land.
-  describe('Phase 4 — hosted demo blurbs (rescanAvailable=false)', () => {
-    it('reframes the encoded bucket label + blurb to avoid CLAUDE.md jargon', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([
-          pattern({ id: 'e1', canonicalRule: 'demo encoded', alreadyEncoded: true }),
-        ]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
-      // No rescanAvailable → defaults to false → hosted-demo blurbs.
-      render(<CorrectionsPanel dataDirBaseUrl="/x" />);
-      await waitFor(() => {
-        expect(screen.getByLabelText('TOLD NOT TO, STILL DOES IT')).toBeDefined();
-      });
-      const bucket = screen.getByLabelText('TOLD NOT TO, STILL DOES IT');
-      // Multiple elements may match (the title + the blurb both
-      // contain the phrase); presence of any is enough.
-      expect(within(bucket).getAllByText(/told not to/i).length).toBeGreaterThan(0);
-      // Canonical CLAUDE.md jargon must not leak into the demo copy.
-      expect(within(bucket).queryByText(/already exists in CLAUDE\.md/i)).toBeNull();
-    });
+  // The Phase 4 hosted-demo blurb relabeling is gone — fixed taxonomy
+  // (RECURRING / ENCODED / NEW) was replaced with LLM-derived dynamic
+  // topic buckets, so there's no per-host bucket copy to reframe.
+  // The hosted demo fixture in `demoUpload.ts` now ships its own
+  // topic assignments and renders identically to local mining output.
 
-    it('reframes the recurring bucket label to "STILL FAILING AFTER A FIX"', async () => {
+  // Header-row redesign: "Generated <iso>" was demoted from a row of
+  // its own to a "Last mined …" chip in the title row. Verify the chip
+  // renders relative time and keeps the absolute ISO in `title=` for
+  // debugging without polluting the layout.
+  describe('Header timestamp chip', () => {
+    it('renders the chip in the title row when corrections.json has generatedAt', async () => {
       mockedLoadCorrections.mockResolvedValue(
-        file([
-          pattern({
-            id: 'r1',
-            canonicalRule: 'demo recurring',
-            recurringPostApplication: true,
-          }),
-        ]),
-      );
-      mockedLoadCandidates.mockResolvedValue(null);
-      render(<CorrectionsPanel dataDirBaseUrl="/x" />);
-      await waitFor(() => {
-        expect(screen.getByLabelText('STILL FAILING AFTER A FIX')).toBeDefined();
-      });
-    });
-
-    it('keeps the canonical labels when rescanAvailable=true (local dev)', async () => {
-      mockedLoadCorrections.mockResolvedValue(
-        file([
-          pattern({ id: 'e1', canonicalRule: 'local encoded', alreadyEncoded: true }),
-        ]),
+        file([pattern({ id: 'n1', canonicalRule: 'rule one' })]),
       );
       mockedLoadCandidates.mockResolvedValue(null);
       render(<CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />);
       await waitFor(() => {
-        expect(screen.getByLabelText('ALREADY ENCODED BUT FAILING')).toBeDefined();
+        expect(screen.getByText(/Last mined/i)).toBeDefined();
       });
-      // Hosted-only label must not be present.
-      expect(screen.queryByLabelText('TOLD NOT TO, STILL DOES IT')).toBeNull();
+      const chip = screen.getByText(/Last mined/i);
+      // Absolute ISO survives in `title=` for tooltip / debugging.
+      expect(chip.getAttribute('title')).toMatch(/Generated 20\d\d-/);
+      // Demoted row that used to read "Generated 20...Z" should be gone.
+      expect(screen.queryByText(/^Generated 20\d\d-/)).toBeNull();
+    });
+  });
+
+  // First-principles simplification (Tight): CoverageMeter shows just
+  // the bar + one figure ("271 / 581 mined"). The label, funnel
+  // sentence, actionable %, and pattern count are gone — diagnostic
+  // info now lives only behind the "details ▸" chevron.
+  describe('CoverageMeter — Tight layout', () => {
+    it('renders just the bar + "N / M mined" figure (no label, no funnel sentence)', async () => {
+      const c: CorrectionsFile = {
+        generatedAt: 1_700_000_000_000,
+        corrections: [
+          { id: 'c1', classification: { actionable: true, ruleSummary: 'r' } },
+          { id: 'c2', classification: { actionable: false, ruleSummary: 'r' } },
+          { id: 'c3', classification: { actionable: true, ruleSummary: 'r' } },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+        patterns: [pattern({ id: 'p1', canonicalRule: 'pat one' })],
+        pipeline: {
+          heuristicRecall: true,
+          llmClassification: true,
+          embeddingClustering: true,
+          claudeMdCrossCheck: true,
+        },
+      };
+      const cands = {
+        ...c,
+        corrections: [
+          { id: 'c1' },
+          { id: 'c2' },
+          { id: 'c3' },
+          { id: 'c4' },
+          { id: 'c5' },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ] as any,
+      };
+      mockedLoadCorrections.mockResolvedValue(c);
+      mockedLoadCandidates.mockResolvedValue(cands);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      await waitFor(() => {
+        const figure = container.querySelector(
+          '.lcars-corrections__coverage-figure',
+        );
+        expect(figure?.textContent ?? '').toMatch(/3\s*\/\s*5\s*mined/);
+      });
+      // Cut by the simplification — these strings should be absent.
+      expect(screen.queryByText('MINING PROGRESS')).toBeNull();
+      expect(screen.queryByText('ANALYSIS COVERAGE')).toBeNull();
+      expect(screen.queryByText(/Of the .* mined/)).toBeNull();
+      expect(screen.queryByText(/became actionable corrections/)).toBeNull();
+      expect(screen.queryByText(/still to mine/)).toBeNull();
+    });
+  });
+
+  // MINE ALL collapse: the recent/older split was killed in favor of a
+  // single CTA that mines every unprocessed candidate in one pass.
+  // Verify the trigger renders one status + one button, and that all
+  // the historical jargon (recent/older/backfill/auto-window) is gone.
+  describe('MiningTrigger — single MINE ALL CTA', () => {
+    it('renders one status sentence + one primary CTA with the total count', async () => {
+      mockedLoadCorrections.mockResolvedValue(
+        file([pattern({ id: 'p1', canonicalRule: 'rule' })]),
+      );
+      mockedLoadCandidates.mockResolvedValue(null);
+      const { container } = render(
+        <CorrectionsPanel dataDirBaseUrl="/x" rescanAvailable />,
+      );
+      // Mocked autoWindow probe returns candidateCount=12; with
+      // selection='all' on the wire, that's the full unprocessed set.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /MINE ALL 12/ }),
+        ).toBeDefined();
+      });
+      const status = container.querySelector(
+        '.lcars-corrections__trigger-status',
+      );
+      expect(status?.textContent ?? '').toMatch(/12 ready to mine/);
+      const cta = screen.getByRole('button', { name: /MINE ALL 12/ });
+      expect(cta.getAttribute('title')).toMatch(/Mine all 12 unprocessed candidates/);
+      // Killed copy — no recent/older split, no backfill jargon, no
+      // auto-window chip, no kicker label.
+      expect(screen.queryByText('NEXT MINING PASS')).toBeNull();
+      expect(screen.queryByText('AUTO WINDOW')).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+RECENT/)).toBeNull();
+      expect(screen.queryByText(/MINE\s+\d+\s+OLDER/)).toBeNull();
+      expect(screen.queryByText(/^BACKFILL OLDER/)).toBeNull();
+      expect(screen.queryByText(/← back to recent/i)).toBeNull();
+      expect(screen.queryByText(/RE-MINE CORRECTIONS/i)).toBeNull();
     });
   });
 

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -30,6 +30,7 @@ import {
   type ApplyCorrectionRequest,
 } from '../data/applyCorrectionClient.js';
 import type { ProposedUpgrade } from '@chat-arch/schema';
+import { formatRelative } from '../util/time.js';
 
 export interface CorrectionsPanelProps {
   /** Same base URL the manifest was fetched from (e.g. "/chat-arch-data"). */
@@ -188,6 +189,16 @@ function formatGenerated(ms: number): string {
   }
 }
 
+/**
+ * Header timestamp formatter. Uses the shared relative-time util so
+ * the chip reads "2d ago" instead of an ISO blob; the absolute ISO
+ * survives in the surrounding `title=` tooltip for debug use.
+ */
+function relativeGenerated(ms: number): string {
+  if (!Number.isFinite(ms)) return 'unknown';
+  return formatRelative(ms);
+}
+
 type ClearState =
   | { status: 'idle' }
   | { status: 'armed' }
@@ -231,10 +242,13 @@ export function CorrectionsPanel({
     };
   }, []);
 
-  const [selection, setSelection] = useState<'recent' | 'backfill'>('recent');
+  // Single-CTA mining (per the "MINE ALL" UX): selection is always 'all'.
+  // The backend's recent/backfill split still exists for future power-user
+  // surfaces but is no longer driven by this panel.
+  const [selection] = useState<'recent' | 'backfill' | 'all'>('all');
 
   const refreshAutoWindow = useCallback(
-    async (sel: 'recent' | 'backfill' = selection) => {
+    async (sel: 'recent' | 'backfill' | 'all' = selection) => {
       const probe = await probeMineCorrections(undefined, sel);
       if (!aliveRef.current) return;
       setAutoWindow(probe?.autoWindow ?? null);
@@ -517,14 +531,13 @@ export function CorrectionsPanel({
       return;
     }
     setMining({ status: 'idle' });
-    setSelection('recent');
     await refresh();
   }, [refresh, selection]);
 
   if (load.status === 'loading') {
     return (
       <section className="lcars-corrections" aria-label="corrections">
-        <Header hostedDemo={!rescanAvailable} />
+        <Header />
         <p className="lcars-corrections__lead">Loading corrections…</p>
       </section>
     );
@@ -533,7 +546,7 @@ export function CorrectionsPanel({
   if (load.status === 'error') {
     return (
       <section className="lcars-corrections" aria-label="corrections">
-        <Header hostedDemo={!rescanAvailable} />
+        <Header />
         <div className="lcars-corrections__error" role="alert">
           <p>Could not load corrections: {load.message}</p>
           <button
@@ -584,7 +597,6 @@ export function CorrectionsPanel({
   return (
     <section className="lcars-corrections" aria-label="corrections">
       <Header
-        hostedDemo={!rescanAvailable}
         {...(typeof corrections?.generatedAt === 'number'
           ? { generatedAt: corrections.generatedAt }
           : {})}
@@ -707,17 +719,8 @@ export function CorrectionsPanel({
           hasCorrections={hasCorrections}
           candidateCount={candidateCount}
           autoWindow={autoWindow}
-          selection={selection}
           onArm={() => setMining({ status: 'armed' })}
           onRefreshAutoWindow={() => void refreshAutoWindow()}
-          onSwitchToBackfill={() => {
-            setSelection('backfill');
-            void refreshAutoWindow('backfill');
-          }}
-          onSwitchToRecent={() => {
-            setSelection('recent');
-            void refreshAutoWindow('recent');
-          }}
           rescanAvailable={rescanAvailable}
         />
       )}
@@ -801,53 +804,31 @@ function CoverageMeter({ coverage }: CoverageMeterProps) {
   const { total, classified, actionable, patterns, scanStats } = coverage;
   const [expanded, setExpanded] = useState(false);
   const pct = total === 0 ? 0 : Math.round((classified / total) * 100);
-  const remaining = Math.max(0, total - classified);
-  const actionablePct =
-    classified === 0 ? 0 : Math.round((actionable / classified) * 100);
 
   return (
     <div
       className="lcars-corrections__coverage"
       role="group"
-      aria-label="analysis coverage"
+      aria-label="mining progress"
     >
-      <div className="lcars-corrections__coverage-row">
-        <span className="lcars-corrections__coverage-label">
-          ANALYSIS COVERAGE
-        </span>
-        <span className="lcars-corrections__coverage-figure">
-          <strong>{fmt(classified)}</strong> / {fmt(total)} candidates
-          classified · {pct}%
-        </span>
-      </div>
       <div
         className="lcars-corrections__coverage-bar"
         role="progressbar"
         aria-valuenow={pct}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-valuetext={`${classified} of ${total} candidates classified`}
+        aria-valuetext={`${classified} of ${total} candidates mined`}
       >
         <span
           className="lcars-corrections__coverage-fill"
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="lcars-corrections__coverage-funnel">
-        {classified > 0 ? (
-          <>
-            <strong>{fmt(actionable)}</strong> actionable ({actionablePct}% of
-            classified) · <strong>{fmt(patterns)}</strong>{' '}
-            {patterns === 1 ? 'pattern' : 'patterns'} surfaced ·{' '}
-            <strong>{fmt(remaining)}</strong> unmined
-          </>
-        ) : (
-          <>
-            <strong>{fmt(remaining)}</strong> candidate
-            {remaining === 1 ? '' : 's'} unmined — no LLM pass run yet.
-          </>
-        )}
-      </p>
+      <div className="lcars-corrections__coverage-row">
+        <span className="lcars-corrections__coverage-figure">
+          <strong>{fmt(classified)}</strong> / {fmt(total)} mined
+        </span>
+      </div>
       {scanStats !== null && (
         <button
           type="button"
@@ -855,18 +836,9 @@ function CoverageMeter({ coverage }: CoverageMeterProps) {
           onClick={() => setExpanded((v) => !v)}
           aria-expanded={expanded}
           aria-controls="lcars-corrections-pipeline-detail"
-          aria-label={`pipeline funnel: ${fmt(scanStats.sessionsScanned)} transcripts produced ${fmt(scanStats.survivingTurns)} prompts producing ${fmt(total)} candidates. ${expanded ? 'Hide' : 'Show'} details.`}
+          aria-label={`${expanded ? 'Hide' : 'Show'} mining details`}
         >
-          <span aria-hidden="true">
-            {fmt(scanStats.sessionsScanned)} transcripts →{' '}
-            {fmt(scanStats.survivingTurns)} prompts → {fmt(total)} candidates
-          </span>
-          <span
-            className="lcars-corrections__coverage-chevron"
-            aria-hidden="true"
-          >
-            {expanded ? '▾' : '▸'}
-          </span>
+          <span aria-hidden="true">{expanded ? '▾' : '▸'} details</span>
         </button>
       )}
       {scanStats !== null && expanded && (
@@ -902,40 +874,48 @@ function CoverageDetail({
     'cowork',
     'cloud',
   ];
-  const absent: string[] = [];
-  for (const s of knownSources) {
-    if ((scanStats.sessionsBySource[s] ?? 0) === 0) absent.push(s);
-  }
 
   return (
     <div
       id="lcars-corrections-pipeline-detail"
       className="lcars-corrections__coverage-detail"
     >
-      {(scanStats.sessionsMissing > 0 || absent.length > 0) && (
-        <div className="lcars-corrections__pipeline">
-          <span className="lcars-corrections__pipeline-label">NOT SCANNED</span>
-          <ul className="lcars-corrections__pipeline-list">
-            {Object.entries(scanStats.sessionsMissingBySource).map(
-              ([source, n]) => (
-                <li key={`miss-${source}`}>
-                  <strong>{fmt(n)}</strong> {SOURCE_LABEL[source] ?? source}{' '}
-                  sessions — no transcript file on disk (stub entries from
-                  aborted/deleted sessions)
-                </li>
-              ),
-            )}
-            {absent.map((source) => (
-              <li key={`absent-${source}`}>
-                <strong>0</strong> {SOURCE_LABEL[source] ?? source} sessions —
-                {source === 'cloud'
-                  ? ' no claude.ai export loaded'
-                  : ' source not present in this corpus'}
+      <div className="lcars-corrections__pipeline">
+        <span className="lcars-corrections__pipeline-label">SCANNED</span>
+        <span className="lcars-corrections__pipeline-sublabel">
+          transcripts read · indexed in manifest
+        </span>
+        <ul className="lcars-corrections__pipeline-list">
+          {knownSources.map((source) => {
+            const total = scanStats.sessionsBySource[source] ?? 0;
+            const missing = scanStats.sessionsMissingBySource[source] ?? 0;
+            const scanned = Math.max(0, total - missing);
+            const note =
+              total === 0
+                ? source === 'cloud'
+                  ? 'no claude.ai export loaded'
+                  : 'not present in this corpus'
+                : missing > 0
+                  ? `${fmt(missing)} indexed but transcript file not on disk — usually deleted or aborted sessions`
+                  : null;
+            return (
+              <li key={`scan-${source}`}>
+                <span className="lcars-corrections__pipeline-source">
+                  {SOURCE_LABEL[source] ?? source}
+                </span>{' '}
+                <strong>
+                  {fmt(scanned)} / {fmt(total)}
+                </strong>
+                {note && (
+                  <span className="lcars-corrections__pipeline-note">
+                    {note}
+                  </span>
+                )}
               </li>
-            ))}
-          </ul>
-        </div>
-      )}
+            );
+          })}
+        </ul>
+      </div>
       <div className="lcars-corrections__pipeline">
         <span className="lcars-corrections__pipeline-label">PIPELINE</span>
         <ul className="lcars-corrections__pipeline-list">
@@ -1103,43 +1083,23 @@ function DangerZone({
 
 interface HeaderProps {
   generatedAt?: number;
-  /**
-   * Phase 4 P0.3: when true, the panel is showing demo data on a
-   * hosted static build (no `/api/mine-corrections`, no apply ledger
-   * back end). Swap the developer-y lead copy ("log a CLAUDE.md edit",
-   * "next mining pass", "applied-improvements.json") for plain
-   * language that explains what corrections ARE — matching the
-   * hosted-demo bucket blurbs above.
-   */
-  hostedDemo?: boolean;
 }
 
-function Header({ generatedAt, hostedDemo = false }: HeaderProps) {
+function Header({ generatedAt }: HeaderProps) {
+  const hasTime = typeof generatedAt === 'number';
   return (
     <header className="lcars-corrections__header">
-      <h2 className="lcars-corrections__title">CORRECTIONS</h2>
-      <p className="lcars-corrections__lead">
-        {hostedDemo ? (
-          <>
-            These are corrections — moments where Claude broke a rule you set, clustered into
-            patterns. Patterns marked <strong>RECURRING</strong> came back even after you patched
-            them; those are the strongest signal that the rule needs reshaping.
-          </>
-        ) : (
-          <>
-            Recurring instructions you keep giving the model — clustered, ranked, and paired with
-            proposed CLAUDE.md upgrades. Click APPLY to log a CLAUDE.md edit you&apos;ve made; the
-            loop closes when the next mining pass shows the rule is no longer recurring. Apply
-            history is recorded in <code>applied-improvements.json</code> next to{' '}
-            <code>corrections.json</code>.
-          </>
+      <div className="lcars-corrections__title-row">
+        <h2 className="lcars-corrections__title">CORRECTIONS</h2>
+        {hasTime && (
+          <span
+            className="lcars-corrections__time"
+            title={`Generated ${formatGenerated(generatedAt!)}`}
+          >
+            Last mined {relativeGenerated(generatedAt!)}
+          </span>
         )}
-      </p>
-      {typeof generatedAt === 'number' && (
-        <p className="lcars-corrections__meta">
-          Generated {formatGenerated(generatedAt)}
-        </p>
-      )}
+      </div>
     </header>
   );
 }
@@ -1148,11 +1108,8 @@ interface MiningTriggerProps {
   hasCorrections: boolean;
   candidateCount: number;
   autoWindow: AutoWindowResult | null;
-  selection: 'recent' | 'backfill';
   onArm: () => void;
   onRefreshAutoWindow: () => void;
-  onSwitchToBackfill: () => void;
-  onSwitchToRecent: () => void;
   /**
    * Phase 4 — when `false`, the host is the hosted static build with
    * no `/api/mine-corrections` endpoint. Mining can never run there;
@@ -1166,14 +1123,10 @@ function MiningTrigger({
   hasCorrections,
   candidateCount,
   autoWindow,
-  selection,
   onArm,
   onRefreshAutoWindow,
-  onSwitchToBackfill,
-  onSwitchToRecent,
   rescanAvailable = true,
 }: MiningTriggerProps) {
-  const ctaLabel = hasCorrections ? 'RE-MINE CORRECTIONS' : 'MINE CORRECTIONS';
   const isIdle = autoWindow?.mode === 'idle';
   const isUnavailable = autoWindow?.mode === 'unavailable';
   // Phase 4 — when the local server is unreachable AND the auto-window
@@ -1183,51 +1136,68 @@ function MiningTrigger({
   const localOnly = !rescanAvailable && autoWindow === null;
   const disabled =
     isIdle || isUnavailable || localOnly || (candidateCount === 0 && !hasCorrections);
-  const modeLabel = selection === 'backfill' ? 'BACKFILL' : 'AUTO WINDOW';
-  const backfill = autoWindow?.backfillAvailable ?? null;
+
+  // With selection='all' the autoWindow result already carries the
+  // entire unprocessed set — no separate "older" count to add.
+  const totalReady = autoWindow?.candidateCount ?? 0;
+  const windowDays = autoWindow?.windowDays ?? null;
+  const hasReady = totalReady > 0 && !isIdle && !isUnavailable;
+
+  const ctaLabel = isIdle
+    ? 'NO NEW CANDIDATES'
+    : isUnavailable
+      ? 'NO DATA'
+      : hasReady
+        ? `MINE ALL ${totalReady}`
+        : hasCorrections
+          ? 'RE-MINE CORRECTIONS'
+          : 'MINE CORRECTIONS';
+
+  const ctaTitle = localOnly
+    ? 'Mining is local-only — install chat-arch on your machine to mine your own corpus.'
+    : isIdle
+      ? 'No new candidates since the last mining run.'
+      : isUnavailable
+        ? 'Run the chat-arch exporter first to produce candidates.'
+        : hasReady && windowDays !== null
+          ? `Mine all ${totalReady} unprocessed candidates (~${windowDays} day span).`
+          : undefined;
+
+  const status = localOnly
+    ? 'Mining is local-only.'
+    : autoWindow === null
+      ? 'Computing…'
+      : isUnavailable
+        ? 'No candidates yet.'
+        : isIdle
+          ? 'Nothing new to mine.'
+          : `${totalReady} ready to mine`;
 
   return (
     <div className="lcars-corrections__trigger">
-      <div className="lcars-corrections__auto">
-        <span className="lcars-corrections__auto-label">{modeLabel}</span>
-        <span className="lcars-corrections__auto-value">
-          {localOnly
-            ? 'mining is local-only'
-            : autoWindow === null
-              ? 'computing…'
-              : autoWindow.mode === 'idle'
-                ? 'no new candidates'
-                : autoWindow.mode === 'unavailable'
-                  ? 'no data'
-                  : `${autoWindow.windowDays}d · ${autoWindow.candidateCount} candidate${autoWindow.candidateCount === 1 ? '' : 's'}`}
-        </span>
+      <div className="lcars-corrections__trigger-status-row">
+        <span className="lcars-corrections__trigger-status">{status}</span>
         <button
           type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--ghost"
+          className="lcars-corrections__btn lcars-corrections__btn--ghost lcars-corrections__btn--icon"
           onClick={onRefreshAutoWindow}
-          aria-label="refresh auto window"
-          title="Recompute auto-window"
+          aria-label="refresh"
+          title="Recompute the candidate count"
         >
           ↻
         </button>
       </div>
-      <button
-        type="button"
-        className="lcars-corrections__btn lcars-corrections__btn--primary"
-        onClick={onArm}
-        disabled={disabled}
-        title={
-          localOnly
-            ? 'Mining is local-only — install chat-arch on your machine to mine your own corpus.'
-            : isIdle
-              ? 'No new candidates since the last mining run.'
-              : isUnavailable
-                ? 'Run the chat-arch exporter first to produce candidates.'
-                : undefined
-        }
-      >
-        ▶ {ctaLabel}
-      </button>
+      <div className="lcars-corrections__trigger-row">
+        <button
+          type="button"
+          className="lcars-corrections__btn lcars-corrections__btn--primary"
+          onClick={onArm}
+          disabled={disabled}
+          {...(ctaTitle ? { title: ctaTitle } : {})}
+        >
+          ▶ {ctaLabel}
+        </button>
+      </div>
       {localOnly && (
         <p className="lcars-corrections__auto-hint">
           Mining is local-only — these demo patterns ship with the bundled fixture.{' '}
@@ -1240,25 +1210,6 @@ function MiningTrigger({
           </a>{' '}
           to mine your own corpus.
         </p>
-      )}
-      {selection === 'recent' && backfill !== null && (
-        <button
-          type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--secondary"
-          onClick={onSwitchToBackfill}
-          title={`${backfill.count} unprocessed older than the recent set, oldest from ${backfill.oldestDate}`}
-        >
-          BACKFILL OLDER ({backfill.count})
-        </button>
-      )}
-      {selection === 'backfill' && (
-        <button
-          type="button"
-          className="lcars-corrections__btn lcars-corrections__btn--ghost"
-          onClick={onSwitchToRecent}
-        >
-          ← RECENT
-        </button>
       )}
     </div>
   );
@@ -1292,8 +1243,11 @@ function ArmedPreview({ autoWindow, onRun, onCancel }: ArmedPreviewProps) {
         {windowDays === 1 ? 'day' : 'days'}. Estimated work:{' '}
         ~{Math.max(1, Math.ceil(candidateCount / 20))} classification batch
         {Math.ceil(candidateCount / 20) === 1 ? '' : 'es'} plus
-        one proposal call per cluster, ~3-8 min wall-clock. Counts against your
-        Claude Code plan usage; no separate billing.
+        one proposal call per cluster,{' '}
+        ~{Math.max(3, Math.ceil(Math.ceil(candidateCount / 20) * 0.75))}-
+        {Math.max(8, Math.ceil(Math.ceil(candidateCount / 20) * 2))} min
+        wall-clock. Counts against your Claude Code plan usage; no separate
+        billing.
       </p>
       <p className="lcars-corrections__armed-reasoning">{reasoning}</p>
       <div className="lcars-corrections__armed-actions">

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -82,6 +82,15 @@ export interface CorrectionsPanelProps {
    */
   overrideCorrections?: CorrectionsFile | null;
   overrideApplied?: AppliedImprovementsFile | null;
+  /**
+   * Phase 4 — demo path. Same role as `overrideCorrections`: when the
+   * host has loaded a demo fixture that bundles a synthesized
+   * `correction-candidates.json` (so the CoverageMeter + pipeline-
+   * stage markers from PR #33 render with non-zero data on the
+   * hosted demo), pass it here. When omitted, the candidates loader
+   * still hits disk as before.
+   */
+  overrideCandidates?: CorrectionsFile | null;
 }
 
 type LoadState =
@@ -182,7 +191,15 @@ function buildTopicBuckets(
     }
     buckets.push({
       key: topic,
-      label: topic.toUpperCase(),
+      // The Untagged sentinel gets a friendlier label so a partial
+      // re-mine (or legacy corrections.json from before tag-topics
+      // landed) doesn't surface a bare "UNTAGGED" header. The
+      // bucket's `key` stays `Untagged` so [data-topic] selectors and
+      // bucket-order rules can still target it.
+      label:
+        topic === UNTAGGED_TOPIC
+          ? 'UNTAGGED · re-mine to assign'
+          : topic.toUpperCase(),
       patterns: group,
       weight,
       hasRecurring,
@@ -190,6 +207,12 @@ function buildTopicBuckets(
     });
   }
   buckets.sort((a, b) => {
+    // The Untagged bucket is a graceful fallback, not signal — pin it
+    // to the bottom regardless of weight/recurring so it doesn't
+    // float above named topics on a partial re-mine.
+    const aUntagged = a.key === UNTAGGED_TOPIC;
+    const bUntagged = b.key === UNTAGGED_TOPIC;
+    if (aUntagged !== bUntagged) return aUntagged ? 1 : -1;
     if (a.hasRecurring !== b.hasRecurring) return a.hasRecurring ? -1 : 1;
     if (b.weight !== a.weight) return b.weight - a.weight;
     return a.label.localeCompare(b.label);
@@ -241,6 +264,7 @@ export function CorrectionsPanel({
   rescanAvailable = false,
   overrideCorrections,
   overrideApplied,
+  overrideCandidates,
 }: CorrectionsPanelProps) {
   const [load, setLoad] = useState<LoadState>({ status: 'loading' });
   // Phase 2b: which pattern (if any) the AppliedImprovementsSummary
@@ -316,7 +340,9 @@ export function CorrectionsPanel({
         overrideCorrections !== undefined
           ? Promise.resolve(overrideCorrections)
           : loadCorrectionsFile(dataDirBaseUrl),
-        loadCorrectionCandidatesFile(dataDirBaseUrl),
+        overrideCandidates !== undefined
+          ? Promise.resolve(overrideCandidates)
+          : loadCorrectionCandidatesFile(dataDirBaseUrl),
         overrideApplied !== undefined
           ? Promise.resolve(overrideApplied)
           : loadAppliedImprovementsFile(dataDirBaseUrl),
@@ -338,7 +364,13 @@ export function CorrectionsPanel({
         message: err instanceof Error ? err.message : String(err),
       });
     }
-  }, [dataDirBaseUrl, refreshAutoWindow, overrideCorrections, overrideApplied]);
+  }, [
+    dataDirBaseUrl,
+    refreshAutoWindow,
+    overrideCorrections,
+    overrideApplied,
+    overrideCandidates,
+  ]);
 
   useEffect(() => {
     void refresh();
@@ -1043,7 +1075,7 @@ function CoverageDetail({
           <span className="lcars-corrections__stage-title">LLM MINE</span>
           <span className="lcars-corrections__stage-note">
             {notRun
-              ? 'pending · click RE-MINE CORRECTIONS to run'
+              ? 'pending · click MINE ALL to run'
               : `done · ${fmt(classified)} classified`}
           </span>
         </header>
@@ -1054,7 +1086,7 @@ function CoverageDetail({
               {notRun ? (
                 <li>
                   No LLM classification pass run yet. Click{' '}
-                  <code>RE-MINE CORRECTIONS</code> to start.
+                  <code>MINE ALL</code> to start.
                 </li>
               ) : (
                 <>

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type {
   AppliedImprovementsFile,
   Correction,
@@ -884,7 +891,14 @@ function CoverageDetail({
   patterns,
 }: CoverageDetailProps) {
   const drops = scanStats.wrapperFiltered + scanStats.tooLongFiltered;
-  const notRun = classified === 0;
+  // Done/pending is keyed off whether any patterns have been mined, NOT
+  // `classified` (which counts only classifications that still appear in
+  // the live candidates set). After a HEURISTIC_RECALL_VERSION bump that
+  // retires every prior candidate, `classified` returns to 0 while
+  // `patterns` is still non-zero — and the badge would otherwise lie
+  // "pending · click RE-MINE CORRECTIONS" while the Last-mined chip and
+  // the pattern list contradicted it.
+  const notRun = patterns === 0;
   const knownSources: ReadonlyArray<string> = [
     'cli-direct',
     'cli-desktop',
@@ -897,99 +911,174 @@ function CoverageDetail({
       id="lcars-corrections-pipeline-detail"
       className="lcars-corrections__coverage-detail"
     >
-      <div className="lcars-corrections__pipeline">
-        <span className="lcars-corrections__pipeline-label">SCANNED</span>
-        <span className="lcars-corrections__pipeline-sublabel">
-          transcripts read · indexed in manifest
-        </span>
-        <ul className="lcars-corrections__pipeline-list">
-          {knownSources.map((source) => {
-            const total = scanStats.sessionsBySource[source] ?? 0;
-            const missing = scanStats.sessionsMissingBySource[source] ?? 0;
-            const scanned = Math.max(0, total - missing);
-            const note =
-              total === 0
-                ? source === 'cloud'
-                  ? 'no claude.ai export loaded'
-                  : 'not present in this corpus'
-                : missing > 0
-                  ? `${fmt(missing)} indexed but transcript file not on disk — usually deleted or aborted sessions`
-                  : null;
-            return (
-              <li key={`scan-${source}`}>
-                <span className="lcars-corrections__pipeline-source">
-                  {SOURCE_LABEL[source] ?? source}
-                </span>{' '}
-                <strong>
-                  {fmt(scanned)} / {fmt(total)}
-                </strong>
-                {note && (
+      {/* Stage 1: Exporter scan — already done by the time the user
+       *  opens this panel. The ✓ + "done" copy answers the user's
+       *  "the headline says 0 mined but everything below has non-zero
+       *  counts" reading: those numbers are scan-stage progress, not
+       *  mine-stage progress. */}
+      <div
+        className="lcars-corrections__stage"
+        data-stage-status="done"
+        aria-label="EXPORTER SCAN stage — done"
+      >
+        <header className="lcars-corrections__stage-header">
+          <span
+            className="lcars-corrections__stage-badge"
+            aria-hidden="true"
+          >
+            ✓
+          </span>
+          <span className="lcars-corrections__stage-title">
+            EXPORTER SCAN
+          </span>
+          <span className="lcars-corrections__stage-note">
+            done · re-runs on SCAN LOCAL
+          </span>
+        </header>
+        <div className="lcars-corrections__stage-body">
+          <div className="lcars-corrections__pipeline">
+            <span className="lcars-corrections__pipeline-label">SCANNED</span>
+            <span className="lcars-corrections__pipeline-sublabel">
+              transcripts read · indexed in manifest
+            </span>
+            <ul className="lcars-corrections__pipeline-list">
+              {knownSources.map((source) => {
+                const total = scanStats.sessionsBySource[source] ?? 0;
+                const missing = scanStats.sessionsMissingBySource[source] ?? 0;
+                const crashed =
+                  scanStats.sessionsCrashedBySource?.[source] ?? 0;
+                const trueMissing = Math.max(0, missing - crashed);
+                const scanned = Math.max(0, total - missing);
+                // Note is a React node (not string) so the split path
+                // can render two stacked lines via <br/>, keeping the
+                // "X missing on disk" / "Y CLI crashed" halves on their
+                // own lines at narrow widths. The single-line branches
+                // collapse to a plain string wrapped in the same span.
+                let note: ReactNode = null;
+                if (total === 0) {
+                  note =
+                    source === 'cloud'
+                      ? 'no claude.ai export loaded'
+                      : 'not present in this corpus';
+                } else if (missing === 0) {
+                  note = null;
+                } else if (crashed > 0 && trueMissing > 0) {
+                  note = (
+                    <>
+                      {fmt(trueMissing)} transcript file missing on disk
+                      <br />
+                      {fmt(crashed)} CLI crashed before writing a transcript
+                    </>
+                  );
+                } else if (crashed > 0) {
+                  note = `${fmt(crashed)} CLI crashed before writing a transcript (audit.jsonl still has the user's turns)`;
+                } else {
+                  note = `${fmt(trueMissing)} transcript file missing on disk (deleted or aborted between session end and scan)`;
+                }
+                return (
+                  <li key={`scan-${source}`}>
+                    <span className="lcars-corrections__pipeline-source">
+                      {SOURCE_LABEL[source] ?? source}
+                    </span>{' '}
+                    <strong>
+                      {fmt(scanned)} / {fmt(total)}
+                    </strong>
+                    {note && (
+                      <span className="lcars-corrections__pipeline-note">
+                        {note}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+          <div className="lcars-corrections__pipeline">
+            <span className="lcars-corrections__pipeline-label">PIPELINE</span>
+            <ul className="lcars-corrections__pipeline-list">
+              <li>
+                <strong>{fmt(scanStats.sessionsInManifest)}</strong> sessions in
+                manifest
+              </li>
+              <li>
+                <strong>{fmt(scanStats.sessionsScanned)}</strong> with transcripts
+                {scanStats.sessionsMissing > 0 && (
                   <span className="lcars-corrections__pipeline-note">
-                    {note}
+                    <span aria-hidden="true">←</span>{' '}
+                    {fmt(scanStats.sessionsMissing)} missing (no transcript file)
                   </span>
                 )}
               </li>
-            );
-          })}
-        </ul>
+              <li>
+                <strong>{fmt(scanStats.survivingTurns)}</strong> user prompts
+                {drops > 0 && (
+                  <span className="lcars-corrections__pipeline-note">
+                    <span aria-hidden="true">←</span> {fmt(drops)} dropped (
+                    {fmt(scanStats.wrapperFiltered)} system wrappers +{' '}
+                    {fmt(scanStats.tooLongFiltered)} pastes &gt;4KB)
+                  </span>
+                )}
+              </li>
+            </ul>
+          </div>
+        </div>
       </div>
-      <div className="lcars-corrections__pipeline">
-        <span className="lcars-corrections__pipeline-label">PIPELINE</span>
-        <ul className="lcars-corrections__pipeline-list">
-          <li>
-            <strong>{fmt(scanStats.sessionsInManifest)}</strong> sessions in
-            manifest
-          </li>
-          <li>
-            <strong>{fmt(scanStats.sessionsScanned)}</strong> with transcripts
-            {scanStats.sessionsMissing > 0 && (
-              <span className="lcars-corrections__pipeline-note">
-                <span aria-hidden="true">←</span>{' '}
-                {fmt(scanStats.sessionsMissing)} missing (no transcript file)
-              </span>
-            )}
-          </li>
-          <li>
-            <strong>{fmt(scanStats.survivingTurns)}</strong> user prompts
-            {drops > 0 && (
-              <span className="lcars-corrections__pipeline-note">
-                <span aria-hidden="true">←</span> {fmt(drops)} dropped (
-                {fmt(scanStats.wrapperFiltered)} system wrappers +{' '}
-                {fmt(scanStats.tooLongFiltered)} pastes &gt;4KB)
-              </span>
-            )}
-          </li>
-        </ul>
-      </div>
-      <div className="lcars-corrections__pipeline">
-        <span className="lcars-corrections__pipeline-label">CLASSIFICATION</span>
-        <ul className="lcars-corrections__pipeline-list">
-          {notRun ? (
-            <li>
-              No LLM classification pass run yet. Click{' '}
-              <code>RE-MINE CORRECTIONS</code> to start.
-            </li>
-          ) : (
-            <>
-              <li>
-                <strong>{fmt(classified)}</strong> classified by LLM
-              </li>
-              <li>
-                <strong>{fmt(actionable)}</strong> actionable
-                <span className="lcars-corrections__pipeline-note">
-                  ({fmt(classified - actionable)} ruled &ldquo;not a real correction&rdquo;)
-                </span>
-              </li>
-              <li>
-                <strong>{fmt(patterns)}</strong>{' '}
-                {patterns === 1 ? 'pattern' : 'patterns'} surfaced
-                <span className="lcars-corrections__pipeline-note">
-                  (clusters of &ge;3 distinct sessions)
-                </span>
-              </li>
-            </>
-          )}
-        </ul>
+      {/* Stage 2: LLM mine — the action the headline bar tracks. The
+       *  ▶ + "pending" copy when nothing's been classified yet makes
+       *  it explicit that the 0 / N count IS the next step (rather
+       *  than a result that contradicts the non-zero scan numbers
+       *  above). */}
+      <div
+        className="lcars-corrections__stage"
+        data-stage-status={notRun ? 'pending' : 'done'}
+        aria-label={`LLM MINE stage — ${notRun ? 'pending' : 'done'}`}
+      >
+        <header className="lcars-corrections__stage-header">
+          <span
+            className="lcars-corrections__stage-badge"
+            aria-hidden="true"
+          >
+            {notRun ? '▶' : '✓'}
+          </span>
+          <span className="lcars-corrections__stage-title">LLM MINE</span>
+          <span className="lcars-corrections__stage-note">
+            {notRun
+              ? 'pending · click RE-MINE CORRECTIONS to run'
+              : `done · ${fmt(classified)} classified`}
+          </span>
+        </header>
+        <div className="lcars-corrections__stage-body">
+          <div className="lcars-corrections__pipeline">
+            <span className="lcars-corrections__pipeline-label">CLASSIFICATION</span>
+            <ul className="lcars-corrections__pipeline-list">
+              {notRun ? (
+                <li>
+                  No LLM classification pass run yet. Click{' '}
+                  <code>RE-MINE CORRECTIONS</code> to start.
+                </li>
+              ) : (
+                <>
+                  <li>
+                    <strong>{fmt(classified)}</strong> classified by LLM
+                  </li>
+                  <li>
+                    <strong>{fmt(actionable)}</strong> actionable
+                    <span className="lcars-corrections__pipeline-note">
+                      ({fmt(classified - actionable)} ruled &ldquo;not a real correction&rdquo;)
+                    </span>
+                  </li>
+                  <li>
+                    <strong>{fmt(patterns)}</strong>{' '}
+                    {patterns === 1 ? 'pattern' : 'patterns'} surfaced
+                    <span className="lcars-corrections__pipeline-note">
+                      (clusters of &ge;3 distinct sessions)
+                    </span>
+                  </li>
+                </>
+              )}
+            </ul>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/viewer/src/components/CorrectionsPanel.tsx
+++ b/packages/viewer/src/components/CorrectionsPanel.tsx
@@ -109,73 +109,94 @@ const RUNNING_LINE_TAIL = 8;
 const STATUS_POLL_MS = 1500;
 const STATUS_LOG_TAIL = 6;
 
-type BucketDef = {
-  key: 'recurring' | 'encoded' | 'new';
+/**
+ * Sentinel topic for patterns emitted by mining runs that predate the
+ * `tag-topics` skill stage. Acts as a graceful fallback so the viewer
+ * doesn't break on legacy `corrections.json` files; re-mining assigns a
+ * real topic and the bucket disappears.
+ */
+const UNTAGGED_TOPIC = 'Untagged';
+
+function topicOf(p: CorrectionPattern): string {
+  return typeof p.topic === 'string' && p.topic.trim().length > 0
+    ? p.topic.trim()
+    : UNTAGGED_TOPIC;
+}
+
+interface TopicBucket {
+  key: string;
   label: string;
-  blurb: string;
-  match: (p: CorrectionPattern) => boolean;
-};
+  patterns: CorrectionPattern[];
+  /** Sum of occurrenceCount across all patterns — drives bucket order. */
+  weight: number;
+  /** True when ≥1 pattern is recurring after applied. Hoists the bucket
+   *  toward the top regardless of weight (recurring is the highest-
+   *  signal finding the user can act on), AND drives the bucket's
+   *  visual urgency via the `data-has-recurring` style hook so the
+   *  user can scan the page for hot spots at a glance. */
+  hasRecurring: boolean;
+  /** True when ≥1 pattern is alreadyEncoded but not recurring — a
+   *  weaker urgency signal than `hasRecurring`. Drives the bucket's
+   *  visual treatment when `hasRecurring` is false. */
+  hasEncoded: boolean;
+}
 
-const BUCKET_DEFS: ReadonlyArray<BucketDef> = [
-  {
-    key: 'recurring',
-    label: 'RECURRING AFTER APPLIED',
-    blurb:
-      'You wrote a rule, the model still gets it wrong. The encoded correction is failing in practice — reword it, add an example, or move it to a hook.',
-    match: (p) => p.recurringPostApplication,
-  },
-  {
-    key: 'encoded',
-    label: 'ALREADY ENCODED BUT FAILING',
-    blurb:
-      'The rule already exists in CLAUDE.md but the model is still being corrected on it — same finding, weaker signal than recurring-after-applied.',
-    match: (p) => p.alreadyEncoded && !p.recurringPostApplication,
-  },
-  {
-    key: 'new',
-    label: 'NEW PATTERNS TO ENCODE',
-    blurb:
-      'Recurring corrections that aren’t encoded anywhere. Pick a target file, paste the patch, and ship it.',
-    match: () => true,
-  },
-];
-
-// Phase 4 — hosted demo blurbs avoid CLAUDE.md / "ship it" language
-// that doesn't apply to a non-developer visitor on chat-arch.dev.
-// Same key ordering and matchers as BUCKET_DEFS so bucketFor() and
-// the bucket grid stay in sync.
-const BUCKET_DEFS_HOSTED_DEMO: ReadonlyArray<BucketDef> = [
-  {
-    key: 'recurring',
-    label: 'STILL FAILING AFTER A FIX',
-    blurb:
-      'You patched this — the timestamp shows when — and the model is still making the same mistake. The rule is too soft, too buried, or the wrong shape.',
-    match: (p) => p.recurringPostApplication,
-  },
-  {
-    key: 'encoded',
-    label: 'TOLD NOT TO, STILL DOES IT',
-    blurb:
-      'The model keeps making this mistake even though it has been told not to. The rule exists somewhere in your config but is being ignored in practice.',
-    match: (p) => p.alreadyEncoded && !p.recurringPostApplication,
-  },
-  {
-    key: 'new',
-    label: 'NEW PATTERNS TO ENCODE',
-    blurb:
-      'Recurring corrections that aren’t written down anywhere. These are good candidates for the next round of rules.',
-    match: () => true,
-  },
-];
-
-function bucketFor(p: CorrectionPattern): 'recurring' | 'encoded' | 'new' {
-  for (const b of BUCKET_DEFS) {
-    if (b.match(p)) return b.key;
+/**
+ * Group patterns by their LLM-derived topic. Buckets are ordered by:
+ *   1. has-recurring desc (recurring topics surface first)
+ *   2. weight desc (larger topics before smaller)
+ *   3. label asc (stable tiebreak)
+ * Within a bucket, recurring patterns sort to the top so the highest-
+ * signal items inside a topic are visible without scrolling.
+ */
+function buildTopicBuckets(
+  patterns: ReadonlyArray<CorrectionPattern>,
+): TopicBucket[] {
+  const seen = new Set<string>();
+  const byTopic = new Map<string, CorrectionPattern[]>();
+  for (const p of patterns) {
+    if (seen.has(p.id)) continue;
+    seen.add(p.id);
+    const topic = topicOf(p);
+    const arr = byTopic.get(topic);
+    if (arr) arr.push(p);
+    else byTopic.set(topic, [p]);
   }
-  return 'new';
+  const buckets: TopicBucket[] = [];
+  for (const [topic, group] of byTopic) {
+    group.sort(sortPatterns);
+    let weight = 0;
+    let hasRecurring = false;
+    let hasEncoded = false;
+    for (const p of group) {
+      weight += p.occurrenceCount;
+      if (p.recurringPostApplication) hasRecurring = true;
+      else if (p.alreadyEncoded) hasEncoded = true;
+    }
+    buckets.push({
+      key: topic,
+      label: topic.toUpperCase(),
+      patterns: group,
+      weight,
+      hasRecurring,
+      hasEncoded,
+    });
+  }
+  buckets.sort((a, b) => {
+    if (a.hasRecurring !== b.hasRecurring) return a.hasRecurring ? -1 : 1;
+    if (b.weight !== a.weight) return b.weight - a.weight;
+    return a.label.localeCompare(b.label);
+  });
+  return buckets;
 }
 
 function sortPatterns(a: CorrectionPattern, b: CorrectionPattern): number {
+  // Recurring-after-applied sorts to the top within a bucket — the
+  // strongest "your rule is failing in practice" signal beats raw
+  // confidence.
+  if (a.recurringPostApplication !== b.recurringPostApplication) {
+    return a.recurringPostApplication ? -1 : 1;
+  }
   if (b.confidence !== a.confidence) return b.confidence - a.confidence;
   return b.occurrenceCount - a.occurrenceCount;
 }
@@ -744,10 +765,6 @@ export function CorrectionsPanel({
         <BucketsView
           corrections={corrections!}
           highlightedPatternId={highlightedPatternId}
-          // Phase 4 — when corrections are showing on a host with no
-          // local server (the hosted demo path), reframe the bucket
-          // header copy to avoid CLAUDE.md / "paste the patch" jargon.
-          hostedDemo={!rescanAvailable}
           {...(applyAvailable ? { onApply: handleApply } : {})}
           {...(onSelectSession ? { onSelectSession } : {})}
         />
@@ -1284,6 +1301,7 @@ const STATUS_LABELS: Record<CorrectionRunStatus['status'], string> = {
   embedding: 'embedding',
   clustering: 'clustering',
   proposing: 'generating proposals',
+  'tagging-topics': 'tagging topics',
   writing: 'writing output',
   complete: 'complete',
   error: 'error',
@@ -1442,17 +1460,6 @@ interface BucketsViewProps {
    * AppliedImprovementsSummary scrolls it into view.
    */
   highlightedPatternId?: string | null;
-  /**
-   * Phase 4 — when true, the panel is rendering demo corrections on
-   * the hosted static build (no `/api/rescan` reachable, no
-   * mining endpoint, no actual CLAUDE.md the user owns). The default
-   * blurb copy explicitly references "the rule already exists in
-   * CLAUDE.md", which is meaningless on a hosted demo. Reframe it
-   * to "the model keeps making this mistake even though it's been
-   * told not to" so the demo reads cleanly to a non-developer
-   * visitor.
-   */
-  hostedDemo?: boolean;
 }
 
 function BucketsView({
@@ -1460,82 +1467,68 @@ function BucketsView({
   onApply,
   onSelectSession,
   highlightedPatternId,
-  hostedDemo = false,
 }: BucketsViewProps) {
-  const bucketDefs = hostedDemo ? BUCKET_DEFS_HOSTED_DEMO : BUCKET_DEFS;
   const instancesById = useMemo(() => {
     const m = new Map<string, Correction>();
     for (const c of corrections.corrections) m.set(c.id, c);
     return m;
   }, [corrections.corrections]);
 
-  const buckets = useMemo(() => {
-    const seen = new Set<string>();
-    const grouped: Record<'recurring' | 'encoded' | 'new', CorrectionPattern[]> = {
-      recurring: [],
-      encoded: [],
-      new: [],
-    };
-    for (const p of corrections.patterns) {
-      if (seen.has(p.id)) continue;
-      seen.add(p.id);
-      grouped[bucketFor(p)].push(p);
-    }
-    for (const k of Object.keys(grouped) as Array<keyof typeof grouped>) {
-      grouped[k].sort(sortPatterns);
-    }
-    return grouped;
-  }, [corrections.patterns]);
+  const buckets = useMemo(
+    () => buildTopicBuckets(corrections.patterns),
+    [corrections.patterns],
+  );
 
   return (
     <div className="lcars-corrections__buckets">
-      {bucketDefs.map((def) => {
-        const items = buckets[def.key];
-        return (
-          <section
-            key={def.key}
-            className={`lcars-corrections__bucket lcars-corrections__bucket--${def.key}`}
-            aria-label={def.label}
-          >
-            <header className="lcars-corrections__bucket-header">
-              <h3 className="lcars-corrections__bucket-title">{def.label}</h3>
-              <span className="lcars-corrections__bucket-count">
-                {items.length} {items.length === 1 ? 'pattern' : 'patterns'}
-              </span>
-            </header>
-            <p className="lcars-corrections__bucket-blurb">{def.blurb}</p>
-            {items.length === 0 ? (
-              <p className="lcars-corrections__bucket-empty">Nothing here — good.</p>
-            ) : (
-              <ul className="lcars-corrections__pattern-list" role="list">
-                {items.map((p) => {
-                  const isHighlighted = highlightedPatternId === p.id;
-                  return (
-                    <li
-                      key={p.id}
-                      data-pattern-id={p.id}
-                      {...(isHighlighted ? { 'data-highlighted': 'true' } : {})}
-                      className="lcars-corrections__pattern-item"
-                    >
-                      <CorrectionPatternCard
-                        pattern={p}
-                        instancesById={instancesById}
-                        defaultExpanded={isHighlighted}
-                        {...(onApply
-                          ? {
-                              onApply: (upgrade, extras) => onApply(p, upgrade, extras),
-                            }
-                          : {})}
-                        {...(onSelectSession ? { onSelectSession } : {})}
-                      />
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </section>
-        );
-      })}
+      {buckets.map((bucket) => (
+        <section
+          key={bucket.key}
+          className="lcars-corrections__bucket"
+          aria-label={bucket.label}
+          data-topic={bucket.key}
+          // Signal-based urgency hooks — restore the visual
+          // differentiation the dropped --recurring/--encoded/--new
+          // modifier classes used to provide. Recurring wins over
+          // encoded (the CSS uses attribute selectors, last rule
+          // wins) so a bucket with both signals reads as urgent.
+          data-has-recurring={bucket.hasRecurring ? 'true' : 'false'}
+          data-has-encoded={bucket.hasEncoded ? 'true' : 'false'}
+        >
+          <header className="lcars-corrections__bucket-header">
+            <h3 className="lcars-corrections__bucket-title">{bucket.label}</h3>
+            <span className="lcars-corrections__bucket-count">
+              {bucket.patterns.length}{' '}
+              {bucket.patterns.length === 1 ? 'pattern' : 'patterns'}
+            </span>
+          </header>
+          <ul className="lcars-corrections__pattern-list" role="list">
+            {bucket.patterns.map((p) => {
+              const isHighlighted = highlightedPatternId === p.id;
+              return (
+                <li
+                  key={p.id}
+                  data-pattern-id={p.id}
+                  {...(isHighlighted ? { 'data-highlighted': 'true' } : {})}
+                  className="lcars-corrections__pattern-item"
+                >
+                  <CorrectionPatternCard
+                    pattern={p}
+                    instancesById={instancesById}
+                    defaultExpanded={isHighlighted}
+                    {...(onApply
+                      ? {
+                          onApply: (upgrade, extras) => onApply(p, upgrade, extras),
+                        }
+                      : {})}
+                    {...(onSelectSession ? { onSelectSession } : {})}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ))}
     </div>
   );
 }

--- a/packages/viewer/src/data/demoUpload.test.ts
+++ b/packages/viewer/src/data/demoUpload.test.ts
@@ -118,6 +118,47 @@ describe('generateDemoUpload — Phase 4 applied-improvements ledger', () => {
   });
 });
 
+// PR #34 ships a `headline?: string` on ProposedUpgrade — the lead-with-
+// punchline card layout falls back to a derived headline when missing,
+// but the demo fixture's whole purpose is to showcase the punchline, so
+// every bundled upgrade should ship an explicit headline.
+describe('generateDemoUpload — Phase 4 ProposedUpgrade headline', () => {
+  it('every ProposedUpgrade in the demo fixture ships a non-empty headline', () => {
+    const data = generateDemoUpload();
+    for (const p of data.corrections!.patterns) {
+      for (const u of p.proposedUpgrades) {
+        expect(typeof u.headline).toBe('string');
+        expect((u.headline ?? '').length).toBeGreaterThan(10);
+      }
+    }
+  });
+});
+
+// PR #33 ships pipeline-stage markers (✓ EXPORTER SCAN / ▶ LLM MINE)
+// gated on a non-empty `correctionCandidates.scanStats`. Without this
+// payload on the demo path the entire stage UI ships invisible.
+describe('generateDemoUpload — Phase 4 corrections candidates fixture', () => {
+  it('bundles a candidates file with scanStats so the CoverageMeter mounts', () => {
+    const data = generateDemoUpload();
+    expect(data.correctionCandidates).toBeDefined();
+    const cands = data.correctionCandidates!;
+    expect(cands.corrections.length).toBeGreaterThan(0);
+    expect(cands.scanStats).toBeDefined();
+    const stats = cands.scanStats!;
+    expect(stats.sessionsInManifest).toBeGreaterThan(0);
+    expect(stats.sessionsScanned).toBeGreaterThan(0);
+    expect(Object.keys(stats.sessionsBySource).length).toBeGreaterThanOrEqual(2);
+    // Stage markers split missing/crashed — both should be exercised
+    // by the demo so the split-note rendering is visible.
+    expect(stats.sessionsCrashedBySource).toBeDefined();
+    const crashedTotal = Object.values(stats.sessionsCrashedBySource ?? {}).reduce(
+      (a, b) => a + b,
+      0,
+    );
+    expect(crashedTotal).toBeGreaterThan(0);
+  });
+});
+
 describe('generateDemoUpload — Phase 4 synthesized rescan delta', () => {
   it('includes a synthesizedRescanDelta with plausible per-source counts', () => {
     const data = generateDemoUpload();

--- a/packages/viewer/src/data/demoUpload.ts
+++ b/packages/viewer/src/data/demoUpload.ts
@@ -358,10 +358,11 @@ function demoCorrection(
   };
 }
 
-/** Build the demo corrections + applied-improvements pair. */
+/** Build the demo corrections + applied-improvements + candidates triple. */
 function buildDemoCorrections(now: number): {
   corrections: CorrectionsFile;
   applied: AppliedImprovementsFile;
+  candidates: CorrectionsFile;
 } {
   const DAY_LOCAL = 86_400_000;
 
@@ -807,7 +808,57 @@ function buildDemoCorrections(now: number): {
     ],
   };
 
-  return { corrections, applied };
+  // ---- Candidates (correction-candidates.json analogue) -----------------
+  //
+  // Drives the CoverageMeter + EXPORTER SCAN / LLM MINE pipeline-stage
+  // markers (PR #33). On the hosted demo there's no exporter to write
+  // the real candidates file to disk, so we synthesize one that:
+  //   - reuses every mined `Correction` so the bucket math (`patterns`
+  //     in candidates set) lands at "fully mined" and the LLM MINE
+  //     badge reads `done · N classified`
+  //   - injects a plausible `scanStats` payload so the SCANNED list
+  //     and the split missing/crashed note exercise both rendering
+  //     paths on the demo
+  //
+  // Numbers chosen to make the panel feel inhabited without lying
+  // about the demo corpus — the totals roughly match the 20 demo
+  // sessions across cli/cowork/cloud splits.
+  const candidates: CorrectionsFile = {
+    generatedAt: now,
+    corrections: allCorrections,
+    patterns: [],
+    pipeline: {
+      heuristicRecall: true,
+      llmClassification: false,
+      embeddingClustering: false,
+      claudeMdCrossCheck: false,
+    },
+    scanStats: {
+      sessionsInManifest: 50,
+      sessionsScanned: 42,
+      sessionsMissing: 8,
+      sessionsBySource: {
+        cowork: 18,
+        'cli-direct': 14,
+        'cli-desktop': 10,
+        cloud: 8,
+      },
+      sessionsMissingBySource: {
+        cowork: 5,
+        'cli-direct': 2,
+        'cli-desktop': 1,
+      },
+      sessionsCrashedBySource: {
+        cowork: 3,
+      },
+      rawUserTurns: 215,
+      wrapperFiltered: 18,
+      tooLongFiltered: 5,
+      survivingTurns: 192,
+    },
+  };
+
+  return { corrections, applied, candidates };
 }
 
 // ---------- synthesis ------------------------------------------------------
@@ -1006,7 +1057,7 @@ export function generateDemoUpload(): UploadedCloudData {
   // rescan delta. Bundled inline so the workshop loop is visible on
   // the hosted demo path without requiring a back-end mining pass.
   // See `buildDemoCorrections` for shape rationale.
-  const { corrections, applied } = buildDemoCorrections(now);
+  const { corrections, applied, candidates } = buildDemoCorrections(now);
 
   return {
     manifest: {
@@ -1030,6 +1081,7 @@ export function generateDemoUpload(): UploadedCloudData {
     sourceLabel: `DEMO DATA · ${enriched.length} fake conversations (bundled fixture)`,
     corrections,
     appliedImprovements: applied,
+    correctionCandidates: candidates,
     // Synthesized so the persistent rescan-delta chip lights up on
     // demo load (Priya's finding: the chip never appears on the demo
     // path because `setRescanDelta` only fires inside the /api/rescan

--- a/packages/viewer/src/data/demoUpload.ts
+++ b/packages/viewer/src/data/demoUpload.ts
@@ -658,6 +658,7 @@ function buildDemoCorrections(now: number): {
     confidence: number,
     recurringPostApplication: boolean,
     alreadyEncoded: boolean,
+    topic: string,
     scopeKind: 'global' | 'project' | 'tool' | 'request-shape' = 'global',
   ): CorrectionPattern => ({
     id,
@@ -671,10 +672,10 @@ function buildDemoCorrections(now: number): {
     confidence,
     recurringPostApplication,
     alreadyEncoded,
+    topic,
   });
 
   const patterns: CorrectionPattern[] = [
-    // RED — recurring after applied
     pattern(
       'demo-pat-1',
       'Use absolute paths in Bash tool calls; do not chain `cd <dir> &&`.',
@@ -683,6 +684,7 @@ function buildDemoCorrections(now: number): {
       0.92,
       true,
       true,
+      'Tool Usage',
     ),
     pattern(
       'demo-pat-2',
@@ -692,8 +694,8 @@ function buildDemoCorrections(now: number): {
       0.81,
       true,
       false,
+      'Output Discipline',
     ),
-    // YELLOW — already encoded but failing
     pattern(
       'demo-pat-3',
       'Use ripgrep (rg) instead of grep for content search.',
@@ -702,6 +704,7 @@ function buildDemoCorrections(now: number): {
       0.78,
       false,
       true,
+      'Tool Usage',
       'tool',
     ),
     pattern(
@@ -712,8 +715,8 @@ function buildDemoCorrections(now: number): {
       0.74,
       false,
       true,
+      'Output Discipline',
     ),
-    // NEW — candidates to encode
     pattern(
       'demo-pat-5',
       'Test-first: write the failing test before the implementation.',
@@ -722,6 +725,7 @@ function buildDemoCorrections(now: number): {
       0.69,
       false,
       false,
+      'Test Discipline',
       'request-shape',
     ),
     pattern(
@@ -732,6 +736,7 @@ function buildDemoCorrections(now: number): {
       0.66,
       false,
       false,
+      'Git Workflow',
       'project',
     ),
   ];

--- a/packages/viewer/src/data/demoUpload.ts
+++ b/packages/viewer/src/data/demoUpload.ts
@@ -563,11 +563,13 @@ function buildDemoCorrections(now: number): {
   const upgrade = (
     target: ProposedUpgrade['target'],
     targetPath: string,
+    headline: string,
     patch: string,
     rationale: string,
   ): ProposedUpgrade => ({
     target,
     targetPath,
+    headline,
     patch,
     rationale,
     applied: false,
@@ -578,12 +580,14 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Add a Bash Tool Use section forbidding `cd <dir> &&` chains.',
       '## Bash Tool Use\n- Always pass absolute paths to the Bash tool. Never chain `cd <dir> && command` — the working directory resets between calls.',
       'Recurs across 4 sessions, 3 projects. Path-prefix problem; canonical fix is a global rule under Bash usage.',
     ),
     upgrade(
       'settings-hook',
       'settings.json :: hooks.PreToolUse',
+      'Escalate `cd &&` ban to a PreToolUse hook — soft rule is being ignored.',
       '{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "node scripts/reject-cd-chain.js" }] }',
       'Soft rule was already shipped (see applied-improvements ledger) and the model still violates it. Promote to a hook so the violation is rejected before it executes.',
     ),
@@ -593,6 +597,7 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Replace soft "clean code" guidance with an explicit no-docstrings rule.',
       '## Documentation\n- Do not add docstrings, JSDoc, or inline comments unless the user explicitly asks for them. Removing unrequested documentation is part of the cleanup pass.',
       'Recurs across 3 sessions; existing rule is too soft ("clean code") and the model defaults to documenting.',
     ),
@@ -602,12 +607,14 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'project-claude-md',
       '<repo>/CLAUDE.md',
+      'Promote ripgrep preference from "Tooling" footnote to a top-level section.',
       '## Search Conventions\n- Use `rg` (ripgrep), not `grep`, for content search. The repo is a pnpm monorepo — `rg` is configured to skip `node_modules`/`dist` automatically.',
       'Already-encoded under "Tooling" but the model bypasses it. Move to a top-level Search Conventions section so it lands in the model\'s default attention.',
     ),
     upgrade(
       'prompt-snippet',
       '(reusable, no fixed path)',
+      'Reusable mid-conversation reminder to use `rg` over `grep -r`.',
       'When searching: prefer `rg <pattern>` over `grep -r`. `rg` is faster, respects `.gitignore`, and is the project default.',
       'Reusable snippet for direct paste into a fresh conversation when the rule is being violated mid-task.',
     ),
@@ -617,6 +624,7 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Hoist the "strip debug output" rule out of a buried list into its own section.',
       '## Quality Gates\n- Remove all debug output (`console.log`, `print`, `dbg!`) before presenting a patch. Debug statements are scaffolding, not deliverable code.',
       'Encoded under Quality Gates; recurs because the rule is buried mid-list. Promote it or split Quality Gates into two sections (security + cleanup).',
     ),
@@ -626,12 +634,14 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'global-claude-md',
       '~/.claude/CLAUDE.md',
+      'Add a new global Workflow rule mandating test-first when adding behavior.',
       '## Workflow\n- Test-first: when adding behavior, write the failing test before the implementation. Show the failing test output, then the implementation, then the passing test.',
       'No matching rule found. Recurs across 4 sessions and projects — strong candidate for a new global directive.',
     ),
     upgrade(
       'skill',
       '~/.claude/skills/test-first/SKILL.md',
+      'Package the test-first procedure as a skill so it auto-triggers on "add a function".',
       '# test-first\n\nWhen the user asks for a new function / endpoint / component, default to:\n1. Draft the failing test.\n2. Run it (show red).\n3. Implement minimal code to pass.\n4. Run tests (show green).\n5. Refactor if needed.',
       'Workflow rule with a clear procedure — packageable as a skill so it triggers automatically on "add a function" requests.',
     ),
@@ -641,6 +651,7 @@ function buildDemoCorrections(now: number): {
     upgrade(
       'project-claude-md',
       '<repo>/CLAUDE.md',
+      'Encode conventional-commits subject-line format as a project Git Conventions rule.',
       '## Git Conventions\n- Commit messages: conventional-commits format. Subject line is ≤72 chars, lowercase verb-first, no trailing period. Example: `fix: drop trailing period from commit subjects`.',
       'No matching rule in the project file; format expectations live only in PR descriptions. Encode as a Git Conventions section so the model picks it up at commit-suggestion time.',
     ),

--- a/packages/viewer/src/data/mineCorrectionsClient.ts
+++ b/packages/viewer/src/data/mineCorrectionsClient.ts
@@ -60,6 +60,7 @@ export interface CorrectionRunStatus {
     | 'embedding'
     | 'clustering'
     | 'proposing'
+    | 'tagging-topics'
     | 'writing'
     | 'complete'
     | 'error';

--- a/packages/viewer/src/data/mineCorrectionsClient.ts
+++ b/packages/viewer/src/data/mineCorrectionsClient.ts
@@ -25,7 +25,7 @@ export interface AutoWindowResult {
   windowDays: number;
   candidateCount: number;
   reasoning: string;
-  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill';
+  mode: 'first-run' | 'incremental' | 'idle' | 'unavailable' | 'backfill' | 'all';
   patternYield: { patterns: number; classified: number; ratio: number } | null;
   backfillAvailable: BackfillInfo | null;
 }
@@ -96,9 +96,9 @@ export interface MineCorrectionsOptions {
   /** Omit to use server-side auto-window selection. */
   windowDays?: number;
   dataDir?: string;
-  /** 'recent' (default) or 'backfill' — flips auto-window selection
-   *  to oldest-unprocessed-first so historical patterns surface. */
-  selection?: 'recent' | 'backfill';
+  /** 'recent' (default), 'backfill', or 'all' — 'all' bypasses the
+   *  cost cap and processes every unprocessed candidate in one pass. */
+  selection?: 'recent' | 'backfill' | 'all';
 }
 
 /**
@@ -108,11 +108,13 @@ export interface MineCorrectionsOptions {
  */
 export async function probeMineCorrections(
   dataDir?: string,
-  selection?: 'recent' | 'backfill',
+  selection?: 'recent' | 'backfill' | 'all',
 ): Promise<MineProbe | null> {
   const params = new URLSearchParams();
   if (dataDir !== undefined && dataDir.length > 0) params.set('dataDir', dataDir);
-  if (selection === 'backfill') params.set('selection', 'backfill');
+  if (selection === 'backfill' || selection === 'all') {
+    params.set('selection', selection);
+  }
   const qs = params.toString();
   const url = qs.length > 0 ? `${MINE_CORRECTIONS_PATH}?${qs}` : MINE_CORRECTIONS_PATH;
   try {

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6659,7 +6659,14 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-weight: 600;
 }
 .lcars-corrections__pipeline-note {
-  margin-left: 8px;
+  display: block;
+  /* 9ch matches .lcars-corrections__pipeline-source min-width so the
+   * note flows on its own line, indented under the source-label
+   * column. Prevents mid-phrase wraps like
+   *   "CLI crashed before writing | a transcript"
+   * at narrow widths. */
+  margin-left: 9ch;
+  margin-top: 2px;
   font-size: 11.5px;
   font-style: italic;
   color: color-mix(in srgb, var(--lcars-text) 85%, transparent);
@@ -6679,6 +6686,57 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-size: 11px;
   font-style: italic;
   color: color-mix(in srgb, var(--lcars-text) 60%, transparent);
+}
+/* Pipeline-stage wrappers: each one groups the work performed by a
+ * single stage of the corrections pipeline. The status badge + note
+ * are load-bearing — they answer the "the headline says 0 mined but
+ * everything below has counts" question by making the EXPORTER SCAN
+ * vs LLM MINE boundary explicit. */
+.lcars-corrections__stage {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-bottom: 6px;
+}
+.lcars-corrections__stage + .lcars-corrections__stage {
+  border-top: 1px dashed color-mix(in srgb, var(--lcars-text) 12%, transparent);
+  padding-top: 10px;
+}
+.lcars-corrections__stage-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.lcars-corrections__stage-badge {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+}
+.lcars-corrections__stage[data-stage-status='done'] .lcars-corrections__stage-badge {
+  color: var(--lcars-sunflower);
+}
+.lcars-corrections__stage[data-stage-status='pending'] .lcars-corrections__stage-badge {
+  color: var(--lcars-peach);
+}
+.lcars-corrections__stage-title {
+  font-family: var(--lcars-font-chrome);
+  font-size: 11.5px;
+  letter-spacing: 0.22em;
+  font-weight: 700;
+  color: var(--lcars-text);
+}
+.lcars-corrections__stage-note {
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+  font-style: italic;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
+.lcars-corrections__stage-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-left: 18px;
 }
 .lcars-corrections__danger {
   display: flex;

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6851,18 +6851,27 @@ button.lcars-applied-summary__stale--button:focus-visible {
   gap: 8px;
   padding: 12px 14px;
   border-radius: 0 8px 8px 0;
+  /* Default neutral treatment — applies to every bucket; the
+   * urgency-attribute selectors below override for buckets containing
+   * recurring / already-encoded patterns. Same visual that the
+   * dropped `--new` modifier class used to render. */
+  border-left: 3px solid color-mix(in srgb, var(--lcars-text) 30%, transparent);
+  background: rgba(0, 0, 0, 0.18);
 }
-.lcars-corrections__bucket--recurring {
-  border-left: 3px solid var(--lcars-peach);
-  background: rgba(255, 153, 51, 0.05);
-}
-.lcars-corrections__bucket--encoded {
+/* Encoded-but-failing signal (weaker urgency, sunflower accent) —
+ * applied when a bucket contains ≥1 alreadyEncoded pattern AND
+ * no recurring patterns. */
+.lcars-corrections__bucket[data-has-encoded='true'] {
   border-left: 3px solid var(--lcars-sunflower);
   background: rgba(255, 204, 102, 0.05);
 }
-.lcars-corrections__bucket--new {
-  border-left: 3px solid color-mix(in srgb, var(--lcars-text) 30%, transparent);
-  background: rgba(0, 0, 0, 0.18);
+/* Recurring-after-applied signal (highest urgency, peach accent) —
+ * declared last so it wins over the encoded rule when a bucket
+ * carries both signals. Same intent as the dropped `--recurring`
+ * modifier class: scan the page for these first. */
+.lcars-corrections__bucket[data-has-recurring='true'] {
+  border-left: 3px solid var(--lcars-peach);
+  background: rgba(255, 153, 51, 0.05);
 }
 .lcars-corrections__bucket-header {
   display: flex;
@@ -6876,10 +6885,17 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-size: 12.5px;
   letter-spacing: 0.18em;
   font-weight: 700;
+  /* Default neutral title color — matches the dropped `--new` modifier.
+   * Urgency selectors below override per signal. */
+  color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
 }
-.lcars-corrections__bucket--recurring .lcars-corrections__bucket-title { color: var(--lcars-peach); }
-.lcars-corrections__bucket--encoded   .lcars-corrections__bucket-title { color: var(--lcars-sunflower); }
-.lcars-corrections__bucket--new       .lcars-corrections__bucket-title { color: color-mix(in srgb, var(--lcars-text) 92%, transparent); }
+.lcars-corrections__bucket[data-has-encoded='true'] .lcars-corrections__bucket-title {
+  color: var(--lcars-sunflower);
+}
+/* Recurring last so it wins when both signals are present. */
+.lcars-corrections__bucket[data-has-recurring='true'] .lcars-corrections__bucket-title {
+  color: var(--lcars-peach);
+}
 .lcars-corrections__bucket-count {
   font-family: var(--lcars-font-chrome);
   font-size: 10.5px;

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -7090,10 +7090,64 @@ button.lcars-applied-summary__stale--button:focus-visible {
 .lcars-correction-pattern__section-title {
   margin: 0;
   font-family: var(--lcars-font-chrome);
-  font-size: 10.5px;
-  letter-spacing: 0.18em;
-  color: color-mix(in srgb, var(--lcars-text) 88%, transparent);
+  /* Bumped from 10.5px → 13px after UX feedback: the old size read as
+     a chip label and the eye skipped right past it, making it hard to
+     find the section breaks inside a dense card. */
+  font-size: 13px;
+  letter-spacing: 0.22em;
+  color: var(--lcars-peach);
   font-weight: 700;
+  /* Subtle left accent so the header is found by both shape and
+     color, not color alone. Matches the LCARS chrome elsewhere in
+     the viewer where section labels live next to a colored bar. */
+  padding-left: 8px;
+  border-left: 3px solid var(--lcars-peach);
+  line-height: 1.2;
+}
+
+/* EVIDENCE toggle: header sits inside a button so the whole row is
+   clickable. Reset the button chrome so it reads as a header with a
+   hint to its right, not a generic button. */
+.lcars-correction-pattern__evidence-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+}
+.lcars-correction-pattern__evidence-toggle:focus-visible {
+  outline: 2px solid var(--lcars-peach);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+.lcars-correction-pattern__evidence-toggle-hint {
+  font-family: var(--lcars-font-chrome);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
+.lcars-correction-pattern__evidence-toggle:hover .lcars-correction-pattern__evidence-toggle-hint {
+  color: var(--lcars-peach);
+}
+
+/* Upgrade headline: the punchline. Sits above the target chip + path
+   so the user reads "what changes and why" in one glance before any
+   diagnosis prose or diff. Larger + brighter than rationale, which
+   stays as supporting detail below. */
+.lcars-correction-pattern__upgrade-headline {
+  margin: 0 0 2px 0;
+  font-size: 14px;
+  line-height: 1.45;
+  font-weight: 600;
+  color: var(--lcars-text);
+  max-width: 78ch;
 }
 .lcars-correction-pattern__instance-list,
 .lcars-correction-pattern__upgrade-list {

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -6134,6 +6134,13 @@
   flex-direction: column;
   gap: 4px;
 }
+.lcars-corrections__title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
 .lcars-corrections__title {
   font-family: var(--lcars-font-chrome);
   font-size: 18px;
@@ -6142,19 +6149,19 @@
   color: var(--lcars-peach);
   margin: 0;
 }
+.lcars-corrections__time {
+  font-family: var(--lcars-font-chrome);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
 .lcars-corrections__lead {
   margin: 0;
   max-width: 78ch;
   font-size: 13px;
   line-height: 1.5;
   color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
-}
-.lcars-corrections__meta {
-  margin: 0;
-  font-size: 11px;
-  font-family: var(--lcars-font-chrome);
-  letter-spacing: 0.12em;
-  color: color-mix(in srgb, var(--lcars-text) 85%, transparent);
 }
 .lcars-corrections__empty {
   margin: 0;
@@ -6197,29 +6204,28 @@
 }
 .lcars-corrections__trigger {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 6px;
 }
-.lcars-corrections__auto {
-  display: inline-flex;
+.lcars-corrections__trigger-status-row {
+  display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 10px 4px 12px;
-  border: 1px solid color-mix(in srgb, var(--lcars-peach) 35%, transparent);
-  border-radius: 999px;
-  background: rgba(0, 0, 0, 0.25);
 }
-.lcars-corrections__auto-label {
-  font-family: var(--lcars-font-chrome);
-  font-size: 10px;
-  letter-spacing: 0.2em;
-  color: color-mix(in srgb, var(--lcars-text) 80%, transparent);
+.lcars-corrections__trigger-status {
+  font-size: 13px;
+  color: color-mix(in srgb, var(--lcars-text) 90%, transparent);
 }
-.lcars-corrections__auto-value {
-  font-family: var(--lcars-font-mono, monospace);
-  font-size: 12px;
-  color: var(--lcars-text);
+.lcars-corrections__trigger-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.lcars-corrections__btn--icon {
+  padding: 2px 8px;
+  font-size: 14px;
+  letter-spacing: 0;
 }
 .lcars-corrections__armed-reasoning {
   margin: 0;
@@ -6559,13 +6565,6 @@ button.lcars-applied-summary__stale--button:focus-visible {
   gap: 12px;
   flex-wrap: wrap;
 }
-.lcars-corrections__coverage-label {
-  font-family: var(--lcars-font-chrome);
-  font-size: 10px;
-  letter-spacing: 0.22em;
-  color: var(--lcars-sunflower);
-  font-weight: 700;
-}
 .lcars-corrections__coverage-figure {
   font-size: 12.5px;
   color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
@@ -6591,16 +6590,6 @@ button.lcars-applied-summary__stale--button:focus-visible {
     var(--lcars-peach)
   );
   transition: width 240ms ease-out;
-}
-.lcars-corrections__coverage-funnel {
-  margin: 2px 0 0 0;
-  font-size: 12px;
-  line-height: 1.5;
-  color: color-mix(in srgb, var(--lcars-text) 92%, transparent);
-}
-.lcars-corrections__coverage-funnel strong {
-  color: var(--lcars-text);
-  font-variant-numeric: tabular-nums;
 }
 .lcars-corrections__coverage-provenance {
   display: flex;
@@ -6674,6 +6663,22 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-size: 11.5px;
   font-style: italic;
   color: color-mix(in srgb, var(--lcars-text) 85%, transparent);
+}
+.lcars-corrections__pipeline-source {
+  display: inline-block;
+  min-width: 9ch;
+  font-family: var(--lcars-font-chrome);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--lcars-text) 75%, transparent);
+}
+.lcars-corrections__pipeline-sublabel {
+  margin-top: -2px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+  font-style: italic;
+  color: color-mix(in srgb, var(--lcars-text) 60%, transparent);
 }
 .lcars-corrections__danger {
   display: flex;

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -46,6 +46,16 @@ export interface UploadedCloudData {
   corrections?: CorrectionsFile;
   appliedImprovements?: AppliedImprovementsFile;
   /**
+   * Phase 4 — demo path only. The corrections-candidates file is what
+   * drives the CoverageMeter + pipeline-stage markers (EXPORTER SCAN /
+   * LLM MINE) in the panel. Real cloud-zip uploads omit this — the
+   * panel falls back to the network fetch of `correction-candidates.
+   * json` from disk. On the hosted demo there's nothing on disk, so
+   * without a synthesized candidates file the CoverageMeter never
+   * mounts and PR #33's stage markers ship invisible.
+   */
+  correctionCandidates?: CorrectionsFile;
+  /**
    * Synthesized "what just rescanned" payload for the persistent
    * rescan-delta chip. The chip's normal source is the `/api/rescan`
    * success branch in onRescan; demo loads have no such pass to feed


### PR DESCRIPTION
## Summary

Bridge PR to land four stacked corrections-work commits onto `main`. Each was merged into `feature/corrections-ux-simplification` (the long-lived stack base) rather than directly to `main` — see the heads-up in #33's description. This is the lone PR needed to unstack everything in one squash-merge and trigger a Cloudflare Pages deploy.

## Commits stacked on main

| SHA       | PR  | What it ships |
|-----------|-----|---------------|
| `3b36fbc` | (—) | Pre-squash variant of #31's "simplify CORRECTIONS header + collapse MINE ALL CTA" — already shipped to main as `34467fb` (#31) via the squash merge; included here only because the feature branch was cut before that squash. Net diff vs main is empty for this commit. |
| `405cf2b` | #32 | LLM-derived topic buckets replace the fixed taxonomy |
| `2f35129` | #33 | Pipeline-stage markers (✓ EXPORTER SCAN / ▶ LLM MINE) + split missing/crashed transcript counts in SCANNED |
| `17bf94d` | #34 | Unblock MINE ALL — silent-abort fix when sub-agent cap fires in headless mode + EVIDENCE heading a11y |

Net diff: 16 files, ~+2187/−608 (the bulk is test coverage + the topic-bucket refactor in `CorrectionsPanel.tsx`).

## Test plan

- [x] Each constituent PR's CI already passed (lint + test + build) on its own merge into `feature/corrections-ux-simplification`
- [x] Both #33 and #34 had adversarial review passes with validated fixes folded in
- [x] Visual QA at mobile/tablet/desktop tiers confirmed stage markers, split-note layout, and EVIDENCE heading a11y on the merged stack
- [ ] CI green on this bridge PR (will run automatically on open)
- [ ] Cloudflare Pages deploy succeeds after squash-merge

## Notes

Squash-merge the bridge PR so `main` gets one tidy commit ("bridge: #32 + #33 + #34") rather than the four-commit history. The constituent PR numbers stay searchable via the body anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)