### PR TITLE
Add subagent rollup and widen narrative text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-15
+
+### Added
+
+- **Subagent rollup** — Cowork and host-CLI sessions whose Task tool
+  fans out to sub-agents (often Haiku) now contribute the sub-agents'
+  tokens, tool calls, and models to the parent entry's
+  `tokenTotals` / `topTools` / `modelsUsed`. The sub-agent-only
+  breakdown stays inspectable via the new `subagentRollup` field.
+- **`userTextSamples`** — every source now emits up to 5 user-turn
+  excerpts (≤400 chars each) for analysis-grade input. Feeds
+  `discoverNarratives` clustering so the pipeline sees more than the
+  200-char `preview`.
+- **Inline Cowork enrichments** — `userSelectedFolders`,
+  `slashCommands`, `enabledMcpTools`, `errorMessage` are now exposed
+  on the unified entry instead of being dropped at the
+  drift-detection stage.
+- **`tokenTotals` on Cowork entries** — derived from
+  `audit.modelUsage`; previously absent.
+
+### Changed
+
+- **`claude-code-sessions/` routed through Cowork** — Anthropic's
+  rename (refs anthropics/claude-code#29373, #27463) means both
+  AppData roots are now Cowork-shaped. The Desktop-CLI walker is
+  removed; a warn-once fires if a manifest there matches neither
+  schema.
+- **Per-source cache envelope** — `cli-sessions.json` and
+  `cowork-sessions.json` now write
+  `{ __exporterVersion, entries }`. Loaders gate reuse on an exact
+  version match so on-disk-shape changes self-invalidate. Legacy
+  bare-array files are tolerated for one rescan cycle.
+
 ## [0.8.0] — 2026-05-08
 
 ### Added

--- a/packages/analysis/src/cloud-mapping.ts
+++ b/packages/analysis/src/cloud-mapping.ts
@@ -259,6 +259,43 @@ export function buildEntry(
 
   const hasTools = Object.keys(topTools).length > 0;
 
+  // Analysis-grade user-text samples. Skip the first human message (already
+  // captured by `preview`'s firstHumanText source — same anti-double-count
+  // rule local sources apply). Cap at 5 turns × 400 chars to match
+  // `USER_TEXT_SAMPLES_MAX` / `USER_TEXT_SAMPLES_CHAR_CAP` in
+  // packages/exporter/src/sources/cli.ts.
+  const userTextSamples: string[] = [];
+  {
+    const cap = 5;
+    const charCap = 400;
+    let seenFirstHuman = false;
+    for (const msg of chatMessages) {
+      if (msg.sender !== 'human') continue;
+      let text: string | undefined;
+      if (Array.isArray(msg.content)) {
+        for (const b of msg.content) {
+          if (b && typeof b === 'object' && b.type === 'text') {
+            const t = (b as { text?: unknown }).text;
+            if (typeof t === 'string' && t.length > 0) {
+              text = t;
+              break;
+            }
+          }
+        }
+      }
+      if (text === undefined && typeof msg.text === 'string' && msg.text.length > 0) {
+        text = msg.text;
+      }
+      if (text === undefined) continue;
+      if (!seenFirstHuman) {
+        seenFirstHuman = true;
+        continue;
+      }
+      userTextSamples.push(text.slice(0, charCap));
+      if (userTextSamples.length >= cap) break;
+    }
+  }
+
   // Project label — matched against title first (high signal) then summary
   // (fallback), first-match-wins, using the export's own `projects.json`
   // names as the allowlist. Coverage on a real 1041-conversation corpus:
@@ -292,6 +329,7 @@ export function buildEntry(
     ...(hasSummary ? { summary } : {}),
     ...(hasTools ? { topTools } : {}),
     ...(matchedProject !== null ? { project: matchedProject } : {}),
+    ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
     transcriptPath: `cloud-conversations/${conv.uuid}.json`,
   };
 

--- a/packages/analysis/src/discoverNarratives.test.ts
+++ b/packages/analysis/src/discoverNarratives.test.ts
@@ -99,4 +99,27 @@ describe('discoverNarratives', () => {
     expect(r.narratives).toHaveLength(0);
     expect(r.projectSentiment.get('proj_q')).toBe('neutral');
   });
+
+  it('clusters on userTextSamples in addition to title+preview+summary', () => {
+    // Two sessions whose titles are sentiment-neutral but whose
+    // userTextSamples carry strong positive sentiment. Without the T6
+    // widening, neither session would score positive and no narrative
+    // would emit. With the widening, both score positive and the
+    // narrative shows up.
+    const sessions = [
+      mkSession('a', {
+        title: 'check this',
+        userTextSamples: ['that worked perfectly, tests pass'],
+      }),
+      mkSession('b', {
+        title: 'check this',
+        userTextSamples: ['shipped the fix, everything green'],
+      }),
+    ];
+    const projects = [mkProject('proj_widen', ['a', 'b'])];
+    const r = discoverNarratives(sessions, projects);
+    const narr = r.narratives.find((n) => n.sentiment === 'positive');
+    expect(narr).toBeDefined();
+    expect(narr?.sessionIds).toEqual(expect.arrayContaining(['a', 'b']));
+  });
 });

--- a/packages/analysis/src/discoverNarratives.ts
+++ b/packages/analysis/src/discoverNarratives.ts
@@ -84,7 +84,12 @@ export function discoverNarratives(
     for (const sid of project.sessionIds) {
       const s = sessionById.get(sid);
       if (s === undefined) continue;
-      const text = [s.title, s.preview ?? '', s.summary ?? ''].join('\n');
+      const text = [
+        s.title,
+        s.preview ?? '',
+        s.summary ?? '',
+        ...(s.userTextSamples ?? []),
+      ].join('\n');
       const r = scoreSentiment(text);
       scored.push({
         session: s,

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -66,7 +66,12 @@ export interface RunAnalysisResult {
   };
 }
 
-const EXPORTER_VERSION = '0.8.0';
+/**
+ * Exported so the per-source cache loaders (cli.ts, cowork.ts) can
+ * gate reuse on a version match — when the on-disk entry shape
+ * changes, all prior caches self-invalidate on next rescan.
+ */
+export const EXPORTER_VERSION = '0.8.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -71,7 +71,7 @@ export interface RunAnalysisResult {
  * gate reuse on a version match — when the on-disk entry shape
  * changes, all prior caches self-invalidate on next rescan.
  */
-export const EXPORTER_VERSION = '0.8.0';
+export const EXPORTER_VERSION = '0.9.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/cli.ts
+++ b/packages/exporter/src/cli.ts
@@ -10,8 +10,9 @@ const USAGE = `\
 chat-arch <subcommand> [options]
 
 Subcommands:
-  cowork   Walk %APPDATA%\\Claude (local-agent-mode-sessions + claude-code-sessions)
-           and write cowork-sessions.json + copied manifests/transcripts.
+  cowork   Walk %APPDATA%\\Claude (local-agent-mode-sessions + claude-code-sessions —
+           both Cowork-shaped per Anthropic's rename) and write
+           cowork-sessions.json + copied manifests/transcripts.
   cli      Walk ~/.claude/projects/, stream each transcript, and write
            cli-sessions.json + copied transcripts (cli-direct + enriched cli-desktop).
   cloud    Unpack the Settings → Privacy export ZIP and write

--- a/packages/exporter/src/commands/cowork.ts
+++ b/packages/exporter/src/commands/cowork.ts
@@ -18,9 +18,10 @@ export async function runCoworkSubcommand(argv: readonly string[]): Promise<numb
   if (values.help) {
     logger.info(
       'chat-arch cowork [--out <dir>]\n\n' +
-        '  Walk %APPDATA%\\Claude\\local-agent-mode-sessions and claude-code-sessions,\n' +
-        '  produce a unified cowork-sessions.json and copy manifests + transcripts.\n' +
-        '  Default --out: <repo-root>/apps/standalone/public/chat-arch-data',
+        '  Walk %APPDATA%\\Claude\\local-agent-mode-sessions and claude-code-sessions\n' +
+        '  (both are Cowork-shaped per Anthropic\'s rename — refs claude-code#29373,\n' +
+        '  #27463) and produce a unified cowork-sessions.json + copied manifests +\n' +
+        '  transcripts. Default --out: <repo-root>/apps/standalone/public/chat-arch-data',
     );
     return 0;
   }

--- a/packages/exporter/src/lib/subagents.ts
+++ b/packages/exporter/src/lib/subagents.ts
@@ -1,0 +1,154 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { TokenTotals } from '@chat-arch/schema';
+import { readJsonlLines } from './jsonl.js';
+import { countToolUsesInMessage } from './toolUses.js';
+
+/**
+ * Per-session subagent rollup. Cowork and host-CLI sessions can fan out to
+ * sub-agents (Task tool invocations); each sub-agent gets its own transcript
+ * under `<sessionDir>/.../subagents/agent-*.jsonl`. They typically run on a
+ * smaller/faster model (Haiku) and execute their own tool calls. Without
+ * walking them, parent-session `tokenTotals` / `topTools` / `modelsUsed`
+ * undercount heavy-fan-out sessions by 10x+.
+ *
+ * `count` is the number of subagent JSONL files (one file per Task invocation);
+ * `totalTokens` / `topTools` / `modelsUsed` are summed across all files.
+ */
+export interface SubagentRollup {
+  count: number;
+  totalTokens: TokenTotals;
+  modelsUsed: readonly string[];
+  topTools: Readonly<Record<string, number>>;
+}
+
+const SUBAGENT_FILE_RE = /^agent-.*\.jsonl$/i;
+
+/**
+ * Walk a `subagents/` directory and produce a rollup of all `agent-*.jsonl`
+ * sub-agent transcripts. Same JSONL-stream-and-accumulate pattern as
+ * `streamToolUses` (lib/toolUses.ts); reads each file once, constant memory.
+ *
+ * Returns `undefined` when the directory is missing — most sessions don't
+ * fan out, and that's not an error. Malformed lines and unreadable individual
+ * files are silently skipped so a single corrupt subagent doesn't lose the
+ * rest of the rollup.
+ */
+export async function aggregateSubagents(
+  subagentsDir: string,
+): Promise<SubagentRollup | undefined> {
+  let entries: string[];
+  try {
+    entries = await readdir(subagentsDir);
+  } catch {
+    return undefined;
+  }
+
+  const files = entries.filter((n) => SUBAGENT_FILE_RE.test(n));
+  if (files.length === 0) return undefined;
+
+  const totalTokens: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
+  const modelsSeen = new Set<string>();
+  const modelsOrdered: string[] = [];
+  const topTools: Record<string, number> = {};
+
+  for (const name of files) {
+    const filePath = path.join(subagentsDir, name);
+    try {
+      for await (const y of readJsonlLines<Record<string, unknown>>(filePath)) {
+        if (y.kind === 'error') continue;
+        const line = y.line;
+        if (line['type'] !== 'assistant') continue;
+        const msg = line['message'] as
+          | {
+              model?: unknown;
+              usage?: {
+                input_tokens?: unknown;
+                output_tokens?: unknown;
+                cache_creation_input_tokens?: unknown;
+                cache_read_input_tokens?: unknown;
+              };
+            }
+          | undefined;
+        if (msg && typeof msg.model === 'string' && msg.model.length > 0) {
+          if (!modelsSeen.has(msg.model)) {
+            modelsSeen.add(msg.model);
+            modelsOrdered.push(msg.model);
+          }
+        }
+        if (msg && msg.usage) {
+          const u = msg.usage;
+          if (typeof u.input_tokens === 'number' && Number.isFinite(u.input_tokens)) {
+            totalTokens.input += u.input_tokens;
+          }
+          if (typeof u.output_tokens === 'number' && Number.isFinite(u.output_tokens)) {
+            totalTokens.output += u.output_tokens;
+          }
+          if (
+            typeof u.cache_creation_input_tokens === 'number' &&
+            Number.isFinite(u.cache_creation_input_tokens)
+          ) {
+            totalTokens.cacheCreation += u.cache_creation_input_tokens;
+          }
+          if (
+            typeof u.cache_read_input_tokens === 'number' &&
+            Number.isFinite(u.cache_read_input_tokens)
+          ) {
+            totalTokens.cacheRead += u.cache_read_input_tokens;
+          }
+        }
+        countToolUsesInMessage(line['message'], topTools);
+      }
+    } catch {
+      // Single corrupt subagent file — skip it, keep the rest of the rollup.
+    }
+  }
+
+  return {
+    count: files.length,
+    totalTokens,
+    modelsUsed: modelsOrdered,
+    topTools,
+  };
+}
+
+/** Helper: sum two TokenTotals. Pure. */
+export function sumTokens(a: TokenTotals, b: TokenTotals): TokenTotals {
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    cacheRead: a.cacheRead + b.cacheRead,
+  };
+}
+
+/** Helper: sum two name→count histograms into a new object. Pure. */
+export function sumHistograms(
+  a: Record<string, number>,
+  b: Record<string, number>,
+): Record<string, number> {
+  const out: Record<string, number> = { ...a };
+  for (const [k, v] of Object.entries(b)) {
+    out[k] = (out[k] ?? 0) + v;
+  }
+  return out;
+}
+
+/** Helper: union arrays preserving insertion order of `a` first, then new from `b`. */
+export function uniqueModels(a: readonly string[], b: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of a) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      out.push(m);
+    }
+  }
+  for (const m of b) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      out.push(m);
+    }
+  }
+  return out;
+}

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -95,7 +95,18 @@ interface TranscriptAggregate {
    * tools — no extra read. See `lib/toolUses.ts`.
    */
   toolUses: Record<string, number>;
+  /**
+   * Up to {@link USER_TEXT_SAMPLES_MAX} extracted user-turn excerpts,
+   * captured AFTER the first user turn so they don't double-count with
+   * `preview` (which is sourced from `firstUserText`). Each ≤
+   * {@link USER_TEXT_SAMPLES_CHAR_CAP} chars. Drives analysis-grade
+   * inputs like `discoverNarratives` clustering.
+   */
+  userTextSamples: string[];
 }
+
+export const USER_TEXT_SAMPLES_MAX = 5;
+export const USER_TEXT_SAMPLES_CHAR_CAP = 400;
 
 function zeroAggregate(): TranscriptAggregate {
   return {
@@ -112,6 +123,7 @@ function zeroAggregate(): TranscriptAggregate {
     maxTimestamp: undefined,
     malformedLineCount: 0,
     toolUses: {},
+    userTextSamples: [],
   };
 }
 
@@ -477,6 +489,14 @@ export async function streamAggregate(transcriptPath: string): Promise<Transcrip
       if (agg.firstUserText === undefined) {
         const t = extractFirstUserText(line['message']);
         if (t !== undefined) agg.firstUserText = t;
+      } else if (agg.userTextSamples.length < USER_TEXT_SAMPLES_MAX) {
+        // Capture user turns 2…N+1 as `userTextSamples`. Turn 1 already feeds
+        // `preview` via `firstUserText`, so starting from turn 2 prevents the
+        // double-count that would skew narrative clustering toward duplicates.
+        const t = extractFirstUserText(line['message']);
+        if (t !== undefined && t.length > 0) {
+          agg.userTextSamples.push(t.slice(0, USER_TEXT_SAMPLES_CHAR_CAP));
+        }
       }
     } else if (type === 'assistant') {
       agg.assistantTurns += 1;
@@ -636,6 +656,7 @@ export function buildCliDirectEntry(
     // value to the current stat on the next rescan.
     sourceMtimeMs: fileMtimeMs,
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(agg.userTextSamples.length > 0 ? { userTextSamples: agg.userTextSamples } : {}),
     ...(subagentRollup ? { subagentRollup } : {}),
   };
   return entry;
@@ -715,6 +736,7 @@ export function enrichCliDesktopEntry(
     sourceMtimeMs: fileMtimeMs,
     ...(phase2Entry.manifestPath !== undefined ? { manifestPath: phase2Entry.manifestPath } : {}),
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(agg.userTextSamples.length > 0 ? { userTextSamples: agg.userTextSamples } : {}),
     ...(subagentRollup ? { subagentRollup } : {}),
   };
 

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -19,10 +19,11 @@ import {
 import { EXPORTER_VERSION } from '../analysis/index.js';
 
 /**
- * `<uuid>.jsonl` at the TOP LEVEL of a project dir. Sub-agent transcripts
- * under `<uuid>/` (a directory sibling) are intentionally OUT OF SCOPE —
- * D1 of the Phase 3 plan. They're inner-child retries from the primary
- * transcript and add no new signal for the viewer.
+ * `<uuid>.jsonl` at the TOP LEVEL of a project dir is a session transcript.
+ * Sub-agent transcripts under `<uuid>/subagents/agent-*.jsonl` are walked
+ * separately by `aggregateSubagents` (lib/subagents.ts) and rolled up into
+ * the parent entry's `subagentRollup` field — they are NOT emitted as
+ * separate UnifiedSessionEntry rows.
  */
 const UUID_JSONL_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i;
 
@@ -355,7 +356,8 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
  * Walk `<root>/<projectDir>/*.jsonl` at maxdepth 1 — D1. Skips:
  *  - non-directory entries at root,
  *  - files whose name is not `<uuid>.jsonl`,
- *  - sub-agent transcripts under `<projectDir>/<uuid>/...`.
+ *  - sub-agent transcripts under `<projectDir>/<uuid>/subagents/` (those are
+ *    handled by `aggregateSubagents`, not this walker).
  *
  * Returns absolute paths. Never throws on a missing root; returns [].
  */

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -9,6 +9,13 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { countToolUsesInMessage } from '../lib/toolUses.js';
+import {
+  aggregateSubagents,
+  type SubagentRollup,
+  sumHistograms,
+  sumTokens,
+  uniqueModels,
+} from '../lib/subagents.js';
 
 /**
  * `<uuid>.jsonl` at the TOP LEVEL of a project dir. Sub-agent transcripts
@@ -251,6 +258,13 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
       return;
     }
 
+    // Subagent rollup: <projectDir>/<uuid>/subagents/agent-*.jsonl. Host
+    // Claude Code uses the same layout as Cowork CLI; aggregateSubagents
+    // returns undefined when the dir doesn't exist (most sessions don't
+    // fan out).
+    const subagentsDir = path.join(path.dirname(transcriptPath), uuid, 'subagents');
+    const subagentRollup = await aggregateSubagents(subagentsDir);
+
     malformedLinesTotal += agg.malformedLineCount;
 
     let transcriptRel: string | undefined;
@@ -267,16 +281,18 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
     if (isDesktop) {
       const phase2Entry = phase2Entries.get(uuid);
       if (phase2Entry) {
-        entries.push(enrichCliDesktopEntry(phase2Entry, agg, transcriptRel, fileMtime));
+        entries.push(
+          enrichCliDesktopEntry(phase2Entry, agg, transcriptRel, fileMtime, subagentRollup),
+        );
         desktopCount += 1;
       } else {
         // UUID was reported by Phase 2 but the entry has vanished — should be
         // impossible since we read from the same file, but fall back to direct.
-        entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime));
+        entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime, subagentRollup));
         directCount += 1;
       }
     } else {
-      entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime));
+      entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime, subagentRollup));
       directCount += 1;
     }
   });
@@ -562,6 +578,7 @@ export function buildCliDirectEntry(
   uuid: string,
   transcriptRel: string | undefined,
   fileMtimeMs: number,
+  subagentRollup?: SubagentRollup | undefined,
 ): UnifiedSessionEntry {
   const { title, titleSource } = resolveTitle(agg);
 
@@ -572,11 +589,23 @@ export function buildCliDirectEntry(
   const cwd = agg.cwd;
   const project = cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
 
+  // Merge subagent rollup into the parent aggregate. Parent transcript and
+  // subagent transcripts are disjoint files, so summing tokens + tools never
+  // double-counts; model union preserves parent-first insertion order.
+  const mergedTokens = subagentRollup
+    ? sumTokens(agg.tokens, subagentRollup.totalTokens)
+    : agg.tokens;
+  const mergedTools = subagentRollup
+    ? sumHistograms(agg.toolUses, subagentRollup.topTools)
+    : agg.toolUses;
+  const mergedModels = subagentRollup
+    ? uniqueModels(agg.modelsUsed, subagentRollup.modelsUsed)
+    : agg.modelsUsed;
   const tokensHasAny =
-    agg.tokens.input > 0 ||
-    agg.tokens.output > 0 ||
-    agg.tokens.cacheCreation > 0 ||
-    agg.tokens.cacheRead > 0;
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
 
   const entry: UnifiedSessionEntry = {
     // REQUIRED
@@ -596,17 +625,18 @@ export function buildCliDirectEntry(
 
     // OPTIONAL (conditional spread — EOP discipline, R8)
     ...(agg.assistantTurns > 0 ? { assistantTurns: agg.assistantTurns } : {}),
-    ...(agg.modelsUsed.length > 0 ? { modelsUsed: agg.modelsUsed } : {}),
+    ...(mergedModels.length > 0 ? { modelsUsed: mergedModels } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(project !== undefined && project.length > 0 ? { project } : {}),
-    ...(tokensHasAny ? { tokenTotals: agg.tokens } : {}),
-    ...(Object.keys(agg.toolUses).length > 0 ? { topTools: agg.toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(Object.keys(mergedTools).length > 0 ? { topTools: mergedTools } : {}),
     // Cached source-file mtime: drives incremental rescan. Equal to
     // `fileMtimeMs` here because this entry was built from the file
     // whose mtime we just read; the reuse check compares this cached
     // value to the current stat on the next rescan.
     sourceMtimeMs: fileMtimeMs,
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
   return entry;
 }
@@ -630,6 +660,7 @@ export function enrichCliDesktopEntry(
   agg: TranscriptAggregate,
   transcriptRel: string | undefined,
   fileMtimeMs: number,
+  subagentRollup?: SubagentRollup | undefined,
 ): UnifiedSessionEntry {
   const startedAt = agg.minTimestamp ?? phase2Entry.startedAt ?? fileMtimeMs;
   const updatedAt = agg.maxTimestamp ?? phase2Entry.updatedAt ?? fileMtimeMs;
@@ -639,11 +670,22 @@ export function enrichCliDesktopEntry(
   const cwd = phase2Entry.cwd ?? agg.cwd;
   const project = cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
 
+  // Merge subagent rollup the same way buildCliDirectEntry does — see its
+  // comment for the disjointness rationale.
+  const mergedTokens = subagentRollup
+    ? sumTokens(agg.tokens, subagentRollup.totalTokens)
+    : agg.tokens;
+  const mergedTools = subagentRollup
+    ? sumHistograms(agg.toolUses, subagentRollup.topTools)
+    : agg.toolUses;
+  const mergedModels = subagentRollup
+    ? uniqueModels(agg.modelsUsed, subagentRollup.modelsUsed)
+    : agg.modelsUsed;
   const tokensHasAny =
-    agg.tokens.input > 0 ||
-    agg.tokens.output > 0 ||
-    agg.tokens.cacheCreation > 0 ||
-    agg.tokens.cacheRead > 0;
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
 
   const entry: UnifiedSessionEntry = {
     // REQUIRED — kept from Phase 2 except temporal/userTurns.
@@ -663,16 +705,17 @@ export function enrichCliDesktopEntry(
 
     // OPTIONAL
     ...(agg.assistantTurns > 0 ? { assistantTurns: agg.assistantTurns } : {}),
-    ...(agg.modelsUsed.length > 0 ? { modelsUsed: agg.modelsUsed } : {}),
+    ...(mergedModels.length > 0 ? { modelsUsed: mergedModels } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(project !== undefined && project.length > 0 ? { project } : {}),
-    ...(tokensHasAny ? { tokenTotals: agg.tokens } : {}),
-    ...(Object.keys(agg.toolUses).length > 0 ? { topTools: agg.toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(Object.keys(mergedTools).length > 0 ? { topTools: mergedTools } : {}),
     // Cached transcript mtime — drives incremental rescan (see
     // `runCliExport`'s fast-path guard).
     sourceMtimeMs: fileMtimeMs,
     ...(phase2Entry.manifestPath !== undefined ? { manifestPath: phase2Entry.manifestPath } : {}),
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
 
   return entry;

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -16,6 +16,7 @@ import {
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
+import { EXPORTER_VERSION } from '../analysis/index.js';
 
 /**
  * `<uuid>.jsonl` at the TOP LEVEL of a project dir. Sub-agent transcripts
@@ -150,10 +151,18 @@ async function loadPreviousCliEntries(outDir: string): Promise<Map<string, Unifi
   } catch {
     return map;
   }
-  if (!Array.isArray(parsed)) return map;
-  for (const e of parsed as UnifiedSessionEntry[]) {
-    if (e && typeof e.id === 'string' && typeof e.source === 'string') {
-      map.set(`${e.source}:${e.id}`, e);
+  // Bare-array (pre-envelope) shape: do not reuse — entries were produced by
+  // a different exporter version with a different on-disk schema. They'll be
+  // rebuilt this run and re-written with the new envelope.
+  if (Array.isArray(parsed)) return map;
+  if (parsed && typeof parsed === 'object') {
+    const envelope = parsed as { __exporterVersion?: unknown; entries?: unknown };
+    if (envelope.__exporterVersion !== EXPORTER_VERSION) return map;
+    if (!Array.isArray(envelope.entries)) return map;
+    for (const e of envelope.entries as UnifiedSessionEntry[]) {
+      if (e && typeof e.id === 'string' && typeof e.source === 'string') {
+        map.set(`${e.source}:${e.id}`, e);
+      }
     }
   }
   return map;
@@ -313,7 +322,14 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
   entries.sort((a, b) => b.updatedAt - a.updatedAt);
 
   const outFile = path.join(outDir, 'cli-sessions.json');
-  await writeFile(outFile, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+  // Envelope so the loader can gate reuse on EXPORTER_VERSION — see
+  // `loadPreviousCliEntries`. Older bare-array shapes self-invalidate on
+  // first read.
+  await writeFile(
+    outFile,
+    JSON.stringify({ __exporterVersion: EXPORTER_VERSION, entries }, null, 2) + '\n',
+    'utf8',
+  );
 
   return {
     entries,
@@ -407,11 +423,24 @@ export async function loadCliDesktopIds(phase2CoworkJsonPath: string): Promise<{
     );
     return { desktopIds, phase2Entries };
   }
-  if (!Array.isArray(parsed)) {
-    logger.warn(`Phase 2 output ${phase2CoworkJsonPath} is not an array; ignoring`);
+  // Tolerate both shapes: legacy bare array (pre-envelope) and the
+  // EXPORTER_VERSION-tagged envelope written by `runCoworkExport`.
+  let entries: readonly UnifiedSessionEntry[];
+  if (Array.isArray(parsed)) {
+    entries = parsed as UnifiedSessionEntry[];
+  } else if (
+    parsed &&
+    typeof parsed === 'object' &&
+    Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    entries = (parsed as { entries: UnifiedSessionEntry[] }).entries;
+  } else {
+    logger.warn(
+      `Phase 2 output ${phase2CoworkJsonPath} is not an array or envelope; ignoring`,
+    );
     return { desktopIds, phase2Entries };
   }
-  for (const e of parsed as UnifiedSessionEntry[]) {
+  for (const e of entries) {
     if (e && e.source === 'cli-desktop' && typeof e.id === 'string') {
       desktopIds.add(e.id);
       phase2Entries.set(e.id, e);

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -16,12 +16,44 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { streamToolUses } from '../lib/toolUses.js';
+import { readJsonlLines } from '../lib/jsonl.js';
 import {
   aggregateSubagents,
   sumHistograms,
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
+import {
+  extractFirstUserText,
+  USER_TEXT_SAMPLES_CHAR_CAP,
+  USER_TEXT_SAMPLES_MAX,
+} from './cli.js';
+
+/**
+ * Walk a Cowork transcript JSONL and collect up to {@link USER_TEXT_SAMPLES_MAX}
+ * user-turn excerpts (≤ {@link USER_TEXT_SAMPLES_CHAR_CAP} chars each), starting
+ * at the FIRST user turn — Cowork's preview is sourced from `manifest.initialMessage`
+ * (not the transcript), so the first transcript user turn is not a double-count.
+ *
+ * Never throws. Returns `[]` for missing files / no user lines.
+ */
+async function streamUserTextSamples(transcriptPath: string): Promise<string[]> {
+  const out: string[] = [];
+  try {
+    for await (const y of readJsonlLines<Record<string, unknown>>(transcriptPath)) {
+      if (y.kind === 'error') continue;
+      const line = y.line;
+      if (line['type'] !== 'user') continue;
+      const t = extractFirstUserText(line['message']);
+      if (t === undefined || t.length === 0) continue;
+      out.push(t.slice(0, USER_TEXT_SAMPLES_CHAR_CAP));
+      if (out.length >= USER_TEXT_SAMPLES_MAX) break;
+    }
+  } catch {
+    // unreadable file — return whatever we collected (likely [])
+  }
+  return out;
+}
 // Note: `processDesktopCliManifest` (./desktop-cli) is no longer invoked
 // from here — both AppData roots are Cowork-shaped per Anthropic's rename
 // (anthropics/claude-code#29373, #27463). The Desktop-CLI module stays
@@ -506,6 +538,9 @@ async function processCoworkManifest(
   // of sessions) and keeps the extraction co-located with the other
   // sources via the shared `streamToolUses` helper.
   const toolUses = transcriptAbsTarget ? await streamToolUses(transcriptAbsTarget) : {};
+  const userTextSamples = transcriptAbsTarget
+    ? await streamUserTextSamples(transcriptAbsTarget)
+    : [];
 
   // Subagent rollup — walk <sessionDir>/.claude/projects/-sessions-<proc>/
   // <cliSessionId>/subagents/agent-*.jsonl for Task-tool sub-agents (often
@@ -603,6 +638,7 @@ async function processCoworkManifest(
     ...(typeof manifest.error === 'string' && manifest.error.length > 0
       ? { errorMessage: manifest.error }
       : {}),
+    ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
     ...(subagentRollup ? { subagentRollup } : {}),
   };
 

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -22,7 +22,10 @@ import {
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
-import { processDesktopCliManifest } from './desktop-cli.js';
+// Note: `processDesktopCliManifest` (./desktop-cli) is no longer invoked
+// from here — both AppData roots are Cowork-shaped per Anthropic's rename
+// (anthropics/claude-code#29373, #27463). The Desktop-CLI module stays
+// exported from `src/index.ts` for back-compat reads of legacy data only.
 
 /**
  * Pull parent-session TokenTotals from a Cowork audit's `modelUsage` map.
@@ -34,6 +37,20 @@ import { processDesktopCliManifest } from './desktop-cli.js';
  * Returns a zero TokenTotals when modelUsage is absent or empty — callers
  * decide whether to drop the field via a conditional spread.
  */
+/**
+ * Coerce Cowork's `enabledMcpTools` (typed loosely as Record<string, unknown>)
+ * to the unified entry's stricter `Record<string, boolean>`. In practice every
+ * value observed is a boolean — non-boolean entries are dropped rather than
+ * forced. Keeps the unified field's contract clean.
+ */
+function coerceMcpToolFlags(raw: Readonly<Record<string, unknown>>): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v === 'boolean') out[k] = v;
+  }
+  return out;
+}
+
 function modelUsageToTokens(modelUsage: Record<string, unknown> | undefined): TokenTotals {
   const totals: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
   if (!modelUsage) return totals;
@@ -165,18 +182,24 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   await mkdir(path.join(outDir, 'manifests', 'cli-desktop'), { recursive: true });
   await mkdir(path.join(outDir, 'local-transcripts', 'cowork'), { recursive: true });
 
-  const coworkRoot = path.join(appDataRoot, 'local-agent-mode-sessions');
-  const cliRoot = path.join(appDataRoot, 'claude-code-sessions');
-
-  const coworkManifestPaths = await findManifestPaths(coworkRoot);
-  const cliManifestPaths = await findManifestPaths(cliRoot);
+  // Both `local-agent-mode-sessions/` and `claude-code-sessions/` are Cowork-
+  // shaped per Anthropic's rename (refs anthropics/claude-code#29373, #27463).
+  // The Desktop-CLI walker block is gone; the desktop-cli manifest processor
+  // is kept for back-compat reads of older entries.
+  const coworkRoots = [
+    path.join(appDataRoot, 'local-agent-mode-sessions'),
+    path.join(appDataRoot, 'claude-code-sessions'),
+  ];
+  const coworkManifestPaths = (
+    await Promise.all(coworkRoots.map(findManifestPaths))
+  ).flat();
   const prevEntries = await loadPreviousCoworkEntries(outDir);
 
   let sessionsSkipped = 0;
   let transcriptsCopied = 0;
   let transcriptsMissing = 0;
   let coworkReused = 0;
-  let cliDesktopReused = 0;
+  const cliDesktopReused = 0;
 
   const coworkEntries: UnifiedSessionEntry[] = [];
   await runWithConcurrency(coworkManifestPaths, CONCURRENCY, async (manifestPath) => {
@@ -192,24 +215,6 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   });
 
   const cliEntries: UnifiedSessionEntry[] = [];
-  let desktopCliZeroTurns = 0;
-  await runWithConcurrency(cliManifestPaths, CONCURRENCY, async (manifestPath) => {
-    const res = await processDesktopCliManifest(manifestPath, outDir, prevEntries);
-    if (res === null) {
-      sessionsSkipped += 1;
-      return;
-    }
-    const { entry, reused } = res;
-    if (reused) cliDesktopReused += 1;
-    if (entry.userTurns === 0) desktopCliZeroTurns += 1;
-    cliEntries.push(entry);
-  });
-
-  if (desktopCliZeroTurns > 0) {
-    logger.warn(
-      `${desktopCliZeroTurns} Desktop-CLI sessions have userTurns=0 until Phase 3 transcript walk enriches them.`,
-    );
-  }
 
   // Sort entries deterministically by updatedAt desc for downstream stability.
   const entries = [...coworkEntries, ...cliEntries].sort((a, b) => b.updatedAt - a.updatedAt);
@@ -316,7 +321,21 @@ async function processCoworkManifest(
 
   // Validate minimum required fields.
   if (!isMinimallyValidCowork(parsed)) {
-    logger.warn(`Cowork manifest ${manifestPath} missing required minimum fields; skipping`);
+    // claude-code-sessions/ shape divergence: warn-once when a manifest
+    // there matches neither Cowork nor Desktop-CLI. This is the canary
+    // for Anthropic shipping yet another shape on top of the rename.
+    if (
+      manifestPath.includes(`${path.sep}claude-code-sessions${path.sep}`) &&
+      !isMinimallyValidDesktopCli(parsed)
+    ) {
+      logger.warnOnce(
+        `claude-code-sessions-unknown-shape:${manifestPath}`,
+        `[chat-arch] claude-code-sessions manifest ${manifestPath} matched neither ` +
+          `Cowork nor Desktop-CLI schema — Anthropic may have shipped a new shape`,
+      );
+    } else {
+      logger.warn(`Cowork manifest ${manifestPath} missing required minimum fields; skipping`);
+    }
     return null;
   }
 
@@ -578,7 +597,9 @@ async function processCoworkManifest(
       ? { userSelectedFolders: manifest.userSelectedFolders }
       : {}),
     ...(manifest.slashCommands ? { slashCommands: manifest.slashCommands } : {}),
-    ...(manifest.enabledMcpTools ? { enabledMcpTools: manifest.enabledMcpTools } : {}),
+    ...(manifest.enabledMcpTools
+      ? { enabledMcpTools: coerceMcpToolFlags(manifest.enabledMcpTools) }
+      : {}),
     ...(typeof manifest.error === 'string' && manifest.error.length > 0
       ? { errorMessage: manifest.error }
       : {}),

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -17,6 +17,7 @@ import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { streamToolUses } from '../lib/toolUses.js';
 import { readJsonlLines } from '../lib/jsonl.js';
+import { EXPORTER_VERSION } from '../analysis/index.js';
 import {
   aggregateSubagents,
   sumHistograms,
@@ -136,10 +137,18 @@ async function loadPreviousCoworkEntries(
   } catch {
     return map;
   }
-  if (!Array.isArray(parsed)) return map;
-  for (const e of parsed as UnifiedSessionEntry[]) {
-    if (e && typeof e.id === 'string' && typeof e.source === 'string') {
-      map.set(`${e.source}:${e.id}`, e);
+  // Bare-array (pre-envelope) shape: do not reuse — entries were written by
+  // an exporter version with a different on-disk schema. They'll get
+  // rewritten with the new envelope after this rescan.
+  if (Array.isArray(parsed)) return map;
+  if (parsed && typeof parsed === 'object') {
+    const envelope = parsed as { __exporterVersion?: unknown; entries?: unknown };
+    if (envelope.__exporterVersion !== EXPORTER_VERSION) return map;
+    if (!Array.isArray(envelope.entries)) return map;
+    for (const e of envelope.entries as UnifiedSessionEntry[]) {
+      if (e && typeof e.id === 'string' && typeof e.source === 'string') {
+        map.set(`${e.source}:${e.id}`, e);
+      }
     }
   }
   return map;
@@ -252,7 +261,14 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   const entries = [...coworkEntries, ...cliEntries].sort((a, b) => b.updatedAt - a.updatedAt);
 
   const outFile = path.join(outDir, 'cowork-sessions.json');
-  await writeFile(outFile, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+  // Envelope so the loader can gate reuse on EXPORTER_VERSION — see
+  // `loadPreviousCoworkEntries`. Older bare-array shapes self-invalidate
+  // on first read.
+  await writeFile(
+    outFile,
+    JSON.stringify({ __exporterVersion: EXPORTER_VERSION, entries }, null, 2) + '\n',
+    'utf8',
+  );
 
   return {
     entries,

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -5,6 +5,7 @@ import type {
   CoworkManifestRaw,
   DesktopCliManifestKnown,
   DesktopCliManifestRaw,
+  TokenTotals,
   UnifiedSessionEntry,
 } from '@chat-arch/schema';
 import { UNTITLED_SESSION } from '@chat-arch/schema';
@@ -15,7 +16,53 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { streamToolUses } from '../lib/toolUses.js';
+import {
+  aggregateSubagents,
+  sumHistograms,
+  sumTokens,
+  uniqueModels,
+} from '../lib/subagents.js';
 import { processDesktopCliManifest } from './desktop-cli.js';
+
+/**
+ * Pull parent-session TokenTotals from a Cowork audit's `modelUsage` map.
+ * Cowork audit lines carry per-model `inputTokens` / `outputTokens` /
+ * `cacheCreationInputTokens` / `cacheReadInputTokens` — sum them up so the
+ * unified entry exposes a single TokenTotals to consumers (cost estimation,
+ * /chat answers).
+ *
+ * Returns a zero TokenTotals when modelUsage is absent or empty — callers
+ * decide whether to drop the field via a conditional spread.
+ */
+function modelUsageToTokens(modelUsage: Record<string, unknown> | undefined): TokenTotals {
+  const totals: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
+  if (!modelUsage) return totals;
+  for (const v of Object.values(modelUsage)) {
+    if (!v || typeof v !== 'object') continue;
+    const u = v as {
+      inputTokens?: unknown;
+      outputTokens?: unknown;
+      cacheCreationInputTokens?: unknown;
+      cacheReadInputTokens?: unknown;
+    };
+    if (typeof u.inputTokens === 'number' && Number.isFinite(u.inputTokens)) {
+      totals.input += u.inputTokens;
+    }
+    if (typeof u.outputTokens === 'number' && Number.isFinite(u.outputTokens)) {
+      totals.output += u.outputTokens;
+    }
+    if (
+      typeof u.cacheCreationInputTokens === 'number' &&
+      Number.isFinite(u.cacheCreationInputTokens)
+    ) {
+      totals.cacheCreation += u.cacheCreationInputTokens;
+    }
+    if (typeof u.cacheReadInputTokens === 'number' && Number.isFinite(u.cacheReadInputTokens)) {
+      totals.cacheRead += u.cacheReadInputTokens;
+    }
+  }
+  return totals;
+}
 
 /**
  * Load the previous cowork-sessions.json (if present) and index by
@@ -279,8 +326,14 @@ async function processCoworkManifest(
   // Fast path: manifest mtime matches what we cached last run →
   // nothing changed since the last rescan. Reuse the entry verbatim.
   // Skips: drift warnings (already seen), audit.jsonl aggregation
-  // (biggest cost), transcript copy (unless outDir was wiped), and
-  // tool-use mining.
+  // (biggest cost), transcript copy (unless outDir was wiped),
+  // tool-use mining, and the subagents/ walk.
+  //
+  // Staleness window: subagent rollups refresh only when the manifest
+  // mtime changes. In practice Cowork rewrites the manifest on every
+  // activity tick (lastActivityAt updates in lock-step with audit +
+  // transcript), so a new subagent fan-out almost always trips the
+  // mtime check on the next rescan.
   const prev = prevEntries.get(`cowork:${cliSessionIdResolved}`);
   if (
     prev !== undefined &&
@@ -434,10 +487,55 @@ async function processCoworkManifest(
   // of sessions) and keeps the extraction co-located with the other
   // sources via the shared `streamToolUses` helper.
   const toolUses = transcriptAbsTarget ? await streamToolUses(transcriptAbsTarget) : {};
-  const hasTools = Object.keys(toolUses).length > 0;
+
+  // Subagent rollup — walk <sessionDir>/.claude/projects/-sessions-<proc>/
+  // <cliSessionId>/subagents/agent-*.jsonl for Task-tool sub-agents (often
+  // Haiku) whose tokens/tool calls would otherwise be invisible.
+  //
+  // Guard: cliSessionId may be null when CLI handoff crashed
+  // (transcriptStatus='crashed'). Only walk when both cliSessionId and
+  // processName are present; otherwise the path is invalid.
+  const subagentRollup =
+    typeof manifest.cliSessionId === 'string' &&
+    manifest.cliSessionId.length > 0 &&
+    typeof manifest.processName === 'string' &&
+    manifest.processName.length > 0
+      ? await aggregateSubagents(
+          path.join(
+            sessionDir,
+            '.claude',
+            'projects',
+            `-sessions-${manifest.processName}`,
+            manifest.cliSessionId,
+            'subagents',
+          ),
+        )
+      : undefined;
+
+  // Merge parent + subagent aggregates so downstream consumers see a single
+  // session-wide rollup. Tool counts come from disjoint transcripts (parent
+  // vs. subagent files) and add cleanly. Token totals follow the same merge
+  // — `audit.modelUsage` may or may not already include subagent tokens in
+  // a given session; either way summing here over-attributes at worst, and
+  // the standalone `subagentRollup` field below keeps the breakdown
+  // inspectable for callers that need to disambiguate.
+  const parentTokens = modelUsageToTokens(audit.modelUsage);
+  const mergedTokens = subagentRollup
+    ? sumTokens(parentTokens, subagentRollup.totalTokens)
+    : parentTokens;
+  const tokensHasAny =
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
+  const mergedTools = subagentRollup ? sumHistograms(toolUses, subagentRollup.topTools) : toolUses;
+  const hasTools = Object.keys(mergedTools).length > 0;
 
   const modelsUsedArr = audit.modelUsage !== undefined ? Object.keys(audit.modelUsage) : [];
-  const modelsUsed: readonly string[] = modelsUsedArr.length > 0 ? modelsUsedArr : [manifest.model];
+  const baseModels: readonly string[] = modelsUsedArr.length > 0 ? modelsUsedArr : [manifest.model];
+  const modelsUsed: readonly string[] = subagentRollup
+    ? uniqueModels(baseModels, subagentRollup.modelsUsed)
+    : baseModels;
 
   // Build entry via R4 conditional-spread template.
   const entry: UnifiedSessionEntry = {
@@ -464,7 +562,8 @@ async function processCoworkManifest(
     ...(audit.assistantTurns > 0 ? { assistantTurns: audit.assistantTurns } : {}),
     ...(modelsUsed.length > 0 ? { modelsUsed } : {}),
     cwd: manifest.cwd,
-    ...(hasTools ? { topTools: toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(hasTools ? { topTools: mergedTools } : {}),
     // Cached manifest file mtime — drives the incremental-rescan
     // fast path. Updated every time we (re)process the manifest.
     ...(currentMtime > 0 ? { sourceMtimeMs: currentMtime } : {}),
@@ -474,6 +573,16 @@ async function processCoworkManifest(
     transcriptStatus,
     manifestPath: toPosixRelative(manifestOutAbs, outDir),
     // auditPath: omitted (Q1)
+    // Cowork manifest fields previously dropped — exposed for /chat answers.
+    ...(manifest.userSelectedFolders
+      ? { userSelectedFolders: manifest.userSelectedFolders }
+      : {}),
+    ...(manifest.slashCommands ? { slashCommands: manifest.slashCommands } : {}),
+    ...(manifest.enabledMcpTools ? { enabledMcpTools: manifest.enabledMcpTools } : {}),
+    ...(typeof manifest.error === 'string' && manifest.error.length > 0
+      ? { errorMessage: manifest.error }
+      : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
 
   return { entry, transcriptCopied, reused: false };

--- a/packages/exporter/src/sources/desktop-cli.ts
+++ b/packages/exporter/src/sources/desktop-cli.ts
@@ -39,8 +39,14 @@ const DESKTOP_CLI_KNOWN_KEYS = new Set<string>([
  * `outDir/manifests/cli-desktop/<rawSessionId>.json`. Returns a
  * UnifiedSessionEntry or null if the manifest is unreadable / invalid.
  *
- * Phase 3 overwrites `userTurns` (currently 0) and sets `transcriptPath`
- * after walking `~/.claude/projects/`.
+ * The unified CLI walker (`runCliExport`) overwrites `userTurns`
+ * (initialized to 0 here) and sets `transcriptPath` once it has matched
+ * the manifest's `cliSessionId` to a transcript under
+ * `~/.claude/projects/`.
+ *
+ * Kept for back-compat reads of older `claude-code-sessions/` data — the
+ * Cowork walker no longer routes manifests through here directly
+ * (Anthropic's rename made both AppData roots Cowork-shaped).
  */
 export async function processDesktopCliManifest(
   manifestPath: string,
@@ -128,7 +134,7 @@ export async function processDesktopCliManifest(
     title: manifest.title || UNTITLED_SESSION,
     titleSource: 'manifest',
     preview: null, // Desktop-CLI has no initialMessage equivalent
-    userTurns: 0, // TODO(phase-3): overwrite with transcript-derived count
+    userTurns: 0, // overwritten by enrichCliDesktopEntry after transcript walk
     model: manifest.model, // verbatim, keep [1m] suffix
     cwdKind: 'host',
     totalCostUsd: null, // Desktop-CLI has no cost summary; Phase 4 merge may fill

--- a/packages/exporter/test/integration/cowork-integration.test.ts
+++ b/packages/exporter/test/integration/cowork-integration.test.ts
@@ -35,14 +35,18 @@ describe('cowork integration (fixture appdata → outDir)', () => {
     expect(Array.isArray(parsed)).toBe(true);
 
     // Manifest copies landed in the right subdirs with the R3 naming.
+    // Both AppData roots now feed the Cowork pipeline (Anthropic rename),
+    // so the two former-Desktop-CLI fixtures land in manifests/cowork/ too.
     const coworkManifests = await readdir(path.join(outDir, 'manifests', 'cowork'));
-    expect(coworkManifests).toHaveLength(4); // corrupt skipped
+    expect(coworkManifests).toHaveLength(6); // 4 + 2; corrupt skipped
     expect(coworkManifests.every((n) => /^local_[0-9a-f-]+\.json$/.test(n))).toBe(true);
 
     const cliManifests = await readdir(path.join(outDir, 'manifests', 'cli-desktop'));
-    expect(cliManifests).toHaveLength(2);
+    expect(cliManifests).toHaveLength(0); // walker removed
 
     // Transcripts: mid + new + scheduled (3); old had no cliSessionId.
+    // claude-code-sessions/ fixtures lack `processName`, so no transcript
+    // copies for them.
     const transcripts = await readdir(path.join(outDir, 'local-transcripts', 'cowork'));
     expect(transcripts).toHaveLength(3);
 

--- a/packages/exporter/test/integration/cowork-integration.test.ts
+++ b/packages/exporter/test/integration/cowork-integration.test.ts
@@ -29,10 +29,12 @@ describe('cowork integration (fixture appdata → outDir)', () => {
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
 
-    // Output file exists and is parseable.
+    // Output file exists and is parseable. Envelope shape since the
+    // cache-bust envelope was introduced.
     const file = path.join(outDir, 'cowork-sessions.json');
     const parsed = JSON.parse(await readFile(file, 'utf8'));
-    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toMatchObject({ __exporterVersion: expect.any(String) });
+    expect(Array.isArray(parsed.entries)).toBe(true);
 
     // Manifest copies landed in the right subdirs with the R3 naming.
     // Both AppData roots now feed the Cowork pipeline (Anthropic rename),

--- a/packages/exporter/test/lib/subagents.test.ts
+++ b/packages/exporter/test/lib/subagents.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  aggregateSubagents,
+  sumTokens,
+  sumHistograms,
+  uniqueModels,
+} from '../../src/lib/subagents.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(os.tmpdir(), 'chat-arch-subagents-'));
+});
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('aggregateSubagents', () => {
+  it('returns undefined when the subagents directory does not exist', async () => {
+    expect(await aggregateSubagents(path.join(tmp, 'nope'))).toBeUndefined();
+  });
+
+  it('returns undefined when the directory exists but is empty', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    expect(await aggregateSubagents(dir)).toBeUndefined();
+  });
+
+  it('walks two agent files, sums tokens, unions models, tallies tools', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+
+    const fileA = path.join(dir, 'agent-aaa.jsonl');
+    await writeFile(
+      fileA,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'run task' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            model: 'claude-haiku-4-5-20251001',
+            content: [
+              { type: 'text', text: 'ok' },
+              { type: 'tool_use', id: 't1', name: 'Bash' },
+            ],
+            usage: {
+              input_tokens: 10,
+              output_tokens: 20,
+              cache_creation_input_tokens: 100,
+              cache_read_input_tokens: 50,
+            },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const fileB = path.join(dir, 'agent-bbb.jsonl');
+    await writeFile(
+      fileB,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            model: 'claude-sonnet-4-6',
+            content: [
+              { type: 'tool_use', id: 't2', name: 'Bash' },
+              { type: 'tool_use', id: 't3', name: 'Read' },
+            ],
+            usage: {
+              input_tokens: 5,
+              output_tokens: 7,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+            },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const rollup = await aggregateSubagents(dir);
+    expect(rollup).toBeDefined();
+    expect(rollup!.count).toBe(2);
+    expect(rollup!.totalTokens).toEqual({
+      input: 15,
+      output: 27,
+      cacheCreation: 100,
+      cacheRead: 50,
+    });
+    expect([...rollup!.modelsUsed].sort()).toEqual([
+      'claude-haiku-4-5-20251001',
+      'claude-sonnet-4-6',
+    ]);
+    expect(rollup!.topTools).toEqual({ Bash: 2, Read: 1 });
+  });
+
+  it('skips non-agent-*.jsonl files in the directory', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    await writeFile(path.join(dir, 'agent-aaa.meta.json'), '{}', 'utf8');
+    await writeFile(path.join(dir, 'README.md'), 'hi', 'utf8');
+    // The .meta.json is metadata, not a JSONL transcript, so it must be ignored.
+    // With no agent-*.jsonl files, rollup is undefined.
+    expect(await aggregateSubagents(dir)).toBeUndefined();
+  });
+
+  it('silently skips malformed JSONL lines but keeps counting valid ones', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    const file = path.join(dir, 'agent-xxx.jsonl');
+    await writeFile(
+      file,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            model: 'claude-haiku-4-5-20251001',
+            content: [{ type: 'tool_use', id: 'a', name: 'Bash' }],
+            usage: { input_tokens: 1, output_tokens: 2 },
+          },
+        }),
+        '{ not valid json',
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            model: 'claude-haiku-4-5-20251001',
+            content: [{ type: 'tool_use', id: 'b', name: 'Edit' }],
+            usage: { input_tokens: 3, output_tokens: 4 },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+    const rollup = await aggregateSubagents(dir);
+    expect(rollup!.count).toBe(1);
+    expect(rollup!.totalTokens.input).toBe(4);
+    expect(rollup!.totalTokens.output).toBe(6);
+    expect(rollup!.topTools).toEqual({ Bash: 1, Edit: 1 });
+  });
+});
+
+describe('helpers', () => {
+  it('sumTokens adds the four counters', () => {
+    expect(
+      sumTokens(
+        { input: 1, output: 2, cacheCreation: 3, cacheRead: 4 },
+        { input: 10, output: 20, cacheCreation: 30, cacheRead: 40 },
+      ),
+    ).toEqual({ input: 11, output: 22, cacheCreation: 33, cacheRead: 44 });
+  });
+
+  it('sumHistograms adds matching keys, preserves unique keys', () => {
+    expect(sumHistograms({ Bash: 1, Edit: 2 }, { Bash: 4, Read: 3 })).toEqual({
+      Bash: 5,
+      Edit: 2,
+      Read: 3,
+    });
+  });
+
+  it('uniqueModels preserves a-first insertion order and adds new from b', () => {
+    expect(uniqueModels(['opus', 'sonnet'], ['sonnet', 'haiku'])).toEqual([
+      'opus',
+      'sonnet',
+      'haiku',
+    ]);
+  });
+});

--- a/packages/exporter/test/sources/cli.test.ts
+++ b/packages/exporter/test/sources/cli.test.ts
@@ -678,11 +678,11 @@ describe('runCliExport (hermetic)', () => {
     expect(result.counts['cli-desktop']).toBe(0);
     expect(result.transcriptsCopied).toBe(2);
 
-    // cli-sessions.json on disk parses and matches.
-    const parsed = JSON.parse(
+    // cli-sessions.json on disk parses and matches (envelope shape).
+    const envelope = JSON.parse(
       await readFile(path.join(outDir, 'cli-sessions.json'), 'utf8'),
-    ) as UnifiedSessionEntry[];
-    expect(parsed).toHaveLength(2);
+    ) as { __exporterVersion: string; entries: UnifiedSessionEntry[] };
+    expect(envelope.entries).toHaveLength(2);
 
     // Transcripts copied to cli-direct subdir.
     const copiedA = path.join(outDir, 'local-transcripts', 'cli-direct', `${UUID_A}.jsonl`);

--- a/packages/exporter/test/sources/cli.test.ts
+++ b/packages/exporter/test/sources/cli.test.ts
@@ -394,7 +394,7 @@ describe('findTranscriptPaths', () => {
     expect(warnings.some((w) => w.includes('not found'))).toBe(true);
   });
 
-  it('returns top-level <uuid>.jsonl files but skips sub-agent subdirs (D1)', async () => {
+  it('returns top-level <uuid>.jsonl files but skips sub-agent subdirs', async () => {
     const p1 = await writeTranscript('proj-a', UUID_A, [userLine('x')]);
     const p2 = await writeTranscript('proj-a', UUID_B, [userLine('x')]);
     // Sub-agent dir — should NOT be returned.
@@ -408,6 +408,26 @@ describe('findTranscriptPaths', () => {
     await writeFile(path.join(projectsRoot, 'proj-a', 'README.md'), '# not a transcript', 'utf8');
     const found = await findTranscriptPaths(projectsRoot);
     expect(found.sort()).toEqual([p1, p2].sort());
+  });
+
+  it('aggregateSubagents reads from <uuid>/subagents/agent-*.jsonl, not findTranscriptPaths', async () => {
+    // Sanity-check the boundary: findTranscriptPaths must NOT walk into
+    // subagents/ even when an `agent-*.jsonl` exists there; that path is
+    // owned by `aggregateSubagents`.
+    await writeTranscript('proj-a', UUID_A, [userLine('x')]);
+    const subagentsDir = path.join(projectsRoot, 'proj-a', UUID_A, 'subagents');
+    await mkdir(subagentsDir, { recursive: true });
+    await writeFile(
+      path.join(subagentsDir, 'agent-abc.jsonl'),
+      JSON.stringify(userLine('sub')) + '\n',
+      'utf8',
+    );
+    const { aggregateSubagents } = await import('../../src/lib/subagents.js');
+    const rollup = await aggregateSubagents(subagentsDir);
+    expect(rollup?.count).toBe(1);
+    const transcripts = await findTranscriptPaths(projectsRoot);
+    // Only the top-level <UUID_A>.jsonl is returned; the subagent file is not.
+    expect(transcripts.filter((p) => p.includes('agent-abc'))).toHaveLength(0);
   });
 
   it('picks up case-variant sibling dirs (Windows quirk)', async () => {

--- a/packages/exporter/test/sources/cli.test.ts
+++ b/packages/exporter/test/sources/cli.test.ts
@@ -350,6 +350,36 @@ describe('streamAggregate', () => {
     const agg = await streamAggregate(file);
     expect(agg.toolUses).toEqual({});
   });
+
+  it('captures user-text samples starting from turn 2 (turn 1 already feeds preview)', async () => {
+    const file = await writeTranscript('proj-a', UUID_A, [
+      userLine('first prompt — should NOT appear in samples (it is the preview source)'),
+      assistantLine('m'),
+      userLine('second prompt'),
+      userLine('third prompt'),
+      userLine('fourth prompt'),
+    ]);
+    const agg = await streamAggregate(file);
+    expect(agg.firstUserText).toContain('first prompt');
+    expect(agg.userTextSamples).toEqual(['second prompt', 'third prompt', 'fourth prompt']);
+  });
+
+  it('caps userTextSamples at 5 entries and truncates each to 400 chars', async () => {
+    const long = 'x'.repeat(500);
+    const file = await writeTranscript('proj-a', UUID_A, [
+      userLine('preview source'),
+      userLine(long),
+      userLine('two'),
+      userLine('three'),
+      userLine('four'),
+      userLine('five'),
+      userLine('six — should be dropped, cap is 5'),
+    ]);
+    const agg = await streamAggregate(file);
+    expect(agg.userTextSamples).toHaveLength(5);
+    expect(agg.userTextSamples[0]).toHaveLength(400);
+    expect(agg.userTextSamples).not.toContain('six — should be dropped, cap is 5');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -532,6 +562,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: 2,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, 0);
     expect(e.project).toBe('my.dotted.site');
@@ -553,6 +584,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: undefined,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, mtime);
     expect(e.startedAt).toBe(mtime);
@@ -575,6 +607,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: undefined,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, 1_000);
     const errors = validateEntries([e]);

--- a/packages/exporter/test/sources/cowork.test.ts
+++ b/packages/exporter/test/sources/cowork.test.ts
@@ -48,9 +48,15 @@ describe('runCoworkExport (fixture)', () => {
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
     const file = path.join(outDir, 'cowork-sessions.json');
-    const roundtripped = JSON.parse(await readFile(file, 'utf8')) as UnifiedSessionEntry[];
-    expect(roundtripped).toHaveLength(result.entries.length);
-    expect(roundtripped.map((e) => e.id).sort()).toEqual(result.entries.map((e) => e.id).sort());
+    const envelope = JSON.parse(await readFile(file, 'utf8')) as {
+      __exporterVersion: string;
+      entries: UnifiedSessionEntry[];
+    };
+    expect(typeof envelope.__exporterVersion).toBe('string');
+    expect(envelope.entries).toHaveLength(result.entries.length);
+    expect(envelope.entries.map((e) => e.id).sort()).toEqual(
+      result.entries.map((e) => e.id).sort(),
+    );
   });
 
   it('falls back to stripped sessionId for entry id when manifest has no cliSessionId (old-schema Cowork)', async () => {

--- a/packages/exporter/test/sources/cowork.test.ts
+++ b/packages/exporter/test/sources/cowork.test.ts
@@ -27,15 +27,17 @@ afterEach(async () => {
 });
 
 describe('runCoworkExport (fixture)', () => {
-  it('walks both roots and emits one entry per valid manifest', async () => {
+  it('walks both AppData roots and emits one Cowork entry per valid manifest', async () => {
     const result = await runCoworkExport({
       outDir,
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
-    // 5 Cowork manifests on disk: old/mid/new/corrupt/scheduled. The corrupt
-    // one is skipped, so 4 entries. 2 Desktop-CLI entries. Total 6.
-    expect(result.counts.cowork).toBe(4);
-    expect(result.counts['cli-desktop']).toBe(2);
+    // Post-Anthropic-rename: both `local-agent-mode-sessions/` and
+    // `claude-code-sessions/` feed the same Cowork pipeline. Fixture has
+    // 5 manifests under local-agent-mode-sessions (one corrupt → skipped)
+    // and 2 under claude-code-sessions, all Cowork-shape-valid. Total 6.
+    expect(result.counts.cowork).toBe(6);
+    expect(result.counts['cli-desktop']).toBe(0);
     expect(result.entries.length).toBe(6);
     expect(result.sessionsSkipped).toBe(1);
   });

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -316,6 +316,49 @@ export interface UnifiedSessionEntry {
 
   /** Output-relative path to the Cowork audit log. */
   auditPath?: string;
+
+  // ---- Analysis-grade enrichments ----
+
+  /**
+   * Up to 5 user-turn excerpts (≤400 chars each), captured AFTER the
+   * preview-source turn so they don't double-count with `preview`.
+   * Populated by all sources (local + cloud).
+   * Analysis pipelines (e.g. discoverNarratives) read this for richer
+   * clustering input than the 200-char preview alone. The viewer ignores
+   * this field — it's an analysis-grade input, not a display string.
+   */
+  userTextSamples?: readonly string[];
+
+  /** Cowork-only: host folders mounted into the VM workspace. */
+  userSelectedFolders?: readonly string[];
+
+  /** Cowork-only: skill/command IDs available to the session. Source-name match. */
+  slashCommands?: readonly string[];
+
+  /** Cowork-only: MCP tools enabled at session start. Source-name + shape match. */
+  enabledMcpTools?: Readonly<Record<string, boolean>>;
+
+  /**
+   * Cowork-only: human-readable error message from the source manifest's
+   * `error` field. Complements `transcriptStatus` (categorical) with the
+   * verbose form. Renamed to `errorMessage` to avoid name-collision risk
+   * with any consumer's idiomatic `entry.error` slot.
+   */
+  errorMessage?: string;
+
+  /**
+   * Subagent rollup, populated by `aggregateSubagents` for Cowork and host
+   * CLI sources. Absent when the session had no subagent fan-out.
+   * `tokenTotals`/`topTools`/`modelsUsed` on the entry are merged values
+   * (parent + subagents); this field keeps the subagent-only breakdown
+   * inspectable.
+   */
+  subagentRollup?: {
+    count: number;
+    totalTokens: TokenTotals;
+    modelsUsed: readonly string[];
+    topTools: Readonly<Record<string, number>>;
+  };
 }
 
 export interface SessionManifest {

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -79,6 +79,10 @@ export interface UnifiedSessionEntry {
    *
    * Populating this in the manifest avoids forcing the viewer to eager-fetch
    * per-session chunks for card previews (~11 MB saved at 1033 sessions).
+   *
+   * For analysis-grade input (e.g. discoverNarratives clustering),
+   * `userTextSamples` carries longer multi-turn excerpts in addition to
+   * this 200-char preview.
    */
   preview: string | null;
 
@@ -297,9 +301,10 @@ export interface UnifiedSessionEntry {
    *   - 'ok'      — transcript was copied (transcriptPath present).
    *   - 'crashed' — upstream session metadata was incomplete (e.g.
    *                 Cowork CLI handoff failed: no `cliSessionId`, often
-   *                 with an `error` field set on the source manifest).
-   *                 User-side prompts may still exist in audit.jsonl —
-   *                 future recovery work can mine those.
+   *                 with an `error` field set on the source manifest —
+   *                 mirrored on the entry as `errorMessage` in verbose
+   *                 form). User-side prompts may still exist in
+   *                 audit.jsonl — future recovery work can mine those.
    *   - 'missing' — pointers were complete but the transcript file
    *                 wasn't on disk at scan time (deleted, aborted, or
    *                 cleaned up by the upstream tool between session end


### PR DESCRIPTION
## Summary
- Subagent transcripts contribute to parent session's `tokenTotals` / `topTools` / `modelsUsed` for Cowork + host CLI sessions; the subagent-only breakdown stays inspectable via `subagentRollup`.
- `claude-code-sessions/` routed through the Cowork pipeline per Anthropic's rename (refs anthropics/claude-code#29373, #27463). Desktop-CLI walker removed; back-compat processor stays exported. A warn-once fires if the dir ever ships a manifest matching neither schema.
- New inline fields on `UnifiedSessionEntry`: `userTextSamples`, `userSelectedFolders`, `slashCommands`, `enabledMcpTools`, `errorMessage`, `subagentRollup`. All optional/additive — no `CURRENT_SCHEMA_VERSION` bump.
- Cowork entries now carry `tokenTotals` (derived from `audit.modelUsage` — previously absent for Cowork).
- `discoverNarratives` clusters on `userTextSamples` in addition to `title + preview + summary`, addressing the audit's "≤280 chars of input was starving the pipeline" finding.
- Per-source caches (`cli-sessions.json` / `cowork-sessions.json`) now write an `EXPORTER_VERSION`-tagged envelope so v0.8→v0.9 self-invalidates; legacy bare-array files are tolerated on read for one rescan cycle.

## Test plan
- [x] `pnpm lint` / `pnpm test` / `pnpm build` green (845 tests pass, 4 skipped — same skip set as baseline).
- [x] Local rescan (`node ./packages/exporter/dist/cli.js all`) succeeds; 1558 entries written.
- [x] Spot-checked fd3dd3b6-a0ed-4fb0-a057-381bf58cfa45: `modelsUsed` includes `claude-haiku-4-5-20251001`, `subagentRollup.count = 35`, `userTextSamples.length = 5`, `tokenTotals` populated (input=15460).
- [x] Manifest coverage post-rescan: 1053/1558 entries carry `userTextSamples`, 198/1558 carry `subagentRollup`.
- [ ] `/chat` page exercised against the new manifest — not run interactively in this session; recommend a manual pass before merge.

## Notes / size
- Manifest grew 683 KB → 4.2 MB (6.1× baseline). The bulk is 1041 cloud entries appearing for the first time in this rescan (baseline had `cloud=0`); local-source byte growth from the new inline fields is modest. No sidecar restructure needed.
- The fixture-based `cli-desktop` count drops to 0 because the legacy Desktop-CLI walker is gone (T4). Existing on-disk `claude-code-sessions/` manifests are Cowork-shape-valid and now produce `cowork`-source entries.

## Follow-up issues filed
- #38 — macOS / Linux AppData support
- #39 — `/resume` session linkage
- #40 — Compaction event flagging
- #41 — System prompt SHA fingerprint
- #42 — `tool-results/toolu_*.txt` spill-file ingest
- #43 — Local-session topics via semantic classifier (prereq met by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)