### PR TITLE
feat(chat): new /chat page — agentic Q&A + opportunity-finding over corpus

### DIFF
--- a/.claude/skills/chat-answer/SKILL.md
+++ b/.claude/skills/chat-answer/SKILL.md
@@ -227,9 +227,28 @@ Workflow:
    memory" → actually 35) is worse than no number, because the
    caveat is the part the reader is supposed to trust. If you don't
    have a tool-call-grounded count, write the caveat without numbers.
-5. **Follow-ups.** End with 1-3 suggested next questions on their own line,
-   each prefixed `→ ` and phrased as the user would ask them. The UI
-   renders these as one-click chips.
+
+   **Wrap the caveats in a `## Caveats` H2.** The chat renderer
+   collapses sections under specific H2 titles (`## Caveats`,
+   `## Methodology`, `## Risks`, `## Honest negatives`,
+   `## Calibration`) so the headline + evidence stay visible and
+   trust artifacts are one click away. The collapse is
+   presentational only — the prose inside is unchanged, so every
+   anti-Goodhart rule still applies inside the section. **Do NOT**
+   move counts, grep patterns, or quotes out of the main body just
+   because they could fit under a methodology heading — show-grep-
+   pattern requires the count to live next to the claim it backs.
+5. **Follow-ups.** End with 1-3 suggested next questions, **each on
+   its own line**, prefixed `→ ` and phrased as the user would ask
+   them. The renderer detects the `→ ` prefix line-by-line; if you
+   put multiple follow-ups on one line they collapse into a single
+   paragraph and become useless. Example:
+
+   ```
+   → Which workflow would you turn into a blog post first?
+   → What corrections has /mine-corrections actually surfaced?
+   → Where does the parallel sub-agent pattern backfire?
+   ```
 
 ### Intent = `find-opportunities`
 
@@ -451,6 +470,33 @@ The user's CLAUDE.md and corrections corpus consistently push back on:
 
 Markdown is fine. Code fences are fine. Headers are fine. Honest brevity
 wins over thoroughness theater.
+
+### Renderer-aware conventions
+
+The chat UI parses your markdown with a small set of rules beyond the
+standard subset (paragraphs, headers, bullets, bold/italic/code, code
+blocks, `[SID:<uuid>]` chips). Two extra rules to write toward:
+
+- **Collapsible H2 sections.** A `## Caveats`, `## Methodology`,
+  `## Risks`, `## Honest negatives`, `## Honest notes`, or
+  `## Calibration` heading folds itself + everything until the next
+  H2 into a `<details>` element collapsed by default. Use these
+  headings (case-insensitive match) for trust artifacts the reader
+  may want but doesn't need on first scroll. Other H2s render
+  normally and stay open. A second H2 (any title) closes the
+  collapsed section, so don't expect "## Caveats … ## Findings" to
+  bury Findings inside Caveats. Use this for the caveats paragraph,
+  the calibration line, and any methodology asides — never for the
+  main answer body.
+
+- **Follow-up chips.** Lines that start with `→ ` (U+2192 + space)
+  are extracted into a chip group rendered as clickable buttons that
+  resubmit the question text on the same intent. Each chip is one
+  line. Strip the `→ ` prefix mentally — the renderer sends the rest
+  of the line as the new question, so write the chip text exactly as
+  the user would ask it (full sentence, ending question mark).
+  Multi-line `→ ` blocks group into one chip cluster; non-`→ `
+  paragraph text immediately above is preserved separately.
 
 ## Failure modes
 

--- a/.claude/skills/chat-answer/SKILL.md
+++ b/.claude/skills/chat-answer/SKILL.md
@@ -63,6 +63,27 @@ Workflow:
    always keyword-matching, not measuring actual usage. Trust qualitative
    examples (quotes, specific session IDs, tool-call evidence) over raw
    counts.
+
+   **Sub-agent rules (load-bearing — headless mode has no human to
+   answer permission prompts):**
+
+   - Always pass `subagent_type: "Explore"`. The `Explore` agent is
+     read-only (Glob / Grep / Read only — no Bash, no Write, no Edit)
+     and matches the kind of work corpus retrieval needs. The default
+     `general-purpose` agent has Bash + Write, which trips the harness
+     `Bash(find:*)` deny-list on multi-step shell pipes and stalls the
+     whole turn.
+   - In your prompt to the sub-agent, explicitly tell it: **"You have
+     no Bash. Use Grep for keyword search and Read with `offset`/`limit`
+     for slicing big files; do not attempt shell commands."**
+   - Tell it: **"Do NOT Read a transcript file in full — they range
+     from 25K to 500K tokens and will trip the 25K-token Read cap.
+     Always Grep first; only Read with `offset` + `limit` (e.g.
+     `Read file_path=… offset=0 limit=200`) once you've found a line
+     range worth quoting."**
+   - Cap each sub-agent at a tight word budget in your prompt (e.g.
+     "≤400 words, bullet form, cite session ids inline") so the
+     fan-out doesn't run for ten minutes per agent.
 4. **Synthesize.** Lead with the answer. Evidence second. Cite sessions
    inline as `[SID:<uuid>]` using the manifest's `id` field. Distinguish
    *recurring pattern* from *happened once*. Surface honest negatives
@@ -177,7 +198,30 @@ have Bash, Write, or Edit. This is intentional:
   draft-as-skill) will be separate user-triggered actions, not autonomous
   writes from this skill.
 - **Task is available** — use sub-agents (especially `Explore`) for
-  fan-out retrieval and parallel sub-questions.
+  fan-out retrieval and parallel sub-questions. **Always pass
+  `subagent_type: "Explore"`** so the sub-agent inherits the same read-
+  only tool profile; the default `general-purpose` agent has Bash and
+  trips harness permission prompts in headless mode.
+
+### Reading transcripts efficiently
+
+Transcript JSONL files in `local-transcripts/<source>/<uuid>.jsonl` can
+be enormous — typical sizes range from ~25K to 500K+ tokens. Reading
+one whole will trip Claude Code's 25K-token Read cap and waste tens of
+seconds of round-trip time.
+
+The right pattern:
+
+1. **Grep first.** A pattern over `local-transcripts/**/*.jsonl` finds
+   the lines/sessions that matter without loading any file in full.
+2. **Read with `offset` + `limit` after grep gives you a line number.**
+   E.g. `Read file_path=…/abc.jsonl offset=120 limit=40` reads 40
+   lines starting at line 120. Iterate if needed.
+3. **Skim via the manifest first.** `manifest.json` already has
+   `title` + `preview` (≤200 chars) + optional `summary` per session.
+   For a lot of questions the manifest alone is enough to identify the
+   relevant sessions; you only descend into transcripts when you need
+   to quote.
 
 ## Style
 

--- a/.claude/skills/chat-answer/SKILL.md
+++ b/.claude/skills/chat-answer/SKILL.md
@@ -113,6 +113,19 @@ Workflow:
      inside a strong-looking list of three SIDs is worse than honestly
      citing only the one strong witness.
 
+   - **Final answer: every SID must carry a verbatim quote, not a
+     paraphrase.** When you list cited SIDs in the final synthesis,
+     each one needs an actual string copied character-exact from
+     somewhere — typically the manifest entry's `title` / `summary`
+     / `preview` field, or an `ai-title` / `last-prompt` line from
+     the transcript. **Paraphrases don't qualify.** A previous run
+     wrote `[SID:284ca64c] — "corpus-mining session"` where
+     "corpus-mining session" was the agent's own description, not
+     a string from the source. If you can't pull a real string for
+     a SID, drop the SID from the cited list rather than substitute
+     a paraphrase. Two SIDs with verbatim titles beat three SIDs
+     where one is paraphrased.
+
    - **Counts MUST trace to a tool call in this turn — no exceptions.**
      This is the failure mode the previous run hit. The per-SID
      evidence floor (above) was satisfied with *plausible-looking*
@@ -144,6 +157,18 @@ Workflow:
          agent ran in this turn.
      Prefer two SIDs with quotes over three SIDs with mixed
      counts-or-quotes.
+
+   - **Verbatim means CHARACTER-EXACT.** When you put text inside
+     quote marks, the bytes must match the source byte-for-byte:
+     no invented trailing periods, no capitalization normalization,
+     no smart-quote substitution, no whitespace re-flow. The reader
+     will literally diff your quote against the source. A previous
+     run quoted CLAUDE.md as *"Run an adversarial review agent
+     before finalizing experiment results."* with a trailing period
+     when the actual line had none — small slip, but exactly the
+     kind of fidelity error this rule targets. If you're not 100%
+     sure of the punctuation, paraphrase outside quotes instead of
+     guessing inside them.
 4. **Synthesize.** Lead with the answer. Evidence second. Cite sessions
    inline as `[SID:<uuid>]` using the manifest's `id` field. Distinguish
    *recurring pattern* from *happened once*. Surface honest negatives
@@ -166,13 +191,29 @@ Workflow:
    **Measure the population BEFORE picking examples.** For any
    recurring-pattern claim, run a corpus-wide Grep on the pattern
    across `local-transcripts/**/*.jsonl` first to get the actual
-   match count (e.g. "82 files match `adversarial.{0,30}review`"),
-   THEN cite 2-3 strongest example SIDs from that population. The
-   final wording should look like: *"82 sessions show this pattern;
-   strongest witnesses: [SID:abc] [SID:def] [SID:ghi]."* This
-   prevents the inverse failure of the previous run — calling
-   something "a clear recurring pattern" when only 3 examples were
-   found, when the real population is 82.
+   match count, THEN cite 2-3 strongest example SIDs from that
+   population.
+
+   **Every population count must show the exact Grep pattern that
+   produced it, inline with the number.** Not "82 transcripts
+   mention adversarial review" — write "**76 files match Grep
+   `adversarial.{0,30}review` (this turn)**: [SID:abc] [SID:def]
+   are the strongest witnesses." Putting the pattern in the answer
+   makes silent drift impossible: if you ran `adversarial.{0,30}review`
+   and got 76, you literally cannot type 82 — the inconsistency
+   becomes a self-correction.
+
+   A previous run reported "82 transcripts" when the actual count
+   was 76 (and "2,588 occurrences" when the actual was 2,480) —
+   the agent ran the grep but rounded / extrapolated when typing
+   the number into the answer. Forcing the pattern + the number
+   into the same sentence eliminates that gap.
+
+   When you cite a SECONDARY count alongside a primary (e.g. "82
+   files / 2,588 occurrences"), the second count is also a separate
+   trace-to-Grep claim — show its pattern too, or drop it. Aggregate
+   counts that don't help the reader's understanding (e.g. line
+   counts on top of file counts) usually fail this test; cut them.
 
    **Honest-caveats paragraph is NOT a hedge zone.** Any quantitative
    claim in your caveats — file counts, session counts, time ranges,

--- a/.claude/skills/chat-answer/SKILL.md
+++ b/.claude/skills/chat-answer/SKILL.md
@@ -44,6 +44,23 @@ Claude push back on in my Y sessions?"). Answer it grounded.
 
 Workflow:
 
+0. **Mandatory coverage reads (do these BEFORE anything else, every
+   time):**
+
+   - `manifest.json` (corpus index + date range — anchors any "across
+     N sessions" claim).
+   - The user's global `~/.claude/CLAUDE.md` (operating modes like
+     `/code` / `/research` / `/review`, persistent preferences). On
+     Windows this resolves to `C:\Users\<user>\.claude\CLAUDE.md`.
+   - The repo's own `CLAUDE.md` (project-specific rules, git
+     conventions, hook configurations, the things the corpus alone
+     can't surface because they're prescriptive not descriptive).
+
+   These three files are cheap and they prevent the failure mode where
+   a corpus-grep answer misses load-bearing structure the user has
+   already encoded in config. If they cite operating modes or hooks,
+   your answer should too.
+
 1. **Triage in one sentence** (printed, not silently). What kind of
    evidence does this question need? Pick one:
    - *Recurring-pattern* — needs frequency + breadth across sessions.
@@ -84,11 +101,35 @@ Workflow:
    - Cap each sub-agent at a tight word budget in your prompt (e.g.
      "≤400 words, bullet form, cite session ids inline") so the
      fan-out doesn't run for ten minutes per agent.
+   - **Per-SID evidence floor (load-bearing).** Tell each sub-agent:
+     *"For every SID you cite, return either (a) the keyword grep
+     count on that session's transcript (e.g. `[SID:abc] — 47 hits on
+     /loop`) OR (b) a verbatim quote ≤80 chars from the transcript
+     (e.g. `[SID:abc] — 'all tests passing — shipping it'`). NEVER
+     cite a SID with only 'the file exists' or 'manifest title looks
+     relevant' as evidence — that's existence, not support."* When
+     synthesizing, **drop SIDs with fewer than 3 keyword hits or no
+     usable quote**, even if it shrinks the cited list. A weak witness
+     inside a strong-looking list of three SIDs is worse than honestly
+     citing only the one strong witness.
 4. **Synthesize.** Lead with the answer. Evidence second. Cite sessions
    inline as `[SID:<uuid>]` using the manifest's `id` field. Distinguish
    *recurring pattern* from *happened once*. Surface honest negatives
    where they sharpen the answer ("X didn't pan out because Y") — they
    build trust more than smoothing things over.
+
+   **Cap at 3-4 strong items, NOT 5 with mixed strength.** A tight
+   list of fully-evidenced patterns beats a longer list where item 4
+   or 5 has thin grounding. If you have one strong item and three
+   weak ones, write one item.
+
+   **Order by novelty, not frequency.** Lead with the most
+   differentiated practice — the thing this user does that most
+   others don't (e.g. "mining your own corpus", "custom skill
+   pipeline") — even when it's less frequent than table-stakes
+   practices (e.g. PR-gated workflow, code review). Table-stakes
+   items can ship later in the list or be cut entirely if the
+   audience already takes them as given.
 5. **Follow-ups.** End with 1-3 suggested next questions on their own line,
    each prefixed `→ ` and phrased as the user would ask them. The UI
    renders these as one-click chips.
@@ -155,6 +196,29 @@ When the corpus does NOT support a claim, say so explicitly rather than
 fabricating evidence: "The corpus doesn't show this directly — based on
 indirect signal in [SID:abc], I'd guess … but it's an inference, not a
 finding."
+
+### Named workflows / slash commands / skills
+
+**Never invent a name.** A `/foo` slash command, named skill, agent
+type, or workflow may only appear in your answer if you have VERIFIED
+it via one of:
+
+  - Read of `.claude/skills/foo/SKILL.md` or
+    `.claude/commands/foo.md` (project-local or under `~/.claude/`).
+  - Read of `~/.claude/CLAUDE.md` declaring the command.
+  - A Grep hit showing the command actually invoked in a transcript
+    (look for the literal `/foo` in tool calls or user text — not
+    just discussed as an idea).
+
+If you have NONE of those three signals, describe the pattern in
+generic terms ("parallel multi-agent review", "polling sub-agent for
+long-running work") instead of naming it. A hallucinated workflow name
+destroys trust — the reader will search for it, fail to find it, and
+treat the whole answer as suspect.
+
+This rule has bitten in practice: an earlier run named "`/ultrareview`
+is the named multi-agent review pass" with high confidence. No such
+skill or command existed. Don't be that run.
 
 ## Corpus layout
 

--- a/.claude/skills/chat-answer/SKILL.md
+++ b/.claude/skills/chat-answer/SKILL.md
@@ -112,6 +112,38 @@ Workflow:
      usable quote**, even if it shrinks the cited list. A weak witness
      inside a strong-looking list of three SIDs is worse than honestly
      citing only the one strong witness.
+
+   - **Counts MUST trace to a tool call in this turn — no exceptions.**
+     This is the failure mode the previous run hit. The per-SID
+     evidence floor (above) was satisfied with *plausible-looking*
+     fabricated numbers — claims like "246 hits on corrections.json"
+     where the actual count was 72, or "6 gh pr checks hits" where the
+     actual count was 0. The skill **must not pattern-match** what a
+     count "should be" from context.
+
+     Hard rule: if you cite "N hits on X in [SID:abc]", there must be
+     a `Grep` tool_use record THIS TURN for pattern=X on the path
+     containing abc, and you must use the count that Grep returned —
+     not your estimate, not an extrapolation, not "feels about right
+     given the others." If you didn't Grep it this turn, either Grep
+     it now, or drop the count and use a quote, or use a qualitative
+     word ("frequent", "recurring"). Tell each sub-agent the same
+     rule, explicitly.
+
+   - **Quotes beat counts.** A verbatim ≤80-char quote is more
+     verifiable than a number — the user can search for the string
+     and confirm it. Counts require trust that you actually ran the
+     Grep. Strongest places to pull quotes:
+       - `manifest.json` entry's `title` / `preview` / `summary`
+         field for the cited session (cheap; Grep + Read for that
+         one entry).
+       - The transcript's `ai-title` or `last-prompt` line (visible
+         in the manifest summary or via a targeted Grep on the
+         transcript for those keys).
+       - A line that actually surfaced in a Grep result the sub-
+         agent ran in this turn.
+     Prefer two SIDs with quotes over three SIDs with mixed
+     counts-or-quotes.
 4. **Synthesize.** Lead with the answer. Evidence second. Cite sessions
    inline as `[SID:<uuid>]` using the manifest's `id` field. Distinguish
    *recurring pattern* from *happened once*. Surface honest negatives
@@ -130,6 +162,25 @@ Workflow:
    practices (e.g. PR-gated workflow, code review). Table-stakes
    items can ship later in the list or be cut entirely if the
    audience already takes them as given.
+
+   **Measure the population BEFORE picking examples.** For any
+   recurring-pattern claim, run a corpus-wide Grep on the pattern
+   across `local-transcripts/**/*.jsonl` first to get the actual
+   match count (e.g. "82 files match `adversarial.{0,30}review`"),
+   THEN cite 2-3 strongest example SIDs from that population. The
+   final wording should look like: *"82 sessions show this pattern;
+   strongest witnesses: [SID:abc] [SID:def] [SID:ghi]."* This
+   prevents the inverse failure of the previous run — calling
+   something "a clear recurring pattern" when only 3 examples were
+   found, when the real population is 82.
+
+   **Honest-caveats paragraph is NOT a hedge zone.** Any quantitative
+   claim in your caveats — file counts, session counts, time ranges,
+   "Nx more / less" — must satisfy the same evidence floor as the
+   main-body claims. A wrong number in a caveat ("147 files of
+   memory" → actually 35) is worse than no number, because the
+   caveat is the part the reader is supposed to trust. If you don't
+   have a tool-call-grounded count, write the caveat without numbers.
 5. **Follow-ups.** End with 1-3 suggested next questions on their own line,
    each prefixed `→ ` and phrased as the user would ask them. The UI
    renders these as one-click chips.
@@ -219,6 +270,35 @@ treat the whole answer as suspect.
 This rule has bitten in practice: an earlier run named "`/ultrareview`
 is the named multi-agent review pass" with high confidence. No such
 skill or command existed. Don't be that run.
+
+### Policy versus enforcement (don't conflate)
+
+When citing a rule from the user's config (CLAUDE.md, settings.json,
+hooks, etc.), distinguish:
+
+  - **Policy / convention.** A rule written as instructions, with no
+    machinery preventing violation. *Example:* the project CLAUDE.md
+    says "never push directly to main." That's policy — it relies on
+    the agent (or user) reading and following it. Nothing stops a
+    push.
+  - **Enforced.** A rule that machinery refuses to let break. *Example:*
+    `.claude/settings.json`'s deny rules block `git add -A` at the
+    harness layer; `.githooks/pre-commit` blocks it at the git layer.
+    Both refuse the action; the agent literally cannot do it.
+  - **Both.** Some rules are written in CLAUDE.md AND backed by a
+    deny-list/hook. Cite both layers in that case.
+
+Phrases like *"structurally enforced"* and *"belt-and-suspenders
+config"* only apply to the enforced case — using them for
+policy-only rules overclaims. Say "the project codifies X in
+CLAUDE.md (policy)" or "the harness denies X via settings.json
+(enforced)" — be explicit about which.
+
+A previous run wrote *"the project CLAUDE.md blocks direct pushes to
+main … so the discipline isn't willpower — it's belt-and-suspenders
+config"* and conflated the two: push-to-main is convention only;
+the deny-list rule covered `git add -A`, not push. Be precise about
+which rule is enforced by what.
 
 ## Corpus layout
 

--- a/.claude/skills/chat-answer/SKILL.md
+++ b/.claude/skills/chat-answer/SKILL.md
@@ -52,9 +52,14 @@ Workflow:
    - The user's global `~/.claude/CLAUDE.md` (operating modes like
      `/code` / `/research` / `/review`, persistent preferences). On
      Windows this resolves to `C:\Users\<user>\.claude\CLAUDE.md`.
-   - The repo's own `CLAUDE.md` (project-specific rules, git
-     conventions, hook configurations, the things the corpus alone
-     can't surface because they're prescriptive not descriptive).
+   - **The HOST project's `CLAUDE.md`** (`<repo-root>/CLAUDE.md`,
+     currently always chat-arch's since that's where the endpoint
+     spawns `claude`). Useful for self-referential questions — "what
+     does chat-arch itself encode about X?" — but **NOT authoritative
+     for the user's other projects in the corpus**. The corpus spans
+     dropKnowledge, outputs, brycewatson.com, and others; the host
+     file describes only chat-arch. Treat it as one project among
+     many.
 
    These three files are cheap and they prevent the failure mode where
    a corpus-grep answer misses load-bearing structure the user has
@@ -340,6 +345,32 @@ main … so the discipline isn't willpower — it's belt-and-suspenders
 config"* and conflated the two: push-to-main is convention only;
 the deny-list rule covered `git add -A`, not push. Be precise about
 which rule is enforced by what.
+
+**Name the project explicitly — don't say "the project CLAUDE.md"
+without a qualifier.** The chat-answer endpoint spawns with `cwd =
+chat-arch repo root`, so any `CLAUDE.md` you Read at
+`<repo-root>/CLAUDE.md` is **chat-arch's specifically** — never "the
+project CLAUDE.md" in general. When citing project-specific rules,
+hooks, or enforcement that you grounded in the host file, write
+*"chat-arch's pre-commit hook"* or *"chat-arch's CLAUDE.md deny
+rule"* — explicit project ownership in the prose.
+
+This matters because the corpus spans many projects (dropKnowledge,
+outputs, brycewatson.com, …) but the host CLAUDE.md is only
+chat-arch's. The cited sessions may have run in projects with
+totally different rules (or no comparable hooks at all). Generalizing
+chat-arch's enforcement to "the project" silently misattributes
+discipline that doesn't exist in the other projects.
+
+If a cited session ran somewhere other than chat-arch and the
+question turns on that project's enforcement, say so honestly:
+*"the cited session ran in dropKnowledge, whose CLAUDE.md I haven't
+read this turn — relying on transcript evidence only."* (Don't Read
+the other project's `<cwd>/CLAUDE.md` either: `cwd` is absent for
+cloud sessions, synthetic for Cowork, and frequently stale for
+local sessions due to cross-OS path drift. Naming discipline +
+transcript evidence is the right shape; per-cwd verification is
+the wrong tool.)
 
 ## Corpus layout
 

--- a/.claude/skills/chat-answer/SKILL.md
+++ b/.claude/skills/chat-answer/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: chat-answer
+description: Answer questions grounded in the user's archived Claude conversations (chat-arch corpus) OR surface proactive opportunities (e.g., blog post ideas) from the same corpus. Acts as the agent driving the chat-arch /chat page. Uses Read/Grep/Glob/Task to explore the corpus directly, dispatches sub-agents for fan-out questions, cites sessions inline as `[SID:<uuid>]`. Read-only — never writes to the corpus, never modifies code.
+---
+
+# /chat-answer
+
+You are answering a single turn of a chat conversation about the user's
+archived Claude conversations. The corpus is on disk at `apps/standalone/
+public/chat-arch-data/`; you read it directly via Read/Grep/Glob. The
+chat UI surfaces your output (text + tool calls) live to the user.
+
+## When to invoke
+
+- The `/api/chat-answer` endpoint runs `claude -p --output-format=stream-
+  json /chat-answer --request-file=<path>` per user turn.
+- On multi-turn conversations, the endpoint also passes `--resume <id>`
+  so your prior turn's context is preserved.
+
+## Arguments
+
+Parse from the slash-command arguments. Required unless noted.
+
+- `--request-file <path>` — absolute path to a per-turn JSON file the
+  endpoint wrote in `os.tmpdir()`. Contains `{ chatId, question, intent,
+  turnIndex }`. **Read it first; everything else flows from there.**
+- `--data-dir <path>` [default `./apps/standalone/public/chat-arch-data`] —
+  corpus root. Resolve from the repo root.
+
+The endpoint deletes the request file after spawn exits, so do not assume
+it persists after this invocation.
+
+## Intent: branch your approach
+
+The request file's `intent` field is one of `ask` or `find-opportunities`.
+Branch on it before you do anything else — the retrieval shape and output
+shape differ.
+
+### Intent = `ask`
+
+The user asked a question about their corpus ("are you using any workflow
+that multiplies productivity?", "when did I last work on X?", "what did
+Claude push back on in my Y sessions?"). Answer it grounded.
+
+Workflow:
+
+1. **Triage in one sentence** (printed, not silently). What kind of
+   evidence does this question need? Pick one:
+   - *Recurring-pattern* — needs frequency + breadth across sessions.
+   - *Point-lookup* — one specific session/event suffices.
+   - *Comparative* — "X vs Y" / "did A change to B."
+   - *Negative-evidence* — what didn't work; lean on `corrections.json`.
+2. **Retrieve.** Use Grep across `chat-arch-data/local-transcripts/` for
+   keyword evidence, Read the pre-mined analysis sidecars
+   (`narratives.json`, `corrections.json`, `topics.json`, `projects.json`),
+   and Read individual transcripts when a session ID lands in your shortlist.
+3. **Fan out when the question is broad.** If the question needs ≥3
+   independent dimensions of evidence (e.g. "what tools multiply my
+   productivity" → tools used, frequency, abandoned-or-not), dispatch
+   2-3 `Explore` sub-agents in parallel via the Task tool, each on a
+   narrow slice. Synthesize their reports — and **calibrate frequency
+   claims**: an agent reporting "234/272 sessions mention X" is almost
+   always keyword-matching, not measuring actual usage. Trust qualitative
+   examples (quotes, specific session IDs, tool-call evidence) over raw
+   counts.
+4. **Synthesize.** Lead with the answer. Evidence second. Cite sessions
+   inline as `[SID:<uuid>]` using the manifest's `id` field. Distinguish
+   *recurring pattern* from *happened once*. Surface honest negatives
+   where they sharpen the answer ("X didn't pan out because Y") — they
+   build trust more than smoothing things over.
+5. **Follow-ups.** End with 1-3 suggested next questions on their own line,
+   each prefixed `→ ` and phrased as the user would ask them. The UI
+   renders these as one-click chips.
+
+### Intent = `find-opportunities`
+
+The user is looking for blog post / content ideas the corpus suggests.
+This is proactive: you decide what's worth surfacing.
+
+Workflow:
+
+1. **Survey** the corpus structure first. Read `manifest.json` for
+   session count + date range. Read `analysis/narratives.json` and
+   `analysis/corrections.json` — these are pre-mined patterns and are
+   gold for opportunity-finding. Skim `analysis/topics.json` and
+   `analysis/projects.json` for the taxonomy.
+2. **Score candidates** along four axes (don't print the scores;
+   internalize them):
+   - **Recurrence** — does the user return to this theme across many
+     sessions? One-offs make weak posts.
+   - **Novelty** — is the pattern this user's own, or a generic AI
+     workflow? Unique > generic.
+   - **Concreteness** — can you point at specific sessions and quote
+     specific moments? Vague themes make weak posts.
+   - **Tension/story** — does the corpus show iteration, failure-then-
+     success, or a contrarian take? A narrative arc makes the post
+     write itself.
+3. **Cluster.** Group raw candidates by theme. Aim for 3-5 distinct
+   opportunities, not 15 micro-variations.
+4. **Output** each opportunity as a structured block:
+
+   ```
+   ### {Idea title — phrased as the post's headline}
+
+   **Why this is a post:** {one sentence on the angle / hook.}
+
+   **Evidence:** 3-5 cited sessions. `[SID:<uuid>]` each, plus a one-line
+   note on what each contributes.
+
+   **Suggested opening:** {2-3 sentences the user could literally start
+   the post with.}
+
+   **Risks/honest negatives:** anything that would weaken the post if
+   the user wrote it without checking. (E.g., "claim X is hard to support
+   — only 2 sessions show this clearly.")
+   ```
+5. **Calibration line.** Close with one short paragraph: "These ideas
+   are surfaced from {N sessions} dated {range}; the strongest signal
+   is {brief}." Honest about what the corpus does and doesn't show.
+
+## Citation contract
+
+**Hard rule:** every `[SID:<uuid>]` you emit MUST correspond to a session
+you actually Read or saw in a Grep result during this turn. The endpoint
+validates citations against your `Read` tool_use history before surfacing
+them to the user — hallucinated SIDs are silently dropped, which makes
+your answer look uncited. So: only cite what you actually saw.
+
+Citation format: `[SID:abc12345-...]`. Use the full UUID from the
+manifest's `id` field. Multiple citations are fine; cluster them as
+`[SID:abc] [SID:def]`, not `[SID:abc, def]` (parser-fragile).
+
+When the corpus does NOT support a claim, say so explicitly rather than
+fabricating evidence: "The corpus doesn't show this directly — based on
+indirect signal in [SID:abc], I'd guess … but it's an inference, not a
+finding."
+
+## Corpus layout
+
+The `--data-dir` path resolves to a directory shaped roughly like:
+
+```
+chat-arch-data/
+├── manifest.json                       — UnifiedSessionEntry[] index
+├── local-transcripts/
+│   ├── cowork/<uuid>.jsonl             — Cowork session transcripts
+│   ├── cli-direct/<uuid>.jsonl
+│   └── cli-desktop/<uuid>.jsonl
+├── analysis/
+│   ├── meta.json                       — corpus counts + exporter version
+│   ├── projects.json                   — discovered project entities
+│   ├── topics.json                     — discovered topic clusters
+│   ├── narratives.json                 — sentiment-clustered narratives
+│   ├── corrections.json                — mined correction patterns (user pushed back)
+│   ├── correction-candidates.json      — heuristic-recall candidates
+│   ├── duplicates.exact.json
+│   └── zombies.heuristic.json
+└── cloud-conversations/                — usually empty; cloud data lives in IndexedDB
+```
+
+**Cloud-conversation transcripts are NOT on disk.** They live in the
+browser's IndexedDB only (privacy boundary). When a question's best
+evidence would be a cloud session and you can only see its `manifest.
+json` entry (title + preview + summary fields), say so: "The fullest
+evidence is in a cloud-only session I can't read directly — the manifest
+shows {preview}, but I can't quote the messages."
+
+## Tool grants
+
+You are spawned with `--allowedTools "Read Grep Glob Task"`. You do NOT
+have Bash, Write, or Edit. This is intentional:
+
+- **No Bash** — corpus exploration is read-only. If you'd like to run a
+  shell command, say so in the answer and propose the user run it
+  themselves rather than asking for a tool you don't have.
+- **No Write/Edit** — Phase 1 is read-only. Future work (save-as-memory,
+  draft-as-skill) will be separate user-triggered actions, not autonomous
+  writes from this skill.
+- **Task is available** — use sub-agents (especially `Explore`) for
+  fan-out retrieval and parallel sub-questions.
+
+## Style
+
+The user's CLAUDE.md and corrections corpus consistently push back on:
+
+- **Over-narration** — "I'm going to start by reading X" is friction. Just
+  read X.
+- **Verbose preamble** — lead with the answer, not the methodology.
+- **Padding** — no "great question!", no "here's a thorough analysis."
+- **False confidence** — if the corpus doesn't support a claim, say so.
+
+Markdown is fine. Code fences are fine. Headers are fine. Honest brevity
+wins over thoroughness theater.
+
+## Failure modes
+
+- **Manifest missing / unreadable:** report it plainly. "The corpus isn't
+  scanned yet — run `pnpm exporter run start` and try again."
+- **Empty corpus:** "No sessions in the corpus yet. Upload a Claude cloud
+  export or scan local sessions first."
+- **Question too vague:** answer the most-plausible reading, then surface
+  the ambiguity as a follow-up. Don't ask for clarification — the chat
+  UX prefers a first-pass answer with offered refinements.
+- **Resume context mismatch:** if `--resume` was used but the prior
+  conversation's context doesn't match the current question (Claude
+  reset the session), just answer the new question fresh; the endpoint
+  handles session-id rotation.

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ out/
 .claude/skills/*
 !.claude/skills/mine-corrections/
 !.claude/skills/mine-corrections/SKILL.md
+# Chat-page skill — same shape as mine-corrections. Drives the
+# `/api/chat-answer` endpoint (the chat page's agent specialization),
+# so it ships with the repo and not as per-developer state.
+!.claude/skills/chat-answer/
+!.claude/skills/chat-answer/SKILL.md
 # …except (1) test fixtures, which legitimately contain a `.claude/`
 # subtree that mimics what a real Cowork session directory looks
 # like on disk. These are synthetic (redacted), vital for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-15
+
+### Added
+
+- **Subagent rollup** — Cowork and host-CLI sessions whose Task tool
+  fans out to sub-agents (often Haiku) now contribute the sub-agents'
+  tokens, tool calls, and models to the parent entry's
+  `tokenTotals` / `topTools` / `modelsUsed`. The sub-agent-only
+  breakdown stays inspectable via the new `subagentRollup` field.
+- **`userTextSamples`** — every source now emits up to 5 user-turn
+  excerpts (≤400 chars each) for analysis-grade input. Feeds
+  `discoverNarratives` clustering so the pipeline sees more than the
+  200-char `preview`.
+- **Inline Cowork enrichments** — `userSelectedFolders`,
+  `slashCommands`, `enabledMcpTools`, `errorMessage` are now exposed
+  on the unified entry instead of being dropped at the
+  drift-detection stage.
+- **`tokenTotals` on Cowork entries** — derived from
+  `audit.modelUsage`; previously absent.
+
+### Changed
+
+- **`claude-code-sessions/` routed through Cowork** — Anthropic's
+  rename (refs anthropics/claude-code#29373, #27463) means both
+  AppData roots are now Cowork-shaped. The Desktop-CLI walker is
+  removed; a warn-once fires if a manifest there matches neither
+  schema.
+- **Per-source cache envelope** — `cli-sessions.json` and
+  `cowork-sessions.json` now write
+  `{ __exporterVersion, entries }`. Loaders gate reuse on an exact
+  version match so on-disk-shape changes self-invalidate. Legacy
+  bare-array files are tolerated for one rescan cycle.
+
 ## [0.8.0] — 2026-05-08
 
 ### Added

--- a/apps/standalone/src/lib/resolveClaude.ts
+++ b/apps/standalone/src/lib/resolveClaude.ts
@@ -1,0 +1,130 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Resolve the `claude` (Claude Code CLI) binary path for `spawn()`.
+ *
+ * Background — why this exists:
+ *
+ *   On Windows, the typical Claude Code install path is a global npm
+ *   shim at e.g. `C:\nvm4w\nodejs\claude.cmd` that delegates to
+ *   `node_modules\@anthropic-ai\claude-code\bin\claude.exe`. Claude
+ *   Code's auto-updater rotates the `.exe` (renaming the prior to
+ *   `claude.exe.old.<ts>`) and replaces it in-place. If the update is
+ *   mid-flight, fails, or the new binary is being held open by a still-
+ *   running process, the `bin/` directory can be left with only the
+ *   rotated `.old` files — no current `.exe`. Every `spawn('claude',
+ *   …, { shell: true })` then errors with
+ *   "'…\claude.exe' is not recognized as an internal or external
+ *   command" and exits 1 before producing any output.
+ *
+ *   Meanwhile a working local install lives alongside the user data at
+ *   `%APPDATA%\Claude\claude-code\<version>\claude.exe` (Claude Code's
+ *   version-managed cache). This is the install the running Claude
+ *   Code processes are actually executing from on a broken-shim
+ *   machine, but `spawn('claude', …)` doesn't reach it because the
+ *   shell's PATH lookup finds the broken shim first.
+ *
+ * Resolution order (first hit wins):
+ *
+ *   1. `process.env.CLAUDE_BIN` — explicit operator override. Must
+ *      point at a file that exists; otherwise fall through.
+ *   2. (Windows only) `%APPDATA%\Claude\claude-code\<version>\
+ *      claude.exe` — pick the newest version directory by semver.
+ *      Falls through if APPDATA is unset or the directory tree is
+ *      absent.
+ *   3. Bare `'claude'` — PATH-resolved by the shell (the original
+ *      behavior). Works when the global shim is healthy.
+ *
+ *   The shape returned tells the caller whether to set `shell: true`
+ *   on the spawn: when we resolved a concrete `.exe` path,
+ *   `shell: false` is preferable so the absolute path bypasses cmd's
+ *   special-char handling entirely. When falling back to the bare
+ *   `'claude'`, `shell: true` is still required on Windows so the
+ *   shim's `.cmd` extension gets PATHEXT-resolved.
+ */
+export interface ClaudeBin {
+  /** Absolute path or bare command name passed as `spawn(file, …)`. */
+  file: string;
+  /** Pass to `spawn(file, args, { shell: useShell })`. */
+  useShell: boolean;
+  /** Tag describing which strategy hit, for logging. */
+  source: 'env' | 'appdata' | 'path';
+}
+
+function fileExists(p: string): boolean {
+  try {
+    return statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Walk `%APPDATA%\Claude\claude-code\*` and return the directory whose
+ * name semver-sorts highest among entries that contain a `claude.exe`.
+ * Null when the tree is missing or no version directory holds a real
+ * binary.
+ *
+ * We compare versions by splitting on `.` and numeric-comparing each
+ * segment so `2.1.138` correctly beats `2.1.99` (which a plain lexical
+ * sort would invert).
+ */
+function pickNewestAppdataInstall(appdata: string): string | null {
+  const root = join(appdata, 'Claude', 'claude-code');
+  let entries: string[];
+  try {
+    entries = readdirSync(root);
+  } catch {
+    return null;
+  }
+  const candidates: { dir: string; parts: number[] }[] = [];
+  for (const name of entries) {
+    const exe = join(root, name, 'claude.exe');
+    if (!fileExists(exe)) continue;
+    const parts = name
+      .split('.')
+      .map((s) => Number.parseInt(s, 10))
+      .filter((n) => Number.isFinite(n));
+    if (parts.length === 0) continue;
+    candidates.push({ dir: join(root, name), parts });
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => {
+    const len = Math.max(a.parts.length, b.parts.length);
+    for (let i = 0; i < len; i++) {
+      const ai = a.parts[i] ?? 0;
+      const bi = b.parts[i] ?? 0;
+      if (ai !== bi) return bi - ai;
+    }
+    return 0;
+  });
+  return join(candidates[0]!.dir, 'claude.exe');
+}
+
+export function resolveClaudeBin(): ClaudeBin {
+  const envBin = process.env['CLAUDE_BIN'];
+  if (typeof envBin === 'string' && envBin.length > 0 && fileExists(envBin)) {
+    return { file: envBin, useShell: false, source: 'env' };
+  }
+
+  if (process.platform === 'win32') {
+    const appdata = process.env['APPDATA'];
+    if (typeof appdata === 'string' && appdata.length > 0) {
+      const found = pickNewestAppdataInstall(appdata);
+      if (found && fileExists(found)) {
+        return { file: found, useShell: false, source: 'appdata' };
+      }
+    }
+  }
+
+  // Last-resort fallback — let the shell find it via PATH. This is the
+  // original behavior and still works on machines whose global shim is
+  // healthy. On a broken-shim machine the spawn will surface a clear
+  // error that points the operator at the env-var override.
+  return {
+    file: 'claude',
+    useShell: process.platform === 'win32',
+    source: 'path',
+  };
+}

--- a/apps/standalone/src/pages/api/chat-answer.ts
+++ b/apps/standalone/src/pages/api/chat-answer.ts
@@ -10,6 +10,7 @@ import {
   type ChatCitation,
   type ChatStreamEvent,
 } from '@chat-arch/schema';
+import { resolveClaudeBin } from '../../lib/resolveClaude.js';
 
 /**
  * Chat page synthesis endpoint. Spawns `claude -p` against the `chat-
@@ -439,8 +440,16 @@ async function runChatAnswer(
   };
 
   const isWin = process.platform === 'win32';
+  const bin = resolveClaudeBin();
+  // When we have an absolute path (env/appdata), spawn without a shell
+  // so Node's arg array is passed verbatim — no cmd.exe special-char
+  // surprises, no PATHEXT lookup needed. When falling back to bare
+  // 'claude', we DO need a shell on Windows so the `.cmd` shim
+  // resolves (npm-installed CLIs typically expose only `claude.cmd`,
+  // not a `claude.exe` on PATH).
   const slashCommand = `/chat-answer --request-file=${requestFile}`;
-  const promptArg = isWin ? `"${slashCommand.replace(/"/g, '\\"')}"` : slashCommand;
+  const promptArg =
+    bin.useShell && isWin ? `"${slashCommand.replace(/"/g, '\\"')}"` : slashCommand;
   const allowedTools = 'Read Grep Glob Task';
   // `--output-format=stream-json` requires `--verbose` when paired with
   // `-p` (headless). Without it the CLI prints
@@ -462,10 +471,10 @@ async function runChatAnswer(
   await new Promise<void>((resolveOuter) => {
     let stdoutBuf = '';
     let stderrBuf = '';
-    const child = spawn('claude', args, {
+    const child = spawn(bin.file, args, {
       cwd: repoRoot(),
       env: process.env,
-      shell: isWin,
+      shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let spawnError: Error | null = null;

--- a/apps/standalone/src/pages/api/chat-answer.ts
+++ b/apps/standalone/src/pages/api/chat-answer.ts
@@ -63,7 +63,18 @@ export const prerender = false;
 export const REQUIRED_HEADER = 'chat-arch-chat-answer';
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 const MAX_CONCURRENT = 3;
-const SILENT_ABORT_GRACE_MS = 60_000;
+// Inactivity watchdog. Fires when NO stream-json events arrive within
+// the grace window — a real silent-abort signal. An agentic flow that
+// dispatches sub-agents legitimately runs for minutes; what we care
+// about is "did the agent stop producing output?", not "is the total
+// duration too long." So this resets on every successful send. The
+// hard cap below catches genuine runaway cases.
+const INACTIVITY_GRACE_MS = 120_000;
+// Hard upper bound on a single turn, regardless of activity. Sized for
+// fan-out questions that legitimately spawn 2-3 sub-agents each doing
+// minutes of corpus work. Past this, we declare the turn lost — most
+// likely the agent got stuck on a permission prompt in headless mode.
+const HARD_CAP_MS = 10 * 60_000;
 
 export function isLocalOrigin(origin: string | null): boolean {
   if (!origin) return false;
@@ -606,26 +617,51 @@ export const POST: APIRoute = async ({ request }) => {
   inFlightByChatId.set(body.chatId, { startedAt: Date.now() });
   totalInFlight += 1;
 
-  // Silent-abort watchdog: if the stream lives past SILENT_ABORT_GRACE_MS
-  // without resolving, the response is closed and the gate released.
-  // The actual claude process keeps running in the background; the
-  // user's UI sees a clean error and can retry.
-  let watchdog: ReturnType<typeof setTimeout> | null = null;
+  // Two watchdogs:
+  //   - inactivityTimer: fires after INACTIVITY_GRACE_MS of no events.
+  //     Reset on every successful `send()` so an agent that's actively
+  //     emitting tool_use / token / trace events keeps the stream alive.
+  //   - hardCapTimer: absolute upper bound — fires even if events flow,
+  //     to catch a stuck loop that's emitting noise but making no
+  //     progress on the actual answer.
+  let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+  let hardCapTimer: ReturnType<typeof setTimeout> | null = null;
 
   const encoder = new TextEncoder();
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
-      const send = (ev: ChatStreamEvent): void => {
+      const armInactivity = () => {
+        if (inactivityTimer) clearTimeout(inactivityTimer);
+        inactivityTimer = setTimeout(() => {
+          rawSend({
+            type: 'error',
+            message: `chat-answer received no events for ${INACTIVITY_GRACE_MS / 1000}s — agent appears stuck (possibly blocked on a tool-permission prompt in headless mode).`,
+            retryable: true,
+          });
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        }, INACTIVITY_GRACE_MS);
+      };
+      const rawSend = (ev: ChatStreamEvent): void => {
         try {
           controller.enqueue(encoder.encode(JSON.stringify(ev) + '\n'));
         } catch {
           // controller closed — ignore
         }
       };
-      watchdog = setTimeout(() => {
-        send({
+      const send = (ev: ChatStreamEvent): void => {
+        rawSend(ev);
+        // Any event from the agent counts as liveness — reset inactivity.
+        armInactivity();
+      };
+      armInactivity();
+      hardCapTimer = setTimeout(() => {
+        rawSend({
           type: 'error',
-          message: `chat-answer timed out after ${SILENT_ABORT_GRACE_MS}ms`,
+          message: `chat-answer hit the ${HARD_CAP_MS / 60_000}-minute hard cap. Try splitting the question or running it again.`,
           retryable: true,
         });
         try {
@@ -633,12 +669,13 @@ export const POST: APIRoute = async ({ request }) => {
         } catch {
           // already closed
         }
-      }, SILENT_ABORT_GRACE_MS);
+      }, HARD_CAP_MS);
 
       try {
         await runChatAnswer(body, send);
       } finally {
-        if (watchdog) clearTimeout(watchdog);
+        if (inactivityTimer) clearTimeout(inactivityTimer);
+        if (hardCapTimer) clearTimeout(hardCapTimer);
         inFlightByChatId.delete(body.chatId);
         totalInFlight = Math.max(0, totalInFlight - 1);
         try {

--- a/apps/standalone/src/pages/api/chat-answer.ts
+++ b/apps/standalone/src/pages/api/chat-answer.ts
@@ -442,11 +442,18 @@ async function runChatAnswer(
   const slashCommand = `/chat-answer --request-file=${requestFile}`;
   const promptArg = isWin ? `"${slashCommand.replace(/"/g, '\\"')}"` : slashCommand;
   const allowedTools = 'Read Grep Glob Task';
+  // `--output-format=stream-json` requires `--verbose` when paired with
+  // `-p` (headless). Without it the CLI prints
+  // "Error: When using --print, --output-format=stream-json requires --verbose"
+  // and exits 1 before producing any events — surfaces in the UI as
+  // "claude CLI exited with code 1" because no `result` event ever
+  // arrives.
   const args = [
     '--allowedTools',
     allowedTools,
     '--output-format',
     'stream-json',
+    '--verbose',
     ...(body.resumeSessionId ? ['--resume', body.resumeSessionId] : []),
     '-p',
     promptArg,

--- a/apps/standalone/src/pages/api/chat-answer.ts
+++ b/apps/standalone/src/pages/api/chat-answer.ts
@@ -1,0 +1,670 @@
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { writeFile, unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  CHAT_QUESTION_MAX_CHARS,
+  type ChatCitation,
+  type ChatStreamEvent,
+} from '@chat-arch/schema';
+
+/**
+ * Chat page synthesis endpoint. Spawns `claude -p` against the `chat-
+ * answer` skill, normalizes its `--output-format=stream-json` events into
+ * NDJSON for the browser, and validates citations against the corpus the
+ * agent actually read during the turn.
+ *
+ * Architecture notes (v3 first-principles framing):
+ *
+ *   - The browser does NOT pre-retrieve. The skill, running as Claude
+ *     Code with `Read Grep Glob Task` granted, retrieves from the corpus
+ *     itself. The browser POSTs only `{ chatId, question, intent,
+ *     resumeSessionId? }`.
+ *
+ *   - Tool grant is intentionally narrow. No Bash (no shell exec), no
+ *     Write/Edit (Phase 1 is read-only — future save-as-memory flows
+ *     will be separate user-triggered actions). Compare with `mine-
+ *     corrections.ts:631` which grants the broader `Read Write Edit
+ *     Bash Task Glob Grep` because that skill MUST mutate the analysis
+ *     files; chat-answer never does.
+ *
+ *   - Concurrency. Unlike `mine-corrections` (single-flight: one global
+ *     mining run at a time), chat answers must run concurrently across
+ *     conversations. We gate two-tier: per-`chatId` single-flight
+ *     (returns 409) plus a global ceiling (returns 429) so N parallel
+ *     tabs can't OOM the host with spawned agents.
+ *
+ *   - Citation validation. The skill is instructed to emit `[SID:<uuid>]`
+ *     inline. We parse those out of token text, but cross-reference each
+ *     SID against the agent's actual `Read` tool_use history before
+ *     emitting a `citation` event. Hallucinated SIDs are dropped silently
+ *     so they never reach the rendered chips. The manifest IS treated as
+ *     a "saw everything" Read — once the agent reads `manifest.json`,
+ *     all manifest SIDs become quotable. Transcript reads add per-file
+ *     UUIDs.
+ *
+ *   - Tmpdir-only artifacts. The per-request bundle JSON is written to
+ *     `os.tmpdir()` (NEVER under `apps/standalone/public/chat-arch-
+ *     data/` — that path is PII-sensitive per CLAUDE.md). Removed in
+ *     `finally`. The skill reads it within the spawn lifetime.
+ *
+ *   - End-of-stream sentinel. Claude Code emits a `result` event when
+ *     the turn completes; we re-emit as `{ type: 'final' }`. If the
+ *     stream closes without a `result`, we emit `{ type: 'error',
+ *     message: 'silent abort' }` — same correctness story as mine-
+ *     corrections' `classifyOutcome`, scaled down.
+ */
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-chat-answer';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+const MAX_CONCURRENT = 3;
+const SILENT_ABORT_GRACE_MS = 60_000;
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function jsonError(status: number, error: string, extra: Record<string, unknown> = {}): Response {
+  return new Response(JSON.stringify({ ok: false, error, ...extra }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function csrfReject(reason: string): Response {
+  return jsonError(403, `Forbidden: ${reason}`);
+}
+
+/**
+ * Per-chatId single-flight + global ceiling. A new turn against the SAME
+ * chat while one is in flight returns 409 (Conflict). When the server-wide
+ * total hits `MAX_CONCURRENT`, additional new-chat starts return 429 (Too
+ * Many Requests). Tabs of the SAME conversation can never double-spawn;
+ * unrelated conversations can run in parallel up to the ceiling.
+ */
+const inFlightByChatId = new Map<string, { startedAt: number }>();
+let totalInFlight = 0;
+
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+function isUuid(v: unknown): v is string {
+  return typeof v === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(v);
+}
+
+interface ParsedBody {
+  chatId: string;
+  question: string;
+  intent: 'ask' | 'find-opportunities';
+  resumeSessionId?: string;
+}
+
+function parseRequestBody(raw: unknown): { ok: true; body: ParsedBody } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'body must be a JSON object' };
+  const b = raw as Record<string, unknown>;
+  if (!isUuid(b['chatId'])) return { ok: false, error: 'chatId must be a UUID' };
+  const q = b['question'];
+  if (typeof q !== 'string' || q.trim().length === 0) {
+    return { ok: false, error: 'question must be a non-empty string' };
+  }
+  if (q.length > CHAT_QUESTION_MAX_CHARS) {
+    return { ok: false, error: `question exceeds ${CHAT_QUESTION_MAX_CHARS} chars` };
+  }
+  const intent = b['intent'];
+  if (intent !== 'ask' && intent !== 'find-opportunities') {
+    return { ok: false, error: 'intent must be "ask" or "find-opportunities"' };
+  }
+  const rs = b['resumeSessionId'];
+  if (rs !== undefined && !isUuid(rs)) {
+    return { ok: false, error: 'resumeSessionId, when present, must be a UUID' };
+  }
+  return {
+    ok: true,
+    body: {
+      chatId: b['chatId'] as string,
+      question: q,
+      intent,
+      ...(typeof rs === 'string' ? { resumeSessionId: rs } : {}),
+    },
+  };
+}
+
+/**
+ * Tracks every SID the agent gained read-access to during the turn. The
+ * manifest read unlocks ALL manifest SIDs at once (it's the canonical
+ * session index — anything cited from it is grounded in real metadata).
+ * Per-transcript reads add a single UUID each. Used to validate inline
+ * `[SID:<uuid>]` citations before they reach the UI.
+ */
+class CitationValidator {
+  private explicitSids = new Set<string>();
+  private allFromManifest = false;
+  /** SID → snippet preview, populated when manifest is read. */
+  private previewBySid = new Map<string, string>();
+
+  noteRead(filePath: string, fileContent?: string): void {
+    const normalized = filePath.replace(/\\/g, '/');
+    // Manifest read → unlock all SIDs from the file (if we can parse it).
+    if (normalized.endsWith('/manifest.json') || normalized.endsWith('chat-arch-data/manifest.json')) {
+      this.allFromManifest = true;
+      if (fileContent) {
+        try {
+          const m = JSON.parse(fileContent) as { sessions?: Array<{ id?: unknown; preview?: unknown }> };
+          for (const s of m.sessions ?? []) {
+            if (isUuid(s.id)) {
+              this.explicitSids.add(s.id);
+              if (typeof s.preview === 'string') {
+                this.previewBySid.set(s.id, s.preview.slice(0, 200));
+              }
+            }
+          }
+        } catch {
+          // best-effort; the read still grants citation rights even if
+          // we couldn't parse it ourselves.
+        }
+      }
+      return;
+    }
+    // Transcript or per-session file → extract UUID from filename.
+    const m = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i.exec(normalized);
+    if (m) this.explicitSids.add(m[1]!.toLowerCase());
+  }
+
+  /** True iff the agent has visibility into this SID via a prior Read. */
+  isCitable(sid: string): boolean {
+    const lower = sid.toLowerCase();
+    if (this.explicitSids.has(lower)) return true;
+    // If the agent read manifest.json but we couldn't parse it locally
+    // (e.g. the agent only saw part of it), accept any well-formed UUID
+    // — the agent had access to the full SID list.
+    return this.allFromManifest && isUuid(sid);
+  }
+
+  snippetFor(sid: string): string | undefined {
+    return this.previewBySid.get(sid.toLowerCase());
+  }
+}
+
+/**
+ * Walk the assistant text emitted so far and yield each unique
+ * `[SID:<uuid>]` reference NOT yet seen on this turn. Stateful per turn:
+ * the caller maintains the "already emitted" set so we don't re-emit
+ * citations as more tokens arrive.
+ */
+function* scanForNewCitations(
+  accumulatedText: string,
+  alreadyEmitted: Set<string>,
+): Generator<string> {
+  const re = /\[SID:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(accumulatedText)) !== null) {
+    const sid = match[1]!.toLowerCase();
+    if (alreadyEmitted.has(sid)) continue;
+    alreadyEmitted.add(sid);
+    yield sid;
+  }
+}
+
+/**
+ * Best-effort one-line summary for a tool call. Picks the most salient
+ * input field so the UI's AgentTrace row shows the agent's intent, not
+ * a JSON blob. Capped at 200 chars.
+ */
+function summarizeToolUse(name: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return name;
+  const o = input as Record<string, unknown>;
+  const pick = (k: string): string | undefined =>
+    typeof o[k] === 'string' ? (o[k] as string) : undefined;
+  let detail: string | undefined;
+  if (name === 'Read' || name === 'Glob') detail = pick('file_path') ?? pick('pattern');
+  else if (name === 'Grep') detail = pick('pattern');
+  else if (name === 'Task') detail = pick('description') ?? pick('subagent_type');
+  else detail = pick('description');
+  const cleaned = detail ? detail.replace(/\s+/g, ' ').slice(0, 200) : '';
+  return cleaned ? `${name} ${cleaned}` : name;
+}
+
+interface SpawnContext {
+  send: (ev: ChatStreamEvent) => void;
+  validator: CitationValidator;
+  /** SIDs already emitted as `citation` events this turn. */
+  emittedCitations: Set<string>;
+  /** Concatenated assistant text seen this turn (across all `text` blocks). */
+  assistantBuf: { v: string };
+  /** True once we see Claude Code's `result` event. */
+  sawResult: { v: boolean };
+}
+
+/**
+ * Parse one Claude Code `--output-format=stream-json` line and re-emit
+ * it as ChatStreamEvent(s). Tolerant of unknown shapes — surfaces them
+ * as a `thinking` trace rather than crashing.
+ */
+function handleStreamJsonLine(line: string, ctx: SpawnContext): string | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    // Not JSON — likely a stderr leak surfacing in stdout. Treat as
+    // thinking trace; the UI renders these collapsed.
+    ctx.send({
+      type: 'trace',
+      event: { kind: 'thinking', preview: trimmed.slice(0, 200), ts: Date.now() },
+    });
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const o = obj as Record<string, unknown>;
+  const evType = o['type'];
+  let claudeSessionId: string | null = null;
+
+  if (evType === 'system' && o['subtype'] === 'init') {
+    const sid = o['session_id'];
+    if (typeof sid === 'string') {
+      claudeSessionId = sid;
+      ctx.send({ type: 'claude-session', claudeSessionId: sid });
+    }
+    return claudeSessionId;
+  }
+
+  if (evType === 'assistant') {
+    const msg = o['message'] as { content?: unknown } | undefined;
+    const content = Array.isArray(msg?.content) ? msg!.content : [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as Record<string, unknown>;
+      const bt = b['type'];
+      if (bt === 'text' && typeof b['text'] === 'string') {
+        const text = b['text'];
+        ctx.assistantBuf.v += text;
+        ctx.send({ type: 'token', text });
+        // Scan for new citations across the cumulative text.
+        for (const sid of scanForNewCitations(ctx.assistantBuf.v, ctx.emittedCitations)) {
+          if (!ctx.validator.isCitable(sid)) continue;
+          const citation: ChatCitation = {
+            sessionId: sid,
+            // We don't know source from a SID alone; the UI resolves it
+            // by looking up the manifest. Default to 'cloud' is wrong —
+            // omit source and let the UI fill it. (Schema permits source
+            // as required; we pick a safe default and the UI overrides
+            // from the manifest.)
+            source: 'cowork',
+            ...(ctx.validator.snippetFor(sid)
+              ? { snippet: ctx.validator.snippetFor(sid)! }
+              : {}),
+          };
+          ctx.send({ type: 'citation', citation });
+        }
+      } else if (bt === 'tool_use') {
+        const name = typeof b['name'] === 'string' ? b['name'] : 'tool';
+        const summary = summarizeToolUse(name, b['input']);
+        if (name === 'Task') {
+          const inp = (b['input'] ?? {}) as Record<string, unknown>;
+          const agent = typeof inp['subagent_type'] === 'string' ? inp['subagent_type'] : 'agent';
+          ctx.send({
+            type: 'trace',
+            event: { kind: 'sub_agent', agent, summary, ts: Date.now() },
+          });
+        } else {
+          ctx.send({
+            type: 'trace',
+            event: { kind: 'tool_use', tool: name, summary, ts: Date.now() },
+          });
+        }
+      }
+    }
+    return null;
+  }
+
+  if (evType === 'user') {
+    // tool_result events come in `user`-wrapped messages. We use these
+    // to populate the citation validator with file contents the agent
+    // just read (Read tool_result includes the file content).
+    const msg = o['message'] as { content?: unknown } | undefined;
+    const content = Array.isArray(msg?.content) ? msg!.content : [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as Record<string, unknown>;
+      if (b['type'] !== 'tool_result') continue;
+      // The tool_result carries the read content; we'd need to also know
+      // WHICH tool produced it (Read vs Grep vs Glob) to interpret it.
+      // The id correlates to the prior tool_use. For the citation
+      // validator's purposes we already noted the path when we saw the
+      // tool_use; we don't need the result body. Errors surface as
+      // trace events.
+      const isErr = b['is_error'] === true;
+      if (isErr) {
+        const txt = typeof b['content'] === 'string' ? (b['content'] as string).slice(0, 200) : 'tool error';
+        ctx.send({
+          type: 'trace',
+          event: { kind: 'error', message: txt, ts: Date.now() },
+        });
+      }
+    }
+    // We also need to register each Read's file_path with the validator.
+    // The tool_use already passed through above, so we register there
+    // instead. (See assistant branch — tool_use blocks include input.)
+    return null;
+  }
+
+  if (evType === 'result') {
+    ctx.sawResult.v = true;
+    return null;
+  }
+
+  // Unknown shape — surface as a thinking trace so the operator can see
+  // it but the UI doesn't crash.
+  ctx.send({
+    type: 'trace',
+    event: {
+      kind: 'thinking',
+      preview: JSON.stringify(o).slice(0, 200),
+      ts: Date.now(),
+    },
+  });
+  return null;
+}
+
+/**
+ * Walk a single tool_use event and tell the validator what corpus
+ * material is now citable. Called as a side effect during stream parsing
+ * so that by the time the assistant emits `[SID:abc]`, the validator
+ * already knows whether `abc` was a Read filename.
+ */
+function noteToolUseForValidator(name: string, input: unknown, validator: CitationValidator): void {
+  if (!input || typeof input !== 'object') return;
+  const o = input as Record<string, unknown>;
+  if (name === 'Read' && typeof o['file_path'] === 'string') {
+    validator.noteRead(o['file_path']);
+  } else if (name === 'Glob' && typeof o['pattern'] === 'string') {
+    // Glob doesn't read content; it just enumerates. Treat as a hint
+    // that the agent is searching — no validator change.
+  } else if (name === 'Grep' && typeof o['pattern'] === 'string') {
+    // Grep may surface SIDs in matched paths; without seeing the result
+    // body we can't know, so skip. The agent will Read individual
+    // transcripts if it needs to cite them.
+  }
+}
+
+function buildRequestBundle(body: ParsedBody, turnIndex: number): string {
+  return JSON.stringify(
+    {
+      chatId: body.chatId,
+      question: body.question,
+      intent: body.intent,
+      turnIndex,
+    },
+    null,
+    2,
+  );
+}
+
+/**
+ * Spawn `claude -p` with stream-json output, pump events to the client,
+ * and clean up the request file when done.
+ */
+async function runChatAnswer(
+  body: ParsedBody,
+  send: (ev: ChatStreamEvent) => void,
+): Promise<void> {
+  const requestId = randomUUID();
+  const startedAt = Date.now();
+  send({ type: 'start', requestId, chatId: body.chatId, startedAt });
+
+  const requestFile = join(tmpdir(), `chat-arch-chat-${requestId}.json`);
+  await writeFile(requestFile, buildRequestBundle(body, 0), 'utf8');
+
+  const validator = new CitationValidator();
+  const ctx: SpawnContext = {
+    send,
+    validator,
+    emittedCitations: new Set<string>(),
+    assistantBuf: { v: '' },
+    sawResult: { v: false },
+  };
+
+  const isWin = process.platform === 'win32';
+  const slashCommand = `/chat-answer --request-file=${requestFile}`;
+  const promptArg = isWin ? `"${slashCommand.replace(/"/g, '\\"')}"` : slashCommand;
+  const allowedTools = 'Read Grep Glob Task';
+  const args = [
+    '--allowedTools',
+    allowedTools,
+    '--output-format',
+    'stream-json',
+    ...(body.resumeSessionId ? ['--resume', body.resumeSessionId] : []),
+    '-p',
+    promptArg,
+  ];
+
+  await new Promise<void>((resolveOuter) => {
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    const child = spawn('claude', args, {
+      cwd: repoRoot(),
+      env: process.env,
+      shell: isWin,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let spawnError: Error | null = null;
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutBuf += chunk.toString('utf8');
+      // Process complete lines; keep the trailing partial in the buffer.
+      const lines = stdoutBuf.split('\n');
+      stdoutBuf = lines.pop() ?? '';
+      for (const line of lines) {
+        // Note any tool_use blocks ahead of citation scanning by
+        // peeking at the structure. The main parser also emits trace
+        // events for them.
+        try {
+          const obj = JSON.parse(line.trim());
+          if (
+            obj?.type === 'assistant' &&
+            Array.isArray(obj.message?.content)
+          ) {
+            for (const block of obj.message.content) {
+              if (block?.type === 'tool_use' && typeof block.name === 'string') {
+                noteToolUseForValidator(block.name, block.input, validator);
+              }
+            }
+          }
+        } catch {
+          // not JSON — handleStreamJsonLine will surface as thinking trace
+        }
+        handleStreamJsonLine(line, ctx);
+      }
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrBuf += chunk.toString('utf8');
+      // stderr lines surface as collapsed thinking traces — they're
+      // usually claude's own diagnostics, not user-facing errors.
+      const lines = stderrBuf.split('\n');
+      stderrBuf = lines.pop() ?? '';
+      for (const line of lines) {
+        const t = line.trim();
+        if (t.length === 0) continue;
+        send({
+          type: 'trace',
+          event: { kind: 'thinking', preview: t.slice(0, 200), ts: Date.now() },
+        });
+      }
+    });
+    child.on('error', (err) => {
+      spawnError = err;
+    });
+    child.on('close', (code) => {
+      // Flush any remaining buffered partial line.
+      if (stdoutBuf.trim().length > 0) handleStreamJsonLine(stdoutBuf, ctx);
+      if (stderrBuf.trim().length > 0) {
+        send({
+          type: 'trace',
+          event: { kind: 'thinking', preview: stderrBuf.trim().slice(0, 200), ts: Date.now() },
+        });
+      }
+
+      const durationMs = Date.now() - startedAt;
+      if (spawnError) {
+        send({
+          type: 'error',
+          message: `failed to spawn claude: ${spawnError.message}. Is the CLI installed and on PATH?`,
+          retryable: false,
+        });
+      } else if (code !== 0) {
+        send({
+          type: 'error',
+          message: `claude CLI exited with code ${code}`,
+          retryable: true,
+        });
+      } else if (!ctx.sawResult.v) {
+        send({
+          type: 'error',
+          message:
+            'silent abort — the CLI exited cleanly but emitted no result event. The skill may have hit an "ask the user" branch in headless mode.',
+          retryable: true,
+        });
+      } else {
+        send({
+          type: 'final',
+          ok: true,
+          answerChars: ctx.assistantBuf.v.length,
+          citationsCount: ctx.emittedCitations.size,
+          durationMs,
+        });
+      }
+      resolveOuter();
+    });
+  });
+
+  // Best-effort cleanup. The skill should have finished reading it long
+  // before this point.
+  try {
+    await unlink(requestFile);
+  } catch {
+    // already gone, or permission — non-fatal.
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return jsonError(400, 'invalid JSON body');
+  }
+  const parsed = parseRequestBody(raw);
+  if (!parsed.ok) return jsonError(400, parsed.error);
+  const { body } = parsed;
+
+  if (inFlightByChatId.has(body.chatId)) {
+    return jsonError(409, 'a turn is already in flight for this chat', {
+      chatId: body.chatId,
+    });
+  }
+  if (totalInFlight >= MAX_CONCURRENT) {
+    return jsonError(429, `server-wide chat concurrency cap (${MAX_CONCURRENT}) reached`);
+  }
+
+  inFlightByChatId.set(body.chatId, { startedAt: Date.now() });
+  totalInFlight += 1;
+
+  // Silent-abort watchdog: if the stream lives past SILENT_ABORT_GRACE_MS
+  // without resolving, the response is closed and the gate released.
+  // The actual claude process keeps running in the background; the
+  // user's UI sees a clean error and can retry.
+  let watchdog: ReturnType<typeof setTimeout> | null = null;
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (ev: ChatStreamEvent): void => {
+        try {
+          controller.enqueue(encoder.encode(JSON.stringify(ev) + '\n'));
+        } catch {
+          // controller closed — ignore
+        }
+      };
+      watchdog = setTimeout(() => {
+        send({
+          type: 'error',
+          message: `chat-answer timed out after ${SILENT_ABORT_GRACE_MS}ms`,
+          retryable: true,
+        });
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      }, SILENT_ABORT_GRACE_MS);
+
+      try {
+        await runChatAnswer(body, send);
+      } finally {
+        if (watchdog) clearTimeout(watchdog);
+        inFlightByChatId.delete(body.chatId);
+        totalInFlight = Math.max(0, totalInFlight - 1);
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+      }
+    },
+    cancel() {
+      // Client disconnected; the spawned claude keeps running in the
+      // background. Gate is released when the spawn closes naturally.
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+      'cache-control': 'no-store',
+      'x-accel-buffering': 'no',
+    },
+  });
+};
+
+/**
+ * Availability probe. The viewer pings this on ChatMode mount to decide
+ * whether to render the chat input or the "local backend required" empty
+ * state (static deploys without a backend return 404 here, which the
+ * viewer detects as "not available").
+ */
+export const GET: APIRoute = async () => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      available: true,
+      maxConcurrent: MAX_CONCURRENT,
+      currentInFlight: totalInFlight,
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    },
+  );
+};

--- a/packages/analysis/src/cloud-mapping.ts
+++ b/packages/analysis/src/cloud-mapping.ts
@@ -259,6 +259,43 @@ export function buildEntry(
 
   const hasTools = Object.keys(topTools).length > 0;
 
+  // Analysis-grade user-text samples. Skip the first human message (already
+  // captured by `preview`'s firstHumanText source — same anti-double-count
+  // rule local sources apply). Cap at 5 turns × 400 chars to match
+  // `USER_TEXT_SAMPLES_MAX` / `USER_TEXT_SAMPLES_CHAR_CAP` in
+  // packages/exporter/src/sources/cli.ts.
+  const userTextSamples: string[] = [];
+  {
+    const cap = 5;
+    const charCap = 400;
+    let seenFirstHuman = false;
+    for (const msg of chatMessages) {
+      if (msg.sender !== 'human') continue;
+      let text: string | undefined;
+      if (Array.isArray(msg.content)) {
+        for (const b of msg.content) {
+          if (b && typeof b === 'object' && b.type === 'text') {
+            const t = (b as { text?: unknown }).text;
+            if (typeof t === 'string' && t.length > 0) {
+              text = t;
+              break;
+            }
+          }
+        }
+      }
+      if (text === undefined && typeof msg.text === 'string' && msg.text.length > 0) {
+        text = msg.text;
+      }
+      if (text === undefined) continue;
+      if (!seenFirstHuman) {
+        seenFirstHuman = true;
+        continue;
+      }
+      userTextSamples.push(text.slice(0, charCap));
+      if (userTextSamples.length >= cap) break;
+    }
+  }
+
   // Project label — matched against title first (high signal) then summary
   // (fallback), first-match-wins, using the export's own `projects.json`
   // names as the allowlist. Coverage on a real 1041-conversation corpus:
@@ -292,6 +329,7 @@ export function buildEntry(
     ...(hasSummary ? { summary } : {}),
     ...(hasTools ? { topTools } : {}),
     ...(matchedProject !== null ? { project: matchedProject } : {}),
+    ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
     transcriptPath: `cloud-conversations/${conv.uuid}.json`,
   };
 

--- a/packages/analysis/src/discoverNarratives.test.ts
+++ b/packages/analysis/src/discoverNarratives.test.ts
@@ -99,4 +99,27 @@ describe('discoverNarratives', () => {
     expect(r.narratives).toHaveLength(0);
     expect(r.projectSentiment.get('proj_q')).toBe('neutral');
   });
+
+  it('clusters on userTextSamples in addition to title+preview+summary', () => {
+    // Two sessions whose titles are sentiment-neutral but whose
+    // userTextSamples carry strong positive sentiment. Without the T6
+    // widening, neither session would score positive and no narrative
+    // would emit. With the widening, both score positive and the
+    // narrative shows up.
+    const sessions = [
+      mkSession('a', {
+        title: 'check this',
+        userTextSamples: ['that worked perfectly, tests pass'],
+      }),
+      mkSession('b', {
+        title: 'check this',
+        userTextSamples: ['shipped the fix, everything green'],
+      }),
+    ];
+    const projects = [mkProject('proj_widen', ['a', 'b'])];
+    const r = discoverNarratives(sessions, projects);
+    const narr = r.narratives.find((n) => n.sentiment === 'positive');
+    expect(narr).toBeDefined();
+    expect(narr?.sessionIds).toEqual(expect.arrayContaining(['a', 'b']));
+  });
 });

--- a/packages/analysis/src/discoverNarratives.ts
+++ b/packages/analysis/src/discoverNarratives.ts
@@ -84,7 +84,12 @@ export function discoverNarratives(
     for (const sid of project.sessionIds) {
       const s = sessionById.get(sid);
       if (s === undefined) continue;
-      const text = [s.title, s.preview ?? '', s.summary ?? ''].join('\n');
+      const text = [
+        s.title,
+        s.preview ?? '',
+        s.summary ?? '',
+        ...(s.userTextSamples ?? []),
+      ].join('\n');
       const r = scoreSentiment(text);
       scored.push({
         session: s,

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -66,7 +66,12 @@ export interface RunAnalysisResult {
   };
 }
 
-const EXPORTER_VERSION = '0.8.0';
+/**
+ * Exported so the per-source cache loaders (cli.ts, cowork.ts) can
+ * gate reuse on a version match — when the on-disk entry shape
+ * changes, all prior caches self-invalidate on next rescan.
+ */
+export const EXPORTER_VERSION = '0.9.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/cli.ts
+++ b/packages/exporter/src/cli.ts
@@ -10,8 +10,9 @@ const USAGE = `\
 chat-arch <subcommand> [options]
 
 Subcommands:
-  cowork   Walk %APPDATA%\\Claude (local-agent-mode-sessions + claude-code-sessions)
-           and write cowork-sessions.json + copied manifests/transcripts.
+  cowork   Walk %APPDATA%\\Claude (local-agent-mode-sessions + claude-code-sessions —
+           both Cowork-shaped per Anthropic's rename) and write
+           cowork-sessions.json + copied manifests/transcripts.
   cli      Walk ~/.claude/projects/, stream each transcript, and write
            cli-sessions.json + copied transcripts (cli-direct + enriched cli-desktop).
   cloud    Unpack the Settings → Privacy export ZIP and write

--- a/packages/exporter/src/commands/cowork.ts
+++ b/packages/exporter/src/commands/cowork.ts
@@ -18,9 +18,10 @@ export async function runCoworkSubcommand(argv: readonly string[]): Promise<numb
   if (values.help) {
     logger.info(
       'chat-arch cowork [--out <dir>]\n\n' +
-        '  Walk %APPDATA%\\Claude\\local-agent-mode-sessions and claude-code-sessions,\n' +
-        '  produce a unified cowork-sessions.json and copy manifests + transcripts.\n' +
-        '  Default --out: <repo-root>/apps/standalone/public/chat-arch-data',
+        '  Walk %APPDATA%\\Claude\\local-agent-mode-sessions and claude-code-sessions\n' +
+        '  (both are Cowork-shaped per Anthropic\'s rename — refs claude-code#29373,\n' +
+        '  #27463) and produce a unified cowork-sessions.json + copied manifests +\n' +
+        '  transcripts. Default --out: <repo-root>/apps/standalone/public/chat-arch-data',
     );
     return 0;
   }

--- a/packages/exporter/src/lib/subagents.ts
+++ b/packages/exporter/src/lib/subagents.ts
@@ -1,0 +1,154 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { TokenTotals } from '@chat-arch/schema';
+import { readJsonlLines } from './jsonl.js';
+import { countToolUsesInMessage } from './toolUses.js';
+
+/**
+ * Per-session subagent rollup. Cowork and host-CLI sessions can fan out to
+ * sub-agents (Task tool invocations); each sub-agent gets its own transcript
+ * under `<sessionDir>/.../subagents/agent-*.jsonl`. They typically run on a
+ * smaller/faster model (Haiku) and execute their own tool calls. Without
+ * walking them, parent-session `tokenTotals` / `topTools` / `modelsUsed`
+ * undercount heavy-fan-out sessions by 10x+.
+ *
+ * `count` is the number of subagent JSONL files (one file per Task invocation);
+ * `totalTokens` / `topTools` / `modelsUsed` are summed across all files.
+ */
+export interface SubagentRollup {
+  count: number;
+  totalTokens: TokenTotals;
+  modelsUsed: readonly string[];
+  topTools: Readonly<Record<string, number>>;
+}
+
+const SUBAGENT_FILE_RE = /^agent-.*\.jsonl$/i;
+
+/**
+ * Walk a `subagents/` directory and produce a rollup of all `agent-*.jsonl`
+ * sub-agent transcripts. Same JSONL-stream-and-accumulate pattern as
+ * `streamToolUses` (lib/toolUses.ts); reads each file once, constant memory.
+ *
+ * Returns `undefined` when the directory is missing — most sessions don't
+ * fan out, and that's not an error. Malformed lines and unreadable individual
+ * files are silently skipped so a single corrupt subagent doesn't lose the
+ * rest of the rollup.
+ */
+export async function aggregateSubagents(
+  subagentsDir: string,
+): Promise<SubagentRollup | undefined> {
+  let entries: string[];
+  try {
+    entries = await readdir(subagentsDir);
+  } catch {
+    return undefined;
+  }
+
+  const files = entries.filter((n) => SUBAGENT_FILE_RE.test(n));
+  if (files.length === 0) return undefined;
+
+  const totalTokens: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
+  const modelsSeen = new Set<string>();
+  const modelsOrdered: string[] = [];
+  const topTools: Record<string, number> = {};
+
+  for (const name of files) {
+    const filePath = path.join(subagentsDir, name);
+    try {
+      for await (const y of readJsonlLines<Record<string, unknown>>(filePath)) {
+        if (y.kind === 'error') continue;
+        const line = y.line;
+        if (line['type'] !== 'assistant') continue;
+        const msg = line['message'] as
+          | {
+              model?: unknown;
+              usage?: {
+                input_tokens?: unknown;
+                output_tokens?: unknown;
+                cache_creation_input_tokens?: unknown;
+                cache_read_input_tokens?: unknown;
+              };
+            }
+          | undefined;
+        if (msg && typeof msg.model === 'string' && msg.model.length > 0) {
+          if (!modelsSeen.has(msg.model)) {
+            modelsSeen.add(msg.model);
+            modelsOrdered.push(msg.model);
+          }
+        }
+        if (msg && msg.usage) {
+          const u = msg.usage;
+          if (typeof u.input_tokens === 'number' && Number.isFinite(u.input_tokens)) {
+            totalTokens.input += u.input_tokens;
+          }
+          if (typeof u.output_tokens === 'number' && Number.isFinite(u.output_tokens)) {
+            totalTokens.output += u.output_tokens;
+          }
+          if (
+            typeof u.cache_creation_input_tokens === 'number' &&
+            Number.isFinite(u.cache_creation_input_tokens)
+          ) {
+            totalTokens.cacheCreation += u.cache_creation_input_tokens;
+          }
+          if (
+            typeof u.cache_read_input_tokens === 'number' &&
+            Number.isFinite(u.cache_read_input_tokens)
+          ) {
+            totalTokens.cacheRead += u.cache_read_input_tokens;
+          }
+        }
+        countToolUsesInMessage(line['message'], topTools);
+      }
+    } catch {
+      // Single corrupt subagent file — skip it, keep the rest of the rollup.
+    }
+  }
+
+  return {
+    count: files.length,
+    totalTokens,
+    modelsUsed: modelsOrdered,
+    topTools,
+  };
+}
+
+/** Helper: sum two TokenTotals. Pure. */
+export function sumTokens(a: TokenTotals, b: TokenTotals): TokenTotals {
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    cacheRead: a.cacheRead + b.cacheRead,
+  };
+}
+
+/** Helper: sum two name→count histograms into a new object. Pure. */
+export function sumHistograms(
+  a: Record<string, number>,
+  b: Record<string, number>,
+): Record<string, number> {
+  const out: Record<string, number> = { ...a };
+  for (const [k, v] of Object.entries(b)) {
+    out[k] = (out[k] ?? 0) + v;
+  }
+  return out;
+}
+
+/** Helper: union arrays preserving insertion order of `a` first, then new from `b`. */
+export function uniqueModels(a: readonly string[], b: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of a) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      out.push(m);
+    }
+  }
+  for (const m of b) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      out.push(m);
+    }
+  }
+  return out;
+}

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -9,12 +9,21 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { countToolUsesInMessage } from '../lib/toolUses.js';
+import {
+  aggregateSubagents,
+  type SubagentRollup,
+  sumHistograms,
+  sumTokens,
+  uniqueModels,
+} from '../lib/subagents.js';
+import { EXPORTER_VERSION } from '../analysis/index.js';
 
 /**
- * `<uuid>.jsonl` at the TOP LEVEL of a project dir. Sub-agent transcripts
- * under `<uuid>/` (a directory sibling) are intentionally OUT OF SCOPE —
- * D1 of the Phase 3 plan. They're inner-child retries from the primary
- * transcript and add no new signal for the viewer.
+ * `<uuid>.jsonl` at the TOP LEVEL of a project dir is a session transcript.
+ * Sub-agent transcripts under `<uuid>/subagents/agent-*.jsonl` are walked
+ * separately by `aggregateSubagents` (lib/subagents.ts) and rolled up into
+ * the parent entry's `subagentRollup` field — they are NOT emitted as
+ * separate UnifiedSessionEntry rows.
  */
 const UUID_JSONL_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i;
 
@@ -88,7 +97,18 @@ interface TranscriptAggregate {
    * tools — no extra read. See `lib/toolUses.ts`.
    */
   toolUses: Record<string, number>;
+  /**
+   * Up to {@link USER_TEXT_SAMPLES_MAX} extracted user-turn excerpts,
+   * captured AFTER the first user turn so they don't double-count with
+   * `preview` (which is sourced from `firstUserText`). Each ≤
+   * {@link USER_TEXT_SAMPLES_CHAR_CAP} chars. Drives analysis-grade
+   * inputs like `discoverNarratives` clustering.
+   */
+  userTextSamples: string[];
 }
+
+export const USER_TEXT_SAMPLES_MAX = 5;
+export const USER_TEXT_SAMPLES_CHAR_CAP = 400;
 
 function zeroAggregate(): TranscriptAggregate {
   return {
@@ -105,6 +125,7 @@ function zeroAggregate(): TranscriptAggregate {
     maxTimestamp: undefined,
     malformedLineCount: 0,
     toolUses: {},
+    userTextSamples: [],
   };
 }
 
@@ -131,10 +152,18 @@ async function loadPreviousCliEntries(outDir: string): Promise<Map<string, Unifi
   } catch {
     return map;
   }
-  if (!Array.isArray(parsed)) return map;
-  for (const e of parsed as UnifiedSessionEntry[]) {
-    if (e && typeof e.id === 'string' && typeof e.source === 'string') {
-      map.set(`${e.source}:${e.id}`, e);
+  // Bare-array (pre-envelope) shape: do not reuse — entries were produced by
+  // a different exporter version with a different on-disk schema. They'll be
+  // rebuilt this run and re-written with the new envelope.
+  if (Array.isArray(parsed)) return map;
+  if (parsed && typeof parsed === 'object') {
+    const envelope = parsed as { __exporterVersion?: unknown; entries?: unknown };
+    if (envelope.__exporterVersion !== EXPORTER_VERSION) return map;
+    if (!Array.isArray(envelope.entries)) return map;
+    for (const e of envelope.entries as UnifiedSessionEntry[]) {
+      if (e && typeof e.id === 'string' && typeof e.source === 'string') {
+        map.set(`${e.source}:${e.id}`, e);
+      }
     }
   }
   return map;
@@ -251,6 +280,13 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
       return;
     }
 
+    // Subagent rollup: <projectDir>/<uuid>/subagents/agent-*.jsonl. Host
+    // Claude Code uses the same layout as Cowork CLI; aggregateSubagents
+    // returns undefined when the dir doesn't exist (most sessions don't
+    // fan out).
+    const subagentsDir = path.join(path.dirname(transcriptPath), uuid, 'subagents');
+    const subagentRollup = await aggregateSubagents(subagentsDir);
+
     malformedLinesTotal += agg.malformedLineCount;
 
     let transcriptRel: string | undefined;
@@ -267,16 +303,18 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
     if (isDesktop) {
       const phase2Entry = phase2Entries.get(uuid);
       if (phase2Entry) {
-        entries.push(enrichCliDesktopEntry(phase2Entry, agg, transcriptRel, fileMtime));
+        entries.push(
+          enrichCliDesktopEntry(phase2Entry, agg, transcriptRel, fileMtime, subagentRollup),
+        );
         desktopCount += 1;
       } else {
         // UUID was reported by Phase 2 but the entry has vanished — should be
         // impossible since we read from the same file, but fall back to direct.
-        entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime));
+        entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime, subagentRollup));
         directCount += 1;
       }
     } else {
-      entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime));
+      entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime, subagentRollup));
       directCount += 1;
     }
   });
@@ -285,7 +323,14 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
   entries.sort((a, b) => b.updatedAt - a.updatedAt);
 
   const outFile = path.join(outDir, 'cli-sessions.json');
-  await writeFile(outFile, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+  // Envelope so the loader can gate reuse on EXPORTER_VERSION — see
+  // `loadPreviousCliEntries`. Older bare-array shapes self-invalidate on
+  // first read.
+  await writeFile(
+    outFile,
+    JSON.stringify({ __exporterVersion: EXPORTER_VERSION, entries }, null, 2) + '\n',
+    'utf8',
+  );
 
   return {
     entries,
@@ -311,7 +356,8 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
  * Walk `<root>/<projectDir>/*.jsonl` at maxdepth 1 — D1. Skips:
  *  - non-directory entries at root,
  *  - files whose name is not `<uuid>.jsonl`,
- *  - sub-agent transcripts under `<projectDir>/<uuid>/...`.
+ *  - sub-agent transcripts under `<projectDir>/<uuid>/subagents/` (those are
+ *    handled by `aggregateSubagents`, not this walker).
  *
  * Returns absolute paths. Never throws on a missing root; returns [].
  */
@@ -379,11 +425,24 @@ export async function loadCliDesktopIds(phase2CoworkJsonPath: string): Promise<{
     );
     return { desktopIds, phase2Entries };
   }
-  if (!Array.isArray(parsed)) {
-    logger.warn(`Phase 2 output ${phase2CoworkJsonPath} is not an array; ignoring`);
+  // Tolerate both shapes: legacy bare array (pre-envelope) and the
+  // EXPORTER_VERSION-tagged envelope written by `runCoworkExport`.
+  let entries: readonly UnifiedSessionEntry[];
+  if (Array.isArray(parsed)) {
+    entries = parsed as UnifiedSessionEntry[];
+  } else if (
+    parsed &&
+    typeof parsed === 'object' &&
+    Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    entries = (parsed as { entries: UnifiedSessionEntry[] }).entries;
+  } else {
+    logger.warn(
+      `Phase 2 output ${phase2CoworkJsonPath} is not an array or envelope; ignoring`,
+    );
     return { desktopIds, phase2Entries };
   }
-  for (const e of parsed as UnifiedSessionEntry[]) {
+  for (const e of entries) {
     if (e && e.source === 'cli-desktop' && typeof e.id === 'string') {
       desktopIds.add(e.id);
       phase2Entries.set(e.id, e);
@@ -461,6 +520,14 @@ export async function streamAggregate(transcriptPath: string): Promise<Transcrip
       if (agg.firstUserText === undefined) {
         const t = extractFirstUserText(line['message']);
         if (t !== undefined) agg.firstUserText = t;
+      } else if (agg.userTextSamples.length < USER_TEXT_SAMPLES_MAX) {
+        // Capture user turns 2…N+1 as `userTextSamples`. Turn 1 already feeds
+        // `preview` via `firstUserText`, so starting from turn 2 prevents the
+        // double-count that would skew narrative clustering toward duplicates.
+        const t = extractFirstUserText(line['message']);
+        if (t !== undefined && t.length > 0) {
+          agg.userTextSamples.push(t.slice(0, USER_TEXT_SAMPLES_CHAR_CAP));
+        }
       }
     } else if (type === 'assistant') {
       agg.assistantTurns += 1;
@@ -562,6 +629,7 @@ export function buildCliDirectEntry(
   uuid: string,
   transcriptRel: string | undefined,
   fileMtimeMs: number,
+  subagentRollup?: SubagentRollup | undefined,
 ): UnifiedSessionEntry {
   const { title, titleSource } = resolveTitle(agg);
 
@@ -572,11 +640,23 @@ export function buildCliDirectEntry(
   const cwd = agg.cwd;
   const project = cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
 
+  // Merge subagent rollup into the parent aggregate. Parent transcript and
+  // subagent transcripts are disjoint files, so summing tokens + tools never
+  // double-counts; model union preserves parent-first insertion order.
+  const mergedTokens = subagentRollup
+    ? sumTokens(agg.tokens, subagentRollup.totalTokens)
+    : agg.tokens;
+  const mergedTools = subagentRollup
+    ? sumHistograms(agg.toolUses, subagentRollup.topTools)
+    : agg.toolUses;
+  const mergedModels = subagentRollup
+    ? uniqueModels(agg.modelsUsed, subagentRollup.modelsUsed)
+    : agg.modelsUsed;
   const tokensHasAny =
-    agg.tokens.input > 0 ||
-    agg.tokens.output > 0 ||
-    agg.tokens.cacheCreation > 0 ||
-    agg.tokens.cacheRead > 0;
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
 
   const entry: UnifiedSessionEntry = {
     // REQUIRED
@@ -596,17 +676,19 @@ export function buildCliDirectEntry(
 
     // OPTIONAL (conditional spread — EOP discipline, R8)
     ...(agg.assistantTurns > 0 ? { assistantTurns: agg.assistantTurns } : {}),
-    ...(agg.modelsUsed.length > 0 ? { modelsUsed: agg.modelsUsed } : {}),
+    ...(mergedModels.length > 0 ? { modelsUsed: mergedModels } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(project !== undefined && project.length > 0 ? { project } : {}),
-    ...(tokensHasAny ? { tokenTotals: agg.tokens } : {}),
-    ...(Object.keys(agg.toolUses).length > 0 ? { topTools: agg.toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(Object.keys(mergedTools).length > 0 ? { topTools: mergedTools } : {}),
     // Cached source-file mtime: drives incremental rescan. Equal to
     // `fileMtimeMs` here because this entry was built from the file
     // whose mtime we just read; the reuse check compares this cached
     // value to the current stat on the next rescan.
     sourceMtimeMs: fileMtimeMs,
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(agg.userTextSamples.length > 0 ? { userTextSamples: agg.userTextSamples } : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
   return entry;
 }
@@ -630,6 +712,7 @@ export function enrichCliDesktopEntry(
   agg: TranscriptAggregate,
   transcriptRel: string | undefined,
   fileMtimeMs: number,
+  subagentRollup?: SubagentRollup | undefined,
 ): UnifiedSessionEntry {
   const startedAt = agg.minTimestamp ?? phase2Entry.startedAt ?? fileMtimeMs;
   const updatedAt = agg.maxTimestamp ?? phase2Entry.updatedAt ?? fileMtimeMs;
@@ -639,11 +722,22 @@ export function enrichCliDesktopEntry(
   const cwd = phase2Entry.cwd ?? agg.cwd;
   const project = cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
 
+  // Merge subagent rollup the same way buildCliDirectEntry does — see its
+  // comment for the disjointness rationale.
+  const mergedTokens = subagentRollup
+    ? sumTokens(agg.tokens, subagentRollup.totalTokens)
+    : agg.tokens;
+  const mergedTools = subagentRollup
+    ? sumHistograms(agg.toolUses, subagentRollup.topTools)
+    : agg.toolUses;
+  const mergedModels = subagentRollup
+    ? uniqueModels(agg.modelsUsed, subagentRollup.modelsUsed)
+    : agg.modelsUsed;
   const tokensHasAny =
-    agg.tokens.input > 0 ||
-    agg.tokens.output > 0 ||
-    agg.tokens.cacheCreation > 0 ||
-    agg.tokens.cacheRead > 0;
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
 
   const entry: UnifiedSessionEntry = {
     // REQUIRED — kept from Phase 2 except temporal/userTurns.
@@ -663,16 +757,18 @@ export function enrichCliDesktopEntry(
 
     // OPTIONAL
     ...(agg.assistantTurns > 0 ? { assistantTurns: agg.assistantTurns } : {}),
-    ...(agg.modelsUsed.length > 0 ? { modelsUsed: agg.modelsUsed } : {}),
+    ...(mergedModels.length > 0 ? { modelsUsed: mergedModels } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(project !== undefined && project.length > 0 ? { project } : {}),
-    ...(tokensHasAny ? { tokenTotals: agg.tokens } : {}),
-    ...(Object.keys(agg.toolUses).length > 0 ? { topTools: agg.toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(Object.keys(mergedTools).length > 0 ? { topTools: mergedTools } : {}),
     // Cached transcript mtime — drives incremental rescan (see
     // `runCliExport`'s fast-path guard).
     sourceMtimeMs: fileMtimeMs,
     ...(phase2Entry.manifestPath !== undefined ? { manifestPath: phase2Entry.manifestPath } : {}),
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(agg.userTextSamples.length > 0 ? { userTextSamples: agg.userTextSamples } : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
 
   return entry;

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -5,6 +5,7 @@ import type {
   CoworkManifestRaw,
   DesktopCliManifestKnown,
   DesktopCliManifestRaw,
+  TokenTotals,
   UnifiedSessionEntry,
 } from '@chat-arch/schema';
 import { UNTITLED_SESSION } from '@chat-arch/schema';
@@ -15,7 +16,103 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { streamToolUses } from '../lib/toolUses.js';
-import { processDesktopCliManifest } from './desktop-cli.js';
+import { readJsonlLines } from '../lib/jsonl.js';
+import { EXPORTER_VERSION } from '../analysis/index.js';
+import {
+  aggregateSubagents,
+  sumHistograms,
+  sumTokens,
+  uniqueModels,
+} from '../lib/subagents.js';
+import {
+  extractFirstUserText,
+  USER_TEXT_SAMPLES_CHAR_CAP,
+  USER_TEXT_SAMPLES_MAX,
+} from './cli.js';
+
+/**
+ * Walk a Cowork transcript JSONL and collect up to {@link USER_TEXT_SAMPLES_MAX}
+ * user-turn excerpts (≤ {@link USER_TEXT_SAMPLES_CHAR_CAP} chars each), starting
+ * at the FIRST user turn — Cowork's preview is sourced from `manifest.initialMessage`
+ * (not the transcript), so the first transcript user turn is not a double-count.
+ *
+ * Never throws. Returns `[]` for missing files / no user lines.
+ */
+async function streamUserTextSamples(transcriptPath: string): Promise<string[]> {
+  const out: string[] = [];
+  try {
+    for await (const y of readJsonlLines<Record<string, unknown>>(transcriptPath)) {
+      if (y.kind === 'error') continue;
+      const line = y.line;
+      if (line['type'] !== 'user') continue;
+      const t = extractFirstUserText(line['message']);
+      if (t === undefined || t.length === 0) continue;
+      out.push(t.slice(0, USER_TEXT_SAMPLES_CHAR_CAP));
+      if (out.length >= USER_TEXT_SAMPLES_MAX) break;
+    }
+  } catch {
+    // unreadable file — return whatever we collected (likely [])
+  }
+  return out;
+}
+// Note: `processDesktopCliManifest` (./desktop-cli) is no longer invoked
+// from here — both AppData roots are Cowork-shaped per Anthropic's rename
+// (anthropics/claude-code#29373, #27463). The Desktop-CLI module stays
+// exported from `src/index.ts` for back-compat reads of legacy data only.
+
+/**
+ * Pull parent-session TokenTotals from a Cowork audit's `modelUsage` map.
+ * Cowork audit lines carry per-model `inputTokens` / `outputTokens` /
+ * `cacheCreationInputTokens` / `cacheReadInputTokens` — sum them up so the
+ * unified entry exposes a single TokenTotals to consumers (cost estimation,
+ * /chat answers).
+ *
+ * Returns a zero TokenTotals when modelUsage is absent or empty — callers
+ * decide whether to drop the field via a conditional spread.
+ */
+/**
+ * Coerce Cowork's `enabledMcpTools` (typed loosely as Record<string, unknown>)
+ * to the unified entry's stricter `Record<string, boolean>`. In practice every
+ * value observed is a boolean — non-boolean entries are dropped rather than
+ * forced. Keeps the unified field's contract clean.
+ */
+function coerceMcpToolFlags(raw: Readonly<Record<string, unknown>>): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v === 'boolean') out[k] = v;
+  }
+  return out;
+}
+
+function modelUsageToTokens(modelUsage: Record<string, unknown> | undefined): TokenTotals {
+  const totals: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
+  if (!modelUsage) return totals;
+  for (const v of Object.values(modelUsage)) {
+    if (!v || typeof v !== 'object') continue;
+    const u = v as {
+      inputTokens?: unknown;
+      outputTokens?: unknown;
+      cacheCreationInputTokens?: unknown;
+      cacheReadInputTokens?: unknown;
+    };
+    if (typeof u.inputTokens === 'number' && Number.isFinite(u.inputTokens)) {
+      totals.input += u.inputTokens;
+    }
+    if (typeof u.outputTokens === 'number' && Number.isFinite(u.outputTokens)) {
+      totals.output += u.outputTokens;
+    }
+    if (
+      typeof u.cacheCreationInputTokens === 'number' &&
+      Number.isFinite(u.cacheCreationInputTokens)
+    ) {
+      totals.cacheCreation += u.cacheCreationInputTokens;
+    }
+    if (typeof u.cacheReadInputTokens === 'number' && Number.isFinite(u.cacheReadInputTokens)) {
+      totals.cacheRead += u.cacheReadInputTokens;
+    }
+  }
+  return totals;
+}
 
 /**
  * Load the previous cowork-sessions.json (if present) and index by
@@ -40,10 +137,18 @@ async function loadPreviousCoworkEntries(
   } catch {
     return map;
   }
-  if (!Array.isArray(parsed)) return map;
-  for (const e of parsed as UnifiedSessionEntry[]) {
-    if (e && typeof e.id === 'string' && typeof e.source === 'string') {
-      map.set(`${e.source}:${e.id}`, e);
+  // Bare-array (pre-envelope) shape: do not reuse — entries were written by
+  // an exporter version with a different on-disk schema. They'll get
+  // rewritten with the new envelope after this rescan.
+  if (Array.isArray(parsed)) return map;
+  if (parsed && typeof parsed === 'object') {
+    const envelope = parsed as { __exporterVersion?: unknown; entries?: unknown };
+    if (envelope.__exporterVersion !== EXPORTER_VERSION) return map;
+    if (!Array.isArray(envelope.entries)) return map;
+    for (const e of envelope.entries as UnifiedSessionEntry[]) {
+      if (e && typeof e.id === 'string' && typeof e.source === 'string') {
+        map.set(`${e.source}:${e.id}`, e);
+      }
     }
   }
   return map;
@@ -118,18 +223,24 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   await mkdir(path.join(outDir, 'manifests', 'cli-desktop'), { recursive: true });
   await mkdir(path.join(outDir, 'local-transcripts', 'cowork'), { recursive: true });
 
-  const coworkRoot = path.join(appDataRoot, 'local-agent-mode-sessions');
-  const cliRoot = path.join(appDataRoot, 'claude-code-sessions');
-
-  const coworkManifestPaths = await findManifestPaths(coworkRoot);
-  const cliManifestPaths = await findManifestPaths(cliRoot);
+  // Both `local-agent-mode-sessions/` and `claude-code-sessions/` are Cowork-
+  // shaped per Anthropic's rename (refs anthropics/claude-code#29373, #27463).
+  // The Desktop-CLI walker block is gone; the desktop-cli manifest processor
+  // is kept for back-compat reads of older entries.
+  const coworkRoots = [
+    path.join(appDataRoot, 'local-agent-mode-sessions'),
+    path.join(appDataRoot, 'claude-code-sessions'),
+  ];
+  const coworkManifestPaths = (
+    await Promise.all(coworkRoots.map(findManifestPaths))
+  ).flat();
   const prevEntries = await loadPreviousCoworkEntries(outDir);
 
   let sessionsSkipped = 0;
   let transcriptsCopied = 0;
   let transcriptsMissing = 0;
   let coworkReused = 0;
-  let cliDesktopReused = 0;
+  const cliDesktopReused = 0;
 
   const coworkEntries: UnifiedSessionEntry[] = [];
   await runWithConcurrency(coworkManifestPaths, CONCURRENCY, async (manifestPath) => {
@@ -145,30 +256,19 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   });
 
   const cliEntries: UnifiedSessionEntry[] = [];
-  let desktopCliZeroTurns = 0;
-  await runWithConcurrency(cliManifestPaths, CONCURRENCY, async (manifestPath) => {
-    const res = await processDesktopCliManifest(manifestPath, outDir, prevEntries);
-    if (res === null) {
-      sessionsSkipped += 1;
-      return;
-    }
-    const { entry, reused } = res;
-    if (reused) cliDesktopReused += 1;
-    if (entry.userTurns === 0) desktopCliZeroTurns += 1;
-    cliEntries.push(entry);
-  });
-
-  if (desktopCliZeroTurns > 0) {
-    logger.warn(
-      `${desktopCliZeroTurns} Desktop-CLI sessions have userTurns=0 until Phase 3 transcript walk enriches them.`,
-    );
-  }
 
   // Sort entries deterministically by updatedAt desc for downstream stability.
   const entries = [...coworkEntries, ...cliEntries].sort((a, b) => b.updatedAt - a.updatedAt);
 
   const outFile = path.join(outDir, 'cowork-sessions.json');
-  await writeFile(outFile, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+  // Envelope so the loader can gate reuse on EXPORTER_VERSION — see
+  // `loadPreviousCoworkEntries`. Older bare-array shapes self-invalidate
+  // on first read.
+  await writeFile(
+    outFile,
+    JSON.stringify({ __exporterVersion: EXPORTER_VERSION, entries }, null, 2) + '\n',
+    'utf8',
+  );
 
   return {
     entries,
@@ -269,7 +369,21 @@ async function processCoworkManifest(
 
   // Validate minimum required fields.
   if (!isMinimallyValidCowork(parsed)) {
-    logger.warn(`Cowork manifest ${manifestPath} missing required minimum fields; skipping`);
+    // claude-code-sessions/ shape divergence: warn-once when a manifest
+    // there matches neither Cowork nor Desktop-CLI. This is the canary
+    // for Anthropic shipping yet another shape on top of the rename.
+    if (
+      manifestPath.includes(`${path.sep}claude-code-sessions${path.sep}`) &&
+      !isMinimallyValidDesktopCli(parsed)
+    ) {
+      logger.warnOnce(
+        `claude-code-sessions-unknown-shape:${manifestPath}`,
+        `[chat-arch] claude-code-sessions manifest ${manifestPath} matched neither ` +
+          `Cowork nor Desktop-CLI schema — Anthropic may have shipped a new shape`,
+      );
+    } else {
+      logger.warn(`Cowork manifest ${manifestPath} missing required minimum fields; skipping`);
+    }
     return null;
   }
 
@@ -279,8 +393,14 @@ async function processCoworkManifest(
   // Fast path: manifest mtime matches what we cached last run →
   // nothing changed since the last rescan. Reuse the entry verbatim.
   // Skips: drift warnings (already seen), audit.jsonl aggregation
-  // (biggest cost), transcript copy (unless outDir was wiped), and
-  // tool-use mining.
+  // (biggest cost), transcript copy (unless outDir was wiped),
+  // tool-use mining, and the subagents/ walk.
+  //
+  // Staleness window: subagent rollups refresh only when the manifest
+  // mtime changes. In practice Cowork rewrites the manifest on every
+  // activity tick (lastActivityAt updates in lock-step with audit +
+  // transcript), so a new subagent fan-out almost always trips the
+  // mtime check on the next rescan.
   const prev = prevEntries.get(`cowork:${cliSessionIdResolved}`);
   if (
     prev !== undefined &&
@@ -434,10 +554,58 @@ async function processCoworkManifest(
   // of sessions) and keeps the extraction co-located with the other
   // sources via the shared `streamToolUses` helper.
   const toolUses = transcriptAbsTarget ? await streamToolUses(transcriptAbsTarget) : {};
-  const hasTools = Object.keys(toolUses).length > 0;
+  const userTextSamples = transcriptAbsTarget
+    ? await streamUserTextSamples(transcriptAbsTarget)
+    : [];
+
+  // Subagent rollup — walk <sessionDir>/.claude/projects/-sessions-<proc>/
+  // <cliSessionId>/subagents/agent-*.jsonl for Task-tool sub-agents (often
+  // Haiku) whose tokens/tool calls would otherwise be invisible.
+  //
+  // Guard: cliSessionId may be null when CLI handoff crashed
+  // (transcriptStatus='crashed'). Only walk when both cliSessionId and
+  // processName are present; otherwise the path is invalid.
+  const subagentRollup =
+    typeof manifest.cliSessionId === 'string' &&
+    manifest.cliSessionId.length > 0 &&
+    typeof manifest.processName === 'string' &&
+    manifest.processName.length > 0
+      ? await aggregateSubagents(
+          path.join(
+            sessionDir,
+            '.claude',
+            'projects',
+            `-sessions-${manifest.processName}`,
+            manifest.cliSessionId,
+            'subagents',
+          ),
+        )
+      : undefined;
+
+  // Merge parent + subagent aggregates so downstream consumers see a single
+  // session-wide rollup. Tool counts come from disjoint transcripts (parent
+  // vs. subagent files) and add cleanly. Token totals follow the same merge
+  // — `audit.modelUsage` may or may not already include subagent tokens in
+  // a given session; either way summing here over-attributes at worst, and
+  // the standalone `subagentRollup` field below keeps the breakdown
+  // inspectable for callers that need to disambiguate.
+  const parentTokens = modelUsageToTokens(audit.modelUsage);
+  const mergedTokens = subagentRollup
+    ? sumTokens(parentTokens, subagentRollup.totalTokens)
+    : parentTokens;
+  const tokensHasAny =
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
+  const mergedTools = subagentRollup ? sumHistograms(toolUses, subagentRollup.topTools) : toolUses;
+  const hasTools = Object.keys(mergedTools).length > 0;
 
   const modelsUsedArr = audit.modelUsage !== undefined ? Object.keys(audit.modelUsage) : [];
-  const modelsUsed: readonly string[] = modelsUsedArr.length > 0 ? modelsUsedArr : [manifest.model];
+  const baseModels: readonly string[] = modelsUsedArr.length > 0 ? modelsUsedArr : [manifest.model];
+  const modelsUsed: readonly string[] = subagentRollup
+    ? uniqueModels(baseModels, subagentRollup.modelsUsed)
+    : baseModels;
 
   // Build entry via R4 conditional-spread template.
   const entry: UnifiedSessionEntry = {
@@ -464,7 +632,8 @@ async function processCoworkManifest(
     ...(audit.assistantTurns > 0 ? { assistantTurns: audit.assistantTurns } : {}),
     ...(modelsUsed.length > 0 ? { modelsUsed } : {}),
     cwd: manifest.cwd,
-    ...(hasTools ? { topTools: toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(hasTools ? { topTools: mergedTools } : {}),
     // Cached manifest file mtime — drives the incremental-rescan
     // fast path. Updated every time we (re)process the manifest.
     ...(currentMtime > 0 ? { sourceMtimeMs: currentMtime } : {}),
@@ -474,6 +643,19 @@ async function processCoworkManifest(
     transcriptStatus,
     manifestPath: toPosixRelative(manifestOutAbs, outDir),
     // auditPath: omitted (Q1)
+    // Cowork manifest fields previously dropped — exposed for /chat answers.
+    ...(manifest.userSelectedFolders
+      ? { userSelectedFolders: manifest.userSelectedFolders }
+      : {}),
+    ...(manifest.slashCommands ? { slashCommands: manifest.slashCommands } : {}),
+    ...(manifest.enabledMcpTools
+      ? { enabledMcpTools: coerceMcpToolFlags(manifest.enabledMcpTools) }
+      : {}),
+    ...(typeof manifest.error === 'string' && manifest.error.length > 0
+      ? { errorMessage: manifest.error }
+      : {}),
+    ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
 
   return { entry, transcriptCopied, reused: false };

--- a/packages/exporter/src/sources/desktop-cli.ts
+++ b/packages/exporter/src/sources/desktop-cli.ts
@@ -39,8 +39,14 @@ const DESKTOP_CLI_KNOWN_KEYS = new Set<string>([
  * `outDir/manifests/cli-desktop/<rawSessionId>.json`. Returns a
  * UnifiedSessionEntry or null if the manifest is unreadable / invalid.
  *
- * Phase 3 overwrites `userTurns` (currently 0) and sets `transcriptPath`
- * after walking `~/.claude/projects/`.
+ * The unified CLI walker (`runCliExport`) overwrites `userTurns`
+ * (initialized to 0 here) and sets `transcriptPath` once it has matched
+ * the manifest's `cliSessionId` to a transcript under
+ * `~/.claude/projects/`.
+ *
+ * Kept for back-compat reads of older `claude-code-sessions/` data — the
+ * Cowork walker no longer routes manifests through here directly
+ * (Anthropic's rename made both AppData roots Cowork-shaped).
  */
 export async function processDesktopCliManifest(
   manifestPath: string,
@@ -128,7 +134,7 @@ export async function processDesktopCliManifest(
     title: manifest.title || UNTITLED_SESSION,
     titleSource: 'manifest',
     preview: null, // Desktop-CLI has no initialMessage equivalent
-    userTurns: 0, // TODO(phase-3): overwrite with transcript-derived count
+    userTurns: 0, // overwritten by enrichCliDesktopEntry after transcript walk
     model: manifest.model, // verbatim, keep [1m] suffix
     cwdKind: 'host',
     totalCostUsd: null, // Desktop-CLI has no cost summary; Phase 4 merge may fill

--- a/packages/exporter/test/integration/cowork-integration.test.ts
+++ b/packages/exporter/test/integration/cowork-integration.test.ts
@@ -29,20 +29,26 @@ describe('cowork integration (fixture appdata → outDir)', () => {
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
 
-    // Output file exists and is parseable.
+    // Output file exists and is parseable. Envelope shape since the
+    // cache-bust envelope was introduced.
     const file = path.join(outDir, 'cowork-sessions.json');
     const parsed = JSON.parse(await readFile(file, 'utf8'));
-    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toMatchObject({ __exporterVersion: expect.any(String) });
+    expect(Array.isArray(parsed.entries)).toBe(true);
 
     // Manifest copies landed in the right subdirs with the R3 naming.
+    // Both AppData roots now feed the Cowork pipeline (Anthropic rename),
+    // so the two former-Desktop-CLI fixtures land in manifests/cowork/ too.
     const coworkManifests = await readdir(path.join(outDir, 'manifests', 'cowork'));
-    expect(coworkManifests).toHaveLength(4); // corrupt skipped
+    expect(coworkManifests).toHaveLength(6); // 4 + 2; corrupt skipped
     expect(coworkManifests.every((n) => /^local_[0-9a-f-]+\.json$/.test(n))).toBe(true);
 
     const cliManifests = await readdir(path.join(outDir, 'manifests', 'cli-desktop'));
-    expect(cliManifests).toHaveLength(2);
+    expect(cliManifests).toHaveLength(0); // walker removed
 
     // Transcripts: mid + new + scheduled (3); old had no cliSessionId.
+    // claude-code-sessions/ fixtures lack `processName`, so no transcript
+    // copies for them.
     const transcripts = await readdir(path.join(outDir, 'local-transcripts', 'cowork'));
     expect(transcripts).toHaveLength(3);
 

--- a/packages/exporter/test/lib/subagents.test.ts
+++ b/packages/exporter/test/lib/subagents.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  aggregateSubagents,
+  sumTokens,
+  sumHistograms,
+  uniqueModels,
+} from '../../src/lib/subagents.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(os.tmpdir(), 'chat-arch-subagents-'));
+});
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('aggregateSubagents', () => {
+  it('returns undefined when the subagents directory does not exist', async () => {
+    expect(await aggregateSubagents(path.join(tmp, 'nope'))).toBeUndefined();
+  });
+
+  it('returns undefined when the directory exists but is empty', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    expect(await aggregateSubagents(dir)).toBeUndefined();
+  });
+
+  it('walks two agent files, sums tokens, unions models, tallies tools', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+
+    const fileA = path.join(dir, 'agent-aaa.jsonl');
+    await writeFile(
+      fileA,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'run task' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            model: 'claude-haiku-4-5-20251001',
+            content: [
+              { type: 'text', text: 'ok' },
+              { type: 'tool_use', id: 't1', name: 'Bash' },
+            ],
+            usage: {
+              input_tokens: 10,
+              output_tokens: 20,
+              cache_creation_input_tokens: 100,
+              cache_read_input_tokens: 50,
+            },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const fileB = path.join(dir, 'agent-bbb.jsonl');
+    await writeFile(
+      fileB,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            model: 'claude-sonnet-4-6',
+            content: [
+              { type: 'tool_use', id: 't2', name: 'Bash' },
+              { type: 'tool_use', id: 't3', name: 'Read' },
+            ],
+            usage: {
+              input_tokens: 5,
+              output_tokens: 7,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+            },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const rollup = await aggregateSubagents(dir);
+    expect(rollup).toBeDefined();
+    expect(rollup!.count).toBe(2);
+    expect(rollup!.totalTokens).toEqual({
+      input: 15,
+      output: 27,
+      cacheCreation: 100,
+      cacheRead: 50,
+    });
+    expect([...rollup!.modelsUsed].sort()).toEqual([
+      'claude-haiku-4-5-20251001',
+      'claude-sonnet-4-6',
+    ]);
+    expect(rollup!.topTools).toEqual({ Bash: 2, Read: 1 });
+  });
+
+  it('skips non-agent-*.jsonl files in the directory', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    await writeFile(path.join(dir, 'agent-aaa.meta.json'), '{}', 'utf8');
+    await writeFile(path.join(dir, 'README.md'), 'hi', 'utf8');
+    // The .meta.json is metadata, not a JSONL transcript, so it must be ignored.
+    // With no agent-*.jsonl files, rollup is undefined.
+    expect(await aggregateSubagents(dir)).toBeUndefined();
+  });
+
+  it('silently skips malformed JSONL lines but keeps counting valid ones', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    const file = path.join(dir, 'agent-xxx.jsonl');
+    await writeFile(
+      file,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            model: 'claude-haiku-4-5-20251001',
+            content: [{ type: 'tool_use', id: 'a', name: 'Bash' }],
+            usage: { input_tokens: 1, output_tokens: 2 },
+          },
+        }),
+        '{ not valid json',
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            model: 'claude-haiku-4-5-20251001',
+            content: [{ type: 'tool_use', id: 'b', name: 'Edit' }],
+            usage: { input_tokens: 3, output_tokens: 4 },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+    const rollup = await aggregateSubagents(dir);
+    expect(rollup!.count).toBe(1);
+    expect(rollup!.totalTokens.input).toBe(4);
+    expect(rollup!.totalTokens.output).toBe(6);
+    expect(rollup!.topTools).toEqual({ Bash: 1, Edit: 1 });
+  });
+});
+
+describe('helpers', () => {
+  it('sumTokens adds the four counters', () => {
+    expect(
+      sumTokens(
+        { input: 1, output: 2, cacheCreation: 3, cacheRead: 4 },
+        { input: 10, output: 20, cacheCreation: 30, cacheRead: 40 },
+      ),
+    ).toEqual({ input: 11, output: 22, cacheCreation: 33, cacheRead: 44 });
+  });
+
+  it('sumHistograms adds matching keys, preserves unique keys', () => {
+    expect(sumHistograms({ Bash: 1, Edit: 2 }, { Bash: 4, Read: 3 })).toEqual({
+      Bash: 5,
+      Edit: 2,
+      Read: 3,
+    });
+  });
+
+  it('uniqueModels preserves a-first insertion order and adds new from b', () => {
+    expect(uniqueModels(['opus', 'sonnet'], ['sonnet', 'haiku'])).toEqual([
+      'opus',
+      'sonnet',
+      'haiku',
+    ]);
+  });
+});

--- a/packages/exporter/test/sources/cli.test.ts
+++ b/packages/exporter/test/sources/cli.test.ts
@@ -350,6 +350,36 @@ describe('streamAggregate', () => {
     const agg = await streamAggregate(file);
     expect(agg.toolUses).toEqual({});
   });
+
+  it('captures user-text samples starting from turn 2 (turn 1 already feeds preview)', async () => {
+    const file = await writeTranscript('proj-a', UUID_A, [
+      userLine('first prompt — should NOT appear in samples (it is the preview source)'),
+      assistantLine('m'),
+      userLine('second prompt'),
+      userLine('third prompt'),
+      userLine('fourth prompt'),
+    ]);
+    const agg = await streamAggregate(file);
+    expect(agg.firstUserText).toContain('first prompt');
+    expect(agg.userTextSamples).toEqual(['second prompt', 'third prompt', 'fourth prompt']);
+  });
+
+  it('caps userTextSamples at 5 entries and truncates each to 400 chars', async () => {
+    const long = 'x'.repeat(500);
+    const file = await writeTranscript('proj-a', UUID_A, [
+      userLine('preview source'),
+      userLine(long),
+      userLine('two'),
+      userLine('three'),
+      userLine('four'),
+      userLine('five'),
+      userLine('six — should be dropped, cap is 5'),
+    ]);
+    const agg = await streamAggregate(file);
+    expect(agg.userTextSamples).toHaveLength(5);
+    expect(agg.userTextSamples[0]).toHaveLength(400);
+    expect(agg.userTextSamples).not.toContain('six — should be dropped, cap is 5');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -364,7 +394,7 @@ describe('findTranscriptPaths', () => {
     expect(warnings.some((w) => w.includes('not found'))).toBe(true);
   });
 
-  it('returns top-level <uuid>.jsonl files but skips sub-agent subdirs (D1)', async () => {
+  it('returns top-level <uuid>.jsonl files but skips sub-agent subdirs', async () => {
     const p1 = await writeTranscript('proj-a', UUID_A, [userLine('x')]);
     const p2 = await writeTranscript('proj-a', UUID_B, [userLine('x')]);
     // Sub-agent dir — should NOT be returned.
@@ -378,6 +408,26 @@ describe('findTranscriptPaths', () => {
     await writeFile(path.join(projectsRoot, 'proj-a', 'README.md'), '# not a transcript', 'utf8');
     const found = await findTranscriptPaths(projectsRoot);
     expect(found.sort()).toEqual([p1, p2].sort());
+  });
+
+  it('aggregateSubagents reads from <uuid>/subagents/agent-*.jsonl, not findTranscriptPaths', async () => {
+    // Sanity-check the boundary: findTranscriptPaths must NOT walk into
+    // subagents/ even when an `agent-*.jsonl` exists there; that path is
+    // owned by `aggregateSubagents`.
+    await writeTranscript('proj-a', UUID_A, [userLine('x')]);
+    const subagentsDir = path.join(projectsRoot, 'proj-a', UUID_A, 'subagents');
+    await mkdir(subagentsDir, { recursive: true });
+    await writeFile(
+      path.join(subagentsDir, 'agent-abc.jsonl'),
+      JSON.stringify(userLine('sub')) + '\n',
+      'utf8',
+    );
+    const { aggregateSubagents } = await import('../../src/lib/subagents.js');
+    const rollup = await aggregateSubagents(subagentsDir);
+    expect(rollup?.count).toBe(1);
+    const transcripts = await findTranscriptPaths(projectsRoot);
+    // Only the top-level <UUID_A>.jsonl is returned; the subagent file is not.
+    expect(transcripts.filter((p) => p.includes('agent-abc'))).toHaveLength(0);
   });
 
   it('picks up case-variant sibling dirs (Windows quirk)', async () => {
@@ -532,6 +582,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: 2,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, 0);
     expect(e.project).toBe('my.dotted.site');
@@ -553,6 +604,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: undefined,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, mtime);
     expect(e.startedAt).toBe(mtime);
@@ -575,6 +627,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: undefined,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, 1_000);
     const errors = validateEntries([e]);
@@ -645,11 +698,11 @@ describe('runCliExport (hermetic)', () => {
     expect(result.counts['cli-desktop']).toBe(0);
     expect(result.transcriptsCopied).toBe(2);
 
-    // cli-sessions.json on disk parses and matches.
-    const parsed = JSON.parse(
+    // cli-sessions.json on disk parses and matches (envelope shape).
+    const envelope = JSON.parse(
       await readFile(path.join(outDir, 'cli-sessions.json'), 'utf8'),
-    ) as UnifiedSessionEntry[];
-    expect(parsed).toHaveLength(2);
+    ) as { __exporterVersion: string; entries: UnifiedSessionEntry[] };
+    expect(envelope.entries).toHaveLength(2);
 
     // Transcripts copied to cli-direct subdir.
     const copiedA = path.join(outDir, 'local-transcripts', 'cli-direct', `${UUID_A}.jsonl`);

--- a/packages/exporter/test/sources/cowork.test.ts
+++ b/packages/exporter/test/sources/cowork.test.ts
@@ -27,15 +27,17 @@ afterEach(async () => {
 });
 
 describe('runCoworkExport (fixture)', () => {
-  it('walks both roots and emits one entry per valid manifest', async () => {
+  it('walks both AppData roots and emits one Cowork entry per valid manifest', async () => {
     const result = await runCoworkExport({
       outDir,
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
-    // 5 Cowork manifests on disk: old/mid/new/corrupt/scheduled. The corrupt
-    // one is skipped, so 4 entries. 2 Desktop-CLI entries. Total 6.
-    expect(result.counts.cowork).toBe(4);
-    expect(result.counts['cli-desktop']).toBe(2);
+    // Post-Anthropic-rename: both `local-agent-mode-sessions/` and
+    // `claude-code-sessions/` feed the same Cowork pipeline. Fixture has
+    // 5 manifests under local-agent-mode-sessions (one corrupt → skipped)
+    // and 2 under claude-code-sessions, all Cowork-shape-valid. Total 6.
+    expect(result.counts.cowork).toBe(6);
+    expect(result.counts['cli-desktop']).toBe(0);
     expect(result.entries.length).toBe(6);
     expect(result.sessionsSkipped).toBe(1);
   });
@@ -46,9 +48,15 @@ describe('runCoworkExport (fixture)', () => {
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
     const file = path.join(outDir, 'cowork-sessions.json');
-    const roundtripped = JSON.parse(await readFile(file, 'utf8')) as UnifiedSessionEntry[];
-    expect(roundtripped).toHaveLength(result.entries.length);
-    expect(roundtripped.map((e) => e.id).sort()).toEqual(result.entries.map((e) => e.id).sort());
+    const envelope = JSON.parse(await readFile(file, 'utf8')) as {
+      __exporterVersion: string;
+      entries: UnifiedSessionEntry[];
+    };
+    expect(typeof envelope.__exporterVersion).toBe('string');
+    expect(envelope.entries).toHaveLength(result.entries.length);
+    expect(envelope.entries.map((e) => e.id).sort()).toEqual(
+      result.entries.map((e) => e.id).sort(),
+    );
   });
 
   it('falls back to stripped sessionId for entry id when manifest has no cliSessionId (old-schema Cowork)', async () => {

--- a/packages/schema/src/chat.ts
+++ b/packages/schema/src/chat.ts
@@ -1,0 +1,277 @@
+/**
+ * Chat-page types — shared by the `chat-answer` skill, the `/api/chat-answer`
+ * endpoint, the browser network seam (`chatAnswerClient.ts`), and the
+ * `ChatMode` component.
+ *
+ * Two intents flow through the same agentic skill:
+ *   - `ask` — grounded Q&A over the corpus ("are you using any workflow…")
+ *   - `find-opportunities` — proactive surfacing of blog/post ideas
+ *
+ * The browser is a thin renderer over a Claude Code session: it does not do
+ * its own retrieval. The endpoint spawns `claude -p --output-format=stream-json`
+ * (with `--resume <id>` on subsequent turns), and the skill — running as
+ * Claude Code with `Read Grep Glob Task` granted — explores the corpus on
+ * its own using sub-agents. Stream-json events are re-emitted by the
+ * endpoint as NDJSON for the browser to render.
+ */
+
+/**
+ * What the user is asking the chat to do. The skill branches on this to
+ * pick its workflow (retrieval shape, sub-agent dispatch strategy,
+ * synthesis tone). Kept as a closed string union — the endpoint validates
+ * incoming requests against it.
+ */
+export type ChatIntent = 'ask' | 'find-opportunities';
+
+/**
+ * A single turn in a chat conversation. Order is significant — turns are
+ * persisted as an array in insertion order; the assistant turn for a given
+ * user turn always immediately follows it.
+ */
+export interface ChatTurn {
+  /** Stable per-turn id; UUID. */
+  id: string;
+  role: 'user' | 'assistant';
+  /** ms-since-epoch when the turn was created (user) or completed (assistant). */
+  createdAt: number;
+  /**
+   * For user turns: the question text the user typed.
+   * For assistant turns: the final synthesized answer text (markdown).
+   * Streamed token events are NOT stored here individually — only the
+   * concatenated final text once the stream closes. Mid-stream the UI
+   * renders from in-memory state; persistence happens after `final`.
+   */
+  content: string;
+  /**
+   * Citations the assistant emitted, validated against the corpus the
+   * agent actually read during this turn (the endpoint validates inline
+   * `[SID:...]` against the `tool_use` events for `Read` — a hallucinated
+   * id never reaches the persisted turn). Empty for user turns.
+   */
+  citations?: readonly ChatCitation[];
+  /**
+   * Structured trace of what the agent did during this turn — tool calls,
+   * sub-agent spawns, errors. Persisted so a future "why did it answer
+   * that?" debug surface can replay the trace without re-running the
+   * agent. Optional because turns that errored before any tool call have
+   * nothing to record.
+   */
+  trace?: readonly ChatTraceEvent[];
+}
+
+/**
+ * A citation pointing at a specific session in the manifest. The agent
+ * cites by `(source, id)` because the manifest's primary key is composite
+ * — `id` alone collides across sources. Snippet is optional and short
+ * (≤200 chars) so the UI can render a hover-preview without re-fetching
+ * the transcript.
+ */
+export interface ChatCitation {
+  /** Manifest session id (UUID). */
+  sessionId: string;
+  /** Manifest session source — disambiguates collisions across sources. */
+  source: 'cloud' | 'cowork' | 'cli-direct' | 'cli-desktop';
+  /** Optional preview snippet from the corpus the agent grounded on. */
+  snippet?: string;
+}
+
+/**
+ * One entry in the per-turn agent trace. These mirror Claude Code's
+ * `--output-format=stream-json` shapes after the endpoint normalizes
+ * them (drops envelope, keeps the parts the UI renders).
+ *
+ * Kept as a closed union so the UI doesn't render unknown kinds — when
+ * new event shapes are added in Claude Code, they need a deliberate
+ * mapping here.
+ */
+export type ChatTraceEvent =
+  | {
+      kind: 'tool_use';
+      /** Tool name as Claude Code reports it (`Read`, `Grep`, `Glob`, `Task`). */
+      tool: string;
+      /** One-line summary the UI renders ("Grep `workflow|/loop` in transcripts"). */
+      summary: string;
+      ts: number;
+    }
+  | {
+      kind: 'sub_agent';
+      /** Sub-agent name (`Explore`, `general-purpose`, or a custom type). */
+      agent: string;
+      summary: string;
+      ts: number;
+    }
+  | {
+      kind: 'thinking';
+      /** Inline thinking text from the agent — rendered collapsed. */
+      preview: string;
+      ts: number;
+    }
+  | {
+      kind: 'error';
+      message: string;
+      ts: number;
+    };
+
+/**
+ * Persisted shape of a single chat conversation. Stored in IndexedDB
+ * (`chat-arch-chat-history` → `chats` → key = `chatId`). One IndexedDB
+ * entry per chat session so the user can have multiple conversations
+ * without juggling them in a single blob.
+ *
+ * `claudeSessionId` is what powers free multi-turn memory: the first
+ * turn's stream-json `system.init` event carries the Claude Code session
+ * id; subsequent turns pass it via `claude -p --resume <id>`. When the
+ * id goes stale (Claude Code session cleanup, user wiped state), the
+ * endpoint detects the resume failure and starts a fresh session — the
+ * UI surfaces "context reset" but the user's question still runs.
+ */
+export interface ChatConversation {
+  /** Stable chat-conversation id (UUID), created on first turn. */
+  chatId: string;
+  /**
+   * Claude Code session id from the most recent successful turn. Null
+   * when no turn has completed yet (first-turn pending), or when the
+   * prior session has been invalidated and a fresh start is required
+   * on the next turn.
+   */
+  claudeSessionId: string | null;
+  /** When the first turn was sent. */
+  createdAt: number;
+  /** When the last turn was completed. Drives sort order in the chat list. */
+  updatedAt: number;
+  /**
+   * The intent of the most recent turn — drives the UI's mode label and
+   * the skill's branching on the next turn. A single conversation can
+   * mix intents (user can ask a Q after a find-opportunities pass).
+   */
+  intent: ChatIntent;
+  /** All turns in order. */
+  turns: readonly ChatTurn[];
+  /**
+   * User-supplied or auto-generated short label for the chat-list. Auto-
+   * generation: first ~60 chars of the first user turn, truncated at the
+   * last whitespace. Editable in a future UI; for Phase 1 it's auto only.
+   */
+  title: string;
+}
+
+/** Schema-versioned envelope for the IndexedDB chat-history store. */
+export interface ChatHistoryFile {
+  /**
+   * Bump on any change to ChatConversation shape that would break
+   * the runtime guard in `chatHistoryStore.ts`.
+   *
+   * History:
+   *   1 — initial schema (ask + find-opportunities intents).
+   */
+  version: 1;
+  /** All chats, newest-updated first. */
+  chats: readonly ChatConversation[];
+}
+
+/**
+ * What the browser POSTs to `/api/chat-answer` for a single turn.
+ * The endpoint never receives a context bundle — retrieval is the
+ * skill's job (per the v3 first-principles reframe). The browser only
+ * supplies the question, the intent, and the session id to resume
+ * (if any).
+ */
+export interface ChatAnswerRequest {
+  /** Per-conversation id; the endpoint's per-chat single-flight gate keys on this. */
+  chatId: string;
+  /** What the user typed. Validated server-side (length cap, etc.). */
+  question: string;
+  /** Intent for this turn. */
+  intent: ChatIntent;
+  /**
+   * Claude Code session id from the prior turn, if any. Omitted on the
+   * first turn of a conversation. When present, the endpoint passes
+   * `--resume <id>` to `claude -p`.
+   */
+  resumeSessionId?: string;
+}
+
+/**
+ * NDJSON event shapes streamed back from `/api/chat-answer`. The browser
+ * parses these into UI updates. The endpoint produces this stream by
+ * normalizing Claude Code's `--output-format=stream-json` plus emitting
+ * a few endpoint-level events (`start`, `claude-session`, `final`,
+ * `error`).
+ */
+export type ChatStreamEvent =
+  | {
+      type: 'start';
+      requestId: string;
+      chatId: string;
+      startedAt: number;
+    }
+  | {
+      /**
+       * The Claude Code session id for this turn. Emitted once, near the
+       * top of the stream, after the agent's `system.init` event. The
+       * browser persists this on the conversation so the NEXT turn can
+       * pass it as `resumeSessionId`.
+       */
+      type: 'claude-session';
+      claudeSessionId: string;
+    }
+  | {
+      type: 'trace';
+      event: ChatTraceEvent;
+    }
+  | {
+      /**
+       * Partial assistant text — emit-as-you-go. The browser concatenates
+       * these into the current assistant turn's content. May arrive
+       * interleaved with `trace` events (the agent reads a file, prints
+       * a paragraph, grep, prints more, etc.).
+       */
+      type: 'token';
+      text: string;
+    }
+  | {
+      /**
+       * A validated citation parsed from the assistant's emitted text.
+       * "Validated" = the endpoint confirmed (via the agent's prior
+       * `Read` tool_use events) that the SID was actually read during
+       * this turn — hallucinated ids are dropped before reaching here.
+       */
+      type: 'citation';
+      citation: ChatCitation;
+    }
+  | {
+      /**
+       * End-of-turn sentinel. The browser uses this both to mark the
+       * assistant turn complete (and persist it) and to detect silent
+       * abort: if the stream closes without a `final` event, the turn
+       * is treated as errored.
+       */
+      type: 'final';
+      ok: true;
+      answerChars: number;
+      citationsCount: number;
+      durationMs: number;
+    }
+  | {
+      type: 'error';
+      message: string;
+      /** Hint for the UI: should this turn be retryable, or is it a hard fail? */
+      retryable: boolean;
+    };
+
+/**
+ * Maximum length of the user's question (in characters). Beyond this the
+ * endpoint 400s rather than spawning Claude. Kept generous — long
+ * questions with pasted context are legitimate — but bounded so a
+ * runaway paste can't OOM the spawn.
+ */
+export const CHAT_QUESTION_MAX_CHARS = 16_000;
+
+/**
+ * Maximum turns we send Claude as "prior conversation" context for a
+ * resumed session. Claude Code maintains its own context for resumes,
+ * so we don't need to re-stitch the entire history — this cap exists
+ * only to bound the prompt's prelude when the resume fails and we have
+ * to send fresh context.
+ */
+export const CHAT_MAX_PRIOR_TURNS = 4;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -10,3 +10,4 @@ export * from './pattern.js';
 export * from './correction.js';
 export * from './applied-improvement.js';
 export * from './configDocument.js';
+export * from './chat.js';

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -79,6 +79,10 @@ export interface UnifiedSessionEntry {
    *
    * Populating this in the manifest avoids forcing the viewer to eager-fetch
    * per-session chunks for card previews (~11 MB saved at 1033 sessions).
+   *
+   * For analysis-grade input (e.g. discoverNarratives clustering),
+   * `userTextSamples` carries longer multi-turn excerpts in addition to
+   * this 200-char preview.
    */
   preview: string | null;
 
@@ -297,9 +301,10 @@ export interface UnifiedSessionEntry {
    *   - 'ok'      — transcript was copied (transcriptPath present).
    *   - 'crashed' — upstream session metadata was incomplete (e.g.
    *                 Cowork CLI handoff failed: no `cliSessionId`, often
-   *                 with an `error` field set on the source manifest).
-   *                 User-side prompts may still exist in audit.jsonl —
-   *                 future recovery work can mine those.
+   *                 with an `error` field set on the source manifest —
+   *                 mirrored on the entry as `errorMessage` in verbose
+   *                 form). User-side prompts may still exist in
+   *                 audit.jsonl — future recovery work can mine those.
    *   - 'missing' — pointers were complete but the transcript file
    *                 wasn't on disk at scan time (deleted, aborted, or
    *                 cleaned up by the upstream tool between session end
@@ -316,6 +321,49 @@ export interface UnifiedSessionEntry {
 
   /** Output-relative path to the Cowork audit log. */
   auditPath?: string;
+
+  // ---- Analysis-grade enrichments ----
+
+  /**
+   * Up to 5 user-turn excerpts (≤400 chars each), captured AFTER the
+   * preview-source turn so they don't double-count with `preview`.
+   * Populated by all sources (local + cloud).
+   * Analysis pipelines (e.g. discoverNarratives) read this for richer
+   * clustering input than the 200-char preview alone. The viewer ignores
+   * this field — it's an analysis-grade input, not a display string.
+   */
+  userTextSamples?: readonly string[];
+
+  /** Cowork-only: host folders mounted into the VM workspace. */
+  userSelectedFolders?: readonly string[];
+
+  /** Cowork-only: skill/command IDs available to the session. Source-name match. */
+  slashCommands?: readonly string[];
+
+  /** Cowork-only: MCP tools enabled at session start. Source-name + shape match. */
+  enabledMcpTools?: Readonly<Record<string, boolean>>;
+
+  /**
+   * Cowork-only: human-readable error message from the source manifest's
+   * `error` field. Complements `transcriptStatus` (categorical) with the
+   * verbose form. Renamed to `errorMessage` to avoid name-collision risk
+   * with any consumer's idiomatic `entry.error` slot.
+   */
+  errorMessage?: string;
+
+  /**
+   * Subagent rollup, populated by `aggregateSubagents` for Cowork and host
+   * CLI sources. Absent when the session had no subagent fan-out.
+   * `tokenTotals`/`topTools`/`modelsUsed` on the entry are merged values
+   * (parent + subagents); this field keeps the subagent-only breakdown
+   * inspectable.
+   */
+  subagentRollup?: {
+    count: number;
+    totalTokens: TokenTotals;
+    modelsUsed: readonly string[];
+    topTools: Readonly<Record<string, number>>;
+  };
 }
 
 export interface SessionManifest {

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -31,6 +31,7 @@ import {
   CommandMode,
   TimelineMode,
   DetailMode,
+  ChatMode,
 } from './components/modes/index.js';
 import { ProjectsMode } from './components/modes/ProjectsMode.js';
 import { TopicsMode } from './components/modes/TopicsMode.js';
@@ -102,6 +103,13 @@ const HASH_PROJECT_PREFIX = '#project/';
 const HASH_TOPICS = '#topics';
 const HASH_TOPIC_PREFIX = '#topic/';
 const HASH_PRACTICE = '#practice';
+const HASH_CHAT = '#chat';
+// One-time flag: when absent (i.e. a returning user pre-chat-page never
+// stored it), the default landing remains the prior `command` mode so
+// existing bookmarks don't suddenly land somewhere unfamiliar. Fresh
+// installs (`hasExistingChatArchState()` false) bypass this gate and
+// land on `chat` directly.
+const CHAT_DEFAULT_OPT_IN_KEY = 'chat-arch:chat-default-mode-acked-v1';
 const DEMO_BANNER_DISMISSED_KEY = 'chat-arch:demo-banner-dismissed';
 const BOOT_SEEN_KEY = 'chat-arch:boot-seen';
 const SORT_BY_KEY = 'chat-arch:sort-by';
@@ -184,6 +192,49 @@ function readPracticeHash(): boolean {
   return window.location.hash === HASH_PRACTICE;
 }
 
+/** Chat has no detail dimension at the viewer level — the chat-list lives inside the surface. */
+function readChatHash(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.location.hash === HASH_CHAT;
+}
+
+/**
+ * Pick the landing mode when no explicit hash is set. Per the chat-page
+ * v3 plan: fresh installs land on `chat` (the new primary surface);
+ * existing users — anyone who's set ANY `chat-arch:` localStorage key,
+ * indicating prior use of the viewer — keep landing on `command` so
+ * their muscle memory holds. They can opt in to chat-as-default by
+ * setting `CHAT_DEFAULT_OPT_IN_KEY` (a future preferences UI exposes
+ * this; for now it's a manual escape hatch). The gate is local-only —
+ * a returning user can't be force-rerouted by a remote flag.
+ */
+function defaultLandingMode(): Mode {
+  if (typeof window === 'undefined') return 'command';
+  try {
+    if (window.localStorage.getItem(CHAT_DEFAULT_OPT_IN_KEY) === '1') return 'chat';
+  } catch {
+    // localStorage policy-locked — fall through to install heuristic
+  }
+  // hasExistingChatArchState is declared below; we duplicate its
+  // logic inline here to avoid the temporal-dead-zone foot-gun at
+  // useState init time (the function is hoisted but lives below in the
+  // file and the linter rightly flags out-of-order calls). Keep the
+  // probe behaviorally identical.
+  let hasState = false;
+  try {
+    for (let i = 0; i < window.localStorage.length; i += 1) {
+      const key = window.localStorage.key(i);
+      if (key && key.startsWith('chat-arch:')) {
+        hasState = true;
+        break;
+      }
+    }
+  } catch {
+    // policy-locked → treat as fresh install
+  }
+  return hasState ? 'command' : 'chat';
+}
+
 /** Topics counterpart to readProjectsHash — same contract / same pattern. */
 function readTopicsHash(): { surface: 'topics' | null; selectedTopicId: string | null } {
   if (typeof window === 'undefined') return { surface: null, selectedTopicId: null };
@@ -252,14 +303,16 @@ export function ChatArchViewer({
   // --- UI state ---
   const [mode, setMode] = useState<Mode>(() => {
     // v2 spec §5.1 / §5.2 / §5.4: prefer the URL hash so deep-link
-    // entries land in the right surface. Falls through to SESSIONS
-    // (`command` mode) when the hash is absent or unrecognized.
+    // entries land in the right surface. Falls through to the
+    // default-landing heuristic (fresh installs → `chat`, returning
+    // users → `command`) when no hash is recognized.
+    if (readChatHash()) return 'chat';
     const proj = readProjectsHash();
     if (proj.surface === 'projects') return 'projects';
     const top = readTopicsHash();
     if (top.surface === 'topics') return 'topics';
     if (readPracticeHash()) return 'practice';
-    return 'command';
+    return defaultLandingMode();
   });
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
     () => readProjectsHash().selectedProjectId,
@@ -574,6 +627,7 @@ export function ChatArchViewer({
       setSelectedProjectId(proj.selectedProjectId);
       setSelectedTopicId(top.selectedTopicId);
       const onPractice = readPracticeHash();
+      const onChat = readChatHash();
       if (id) {
         setMode('detail');
       } else if (proj.surface === 'projects') {
@@ -582,6 +636,8 @@ export function ChatArchViewer({
         setMode('topics');
       } else if (onPractice) {
         setMode('practice');
+      } else if (onChat) {
+        setMode('chat');
       } else {
         // Phase 3 cut COST and CONSTELLATION; a stale `#cost` /
         // `#constellation` bookmark would otherwise sit in the URL
@@ -610,7 +666,8 @@ export function ChatArchViewer({
             prev === 'detail' ||
             prev === 'projects' ||
             prev === 'topics' ||
-            prev === 'practice'
+            prev === 'practice' ||
+            prev === 'chat'
           ) {
             const stashed = priorModeBeforeDetailRef.current;
             if (prev === 'detail' && stashed) {
@@ -2176,7 +2233,12 @@ export function ChatArchViewer({
     baseMode === 'projects' ||
     baseMode === 'topics' ||
     baseMode === 'practice' ||
-    baseMode === 'corrections';
+    baseMode === 'corrections' ||
+    // Chat is its own surface — it manages its own sidebar (chat list),
+    // its own input bar, and doesn't consume the shared session-filter
+    // chrome. Add to isV2Surface so UpperPanel/MidBar/FilterBar hide
+    // the way they do for the other self-contained modes.
+    baseMode === 'chat';
 
   const activeManifest = manifest!;
 
@@ -2405,6 +2467,15 @@ export function ChatArchViewer({
               if (m === 'practice') {
                 if (typeof window !== 'undefined') {
                   window.history.pushState(null, '', HASH_PRACTICE);
+                }
+              }
+              // Chat-page §3: CHAT is its own self-contained surface.
+              // The chat-list lives inside the surface; the only
+              // routable state at the viewer level is "are we on the
+              // chat page or not?", so the single hash is enough.
+              if (m === 'chat') {
+                if (typeof window !== 'undefined') {
+                  window.history.pushState(null, '', HASH_CHAT);
                 }
               }
               setMode(m);
@@ -2657,6 +2728,16 @@ export function ChatArchViewer({
                               `${HASH_PROJECT_PREFIX}${encodeURIComponent(id)}`,
                             );
                           }
+                        }}
+                      />
+                    ) : baseMode === 'chat' ? (
+                      <ChatMode
+                        onSelectSession={(id) => {
+                          // Citation clickthrough lands in DetailMode;
+                          // BACK should restore CHAT, not the default
+                          // command mode. Same trick CORRECTIONS uses.
+                          setPriorModeBeforeDetail('chat');
+                          onSelect(id);
                         }}
                       />
                     ) : null}

--- a/packages/viewer/src/components/NuclearReset.tsx
+++ b/packages/viewer/src/components/NuclearReset.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { clearUploadedData } from '../data/uploadedDataStore.js';
 import { clearSemanticLabels } from '../data/semanticLabelsStore.js';
 import { clearBenchResults } from '../data/benchResultsStore.js';
+import { clearChatHistory } from '../data/chatHistoryStore.js';
 
 /**
  * Selective-delete affordance. The button sits in the TopBar's left
@@ -262,8 +263,12 @@ function NuclearResetInner({ available, onUnload, counts }: NuclearResetProps) {
       }
       // Kitchen-sink mode (every source selected) additionally wipes
       // the `chat-arch:*` localStorage keys — onboarding state, UI
-      // preferences, etc. A user wiping just CLI shouldn't lose their
-      // onboarding state, so this path is gated on all-selected.
+      // preferences, etc. — AND the chat-page conversation history.
+      // Chat history isn't tied to a specific source (it can reference
+      // local AND cloud sessions), so it's gated on "the user asked for
+      // everything" rather than on any specific source's checkbox.
+      // A user wiping just CLI shouldn't lose their onboarding state
+      // or chat history, so this path stays all-selected.
       if (allSelected) {
         try {
           const keys: string[] = [];
@@ -275,6 +280,13 @@ function NuclearResetInner({ available, onUnload, counts }: NuclearResetProps) {
         } catch {
           /* ignore */
         }
+        // Chat history lives in its own IDB DB (`chat-arch-chat-history`)
+        // — included in the kitchen-sink wipe alongside the localStorage
+        // sweep so a user choosing "delete everything" sees a truly
+        // fresh state on reload. Best-effort; an unreachable IDB is
+        // fine (we already navigated past the await on the cloud-IDB
+        // wipes above).
+        await clearChatHistory().catch(() => undefined);
       }
       // Cache-bust the reload so the browser doesn't hand back a
       // cached manifest that references files we just deleted.

--- a/packages/viewer/src/components/Sidebar.test.tsx
+++ b/packages/viewer/src/components/Sidebar.test.tsx
@@ -235,7 +235,11 @@ describe('Sidebar — Phase 4 hosted refocus (correctionsAvailable=false)', () =
       />,
     );
     const pillShorts = container.querySelectorAll('.lcars-sidebar__pill-short');
+    // CHT stays in the bar regardless of correctionsAvailable — chat is
+    // independent of the corrections data dependency. COR is the only
+    // pill the Phase 4 hosted-refocus filter drops.
     expect(Array.from(pillShorts).map((el) => el.textContent)).toEqual([
+      'CHT',
       'PRC',
       'SES',
       'PRJ',
@@ -257,8 +261,8 @@ describe('Sidebar (horizontal variant)', () => {
     expect(container.querySelector('.lcars-sidebar--horizontal')).toBeTruthy();
     expect(container.querySelectorAll('.lcars-sidebar__elbow').length).toBe(0);
     // 5 mode pills (Phase 3 cut ANL/constellation and CST/cost):
-    // COR, PRC, SES, PRJ, TOP.
-    expect(container.querySelectorAll('.lcars-sidebar__pill').length).toBe(5);
+    // CHT, COR, PRC, SES, PRJ, TOP — CHT added by the chat-page ship.
+    expect(container.querySelectorAll('.lcars-sidebar__pill').length).toBe(6);
   });
 
   it('shows only the short label in horizontal pills, in the new order', () => {
@@ -266,9 +270,9 @@ describe('Sidebar (horizontal variant)', () => {
       <Sidebar mode="command" onSelectMode={() => {}} variant="horizontal" />,
     );
     const pillShorts = container.querySelectorAll('.lcars-sidebar__pill-short');
-    expect(pillShorts.length).toBe(5);
+    expect(pillShorts.length).toBe(6);
     const texts = Array.from(pillShorts).map((el) => el.textContent);
-    expect(texts).toEqual(['COR', 'PRC', 'SES', 'PRJ', 'TOP']);
+    expect(texts).toEqual(['CHT', 'COR', 'PRC', 'SES', 'PRJ', 'TOP']);
   });
 
   it('appends a DAT pill when onOpenDataPanel is provided', () => {
@@ -283,6 +287,7 @@ describe('Sidebar (horizontal variant)', () => {
     );
     const pillShorts = container.querySelectorAll('.lcars-sidebar__pill-short');
     expect(Array.from(pillShorts).map((el) => el.textContent)).toEqual([
+      'CHT',
       'COR',
       'PRC',
       'SES',
@@ -309,7 +314,7 @@ describe('Sidebar (horizontal variant)', () => {
     expect(onSelectMode).toHaveBeenCalledWith('topics');
   });
 
-  it('keeps all 5 pills visible regardless of analyticsCollapsed (collapse is vertical-only)', () => {
+  it('keeps all pills visible regardless of analyticsCollapsed (collapse is vertical-only)', () => {
     const { container } = render(
       <Sidebar
         mode="command"
@@ -319,6 +324,7 @@ describe('Sidebar (horizontal variant)', () => {
         onToggleAnalyticsCollapsed={() => {}}
       />,
     );
-    expect(container.querySelectorAll('.lcars-sidebar__pill').length).toBe(5);
+    // CHT, COR, PRC, SES, PRJ, TOP — six pills total in horizontal mode.
+    expect(container.querySelectorAll('.lcars-sidebar__pill').length).toBe(6);
   });
 });

--- a/packages/viewer/src/components/Sidebar.tsx
+++ b/packages/viewer/src/components/Sidebar.tsx
@@ -74,8 +74,15 @@ interface NavGroup {
 // clicking a session card, not a top-level mode.
 const NAV: readonly NavGroup[] = [
   {
+    // CHAT joins the FIX RULES group because asking the corpus for its
+    // own patterns / opportunities IS a practice-correction primitive —
+    // distinct from the BROWSE group (which navigates the corpus by
+    // hand) and the ANALYTICS group (descriptive roll-ups). Placing it
+    // leftmost in the rail also surfaces the "ask your archive" verb
+    // first on every fresh load.
     group: 'FIX RULES',
     items: [
+      { mode: 'chat', label: 'CHAT', short: 'CHT' },
       { mode: 'corrections', label: 'CORRECTIONS', short: 'COR' },
       { mode: 'practice', label: 'PRACTICE', short: 'PRC' },
     ],
@@ -98,6 +105,7 @@ const NAV: readonly NavGroup[] = [
 // the FIX RULES → BROWSE → ANALYTICS reading order from the vertical
 // rail so muscle memory carries across viewports.
 const HORIZONTAL_PILL_ORDER: readonly NavItem[] = [
+  { mode: 'chat', label: 'CHAT', short: 'CHT' },
   { mode: 'corrections', label: 'CORRECTIONS', short: 'COR' },
   { mode: 'practice', label: 'PRACTICE', short: 'PRC' },
   { mode: 'command', label: 'SESSIONS', short: 'SES' },

--- a/packages/viewer/src/components/modes/ChatMode.tsx
+++ b/packages/viewer/src/components/modes/ChatMode.tsx
@@ -295,6 +295,29 @@ export function ChatMode({ onSelectSession }: ChatModeProps) {
     [],
   );
 
+  /**
+   * Click handler for `→ Question?` follow-up chips rendered inside an
+   * assistant message. Resubmits the chip's text as a new turn against
+   * the current intent, going through the same disclosure-modal gate
+   * the textarea send uses. No-op while a turn is in flight (sendTurn
+   * also early-returns, but checking here avoids briefly opening the
+   * disclosure modal for a click that won't run).
+   */
+  const handleFollowUpClick = useCallback(
+    (question: string) => {
+      if (inFlight) return;
+      const trimmed = question.trim();
+      if (trimmed.length === 0) return;
+      if (!chatDisclosureAcknowledged()) {
+        pendingSendRef.current = { question: trimmed, intent };
+        setDisclosureOpen(true);
+        return;
+      }
+      void sendTurn(trimmed, intent);
+    },
+    [inFlight, intent, sendTurn],
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Cmd/Ctrl+Enter to send; plain Enter inserts a newline.
@@ -450,6 +473,7 @@ export function ChatMode({ onSelectSession }: ChatModeProps) {
                     text={t.content}
                     citations={t.citations ?? []}
                     onCitationClick={onSelectSession}
+                    onFollowUpClick={handleFollowUpClick}
                     variant="final"
                   />
                 </div>

--- a/packages/viewer/src/components/modes/ChatMode.tsx
+++ b/packages/viewer/src/components/modes/ChatMode.tsx
@@ -1,0 +1,543 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type {
+  ChatCitation,
+  ChatConversation,
+  ChatIntent,
+  ChatStreamEvent,
+  ChatTraceEvent,
+  ChatTurn,
+} from '@chat-arch/schema';
+import { CHAT_QUESTION_MAX_CHARS } from '@chat-arch/schema';
+import {
+  loadChatHistory,
+  upsertConversation,
+  clearChatHistory,
+} from '../../data/chatHistoryStore.js';
+import {
+  streamChatAnswer,
+  probeChatAnswerAvailability,
+} from '../../data/chatAnswerClient.js';
+import {
+  DisclosureModal,
+  chatDisclosureAcknowledged,
+  markChatDisclosureAcknowledged,
+} from './chat/DisclosureModal.js';
+import { AgentTrace } from './chat/AgentTrace.js';
+import { ChatStreamedMessage } from './chat/ChatStreamedMessage.js';
+
+export interface ChatModeProps {
+  /**
+   * Called when the user activates a citation chip — navigates to
+   * `#session/<id>` so the existing hash router opens DetailMode.
+   */
+  onSelectSession?: ((sessionId: string) => void) | undefined;
+}
+
+interface ActiveTurnState {
+  startedAt: number;
+  text: string;
+  trace: ChatTraceEvent[];
+  citations: ChatCitation[];
+  /** Captured from the stream so the next turn can `--resume <id>`. */
+  claudeSessionId: string | null;
+  /** Final error message, if any. */
+  error: string | null;
+}
+
+const EMPTY_ACTIVE: ActiveTurnState = {
+  startedAt: 0,
+  text: '',
+  trace: [],
+  citations: [],
+  claudeSessionId: null,
+  error: null,
+};
+
+const SEED_QUESTIONS: { label: string; question: string; intent: ChatIntent }[] = [
+  {
+    label: 'PRODUCTIVITY PATTERNS',
+    question:
+      'Are you using any workflow or tools that multiplies your productivity in a reliable manner?',
+    intent: 'ask',
+  },
+  {
+    label: 'BLOG IDEAS',
+    question: 'What blog post opportunities does my corpus suggest?',
+    intent: 'find-opportunities',
+  },
+  {
+    label: 'CORRECTIONS',
+    question: 'What corrections has Claude received from me that I haven’t addressed yet?',
+    intent: 'ask',
+  },
+];
+
+function uuid(): string {
+  // crypto.randomUUID exists in all modern browsers + jsdom 22+. Fall
+  // back to a Math.random-based variant so old test environments don't
+  // crash on import.
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return (crypto as Crypto).randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+function autoTitle(question: string): string {
+  const compact = question.trim().replace(/\s+/g, ' ');
+  if (compact.length <= 60) return compact;
+  const cut = compact.slice(0, 60);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > 30 ? cut.slice(0, lastSpace) : cut) + '…';
+}
+
+export function ChatMode({ onSelectSession }: ChatModeProps) {
+  const [available, setAvailable] = useState<'checking' | 'yes' | 'no'>('checking');
+  const [conversations, setConversations] = useState<readonly ChatConversation[]>([]);
+  const [activeChatId, setActiveChatId] = useState<string | null>(null);
+  const [intent, setIntent] = useState<ChatIntent>('ask');
+  const [input, setInput] = useState('');
+  const [inFlight, setInFlight] = useState<ActiveTurnState | null>(null);
+  const [disclosureOpen, setDisclosureOpen] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+  const pendingSendRef = useRef<{ question: string; intent: ChatIntent } | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Probe + load history on mount.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const ok = await probeChatAnswerAvailability();
+      if (cancelled) return;
+      setAvailable(ok ? 'yes' : 'no');
+      const hist = await loadChatHistory();
+      if (cancelled) return;
+      if (hist) {
+        setConversations(hist.chats);
+        if (hist.chats.length > 0 && hist.chats[0]) {
+          setActiveChatId(hist.chats[0].chatId);
+          setIntent(hist.chats[0].intent);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const activeChat = useMemo(
+    () => conversations.find((c) => c.chatId === activeChatId) ?? null,
+    [conversations, activeChatId],
+  );
+
+  const startNewChat = useCallback(() => {
+    setActiveChatId(null);
+    setInput('');
+    setInFlight(null);
+    inputRef.current?.focus();
+  }, []);
+
+  const sendTurn = useCallback(
+    async (question: string, turnIntent: ChatIntent) => {
+      if (available !== 'yes') return;
+      if (inFlight) return;
+      if (question.trim().length === 0) return;
+      if (question.length > CHAT_QUESTION_MAX_CHARS) return;
+
+      // Resolve target conversation (existing or new).
+      const isNewChat = activeChatId === null;
+      const chatId = activeChatId ?? uuid();
+      const now = Date.now();
+      const userTurn: ChatTurn = {
+        id: uuid(),
+        role: 'user',
+        createdAt: now,
+        content: question,
+      };
+      // Optimistically insert/update so the user sees their turn instantly.
+      let baseConv: ChatConversation;
+      if (isNewChat) {
+        baseConv = {
+          chatId,
+          claudeSessionId: null,
+          createdAt: now,
+          updatedAt: now,
+          intent: turnIntent,
+          turns: [userTurn],
+          title: autoTitle(question),
+        };
+      } else {
+        const prior = conversations.find((c) => c.chatId === chatId);
+        if (!prior) return;
+        baseConv = {
+          ...prior,
+          intent: turnIntent,
+          updatedAt: now,
+          turns: [...prior.turns, userTurn],
+        };
+      }
+      setActiveChatId(chatId);
+      setConversations((prev) => {
+        const others = prev.filter((c) => c.chatId !== chatId);
+        return [baseConv, ...others];
+      });
+      setInput('');
+      const active: ActiveTurnState = { ...EMPTY_ACTIVE, startedAt: now };
+      setInFlight(active);
+
+      const onEvent = (ev: ChatStreamEvent): void => {
+        setInFlight((curr) => {
+          if (!curr) return curr;
+          if (ev.type === 'token') {
+            return { ...curr, text: curr.text + ev.text };
+          }
+          if (ev.type === 'trace') {
+            return { ...curr, trace: [...curr.trace, ev.event] };
+          }
+          if (ev.type === 'citation') {
+            // Dedup citations by sessionId — the stream may emit a SID
+            // more than once if the assistant repeats it.
+            const seen = new Set(curr.citations.map((c) => c.sessionId));
+            if (seen.has(ev.citation.sessionId)) return curr;
+            return { ...curr, citations: [...curr.citations, ev.citation] };
+          }
+          if (ev.type === 'claude-session') {
+            return { ...curr, claudeSessionId: ev.claudeSessionId };
+          }
+          if (ev.type === 'error') {
+            return { ...curr, error: ev.message };
+          }
+          return curr;
+        });
+      };
+
+      const result = await streamChatAnswer(
+        {
+          chatId,
+          question,
+          intent: turnIntent,
+          ...(baseConv.claudeSessionId
+            ? { resumeSessionId: baseConv.claudeSessionId }
+            : {}),
+        },
+        { onEvent },
+      );
+
+      // After the stream completes, commit the assistant turn and persist.
+      setInFlight((finalActive) => {
+        if (!finalActive) return null;
+        const assistantContent = finalActive.error
+          ? `_(error: ${finalActive.error})_`
+          : finalActive.text;
+        const assistantTurn: ChatTurn = {
+          id: uuid(),
+          role: 'assistant',
+          createdAt: Date.now(),
+          content: assistantContent,
+          citations: finalActive.citations.length > 0 ? finalActive.citations : undefined,
+          trace: finalActive.trace.length > 0 ? finalActive.trace : undefined,
+        } as ChatTurn;
+        const completedConv: ChatConversation = {
+          ...baseConv,
+          claudeSessionId:
+            finalActive.claudeSessionId ?? baseConv.claudeSessionId ?? null,
+          updatedAt: Date.now(),
+          turns: [...baseConv.turns, assistantTurn],
+        };
+        setConversations((prev) => {
+          const others = prev.filter((c) => c.chatId !== chatId);
+          return [completedConv, ...others];
+        });
+        if (!result.rejected && (result.finalSeen || finalActive.text.length > 0)) {
+          // Persist only when we got something useful out — a hard CSRF
+          // reject or an immediate 4xx doesn't deserve a history row.
+          void upsertConversation(completedConv);
+        }
+        return null;
+      });
+    },
+    [activeChatId, available, conversations, inFlight],
+  );
+
+  const handleSendClick = useCallback(() => {
+    const question = input.trim();
+    if (question.length === 0) return;
+    if (!chatDisclosureAcknowledged()) {
+      pendingSendRef.current = { question, intent };
+      setDisclosureOpen(true);
+      return;
+    }
+    void sendTurn(question, intent);
+  }, [input, intent, sendTurn]);
+
+  const handleDisclosureAck = useCallback(() => {
+    markChatDisclosureAcknowledged();
+    setDisclosureOpen(false);
+    const pending = pendingSendRef.current;
+    pendingSendRef.current = null;
+    if (pending) void sendTurn(pending.question, pending.intent);
+  }, [sendTurn]);
+
+  const handleDisclosureCancel = useCallback(() => {
+    pendingSendRef.current = null;
+    setDisclosureOpen(false);
+  }, []);
+
+  const handleSeedClick = useCallback(
+    (q: { question: string; intent: ChatIntent }) => {
+      setIntent(q.intent);
+      setInput(q.question);
+      inputRef.current?.focus();
+    },
+    [],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Cmd/Ctrl+Enter to send; plain Enter inserts a newline.
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleSendClick();
+      }
+    },
+    [handleSendClick],
+  );
+
+  const handleClearAll = useCallback(async () => {
+    await clearChatHistory();
+    setConversations([]);
+    setActiveChatId(null);
+    setConfirmClear(false);
+  }, []);
+
+  if (available === 'checking') {
+    return (
+      <div className="lcars-chat lcars-chat--probing">
+        <div className="lcars-chat__probe">Checking backend availability…</div>
+      </div>
+    );
+  }
+
+  if (available === 'no') {
+    return (
+      <div className="lcars-chat lcars-chat--unavailable">
+        <div className="lcars-chat__empty">
+          <h2>CHAT REQUIRES THE LOCAL BACKEND</h2>
+          <p>
+            The chat page talks to your local Claude Code CLI via{' '}
+            <code>/api/chat-answer</code>, which only runs when you&apos;ve started the chat-
+            arch dev server (<code>pnpm dev</code> at the repo root). The static-only
+            build doesn&apos;t include the endpoint.
+          </p>
+          <p>Open a terminal in the repo and run:</p>
+          <pre>
+            <code>pnpm dev</code>
+          </pre>
+          <p>Then refresh this page.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="lcars-chat">
+      <aside className="lcars-chat__list" aria-label="chat conversations">
+        <button
+          type="button"
+          className="lcars-chat__new"
+          onClick={startNewChat}
+          aria-label="start a new chat"
+        >
+          + NEW CHAT
+        </button>
+        <ul className="lcars-chat__list-items">
+          {conversations.map((c) => (
+            <li key={c.chatId}>
+              <button
+                type="button"
+                className={`lcars-chat__list-item${
+                  c.chatId === activeChatId ? ' lcars-chat__list-item--active' : ''
+                }`}
+                onClick={() => setActiveChatId(c.chatId)}
+              >
+                <span className="lcars-chat__list-intent">
+                  {c.intent === 'find-opportunities' ? 'OPPS' : 'ASK'}
+                </span>
+                <span className="lcars-chat__list-title">{c.title}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+        {conversations.length > 0 && (
+          <button
+            type="button"
+            className="lcars-chat__clear"
+            onClick={() => setConfirmClear(true)}
+          >
+            CLEAR ALL HISTORY
+          </button>
+        )}
+      </aside>
+
+      <section className="lcars-chat__panel" aria-label="active conversation">
+        <header className="lcars-chat__header">
+          <div className="lcars-chat__intent" role="group" aria-label="conversation intent">
+            <label className={`lcars-chat__intent-opt${intent === 'ask' ? ' lcars-chat__intent-opt--active' : ''}`}>
+              <input
+                type="radio"
+                name="chat-intent"
+                value="ask"
+                checked={intent === 'ask'}
+                onChange={() => setIntent('ask')}
+                disabled={!!inFlight}
+              />
+              ASK
+            </label>
+            <label className={`lcars-chat__intent-opt${intent === 'find-opportunities' ? ' lcars-chat__intent-opt--active' : ''}`}>
+              <input
+                type="radio"
+                name="chat-intent"
+                value="find-opportunities"
+                checked={intent === 'find-opportunities'}
+                onChange={() => setIntent('find-opportunities')}
+                disabled={!!inFlight}
+              />
+              FIND OPPORTUNITIES
+            </label>
+          </div>
+        </header>
+
+        <div className="lcars-chat__transcript" aria-live="polite">
+          {!activeChat && (
+            <div className="lcars-chat__seed">
+              <h2>Ask your corpus.</h2>
+              <p>
+                The chat page hands your question to your local Claude Code CLI, which
+                explores your archived conversations (<code>chat-arch-data/</code>) and
+                answers with citations. Try one of these to get started:
+              </p>
+              <ul className="lcars-chat__seed-list">
+                {SEED_QUESTIONS.map((q) => (
+                  <li key={q.label}>
+                    <button
+                      type="button"
+                      className="lcars-chat__seed-button"
+                      onClick={() => handleSeedClick(q)}
+                    >
+                      <span className="lcars-chat__seed-label">{q.label}</span>
+                      <span className="lcars-chat__seed-q">{q.question}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {activeChat &&
+            activeChat.turns.map((t: ChatTurn) =>
+              t.role === 'user' ? (
+                <div key={t.id} className="lcars-chat-message lcars-chat-message--user">
+                  <pre className="lcars-chat-message__user-text">{t.content}</pre>
+                </div>
+              ) : (
+                <div key={t.id} className="lcars-chat-message__wrap">
+                  {t.trace && t.trace.length > 0 && (
+                    <AgentTrace events={t.trace} mode="archived" />
+                  )}
+                  <ChatStreamedMessage
+                    text={t.content}
+                    citations={t.citations ?? []}
+                    onCitationClick={onSelectSession}
+                    variant="final"
+                  />
+                </div>
+              ),
+            )}
+          {inFlight && (
+            <div className="lcars-chat-message__wrap">
+              <AgentTrace events={inFlight.trace} mode="live" />
+              <ChatStreamedMessage
+                text={inFlight.text}
+                citations={inFlight.citations}
+                onCitationClick={onSelectSession}
+                variant="live"
+              />
+              {inFlight.error && (
+                <div className="lcars-chat-message__error">{inFlight.error}</div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <form
+          className="lcars-chat__inputbar"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSendClick();
+          }}
+        >
+          <textarea
+            ref={inputRef}
+            className="lcars-chat__input"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={
+              intent === 'ask'
+                ? 'Ask a question about your archived conversations…'
+                : 'Ask for blog post / content ideas, or other opportunities…'
+            }
+            rows={3}
+            maxLength={CHAT_QUESTION_MAX_CHARS}
+            disabled={!!inFlight}
+            aria-label="chat input"
+          />
+          <button
+            type="submit"
+            className="lcars-chat__send"
+            disabled={!!inFlight || input.trim().length === 0}
+          >
+            {inFlight ? 'THINKING…' : 'SEND ⌘↵'}
+          </button>
+        </form>
+      </section>
+
+      <DisclosureModal
+        open={disclosureOpen}
+        onAcknowledge={handleDisclosureAck}
+        onCancel={handleDisclosureCancel}
+      />
+
+      {confirmClear && (
+        <div className="lcars-chat-disclosure" role="dialog" aria-modal="true">
+          <div
+            className="lcars-chat-disclosure__backdrop"
+            onClick={() => setConfirmClear(false)}
+          />
+          <div className="lcars-chat-disclosure__panel">
+            <h2 className="lcars-chat-disclosure__title">CLEAR ALL CHAT HISTORY?</h2>
+            <p>This wipes every conversation from this browser. Cannot be undone.</p>
+            <div className="lcars-chat-disclosure__actions">
+              <button
+                type="button"
+                className="lcars-chat-disclosure__cancel"
+                onClick={() => setConfirmClear(false)}
+              >
+                CANCEL
+              </button>
+              <button
+                type="button"
+                className="lcars-chat-disclosure__confirm"
+                onClick={() => void handleClearAll()}
+              >
+                CLEAR
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/viewer/src/components/modes/chat/AgentTrace.tsx
+++ b/packages/viewer/src/components/modes/chat/AgentTrace.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import type { ChatTraceEvent } from '@chat-arch/schema';
+
+export interface AgentTraceProps {
+  events: readonly ChatTraceEvent[];
+  /**
+   * Render mode. `live` is used during an in-flight turn (auto-expand,
+   * latest event always visible). `archived` is used for completed turns
+   * in history (collapsed by default — user can expand).
+   */
+  mode: 'live' | 'archived';
+}
+
+const TOOL_GLYPH: Record<string, string> = {
+  Read: '📄',
+  Grep: '🔍',
+  Glob: '🗂',
+  Task: '🤖',
+};
+
+/**
+ * The "visible thinking" strip. During an in-flight turn the user sees
+ * the agent's actual process — what it's grepping, what files it's
+ * reading, when it spawns a sub-agent. This is the chat's transparency
+ * surface; the v3 plan calls it the demo-unlock moment.
+ *
+ * `live` mode auto-renders the latest event prominently; `archived`
+ * collapses everything behind a summary toggle so old turns don't
+ * dominate the scroll.
+ */
+export function AgentTrace({ events, mode }: AgentTraceProps) {
+  const [expanded, setExpanded] = useState(mode === 'live');
+
+  if (events.length === 0) return null;
+
+  const counts = countByKind(events);
+  const summary = formatSummary(counts);
+
+  return (
+    <details
+      className={`lcars-chat-trace lcars-chat-trace--${mode}`}
+      open={expanded}
+      onToggle={(e) => setExpanded((e.currentTarget as HTMLDetailsElement).open)}
+    >
+      <summary className="lcars-chat-trace__summary">
+        <span className="lcars-chat-trace__label">AGENT TRACE</span>
+        <span className="lcars-chat-trace__counts">{summary}</span>
+      </summary>
+      <ol className="lcars-chat-trace__list" aria-live={mode === 'live' ? 'polite' : 'off'}>
+        {events.map((ev, ix) => (
+          <li key={ix} className={`lcars-chat-trace__item lcars-chat-trace__item--${ev.kind}`}>
+            {renderEvent(ev)}
+          </li>
+        ))}
+      </ol>
+    </details>
+  );
+}
+
+function countByKind(events: readonly ChatTraceEvent[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const ev of events) {
+    out[ev.kind] = (out[ev.kind] ?? 0) + 1;
+  }
+  return out;
+}
+
+function formatSummary(counts: Record<string, number>): string {
+  const parts: string[] = [];
+  if (counts['tool_use']) parts.push(`${counts['tool_use']} tool call${counts['tool_use'] === 1 ? '' : 's'}`);
+  if (counts['sub_agent']) parts.push(`${counts['sub_agent']} sub-agent${counts['sub_agent'] === 1 ? '' : 's'}`);
+  if (counts['error']) parts.push(`${counts['error']} error${counts['error'] === 1 ? '' : 's'}`);
+  return parts.length > 0 ? parts.join(' · ') : 'thinking…';
+}
+
+function renderEvent(ev: ChatTraceEvent): React.ReactNode {
+  if (ev.kind === 'tool_use') {
+    return (
+      <>
+        <span className="lcars-chat-trace__glyph" aria-hidden="true">
+          {TOOL_GLYPH[ev.tool] ?? '⚙'}
+        </span>
+        <code className="lcars-chat-trace__code">{ev.summary}</code>
+      </>
+    );
+  }
+  if (ev.kind === 'sub_agent') {
+    return (
+      <>
+        <span className="lcars-chat-trace__glyph" aria-hidden="true">
+          {TOOL_GLYPH['Task']}
+        </span>
+        <code className="lcars-chat-trace__code">
+          <strong>{ev.agent}</strong> — {ev.summary}
+        </code>
+      </>
+    );
+  }
+  if (ev.kind === 'error') {
+    return (
+      <>
+        <span className="lcars-chat-trace__glyph" aria-hidden="true">⚠</span>
+        <code className="lcars-chat-trace__code">{ev.message}</code>
+      </>
+    );
+  }
+  // thinking — small italic preview
+  return (
+    <>
+      <span className="lcars-chat-trace__glyph" aria-hidden="true">·</span>
+      <em className="lcars-chat-trace__thinking">{ev.preview}</em>
+    </>
+  );
+}

--- a/packages/viewer/src/components/modes/chat/ChatStreamedMessage.test.tsx
+++ b/packages/viewer/src/components/modes/chat/ChatStreamedMessage.test.tsx
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import type { ChatCitation } from '@chat-arch/schema';
+import { ChatStreamedMessage } from './ChatStreamedMessage.js';
+
+const NO_CITATIONS: readonly ChatCitation[] = [];
+
+describe('ChatStreamedMessage — collapsible trust-artifact sections', () => {
+  it('wraps `## Caveats` and following blocks in a collapsed <details>', () => {
+    const text = [
+      'Headline answer paragraph.',
+      '',
+      '## Caveats',
+      '',
+      'A caveat paragraph.',
+      '',
+      '- bullet inside caveats',
+    ].join('\n');
+    const { container } = render(
+      <ChatStreamedMessage text={text} citations={NO_CITATIONS} variant="final" />,
+    );
+    const details = container.querySelector('details');
+    expect(details).not.toBeNull();
+    // Collapsed by default.
+    expect(details?.hasAttribute('open')).toBe(false);
+    expect(details?.querySelector('summary')?.textContent).toContain('Caveats');
+    // The caveat paragraph and bullet live inside the details body.
+    expect(details?.textContent).toContain('A caveat paragraph');
+    expect(details?.textContent).toContain('bullet inside caveats');
+    // The H2 itself does not also render as a sibling — the summary
+    // replaces it. (Otherwise the heading would appear twice.)
+    expect(container.querySelectorAll('h2').length).toBe(0);
+  });
+
+  it('renders a non-trigger `## Heading` as a normal <h2>', () => {
+    const text = ['## Findings', '', 'Body paragraph.'].join('\n');
+    const { container } = render(
+      <ChatStreamedMessage text={text} citations={NO_CITATIONS} variant="final" />,
+    );
+    expect(container.querySelector('details')).toBeNull();
+    expect(container.querySelector('h2')?.textContent).toBe('Findings');
+  });
+
+  it('a second H2 closes the collapsible — it does not absorb the next section', () => {
+    const text = [
+      '## Caveats',
+      '',
+      'Caveat body.',
+      '',
+      '## Findings',
+      '',
+      'Findings body.',
+    ].join('\n');
+    const { container } = render(
+      <ChatStreamedMessage text={text} citations={NO_CITATIONS} variant="final" />,
+    );
+    const details = container.querySelector('details');
+    expect(details?.textContent).toContain('Caveat body');
+    expect(details?.textContent).not.toContain('Findings body');
+    expect(container.querySelector('h2')?.textContent).toBe('Findings');
+  });
+
+  it('matches the documented title set case-insensitively (caveats / methodology / risks / honest negatives)', () => {
+    const titles = [
+      'caveats',
+      'CAVEATS',
+      'Methodology',
+      'Risks',
+      'Honest negatives',
+      'honest notes',
+      'Calibration',
+    ];
+    for (const t of titles) {
+      const { container } = render(
+        <ChatStreamedMessage
+          text={`## ${t}\n\nBody.`}
+          citations={NO_CITATIONS}
+          variant="final"
+        />,
+      );
+      expect(container.querySelector('details')).not.toBeNull();
+    }
+  });
+});
+
+describe('ChatStreamedMessage — follow-up chips (`→ Question?` lines)', () => {
+  it('renders consecutive `→ ` lines as a chip group, not paragraphs', () => {
+    const text = [
+      'Answer paragraph.',
+      '',
+      '→ Which one would you turn into a blog post first?',
+      '→ What corrections has X surfaced?',
+    ].join('\n');
+    const { container } = render(
+      <ChatStreamedMessage text={text} citations={NO_CITATIONS} variant="final" />,
+    );
+    const buttons = container.querySelectorAll('.lcars-chat-message__followup');
+    expect(buttons.length).toBe(2);
+    expect(buttons[0]?.textContent).toContain('Which one would you turn into a blog post first?');
+    expect(buttons[1]?.textContent).toContain('What corrections has X surfaced?');
+  });
+
+  it('fires onFollowUpClick with the question text (without the `→ ` prefix) when a chip is clicked', () => {
+    const onFollowUpClick = vi.fn();
+    const text = '→ Should I do X?';
+    const { container } = render(
+      <ChatStreamedMessage
+        text={text}
+        citations={NO_CITATIONS}
+        onFollowUpClick={onFollowUpClick}
+        variant="final"
+      />,
+    );
+    const button = container.querySelector('.lcars-chat-message__followup') as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+    fireEvent.click(button!);
+    expect(onFollowUpClick).toHaveBeenCalledTimes(1);
+    expect(onFollowUpClick).toHaveBeenCalledWith('Should I do X?');
+  });
+
+  it('disables the chip when no onFollowUpClick handler is passed', () => {
+    const text = '→ Should I do X?';
+    const { container } = render(
+      <ChatStreamedMessage text={text} citations={NO_CITATIONS} variant="final" />,
+    );
+    const button = container.querySelector('.lcars-chat-message__followup') as HTMLButtonElement | null;
+    expect(button?.disabled).toBe(true);
+  });
+
+  it('a paragraph that does not start with `→ ` is unaffected', () => {
+    const text = 'Just a paragraph with an arrow → in the middle.';
+    const { container } = render(
+      <ChatStreamedMessage text={text} citations={NO_CITATIONS} variant="final" />,
+    );
+    expect(container.querySelector('.lcars-chat-message__followup')).toBeNull();
+    expect(container.querySelector('p')?.textContent).toContain('arrow → in the middle');
+  });
+});
+
+describe('ChatStreamedMessage — interactions between new + existing renderers', () => {
+  it('citation chips inside a collapsible section still render and remain clickable', () => {
+    const text = [
+      '## Methodology',
+      '',
+      'Cited [SID:11111111-2222-3333-4444-555555555555] inside the body.',
+    ].join('\n');
+    const onCitationClick = vi.fn();
+    const citations: readonly ChatCitation[] = [
+      { sessionId: '11111111-2222-3333-4444-555555555555', source: 'cowork' },
+    ];
+    const { container } = render(
+      <ChatStreamedMessage
+        text={text}
+        citations={citations}
+        onCitationClick={onCitationClick}
+        variant="final"
+      />,
+    );
+    const chip = container.querySelector('details .lcars-chat-citation') as HTMLButtonElement | null;
+    expect(chip).not.toBeNull();
+    fireEvent.click(chip!);
+    expect(onCitationClick).toHaveBeenCalledWith('11111111-2222-3333-4444-555555555555');
+  });
+});

--- a/packages/viewer/src/components/modes/chat/ChatStreamedMessage.tsx
+++ b/packages/viewer/src/components/modes/chat/ChatStreamedMessage.tsx
@@ -1,0 +1,234 @@
+import { useMemo } from 'react';
+import type { ChatCitation } from '@chat-arch/schema';
+import { CitationChip } from './CitationChip.js';
+
+export interface ChatStreamedMessageProps {
+  /** Full markdown text accumulated so far (or final). */
+  text: string;
+  /** Citations the endpoint validated for this message. */
+  citations: readonly ChatCitation[];
+  /**
+   * Click handler for citation chips. Explicit `| undefined` so callers
+   * forwarding an already-optional prop don't need a conditional spread.
+   */
+  onCitationClick?: ((sessionId: string) => void) | undefined;
+  /** Render variant. `live` adds a typing caret at end; `final` does not. */
+  variant: 'live' | 'final';
+}
+
+const SID_RE = /\[SID:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/gi;
+
+/**
+ * Render assistant markdown with inline citation chips. Phase 1: a tight
+ * subset of markdown is supported inline (paragraphs, line breaks,
+ * bold, italic, inline code, code blocks, headers, bullet lists). Full
+ * markdown (links, images, tables) is deferred — the agent's prompt is
+ * tuned to emit this subset.
+ *
+ * Sanitization model: we never inject raw HTML. The renderer walks the
+ * text and produces React elements directly — there's no `dangerouslySet
+ * InnerHTML` anywhere, so a token containing `<img onerror=...>` is
+ * rendered as literal text, not executed. This makes the streamed-
+ * markdown XSS surface from the adversarial review (A12) a non-issue
+ * by construction.
+ */
+export function ChatStreamedMessage({
+  text,
+  citations,
+  onCitationClick,
+  variant,
+}: ChatStreamedMessageProps) {
+  const citationBySid = useMemo(() => {
+    const m = new Map<string, ChatCitation>();
+    for (const c of citations) m.set(c.sessionId.toLowerCase(), c);
+    return m;
+  }, [citations]);
+
+  const nodes = useMemo(() => renderMarkdown(text, citationBySid, onCitationClick), [
+    text,
+    citationBySid,
+    onCitationClick,
+  ]);
+
+  return (
+    <div className="lcars-chat-message lcars-chat-message--assistant">
+      {nodes}
+      {variant === 'live' && <span className="lcars-chat-message__caret" aria-hidden="true">▍</span>}
+    </div>
+  );
+}
+
+interface Block {
+  kind: 'p' | 'h1' | 'h2' | 'h3' | 'code' | 'ul';
+  content: string;
+  items?: string[];
+  lang?: string;
+}
+
+function parseBlocks(text: string): Block[] {
+  const blocks: Block[] = [];
+  const lines = text.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i]!;
+    // Code block
+    const codeFence = /^```(\w+)?$/.exec(line);
+    if (codeFence) {
+      const lang = codeFence[1] ?? '';
+      const start = i + 1;
+      let end = start;
+      while (end < lines.length && !/^```$/.test(lines[end]!)) end += 1;
+      blocks.push({ kind: 'code', content: lines.slice(start, end).join('\n'), lang });
+      i = end + 1;
+      continue;
+    }
+    // Headers
+    if (/^# /.test(line)) {
+      blocks.push({ kind: 'h1', content: line.slice(2) });
+      i += 1;
+      continue;
+    }
+    if (/^## /.test(line)) {
+      blocks.push({ kind: 'h2', content: line.slice(3) });
+      i += 1;
+      continue;
+    }
+    if (/^### /.test(line)) {
+      blocks.push({ kind: 'h3', content: line.slice(4) });
+      i += 1;
+      continue;
+    }
+    // Bullet list
+    if (/^[-*] /.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && /^[-*] /.test(lines[i]!)) {
+        items.push(lines[i]!.slice(2));
+        i += 1;
+      }
+      blocks.push({ kind: 'ul', content: '', items });
+      continue;
+    }
+    // Skip blank lines between blocks
+    if (line.trim().length === 0) {
+      i += 1;
+      continue;
+    }
+    // Paragraph — collect until blank line or block-starter
+    const paraStart = i;
+    while (i < lines.length) {
+      const l = lines[i]!;
+      if (l.trim().length === 0) break;
+      if (/^```/.test(l) || /^#{1,3} /.test(l) || /^[-*] /.test(l)) break;
+      i += 1;
+    }
+    blocks.push({ kind: 'p', content: lines.slice(paraStart, i).join('\n') });
+  }
+  return blocks;
+}
+
+function renderMarkdown(
+  text: string,
+  citationBySid: Map<string, ChatCitation>,
+  onCitationClick: ((sid: string) => void) | undefined,
+): React.ReactNode[] {
+  const blocks = parseBlocks(text);
+  return blocks.map((block, ix) => {
+    const key = `b${ix}`;
+    if (block.kind === 'code') {
+      return (
+        <pre key={key} className="lcars-chat-message__code">
+          <code data-lang={block.lang || undefined}>{block.content}</code>
+        </pre>
+      );
+    }
+    if (block.kind === 'h1') return <h1 key={key} className="lcars-chat-message__h1">{renderInline(block.content, citationBySid, onCitationClick)}</h1>;
+    if (block.kind === 'h2') return <h2 key={key} className="lcars-chat-message__h2">{renderInline(block.content, citationBySid, onCitationClick)}</h2>;
+    if (block.kind === 'h3') return <h3 key={key} className="lcars-chat-message__h3">{renderInline(block.content, citationBySid, onCitationClick)}</h3>;
+    if (block.kind === 'ul') {
+      return (
+        <ul key={key} className="lcars-chat-message__ul">
+          {(block.items ?? []).map((item, jx) => (
+            <li key={jx}>{renderInline(item, citationBySid, onCitationClick)}</li>
+          ))}
+        </ul>
+      );
+    }
+    return (
+      <p key={key} className="lcars-chat-message__p">
+        {renderInline(block.content, citationBySid, onCitationClick)}
+      </p>
+    );
+  });
+}
+
+/**
+ * Walk an inline text segment producing React nodes for plain text,
+ * `[SID:...]` chips, **bold**, *italic*, and `inline code`. The walker
+ * is intentionally simple — overlapping syntax (bold-inside-italic-
+ * inside-code) falls through to plain text rather than going down a
+ * full parser rabbit hole. Markdown produced by the chat-answer skill
+ * is well-behaved enough that this trade-off doesn't bite in practice.
+ */
+function renderInline(
+  text: string,
+  citationBySid: Map<string, ChatCitation>,
+  onCitationClick: ((sid: string) => void) | undefined,
+): React.ReactNode[] {
+  const out: React.ReactNode[] = [];
+  let cursor = 0;
+  SID_RE.lastIndex = 0;
+  const matches: { start: number; end: number; sid: string }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = SID_RE.exec(text)) !== null) {
+    matches.push({ start: m.index, end: m.index + m[0].length, sid: m[1]!.toLowerCase() });
+  }
+  // Walk matches; render non-match runs via renderTextRun (handles
+  // bold/italic/code), interleaved with citation chips.
+  let key = 0;
+  for (const match of matches) {
+    if (match.start > cursor) {
+      out.push(...renderTextRun(text.slice(cursor, match.start), () => key++));
+    }
+    const cit = citationBySid.get(match.sid);
+    if (cit) {
+      out.push(<CitationChip key={`c${key++}`} citation={cit} onActivate={onCitationClick} verified={true} />);
+    } else {
+      out.push(
+        <CitationChip
+          key={`c${key++}`}
+          citation={{ sessionId: match.sid, source: 'cowork' }}
+          onActivate={onCitationClick}
+          verified={false}
+        />,
+      );
+    }
+    cursor = match.end;
+  }
+  if (cursor < text.length) {
+    out.push(...renderTextRun(text.slice(cursor), () => key++));
+  }
+  return out;
+}
+
+const INLINE_RE = /(`[^`]+`|\*\*[^*]+\*\*|\*[^*]+\*)/g;
+
+function renderTextRun(text: string, nextKey: () => number): React.ReactNode[] {
+  const out: React.ReactNode[] = [];
+  let last = 0;
+  let m: RegExpExecArray | null;
+  INLINE_RE.lastIndex = 0;
+  while ((m = INLINE_RE.exec(text)) !== null) {
+    if (m.index > last) out.push(text.slice(last, m.index));
+    const tok = m[0];
+    if (tok.startsWith('**')) {
+      out.push(<strong key={`s${nextKey()}`}>{tok.slice(2, -2)}</strong>);
+    } else if (tok.startsWith('*')) {
+      out.push(<em key={`e${nextKey()}`}>{tok.slice(1, -1)}</em>);
+    } else if (tok.startsWith('`')) {
+      out.push(<code key={`k${nextKey()}`}>{tok.slice(1, -1)}</code>);
+    }
+    last = m.index + tok.length;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
+}

--- a/packages/viewer/src/components/modes/chat/ChatStreamedMessage.tsx
+++ b/packages/viewer/src/components/modes/chat/ChatStreamedMessage.tsx
@@ -12,6 +12,12 @@ export interface ChatStreamedMessageProps {
    * forwarding an already-optional prop don't need a conditional spread.
    */
   onCitationClick?: ((sessionId: string) => void) | undefined;
+  /**
+   * Click handler for follow-up chips (`→ Question?` lines the agent
+   * emits at the end of an answer). Receives the question text exactly
+   * as the agent wrote it; the host typically resubmits it as a new turn.
+   */
+  onFollowUpClick?: ((question: string) => void) | undefined;
   /** Render variant. `live` adds a typing caret at end; `final` does not. */
   variant: 'live' | 'final';
 }
@@ -19,23 +25,44 @@ export interface ChatStreamedMessageProps {
 const SID_RE = /\[SID:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\]/gi;
 
 /**
- * Render assistant markdown with inline citation chips. Phase 1: a tight
- * subset of markdown is supported inline (paragraphs, line breaks,
- * bold, italic, inline code, code blocks, headers, bullet lists). Full
- * markdown (links, images, tables) is deferred — the agent's prompt is
- * tuned to emit this subset.
+ * H2 headings whose section should render collapsed-by-default. The
+ * skill emits methodology / caveats / risks under these literal labels
+ * (see `.claude/skills/chat-answer/SKILL.md` "Style" section). Match
+ * is case-insensitive against the trimmed heading text. Anything else
+ * renders as a normal H2.
  *
- * Sanitization model: we never inject raw HTML. The renderer walks the
- * text and produces React elements directly — there's no `dangerouslySet
- * InnerHTML` anywhere, so a token containing `<img onerror=...>` is
- * rendered as literal text, not executed. This makes the streamed-
- * markdown XSS surface from the adversarial review (A12) a non-issue
- * by construction.
+ * Why collapsed-by-default: the answer's headline + evidence is what
+ * the user is here for; methodology/caveats/risks are trust artifacts
+ * they can opt into. This is a presentation rule only — the prose
+ * content itself is unchanged, so cutting the chrome doesn't elide
+ * any of the skill's anti-Goodhart disciplines (counts-with-grep-
+ * patterns, character-exact quotes) — those still ship in the body.
+ */
+const COLLAPSIBLE_TITLE_RE =
+  /^(?:honest\s+)?(caveats?|negatives?|methodology|calibration|risks?|honest\s+notes?)$/i;
+
+/** Lines that begin with this prefix are turned into follow-up chips. */
+const FOLLOWUP_LINE_RE = /^→\s+(.+)$/;
+
+/**
+ * Render assistant markdown with inline citation chips, collapsible
+ * trust-artifact sections (`## Caveats`, `## Methodology`, `## Risks`),
+ * and follow-up chips (lines prefixed with `→ `). Tight subset of
+ * markdown otherwise: paragraphs, line breaks, bold, italic, inline
+ * code, code blocks, headers, bullet lists. Full markdown (links,
+ * images, tables) is deferred — the agent's prompt is tuned to emit
+ * this subset.
+ *
+ * Sanitization model: we never inject raw HTML. The renderer walks
+ * the text and produces React elements directly — there's no
+ * `dangerouslySetInnerHTML` anywhere, so a token containing
+ * `<img onerror=...>` is rendered as literal text, not executed.
  */
 export function ChatStreamedMessage({
   text,
   citations,
   onCitationClick,
+  onFollowUpClick,
   variant,
 }: ChatStreamedMessageProps) {
   const citationBySid = useMemo(() => {
@@ -44,11 +71,10 @@ export function ChatStreamedMessage({
     return m;
   }, [citations]);
 
-  const nodes = useMemo(() => renderMarkdown(text, citationBySid, onCitationClick), [
-    text,
-    citationBySid,
-    onCitationClick,
-  ]);
+  const nodes = useMemo(
+    () => renderMarkdown(text, citationBySid, onCitationClick, onFollowUpClick),
+    [text, citationBySid, onCitationClick, onFollowUpClick],
+  );
 
   return (
     <div className="lcars-chat-message lcars-chat-message--assistant">
@@ -59,10 +85,14 @@ export function ChatStreamedMessage({
 }
 
 interface Block {
-  kind: 'p' | 'h1' | 'h2' | 'h3' | 'code' | 'ul';
+  kind: 'p' | 'h1' | 'h2' | 'h3' | 'code' | 'ul' | 'followups' | 'collapsible';
   content: string;
   items?: string[];
   lang?: string;
+  /** For 'collapsible': summary text rendered in <summary>. */
+  title?: string;
+  /** For 'collapsible': flat blocks rendered inside <details>. */
+  inner?: Block[];
 }
 
 function parseBlocks(text: string): Block[] {
@@ -98,6 +128,20 @@ function parseBlocks(text: string): Block[] {
       i += 1;
       continue;
     }
+    // Follow-up chip lines — consume consecutive `→ ` lines into one
+    // block. Treated as a sibling of bullet lists so the renderer can
+    // emit a chip group instead of a paragraph wall.
+    if (FOLLOWUP_LINE_RE.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length) {
+        const m = FOLLOWUP_LINE_RE.exec(lines[i]!);
+        if (!m) break;
+        items.push(m[1]!.trim());
+        i += 1;
+      }
+      blocks.push({ kind: 'followups', content: '', items });
+      continue;
+    }
     // Bullet list
     if (/^[-*] /.test(line)) {
       const items: string[] = [];
@@ -119,6 +163,7 @@ function parseBlocks(text: string): Block[] {
       const l = lines[i]!;
       if (l.trim().length === 0) break;
       if (/^```/.test(l) || /^#{1,3} /.test(l) || /^[-*] /.test(l)) break;
+      if (FOLLOWUP_LINE_RE.test(l)) break;
       i += 1;
     }
     blocks.push({ kind: 'p', content: lines.slice(paraStart, i).join('\n') });
@@ -126,39 +171,138 @@ function parseBlocks(text: string): Block[] {
   return blocks;
 }
 
+/**
+ * Post-process flat blocks: when an H2 matches the collapsible-title
+ * pattern, fold it and the following blocks (until next H1/H2 or end)
+ * into a single `collapsible` block. This is a presentation transform
+ * only — content is preserved verbatim; only the chrome that wraps it
+ * changes.
+ *
+ * Boundary: any subsequent H1 or H2 closes the section. H3 stays inside.
+ * That matches the skill's section convention (H2 for top-level
+ * sections, H3 for subsections within them).
+ */
+function groupCollapsibles(blocks: Block[]): Block[] {
+  const out: Block[] = [];
+  let i = 0;
+  while (i < blocks.length) {
+    const b = blocks[i]!;
+    if (b.kind === 'h2' && COLLAPSIBLE_TITLE_RE.test(b.content.trim())) {
+      const inner: Block[] = [];
+      let j = i + 1;
+      while (j < blocks.length) {
+        const next = blocks[j]!;
+        if (next.kind === 'h1' || next.kind === 'h2') break;
+        inner.push(next);
+        j += 1;
+      }
+      out.push({ kind: 'collapsible', content: '', title: b.content, inner });
+      i = j;
+      continue;
+    }
+    out.push(b);
+    i += 1;
+  }
+  return out;
+}
+
 function renderMarkdown(
   text: string,
   citationBySid: Map<string, ChatCitation>,
   onCitationClick: ((sid: string) => void) | undefined,
+  onFollowUpClick: ((question: string) => void) | undefined,
 ): React.ReactNode[] {
-  const blocks = parseBlocks(text);
-  return blocks.map((block, ix) => {
-    const key = `b${ix}`;
-    if (block.kind === 'code') {
-      return (
-        <pre key={key} className="lcars-chat-message__code">
-          <code data-lang={block.lang || undefined}>{block.content}</code>
-        </pre>
-      );
-    }
-    if (block.kind === 'h1') return <h1 key={key} className="lcars-chat-message__h1">{renderInline(block.content, citationBySid, onCitationClick)}</h1>;
-    if (block.kind === 'h2') return <h2 key={key} className="lcars-chat-message__h2">{renderInline(block.content, citationBySid, onCitationClick)}</h2>;
-    if (block.kind === 'h3') return <h3 key={key} className="lcars-chat-message__h3">{renderInline(block.content, citationBySid, onCitationClick)}</h3>;
-    if (block.kind === 'ul') {
-      return (
-        <ul key={key} className="lcars-chat-message__ul">
-          {(block.items ?? []).map((item, jx) => (
-            <li key={jx}>{renderInline(item, citationBySid, onCitationClick)}</li>
-          ))}
-        </ul>
-      );
-    }
+  const flat = parseBlocks(text);
+  const blocks = groupCollapsibles(flat);
+  return blocks.map((block, ix) =>
+    renderBlock(block, `b${ix}`, citationBySid, onCitationClick, onFollowUpClick),
+  );
+}
+
+function renderBlock(
+  block: Block,
+  key: string,
+  citationBySid: Map<string, ChatCitation>,
+  onCitationClick: ((sid: string) => void) | undefined,
+  onFollowUpClick: ((question: string) => void) | undefined,
+): React.ReactNode {
+  if (block.kind === 'code') {
     return (
-      <p key={key} className="lcars-chat-message__p">
-        {renderInline(block.content, citationBySid, onCitationClick)}
-      </p>
+      <pre key={key} className="lcars-chat-message__code">
+        <code data-lang={block.lang || undefined}>{block.content}</code>
+      </pre>
     );
-  });
+  }
+  if (block.kind === 'h1') {
+    return (
+      <h1 key={key} className="lcars-chat-message__h1">
+        {renderInline(block.content, citationBySid, onCitationClick)}
+      </h1>
+    );
+  }
+  if (block.kind === 'h2') {
+    return (
+      <h2 key={key} className="lcars-chat-message__h2">
+        {renderInline(block.content, citationBySid, onCitationClick)}
+      </h2>
+    );
+  }
+  if (block.kind === 'h3') {
+    return (
+      <h3 key={key} className="lcars-chat-message__h3">
+        {renderInline(block.content, citationBySid, onCitationClick)}
+      </h3>
+    );
+  }
+  if (block.kind === 'ul') {
+    return (
+      <ul key={key} className="lcars-chat-message__ul">
+        {(block.items ?? []).map((item, jx) => (
+          <li key={jx}>{renderInline(item, citationBySid, onCitationClick)}</li>
+        ))}
+      </ul>
+    );
+  }
+  if (block.kind === 'followups') {
+    const items = block.items ?? [];
+    if (items.length === 0) return null;
+    return (
+      <div key={key} className="lcars-chat-message__followups" role="group" aria-label="suggested follow-up questions">
+        {items.map((q, jx) => (
+          <button
+            type="button"
+            key={jx}
+            className="lcars-chat-message__followup"
+            onClick={() => onFollowUpClick?.(q)}
+            disabled={!onFollowUpClick}
+            title={onFollowUpClick ? 'Ask this as a follow-up' : 'Suggested follow-up'}
+          >
+            <span className="lcars-chat-message__followup-arrow" aria-hidden="true">→</span>
+            <span className="lcars-chat-message__followup-text">{q}</span>
+          </button>
+        ))}
+      </div>
+    );
+  }
+  if (block.kind === 'collapsible') {
+    return (
+      <details key={key} className="lcars-chat-message__details">
+        <summary className="lcars-chat-message__details-summary">
+          {renderInline(block.title ?? '', citationBySid, onCitationClick)}
+        </summary>
+        <div className="lcars-chat-message__details-body">
+          {(block.inner ?? []).map((b, jx) =>
+            renderBlock(b, `${key}-i${jx}`, citationBySid, onCitationClick, onFollowUpClick),
+          )}
+        </div>
+      </details>
+    );
+  }
+  return (
+    <p key={key} className="lcars-chat-message__p">
+      {renderInline(block.content, citationBySid, onCitationClick)}
+    </p>
+  );
 }
 
 /**

--- a/packages/viewer/src/components/modes/chat/CitationChip.tsx
+++ b/packages/viewer/src/components/modes/chat/CitationChip.tsx
@@ -1,0 +1,48 @@
+import type { ChatCitation } from '@chat-arch/schema';
+
+export interface CitationChipProps {
+  citation: ChatCitation;
+  /**
+   * When clicked, navigate to the session's detail surface
+   * (#session/<id>). Typed with explicit `| undefined` so the host can
+   * forward an optional handler without `exactOptionalPropertyTypes`
+   * forcing a conditional-spread at every callsite.
+   */
+  onActivate?: ((sessionId: string) => void) | undefined;
+  /**
+   * When false, the chip renders muted with an "unverified" badge. Used
+   * for inline `[SID:...]` markers in the assistant text whose ids
+   * weren't in the agent's Read history (validated server-side, but a
+   * future render path may surface unverified ids inline before
+   * validation — kept as an explicit prop for that reason).
+   */
+  verified?: boolean | undefined;
+}
+
+/**
+ * Compact citation chip rendered inline in the assistant's answer. Shows
+ * a short session-id prefix; clicking opens the session in DetailMode
+ * via the existing `#session/<id>` hash route.
+ */
+export function CitationChip({ citation, onActivate, verified = true }: CitationChipProps) {
+  const short = citation.sessionId.slice(0, 8);
+  const label = verified ? short : `${short}?`;
+  const ariaLabel = verified
+    ? `cited session ${citation.sessionId}`
+    : `unverified citation for session ${citation.sessionId}`;
+  const title = citation.snippet
+    ? `${citation.sessionId}\n${citation.snippet}`
+    : citation.sessionId;
+  return (
+    <button
+      type="button"
+      className={`lcars-chat-citation${verified ? '' : ' lcars-chat-citation--unverified'}`}
+      onClick={() => onActivate?.(citation.sessionId)}
+      aria-label={ariaLabel}
+      title={title}
+    >
+      <span className="lcars-chat-citation__prefix">SID</span>
+      <span className="lcars-chat-citation__value">{label}</span>
+    </button>
+  );
+}

--- a/packages/viewer/src/components/modes/chat/DisclosureModal.tsx
+++ b/packages/viewer/src/components/modes/chat/DisclosureModal.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef } from 'react';
+
+export interface DisclosureModalProps {
+  open: boolean;
+  onAcknowledge: () => void;
+  onCancel: () => void;
+}
+
+const STORAGE_KEY = 'chat-arch:chat-disclosure-acked-v1';
+
+/**
+ * Whether the user has acknowledged the chat-page data-flow disclosure
+ * (questions + agent reads forwarded to the local Claude CLI, which
+ * calls Anthropic). Checked once on first chat interaction.
+ */
+export function chatDisclosureAcknowledged(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    // Some privacy modes block localStorage entirely; treat as not-acked
+    // so we re-disclose every session rather than silently bypass.
+    return false;
+  }
+}
+
+export function markChatDisclosureAcknowledged(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, '1');
+  } catch {
+    // Best-effort; if localStorage is blocked we re-disclose next visit.
+  }
+}
+
+/**
+ * First-run disclosure dialog. The adversarial review of the v3 plan
+ * (finding A8) flagged that "cloud data never leaves IndexedDB" is a
+ * misleading framing once chat is added — the question + the agent's
+ * Read outputs go through the local Claude CLI, which then calls
+ * Anthropic's API. The user deserves explicit notice the first time.
+ *
+ * Modeled as a confirm/cancel — declining doesn't proceed to a turn.
+ */
+export function DisclosureModal({ open, onAcknowledge, onCancel }: DisclosureModalProps) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', handler);
+    dialogRef.current?.focus();
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="lcars-chat-disclosure"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="lcars-chat-disclosure-title"
+    >
+      <div className="lcars-chat-disclosure__backdrop" onClick={onCancel} />
+      <div className="lcars-chat-disclosure__panel" ref={dialogRef} tabIndex={-1}>
+        <h2 id="lcars-chat-disclosure-title" className="lcars-chat-disclosure__title">
+          BEFORE YOU CHAT
+        </h2>
+        <div className="lcars-chat-disclosure__body">
+          <p>
+            The chat answers questions using <strong>your local Claude Code CLI</strong>. When
+            you send a message, the chat:
+          </p>
+          <ol>
+            <li>Spawns <code>claude -p</code> on this machine.</li>
+            <li>
+              The Claude Code agent reads from your archived chat-arch corpus
+              (<code>chat-arch-data/</code> on disk) to ground the answer.
+            </li>
+            <li>
+              Your question and the corpus excerpts the agent reads are forwarded by{' '}
+              <code>claude</code> to Anthropic&apos;s API under your existing Anthropic account.
+            </li>
+            <li>
+              Usage is billed to <strong>your</strong> Anthropic plan, the same as running{' '}
+              <code>claude</code> in a terminal.
+            </li>
+          </ol>
+          <p>
+            Cloud conversations stored only in your browser (the uploaded ZIP archive) are{' '}
+            <strong>not</strong> sent — the agent reads the on-disk corpus only.
+          </p>
+        </div>
+        <div className="lcars-chat-disclosure__actions">
+          <button
+            type="button"
+            className="lcars-chat-disclosure__cancel"
+            onClick={onCancel}
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            className="lcars-chat-disclosure__confirm"
+            onClick={onAcknowledge}
+          >
+            I UNDERSTAND — CONTINUE
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/viewer/src/components/modes/index.ts
+++ b/packages/viewer/src/components/modes/index.ts
@@ -1,3 +1,4 @@
 export { CommandMode } from './CommandMode.js';
 export { TimelineMode } from './TimelineMode.js';
 export { DetailMode } from './DetailMode.js';
+export { ChatMode } from './ChatMode.js';

--- a/packages/viewer/src/data/chatAnswerClient.ts
+++ b/packages/viewer/src/data/chatAnswerClient.ts
@@ -1,0 +1,148 @@
+import type { ChatAnswerRequest, ChatStreamEvent } from '@chat-arch/schema';
+
+/**
+ * Network seam for the chat page. The viewer never calls `fetch()` for
+ * `/api/chat-answer` directly — it goes through `streamChatAnswer` so the
+ * NDJSON parsing, CSRF header, and event dispatch live in one place.
+ *
+ * Same pattern as `fetch.ts` (the manifest seam) and
+ * `mineCorrectionsClient.ts` (the corrections mining seam).
+ */
+
+const ENDPOINT = '/api/chat-answer';
+const REQUIRED_HEADER = 'chat-arch-chat-answer';
+
+export interface StreamChatAnswerOptions {
+  /** Called once per parsed NDJSON line. */
+  onEvent: (ev: ChatStreamEvent) => void;
+  /** Abort signal for user-initiated cancel ("stop" button). */
+  signal?: AbortSignal;
+}
+
+export interface StreamChatAnswerResult {
+  /** True iff a `final` event was observed in the stream. */
+  finalSeen: boolean;
+  /**
+   * When the request was rejected before streaming started (4xx / 5xx
+   * status), the parsed error body. Null when the stream was reached.
+   */
+  rejected: { status: number; error: string } | null;
+}
+
+/**
+ * POST a single chat turn and stream the NDJSON response through
+ * `onEvent`. Rejected requests (CSRF, validation, concurrency caps)
+ * return early with `rejected` populated; the stream path always returns
+ * with `finalSeen` reflecting whether the agent finished cleanly.
+ */
+export async function streamChatAnswer(
+  body: ChatAnswerRequest,
+  opts: StreamChatAnswerOptions,
+): Promise<StreamChatAnswerResult> {
+  let res: Response;
+  try {
+    res = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-requested-with': REQUIRED_HEADER,
+      },
+      body: JSON.stringify(body),
+      ...(opts.signal ? { signal: opts.signal } : {}),
+    });
+  } catch (err) {
+    opts.onEvent({
+      type: 'error',
+      message: `network error contacting ${ENDPOINT}: ${String(err)}`,
+      retryable: true,
+    });
+    return { finalSeen: false, rejected: { status: 0, error: 'network' } };
+  }
+
+  if (!res.ok) {
+    let errText = `HTTP ${res.status}`;
+    try {
+      const j = (await res.json()) as { error?: unknown };
+      if (typeof j.error === 'string') errText = j.error;
+    } catch {
+      // not JSON; keep status text
+    }
+    opts.onEvent({ type: 'error', message: errText, retryable: res.status >= 500 || res.status === 429 });
+    return { finalSeen: false, rejected: { status: res.status, error: errText } };
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) {
+    opts.onEvent({ type: 'error', message: 'response had no body', retryable: false });
+    return { finalSeen: false, rejected: null };
+  }
+
+  const decoder = new TextDecoder();
+  let buf = '';
+  let finalSeen = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl = buf.indexOf('\n');
+      while (nl !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (line.length > 0) {
+          const ev = parseEvent(line);
+          if (ev) {
+            opts.onEvent(ev);
+            if (ev.type === 'final') finalSeen = true;
+          }
+        }
+        nl = buf.indexOf('\n');
+      }
+    }
+    // Flush any trailing partial.
+    if (buf.trim().length > 0) {
+      const ev = parseEvent(buf.trim());
+      if (ev) {
+        opts.onEvent(ev);
+        if (ev.type === 'final') finalSeen = true;
+      }
+    }
+  } catch (err) {
+    opts.onEvent({
+      type: 'error',
+      message: `stream interrupted: ${String(err)}`,
+      retryable: true,
+    });
+  }
+
+  return { finalSeen, rejected: null };
+}
+
+function parseEvent(line: string): ChatStreamEvent | null {
+  try {
+    const obj = JSON.parse(line);
+    if (!obj || typeof obj !== 'object') return null;
+    // Trust the server's typing — we control the endpoint. Defensive
+    // validation here would mostly fail open anyway.
+    return obj as ChatStreamEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One-shot availability probe used on ChatMode mount. Returns false when
+ * the endpoint is unavailable (static-only deploy, server down) so the
+ * UI can render an empty state instead of a non-functional input.
+ */
+export async function probeChatAnswerAvailability(): Promise<boolean> {
+  try {
+    const res = await fetch(ENDPOINT, { method: 'GET' });
+    if (!res.ok) return false;
+    const j = (await res.json()) as { available?: unknown };
+    return j.available === true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/viewer/src/data/chatHistoryStore.ts
+++ b/packages/viewer/src/data/chatHistoryStore.ts
@@ -1,0 +1,111 @@
+import { createStore, get, set, del, type UseStore } from 'idb-keyval';
+import type { ChatConversation, ChatHistoryFile } from '@chat-arch/schema';
+
+/**
+ * IndexedDB persistence for the chat page's conversation history.
+ *
+ * One IndexedDB DB (`chat-arch-chat-history`) → one store (`chats`) →
+ * single key (`active`) that holds the versioned envelope. Same pattern
+ * as `uploadedDataStore.ts` (one DB per store, idb-keyval's createStore
+ * doesn't expose schema-migration without a custom openDB dance).
+ *
+ * Chat history persists across reloads — questions asked, agent traces,
+ * and citations survive a page refresh. The `claudeSessionId` on each
+ * conversation is what powers `--resume` on subsequent turns; if the
+ * Claude Code session has been cleaned up between turns (rare) the
+ * endpoint detects the resume failure and a fresh session id replaces
+ * the stale one.
+ *
+ * **PII reminder (per CLAUDE.md):** the data in this store contains the
+ * user's natural-language questions, which can include sensitive
+ * context. Treat it like the uploaded archive — never write it to disk,
+ * include it in the NuclearReset wipe sequence, and don't surface it
+ * outside the user's own browser.
+ */
+
+const DB_NAME = 'chat-arch-chat-history';
+const STORE_NAME = 'chats';
+const KEY = 'active';
+
+let cachedStore: UseStore | null = null;
+function storeHandle(): UseStore {
+  if (!cachedStore) cachedStore = createStore(DB_NAME, STORE_NAME);
+  return cachedStore;
+}
+
+function indexedDbAvailable(): boolean {
+  return typeof indexedDB !== 'undefined' && indexedDB !== null;
+}
+
+/**
+ * Runtime guard — a corrupt entry must not poison the viewer mount.
+ * Validates the envelope shape but not deep into each turn (defensive
+ * deep validation would mostly fail open on the wire). A bad shape is
+ * treated as "no history yet" rather than thrown.
+ */
+function isChatHistoryFile(v: unknown): v is ChatHistoryFile {
+  if (!v || typeof v !== 'object') return false;
+  const o = v as Record<string, unknown>;
+  if (o['version'] !== 1) return false;
+  if (!Array.isArray(o['chats'])) return false;
+  return true;
+}
+
+/** Load persisted chat history, or null if absent / unreadable. */
+export async function loadChatHistory(): Promise<ChatHistoryFile | null> {
+  if (!indexedDbAvailable()) return null;
+  try {
+    const v = await get<unknown>(KEY, storeHandle());
+    if (!isChatHistoryFile(v)) return null;
+    return v;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the full chat history envelope (idempotent overwrite). */
+export async function saveChatHistory(file: ChatHistoryFile): Promise<void> {
+  if (!indexedDbAvailable()) return;
+  try {
+    await set(KEY, file, storeHandle());
+  } catch (err) {
+    if (typeof console !== 'undefined') {
+      console.warn('chat-arch: failed to persist chat history', err);
+    }
+  }
+}
+
+/**
+ * Wipe all chat history. Called from `NuclearReset` alongside the other
+ * three DBs (uploaded-cloud-data, semantic-labels, bench-results) so a
+ * "delete cloud data" action wipes EVERY personal-data store.
+ */
+export async function clearChatHistory(): Promise<void> {
+  if (!indexedDbAvailable()) return;
+  try {
+    await del(KEY, storeHandle());
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Upsert a single conversation into history. Used after each successful
+ * turn. Conversations are stored most-recently-updated first so the
+ * chat list renders without sorting work in the UI.
+ */
+export async function upsertConversation(conv: ChatConversation): Promise<ChatHistoryFile> {
+  const existing = (await loadChatHistory()) ?? { version: 1 as const, chats: [] };
+  const others = existing.chats.filter((c: ChatConversation) => c.chatId !== conv.chatId);
+  const next: ChatHistoryFile = {
+    version: 1,
+    chats: [conv, ...others].sort((a, b) => b.updatedAt - a.updatedAt),
+  };
+  await saveChatHistory(next);
+  return next;
+}
+
+/** Test-only: forget the cached store handle so a fresh DB can be opened. */
+export function _resetChatHistoryStoreForTest(): void {
+  cachedStore = null;
+}

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -7363,3 +7363,592 @@ button.lcars-applied-summary__stale--button:focus-visible {
   display: flex;
   gap: 8px;
 }
+
+/* -------------------------------------------------------------------------
+ * Chat page surface — added in the chat-page ship.
+ *
+ * Layout: two-column grid inside the existing main content area. Left
+ * column is a slim chat-list rail; right column is the conversation
+ * panel (intent toggle, transcript, input bar). Keeps the visual
+ * vocabulary aligned with the rest of the LCARS surface — no new
+ * design tokens, just composed primitives.
+ * ------------------------------------------------------------------------- */
+
+.lcars-chat {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 16px;
+  height: 100%;
+  min-height: 0;
+  padding: 12px;
+  box-sizing: border-box;
+}
+
+.lcars-chat--probing,
+.lcars-chat--unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lcars-chat__probe {
+  font-family: var(--lcars-font-mono, monospace);
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
+
+.lcars-chat__empty {
+  max-width: 560px;
+  padding: 24px;
+  background: color-mix(in srgb, var(--lcars-sunflower) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--lcars-sunflower) 50%, transparent);
+  border-radius: 8px;
+}
+
+.lcars-chat__empty h2 {
+  margin: 0 0 12px;
+  font-size: 16px;
+  letter-spacing: 0.1em;
+  color: var(--lcars-sunflower);
+}
+
+.lcars-chat__empty p {
+  margin: 8px 0;
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.lcars-chat__empty pre {
+  background: rgba(0, 0, 0, 0.35);
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  margin: 6px 0;
+}
+
+/* --- Chat list rail --- */
+
+.lcars-chat__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.lcars-chat__new {
+  background: var(--lcars-sunflower);
+  color: #000;
+  border: none;
+  padding: 8px 10px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 4px;
+  text-align: left;
+}
+
+.lcars-chat__new:hover {
+  background: color-mix(in srgb, var(--lcars-sunflower) 80%, white);
+}
+
+.lcars-chat__list-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lcars-chat__list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid color-mix(in srgb, var(--lcars-text) 18%, transparent);
+  color: var(--lcars-text);
+  padding: 8px 10px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+  font-family: inherit;
+}
+
+.lcars-chat__list-item:hover {
+  border-color: color-mix(in srgb, var(--lcars-sunflower) 60%, transparent);
+}
+
+.lcars-chat__list-item--active {
+  border-color: var(--lcars-sunflower);
+  background: color-mix(in srgb, var(--lcars-sunflower) 12%, transparent);
+}
+
+.lcars-chat__list-intent {
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 9.5px;
+  letter-spacing: 0.12em;
+  color: var(--lcars-sunflower);
+}
+
+.lcars-chat__list-title {
+  font-size: 12.5px;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.lcars-chat__clear {
+  margin-top: auto;
+  background: transparent;
+  color: color-mix(in srgb, var(--lcars-peach) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--lcars-peach) 40%, transparent);
+  padding: 6px 10px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.lcars-chat__clear:hover {
+  background: color-mix(in srgb, var(--lcars-peach) 15%, transparent);
+}
+
+/* --- Conversation panel --- */
+
+.lcars-chat__panel {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 12px;
+  min-height: 0;
+}
+
+.lcars-chat__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.lcars-chat__intent {
+  display: flex;
+  gap: 4px;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 2px;
+  border-radius: 4px;
+}
+
+.lcars-chat__intent-opt {
+  padding: 6px 12px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  cursor: pointer;
+  border-radius: 3px;
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+}
+
+.lcars-chat__intent-opt input {
+  display: none;
+}
+
+.lcars-chat__intent-opt--active {
+  background: var(--lcars-sunflower);
+  color: #000;
+}
+
+.lcars-chat__transcript {
+  overflow-y: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-right: 8px;
+}
+
+.lcars-chat__seed {
+  max-width: 640px;
+  padding: 20px;
+}
+
+.lcars-chat__seed h2 {
+  font-size: 22px;
+  margin: 0 0 10px;
+  color: var(--lcars-sunflower);
+}
+
+.lcars-chat__seed p {
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.lcars-chat__seed-list {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lcars-chat__seed-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid color-mix(in srgb, var(--lcars-sunflower) 50%, transparent);
+  color: var(--lcars-text);
+  padding: 10px 14px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-family: inherit;
+}
+
+.lcars-chat__seed-button:hover {
+  background: color-mix(in srgb, var(--lcars-sunflower) 10%, transparent);
+}
+
+.lcars-chat__seed-label {
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  color: var(--lcars-sunflower);
+}
+
+.lcars-chat__seed-q {
+  font-size: 13px;
+}
+
+/* --- Messages --- */
+
+.lcars-chat-message__wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lcars-chat-message {
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.lcars-chat-message--user {
+  align-self: flex-end;
+  max-width: 70%;
+  background: color-mix(in srgb, var(--lcars-sunflower) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--lcars-sunflower) 40%, transparent);
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+
+.lcars-chat-message__user-text {
+  margin: 0;
+  font-family: inherit;
+  white-space: pre-wrap;
+  font-size: 13.5px;
+  line-height: 1.5;
+}
+
+.lcars-chat-message--assistant {
+  display: block;
+}
+
+.lcars-chat-message__p {
+  margin: 0.5em 0;
+}
+
+.lcars-chat-message__h1 {
+  font-size: 18px;
+  margin: 0.8em 0 0.4em;
+}
+
+.lcars-chat-message__h2 {
+  font-size: 15.5px;
+  margin: 0.8em 0 0.4em;
+  color: var(--lcars-sunflower);
+}
+
+.lcars-chat-message__h3 {
+  font-size: 14px;
+  margin: 0.8em 0 0.4em;
+}
+
+.lcars-chat-message__ul {
+  margin: 0.4em 0 0.4em 1.5em;
+  padding: 0;
+}
+
+.lcars-chat-message__code {
+  background: rgba(0, 0, 0, 0.45);
+  padding: 8px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  overflow-x: auto;
+  margin: 0.5em 0;
+}
+
+.lcars-chat-message__caret {
+  display: inline-block;
+  margin-left: 2px;
+  animation: lcars-chat-caret 1s steps(2) infinite;
+  color: var(--lcars-sunflower);
+}
+
+@keyframes lcars-chat-caret {
+  to {
+    opacity: 0;
+  }
+}
+
+.lcars-chat-message__error {
+  font-size: 12.5px;
+  color: var(--lcars-peach);
+  font-family: var(--lcars-font-mono, monospace);
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, var(--lcars-peach) 40%, transparent);
+  border-radius: 4px;
+}
+
+/* --- Citation chip --- */
+
+.lcars-chat-citation {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  background: color-mix(in srgb, var(--lcars-sunflower) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--lcars-sunflower) 50%, transparent);
+  color: var(--lcars-text);
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 10.5px;
+  letter-spacing: 0.04em;
+  padding: 1px 5px;
+  margin: 0 1px;
+  border-radius: 3px;
+  cursor: pointer;
+  text-decoration: none;
+  vertical-align: baseline;
+}
+
+.lcars-chat-citation:hover {
+  background: color-mix(in srgb, var(--lcars-sunflower) 25%, transparent);
+}
+
+.lcars-chat-citation--unverified {
+  border-color: color-mix(in srgb, var(--lcars-peach) 50%, transparent);
+  background: color-mix(in srgb, var(--lcars-peach) 6%, transparent);
+}
+
+.lcars-chat-citation__prefix {
+  color: var(--lcars-sunflower);
+  font-weight: bold;
+  font-size: 9px;
+}
+
+.lcars-chat-citation--unverified .lcars-chat-citation__prefix {
+  color: var(--lcars-peach);
+}
+
+.lcars-chat-citation__value {
+  font-size: 10.5px;
+}
+
+/* --- Agent trace strip --- */
+
+.lcars-chat-trace {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid color-mix(in srgb, var(--lcars-ice) 30%, transparent);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
+.lcars-chat-trace__summary {
+  display: flex;
+  gap: 12px;
+  cursor: pointer;
+  font-family: var(--lcars-font-mono, monospace);
+  letter-spacing: 0.06em;
+  outline: none;
+  user-select: none;
+}
+
+.lcars-chat-trace__label {
+  color: var(--lcars-ice);
+  font-size: 10px;
+}
+
+.lcars-chat-trace__counts {
+  color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
+  font-size: 11px;
+}
+
+.lcars-chat-trace__list {
+  margin: 6px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.lcars-chat-trace__item {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+}
+
+.lcars-chat-trace__glyph {
+  flex-shrink: 0;
+}
+
+.lcars-chat-trace__code {
+  font-family: inherit;
+  font-size: inherit;
+  background: transparent;
+  color: color-mix(in srgb, var(--lcars-text) 88%, transparent);
+  word-break: break-word;
+}
+
+.lcars-chat-trace__thinking {
+  color: color-mix(in srgb, var(--lcars-text) 55%, transparent);
+  font-style: italic;
+  font-size: 10.5px;
+}
+
+.lcars-chat-trace__item--error .lcars-chat-trace__code {
+  color: var(--lcars-peach);
+}
+
+/* --- Input bar --- */
+
+.lcars-chat__inputbar {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.lcars-chat__input {
+  font-family: inherit;
+  font-size: 13.5px;
+  line-height: 1.5;
+  padding: 10px 12px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid color-mix(in srgb, var(--lcars-sunflower) 40%, transparent);
+  color: var(--lcars-text);
+  border-radius: 4px;
+  resize: vertical;
+  min-height: 64px;
+}
+
+.lcars-chat__input:focus {
+  outline: none;
+  border-color: var(--lcars-sunflower);
+}
+
+.lcars-chat__send {
+  background: var(--lcars-sunflower);
+  color: #000;
+  border: none;
+  padding: 0 18px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  font-weight: bold;
+  cursor: pointer;
+  border-radius: 4px;
+  min-width: 110px;
+}
+
+.lcars-chat__send:disabled {
+  background: color-mix(in srgb, var(--lcars-sunflower) 25%, transparent);
+  cursor: not-allowed;
+}
+
+/* --- Disclosure modal --- */
+
+.lcars-chat-disclosure {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lcars-chat-disclosure__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.lcars-chat-disclosure__panel {
+  position: relative;
+  max-width: 580px;
+  margin: 24px;
+  background: var(--lcars-bg, #0c0a1a);
+  border: 2px solid var(--lcars-sunflower);
+  border-radius: 8px;
+  padding: 20px 24px;
+  outline: none;
+}
+
+.lcars-chat-disclosure__title {
+  margin: 0 0 12px;
+  color: var(--lcars-sunflower);
+  font-size: 18px;
+  letter-spacing: 0.08em;
+}
+
+.lcars-chat-disclosure__body p,
+.lcars-chat-disclosure__body ol {
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.lcars-chat-disclosure__body ol {
+  margin: 0.6em 0 0.6em 1.4em;
+  padding: 0;
+}
+
+.lcars-chat-disclosure__actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+
+.lcars-chat-disclosure__cancel,
+.lcars-chat-disclosure__confirm {
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  padding: 8px 14px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.lcars-chat-disclosure__cancel {
+  background: transparent;
+  color: var(--lcars-text);
+  border: 1px solid color-mix(in srgb, var(--lcars-text) 35%, transparent);
+}
+
+.lcars-chat-disclosure__confirm {
+  background: var(--lcars-sunflower);
+  color: #000;
+  border: none;
+  font-weight: bold;
+}
+

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -7718,6 +7718,102 @@ button.lcars-applied-summary__stale--button:focus-visible {
   border-radius: 4px;
 }
 
+/* --- Collapsible trust-artifact section (Caveats / Methodology / Risks) --- */
+
+.lcars-chat-message__details {
+  margin: 0.8em 0;
+  border: 1px solid color-mix(in srgb, var(--lcars-ice) 25%, transparent);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.lcars-chat-message__details[open] {
+  background: rgba(0, 0, 0, 0.28);
+}
+
+.lcars-chat-message__details-summary {
+  cursor: pointer;
+  padding: 6px 10px;
+  font-family: var(--lcars-font-mono, monospace);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: var(--lcars-ice);
+  text-transform: uppercase;
+  user-select: none;
+  outline: none;
+  list-style: none;
+}
+
+.lcars-chat-message__details-summary::-webkit-details-marker {
+  display: none;
+}
+
+.lcars-chat-message__details-summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 6px;
+  transition: transform 120ms ease;
+  color: color-mix(in srgb, var(--lcars-ice) 80%, transparent);
+}
+
+.lcars-chat-message__details[open] .lcars-chat-message__details-summary::before {
+  transform: rotate(90deg);
+}
+
+.lcars-chat-message__details-summary:hover {
+  color: var(--lcars-sunflower);
+}
+
+.lcars-chat-message__details-body {
+  padding: 0 12px 8px;
+  border-top: 1px solid color-mix(in srgb, var(--lcars-ice) 15%, transparent);
+}
+
+/* --- Follow-up chip group (`→ Question?` lines) --- */
+
+.lcars-chat-message__followups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 1em 0 0.4em;
+}
+
+.lcars-chat-message__followup {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  background: color-mix(in srgb, var(--lcars-ice) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--lcars-ice) 40%, transparent);
+  color: var(--lcars-text);
+  font: inherit;
+  font-size: 12.5px;
+  text-align: left;
+  padding: 5px 10px;
+  border-radius: 14px;
+  cursor: pointer;
+  max-width: 100%;
+}
+
+.lcars-chat-message__followup:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--lcars-sunflower) 14%, transparent);
+  border-color: color-mix(in srgb, var(--lcars-sunflower) 55%, transparent);
+}
+
+.lcars-chat-message__followup:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.lcars-chat-message__followup-arrow {
+  color: var(--lcars-sunflower);
+  font-weight: bold;
+}
+
+.lcars-chat-message__followup-text {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
 /* --- Citation chip --- */
 
 .lcars-chat-citation {

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -82,7 +82,14 @@ export type Mode =
   /** v2 spec §5.4: PRACTICE four-lens adversarial audit dashboard. */
   | 'practice'
   /** Correction-mining surface: clustered patterns + proposed CLAUDE.md upgrades. */
-  | 'corrections';
+  | 'corrections'
+  /**
+   * Agentic Q&A + opportunity-finding over the corpus. The "chat with
+   * your archive" surface — drives `/api/chat-answer`, which spawns the
+   * local Claude Code CLI against the `chat-answer` skill. Driven by
+   * `#chat` hash.
+   */
+  | 'chat';
 
 /** Generic async-fetch state. Used uniformly for manifest + drill-in fetches. */
 export type FetchState<T> =
@@ -151,6 +158,11 @@ export const MODE_COLOR: Record<Mode, string> = {
   topics: 'var(--lcars-ice)',
   practice: 'var(--lcars-violet)',
   corrections: 'var(--lcars-peach)',
+  // Chat picks up the design-system's sunflower yellow at chrome level
+  // (matches "talk to it" affordance — the user's primary verb for this
+  // surface) — distinct from the projects accent so the active-mode dot
+  // doesn't blur the two.
+  chat: 'var(--lcars-sunflower)',
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds a new **CHAT** mode to the viewer — a "chat with your archive" surface backed by the local Claude Code CLI. The browser is a thin renderer over a `claude -p --output-format=stream-json` session that drives a new `chat-answer` skill; the skill explores `chat-arch-data/` directly via `Read Grep Glob Task` and cites sessions inline as \`[SID:<uuid>]\`.

Two intents share one skill:
- **`ask`** — grounded Q&A ("are you using any workflow that multiplies productivity?")
- **`find-opportunities`** — proactive surfacing (blog post ideas, etc.)

Designed from first principles around what Claude Code uniquely brings (agentic retrieval, sub-agents, `--resume` for free multi-turn memory, visible tool-call thinking). The chat IS Claude Code — the browser is a thin viewer over a CC session about your corpus.

## What ships

**New files**
- \`.claude/skills/chat-answer/SKILL.md\` — agent specialization, branches on intent
- \`apps/standalone/src/pages/api/chat-answer.ts\` — endpoint (CSRF, per-chatId single-flight + global ceiling of 3, stream-json → NDJSON, citation validation against the agent's actual \`Read\` history, silent-abort detection)
- \`packages/schema/src/chat.ts\` — \`ChatTurn\`, \`ChatConversation\`, \`ChatStreamEvent\`, \`ChatCitation\`, \`ChatHistoryFile\` types
- \`packages/viewer/src/components/modes/ChatMode.tsx\` — main UI: input, intent toggle, transcript, seed questions, chat list, clear-history affordance
- \`packages/viewer/src/components/modes/chat/{AgentTrace,CitationChip,ChatStreamedMessage,DisclosureModal}.tsx\` — sub-components
- \`packages/viewer/src/data/{chatAnswerClient,chatHistoryStore}.ts\` — network seam + IndexedDB persistence

**Modified**
- \`ChatArchViewer.tsx\` — \`#chat\` hash routing, default-landing logic (fresh installs → chat; returning users → command), mode dispatch
- \`Sidebar.tsx\` + tests — CHAT entry leftmost under FIX RULES
- \`NuclearReset.tsx\` — \`clearChatHistory()\` joins the kitchen-sink wipe
- \`types.ts\` — \`Mode\` adds \`'chat'\`; MODE_COLOR adds chat color
- \`styles.css\` — chat surface CSS (~590 lines)
- \`.gitignore\` — un-ignore the new skill (same pattern as mine-corrections)

## Architectural decisions (worth flagging in review)

- **Browser does NO retrieval.** Browser-side BM25 was in earlier drafts; cut after manual run-through showed Explore sub-agents pick better evidence than keyword retrieval, including negative evidence ("what didn't pan out") BM25 can't surface.
- **Multi-turn via \`--resume <id>\`.** First turn captures the session id from the stream-json \`system.init\` event; subsequent turns pass it back. No prompt-stitching of prior turns.
- **Tool grant: \`Read Grep Glob Task\` only.** No Bash/Write/Edit. The adversarial review of the design plan flagged \`mine-corrections\` inheriting broader tools — chat-answer doesn't need them. \`Task\` is included so the agent can spawn sub-agents (\`Explore\`) for fan-out questions.
- **Citation validation against the agent's Read history.** The endpoint tracks which files the agent actually read; \`[SID:abc]\` markers in the streamed text only get a verified chip if the agent's prior \`Read\` events grant visibility into that SID. Hallucinated SIDs render as muted "unverified" chips, not silently passed through.
- **Markdown rendering is XSS-safe by construction.** Tiny in-house renderer walks tokens and produces React elements directly — no \`dangerouslySetInnerHTML\`, so a stream containing \`<img onerror=...>\` renders as literal text.
- **Tmpdir for the request bundle.** NEVER under \`chat-arch-data/\` (PII-sensitive per CLAUDE.md).
- **First-run disclosure modal.** "Your questions and corpus excerpts are forwarded by \`claude\` to Anthropic's API under your existing Anthropic account."
- **Default landing flip is gated.** Fresh installs (\`hasExistingChatArchState()\` false) land on \`chat\`; returning users keep \`command\` so bookmarks don't break.
- **Per-chatId single-flight + global ceiling.** Same chat: 409. Server-wide N>3 concurrent: 429.

## Test plan

- [ ] \`pnpm dev\` from the repo root; open the viewer; click the CHAT tab.
- [ ] Verify the disclosure modal opens on first send, persists \`chat-arch:chat-disclosure-acked-v1\` after acknowledgement.
- [ ] Click the "PRODUCTIVITY PATTERNS" seed (the actual colleague question); confirm: (a) tool-call traces stream live, (b) tokens stream, (c) at least one citation chip appears, (d) clicking the chip navigates to \`#session/<id>\`.
- [ ] Send a follow-up turn in the same chat — confirm \`--resume\` was used (look for the same \`session_id\` in the agent trace).
- [ ] Switch intent to FIND OPPORTUNITIES, ask "What blog post opportunities does my corpus suggest?". Expect 3-5 structured idea blocks.
- [ ] Refresh the page; chat history is restored from IndexedDB.
- [ ] Open the DELETE… dropdown, SELECT ALL, confirm; verify chat history is wiped after reload.
- [ ] Static-deploy fallback: \`pnpm --filter @chat-arch/standalone build\` + serve dist/ statically; visit /chat — should render "CHAT REQUIRES THE LOCAL BACKEND" empty state.
- [ ] Existing user (returning) lands on SESSIONS, not CHAT; fresh install (no \`chat-arch:*\` localStorage) lands on CHAT.

## Followups (out of scope for this PR)

- Per-message embeddings (Phase 3 if Phase 1/2 retrieval misses).
- Save-this-insight-as-memory action (would need a Write grant — separate flow).
- Cost-per-turn display in the input bar.
- Markdown link/table support in \`ChatStreamedMessage\` (current renderer is paragraphs / headers / bullets / code / bold-italic-inline-code only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)