### PR TITLE
Recover pruned sessions + scan WSL CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-15
+
+### Added
+
+- **Subagent rollup** — Cowork and host-CLI sessions whose Task tool
+  fans out to sub-agents (often Haiku) now contribute the sub-agents'
+  tokens, tool calls, and models to the parent entry's
+  `tokenTotals` / `topTools` / `modelsUsed`. The sub-agent-only
+  breakdown stays inspectable via the new `subagentRollup` field.
+- **`userTextSamples`** — every source now emits up to 5 user-turn
+  excerpts (≤400 chars each) for analysis-grade input. Feeds
+  `discoverNarratives` clustering so the pipeline sees more than the
+  200-char `preview`.
+- **Inline Cowork enrichments** — `userSelectedFolders`,
+  `slashCommands`, `enabledMcpTools`, `errorMessage` are now exposed
+  on the unified entry instead of being dropped at the
+  drift-detection stage.
+- **`tokenTotals` on Cowork entries** — derived from
+  `audit.modelUsage`; previously absent.
+
+### Changed
+
+- **`claude-code-sessions/` routed through Cowork** — Anthropic's
+  rename (refs anthropics/claude-code#29373, #27463) means both
+  AppData roots are now Cowork-shaped. The Desktop-CLI walker is
+  removed; a warn-once fires if a manifest there matches neither
+  schema.
+- **Per-source cache envelope** — `cli-sessions.json` and
+  `cowork-sessions.json` now write
+  `{ __exporterVersion, entries }`. Loaders gate reuse on an exact
+  version match so on-disk-shape changes self-invalidate. Legacy
+  bare-array files are tolerated for one rescan cycle.
+
 ## [0.8.0] — 2026-05-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-15
+
+### Added
+
+- **`sessions-index.json` ingestion** — the host-CLI walker now reads
+  Anthropic's per-project `sessions-index.json` and reconstructs
+  lightweight `UnifiedSessionEntry`s for sessions whose `.jsonl` has
+  already been pruned from disk. New `transcriptStatus: 'pruned'`
+  distinguishes them. `userTextSamples` is populated from the index's
+  `firstPrompt` so `discoverNarratives` still gets clustering input.
+- **WSL CLI scanning (Windows host)** — the `cli` and `all` subcommands
+  now enumerate WSL distros via `wsl --list --quiet` and walk
+  `\\wsl.localhost\<distro>\home\<user>\.claude\projects\` for each one
+  via UNC. `docker-desktop` and other system distros are skipped.
+  Failures (no WSL installed, unreachable distro) are warn-once'd and
+  the rest of the scan continues.
+- **`additionalProjectsRoots` option on `runCliExport`** so other
+  callers can feed extra CLI roots without round-tripping through the
+  WSL discovery code (e.g., future macOS / Linux native scans).
+- **`prunedCount` on `CliExportResult`** — reported in the `all`
+  summary alongside the rescanned/reused counts.
+
 ## [0.9.0] — 2026-05-15
 
 ### Added

--- a/packages/analysis/src/cloud-mapping.ts
+++ b/packages/analysis/src/cloud-mapping.ts
@@ -259,6 +259,43 @@ export function buildEntry(
 
   const hasTools = Object.keys(topTools).length > 0;
 
+  // Analysis-grade user-text samples. Skip the first human message (already
+  // captured by `preview`'s firstHumanText source — same anti-double-count
+  // rule local sources apply). Cap at 5 turns × 400 chars to match
+  // `USER_TEXT_SAMPLES_MAX` / `USER_TEXT_SAMPLES_CHAR_CAP` in
+  // packages/exporter/src/sources/cli.ts.
+  const userTextSamples: string[] = [];
+  {
+    const cap = 5;
+    const charCap = 400;
+    let seenFirstHuman = false;
+    for (const msg of chatMessages) {
+      if (msg.sender !== 'human') continue;
+      let text: string | undefined;
+      if (Array.isArray(msg.content)) {
+        for (const b of msg.content) {
+          if (b && typeof b === 'object' && b.type === 'text') {
+            const t = (b as { text?: unknown }).text;
+            if (typeof t === 'string' && t.length > 0) {
+              text = t;
+              break;
+            }
+          }
+        }
+      }
+      if (text === undefined && typeof msg.text === 'string' && msg.text.length > 0) {
+        text = msg.text;
+      }
+      if (text === undefined) continue;
+      if (!seenFirstHuman) {
+        seenFirstHuman = true;
+        continue;
+      }
+      userTextSamples.push(text.slice(0, charCap));
+      if (userTextSamples.length >= cap) break;
+    }
+  }
+
   // Project label — matched against title first (high signal) then summary
   // (fallback), first-match-wins, using the export's own `projects.json`
   // names as the allowlist. Coverage on a real 1041-conversation corpus:
@@ -292,6 +329,7 @@ export function buildEntry(
     ...(hasSummary ? { summary } : {}),
     ...(hasTools ? { topTools } : {}),
     ...(matchedProject !== null ? { project: matchedProject } : {}),
+    ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
     transcriptPath: `cloud-conversations/${conv.uuid}.json`,
   };
 

--- a/packages/analysis/src/discoverNarratives.test.ts
+++ b/packages/analysis/src/discoverNarratives.test.ts
@@ -99,4 +99,27 @@ describe('discoverNarratives', () => {
     expect(r.narratives).toHaveLength(0);
     expect(r.projectSentiment.get('proj_q')).toBe('neutral');
   });
+
+  it('clusters on userTextSamples in addition to title+preview+summary', () => {
+    // Two sessions whose titles are sentiment-neutral but whose
+    // userTextSamples carry strong positive sentiment. Without the T6
+    // widening, neither session would score positive and no narrative
+    // would emit. With the widening, both score positive and the
+    // narrative shows up.
+    const sessions = [
+      mkSession('a', {
+        title: 'check this',
+        userTextSamples: ['that worked perfectly, tests pass'],
+      }),
+      mkSession('b', {
+        title: 'check this',
+        userTextSamples: ['shipped the fix, everything green'],
+      }),
+    ];
+    const projects = [mkProject('proj_widen', ['a', 'b'])];
+    const r = discoverNarratives(sessions, projects);
+    const narr = r.narratives.find((n) => n.sentiment === 'positive');
+    expect(narr).toBeDefined();
+    expect(narr?.sessionIds).toEqual(expect.arrayContaining(['a', 'b']));
+  });
 });

--- a/packages/analysis/src/discoverNarratives.ts
+++ b/packages/analysis/src/discoverNarratives.ts
@@ -84,7 +84,12 @@ export function discoverNarratives(
     for (const sid of project.sessionIds) {
       const s = sessionById.get(sid);
       if (s === undefined) continue;
-      const text = [s.title, s.preview ?? '', s.summary ?? ''].join('\n');
+      const text = [
+        s.title,
+        s.preview ?? '',
+        s.summary ?? '',
+        ...(s.userTextSamples ?? []),
+      ].join('\n');
       const r = scoreSentiment(text);
       scored.push({
         session: s,

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -66,7 +66,12 @@ export interface RunAnalysisResult {
   };
 }
 
-const EXPORTER_VERSION = '0.8.0';
+/**
+ * Exported so the per-source cache loaders (cli.ts, cowork.ts) can
+ * gate reuse on a version match — when the on-disk entry shape
+ * changes, all prior caches self-invalidate on next rescan.
+ */
+export const EXPORTER_VERSION = '0.8.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -71,7 +71,7 @@ export interface RunAnalysisResult {
  * gate reuse on a version match — when the on-disk entry shape
  * changes, all prior caches self-invalidate on next rescan.
  */
-export const EXPORTER_VERSION = '0.9.0';
+export const EXPORTER_VERSION = '0.10.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -71,7 +71,7 @@ export interface RunAnalysisResult {
  * gate reuse on a version match — when the on-disk entry shape
  * changes, all prior caches self-invalidate on next rescan.
  */
-export const EXPORTER_VERSION = '0.8.0';
+export const EXPORTER_VERSION = '0.9.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/cli.ts
+++ b/packages/exporter/src/cli.ts
@@ -10,8 +10,9 @@ const USAGE = `\
 chat-arch <subcommand> [options]
 
 Subcommands:
-  cowork   Walk %APPDATA%\\Claude (local-agent-mode-sessions + claude-code-sessions)
-           and write cowork-sessions.json + copied manifests/transcripts.
+  cowork   Walk %APPDATA%\\Claude (local-agent-mode-sessions + claude-code-sessions —
+           both Cowork-shaped per Anthropic's rename) and write
+           cowork-sessions.json + copied manifests/transcripts.
   cli      Walk ~/.claude/projects/, stream each transcript, and write
            cli-sessions.json + copied transcripts (cli-direct + enriched cli-desktop).
   cloud    Unpack the Settings → Privacy export ZIP and write

--- a/packages/exporter/src/commands/all.ts
+++ b/packages/exporter/src/commands/all.ts
@@ -10,6 +10,7 @@ import { runAnalysis } from '../analysis/index.js';
 import { findRepoRoot } from '../lib/repo-root.js';
 import { validateEntries } from '../lib/validate-entry.js';
 import { logger } from '../lib/logger.js';
+import { discoverWslCliProjectsRoots } from '../lib/wsl.js';
 
 /**
  * Read the cloud-manifest.json written by a previous `cloud` phase.
@@ -95,9 +96,19 @@ export async function runAllSubcommand(argv: readonly string[]): Promise<number>
   // ---- Phase 3: cli ----
   logger.info('  [2/3] cli: scanning…');
   const cliStart = Date.now();
+  // Discover WSL CLI projects roots on Windows (no-op elsewhere). Failures
+  // are warn-once'd internally; we don't fail the whole rescan if WSL is
+  // unreachable.
+  const wslRoots = await discoverWslCliProjectsRoots();
+  if (wslRoots.length > 0) {
+    logger.info(`  [2/3] cli: + ${wslRoots.length} WSL root(s)`);
+  }
   let cliResult;
   try {
-    cliResult = await runCliExport({ outDir });
+    cliResult = await runCliExport({
+      outDir,
+      ...(wslRoots.length > 0 ? { additionalProjectsRoots: wslRoots } : {}),
+    });
   } catch (err) {
     logger.error(`cli phase failed: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
@@ -109,7 +120,8 @@ export async function runAllSubcommand(argv: readonly string[]): Promise<number>
   const cliDeskRescanned = cliResult.counts['cli-desktop'] - cliDeskReused;
   logger.info(
     `  [2/3] cli: cli-direct=${cliResult.counts['cli-direct']} (${cliDirectReused} reused, ${cliDirectRescanned} rescanned) ` +
-      `cli-desktop=${cliResult.counts['cli-desktop']} (${cliDeskReused} reused, ${cliDeskRescanned} rescanned) in ${cliMs} ms`,
+      `cli-desktop=${cliResult.counts['cli-desktop']} (${cliDeskReused} reused, ${cliDeskRescanned} rescanned) ` +
+      `pruned=${cliResult.prunedCount} in ${cliMs} ms`,
   );
 
   // ---- Phase 4: cloud ----

--- a/packages/exporter/src/commands/cli.ts
+++ b/packages/exporter/src/commands/cli.ts
@@ -4,6 +4,7 @@ import { runCliExport } from '../sources/cli.js';
 import { findRepoRoot } from '../lib/repo-root.js';
 import { validateEntries } from '../lib/validate-entry.js';
 import { logger } from '../lib/logger.js';
+import { discoverWslCliProjectsRoots } from '../lib/wsl.js';
 
 export async function runCliSubcommand(argv: readonly string[]): Promise<number> {
   const { values } = parseArgs({
@@ -41,14 +42,24 @@ export async function runCliSubcommand(argv: readonly string[]): Promise<number>
   const started = Date.now();
   logger.info(`cli export → ${outDir}`);
 
+  // WSL CLI projects: on Windows, also walk every WSL distro's
+  // ~/.claude/projects via \\wsl.localhost\<distro>\home\<user>\.claude\
+  // projects. On non-Windows this is a no-op. Failures are warn-once'd
+  // internally; we don't bail the whole export over WSL trouble.
+  const wslRoots = await discoverWslCliProjectsRoots();
+  if (wslRoots.length > 0) {
+    logger.info(`cli export: discovered ${wslRoots.length} WSL CLI projects root(s)`);
+  }
+
   const result = await runCliExport({
     outDir,
     ...(phase2CoworkJsonPath !== undefined ? { phase2CoworkJsonPath } : {}),
+    ...(wslRoots.length > 0 ? { additionalProjectsRoots: wslRoots } : {}),
   });
 
   const elapsedMs = Date.now() - started;
   logger.info(
-    `cli export complete in ${elapsedMs} ms — cli-direct=${result.counts['cli-direct']}, cli-desktop=${result.counts['cli-desktop']}, transcripts copied=${result.transcriptsCopied}, skipped=${result.transcriptsSkipped}, malformed lines=${result.malformedLinesTotal}`,
+    `cli export complete in ${elapsedMs} ms — cli-direct=${result.counts['cli-direct']}, cli-desktop=${result.counts['cli-desktop']}, pruned (reconstructed from sessions-index)=${result.prunedCount}, transcripts copied=${result.transcriptsCopied}, skipped=${result.transcriptsSkipped}, malformed lines=${result.malformedLinesTotal}`,
   );
 
   // Post-write shape validation — R11.

--- a/packages/exporter/src/commands/cowork.ts
+++ b/packages/exporter/src/commands/cowork.ts
@@ -18,9 +18,10 @@ export async function runCoworkSubcommand(argv: readonly string[]): Promise<numb
   if (values.help) {
     logger.info(
       'chat-arch cowork [--out <dir>]\n\n' +
-        '  Walk %APPDATA%\\Claude\\local-agent-mode-sessions and claude-code-sessions,\n' +
-        '  produce a unified cowork-sessions.json and copy manifests + transcripts.\n' +
-        '  Default --out: <repo-root>/apps/standalone/public/chat-arch-data',
+        '  Walk %APPDATA%\\Claude\\local-agent-mode-sessions and claude-code-sessions\n' +
+        '  (both are Cowork-shaped per Anthropic\'s rename — refs claude-code#29373,\n' +
+        '  #27463) and produce a unified cowork-sessions.json + copied manifests +\n' +
+        '  transcripts. Default --out: <repo-root>/apps/standalone/public/chat-arch-data',
     );
     return 0;
   }

--- a/packages/exporter/src/lib/sessionsIndex.ts
+++ b/packages/exporter/src/lib/sessionsIndex.ts
@@ -1,0 +1,198 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import type { UnifiedSessionEntry } from '@chat-arch/schema';
+import { UNTITLED_SESSION } from '@chat-arch/schema';
+import { logger } from './logger.js';
+import { buildPreview } from './preview.js';
+
+/**
+ * `sessions-index.json` is a per-project-dir index Anthropic's CLI maintains
+ * alongside `<uuid>.jsonl` transcripts under `~/.claude/projects/<dir>/`.
+ * Crucially, the index outlives the transcripts: Anthropic auto-prunes old
+ * `.jsonl` files but leaves the index entries behind, preserving session
+ * metadata (sessionId, firstPrompt, messageCount, gitBranch, projectPath,
+ * timestamps) for sessions whose conversation body is gone.
+ *
+ * This walker reconstructs `UnifiedSessionEntry`s from index entries whose
+ * transcript file no longer exists on disk, emitting them with
+ * `transcriptStatus: 'pruned'`. Entries whose transcript IS still on disk
+ * are NOT emitted — they're already covered by `findTranscriptPaths` /
+ * `streamAggregate` (which produce richer entries with tokens, tools,
+ * subagent rollups). De-dup is by the transcript-file existence check.
+ */
+
+interface SessionsIndexEntry {
+  sessionId: string;
+  fullPath?: string;
+  fileMtime?: number;
+  firstPrompt?: string;
+  messageCount?: number;
+  created?: string;
+  modified?: string;
+  gitBranch?: string;
+  projectPath?: string;
+  isSidechain?: boolean;
+}
+
+interface SessionsIndexFile {
+  version?: number;
+  entries?: readonly SessionsIndexEntry[];
+}
+
+/**
+ * Truncate a long firstPrompt down to a title-shaped string.
+ * Mirrors `truncate` in cli.ts:`resolveTitle`.
+ */
+function truncate(s: string, max: number): string {
+  const collapsed = s.replace(/\s+/g, ' ').trim();
+  return collapsed.length <= max ? collapsed : collapsed.slice(0, max);
+}
+
+/**
+ * Walk one `sessions-index.json` and produce synthetic entries for every
+ * indexed session whose `fullPath` transcript no longer exists on disk.
+ *
+ * @param indexPath  Absolute path to a `sessions-index.json` file.
+ * @param cwdKind    `'host'` for Windows-host CLI / WSL CLI walkers (the
+ *                   indexed `projectPath` is a real filesystem path).
+ * @param sourceTag  `'cli-direct'` — pruned sessions match the cli-direct
+ *                   shape; cli-desktop entries come from Cowork manifests
+ *                   which carry their own metadata and don't get pruned
+ *                   from `~/.claude/projects/` since the CLI never touched
+ *                   them in the first place.
+ *
+ * Never throws. Missing / malformed index → returns []. Per-entry
+ * malformed/incomplete records are silently skipped.
+ */
+export async function readPrunedFromSessionsIndex(
+  indexPath: string,
+  cwdKind: 'host',
+  sourceTag: 'cli-direct',
+): Promise<readonly UnifiedSessionEntry[]> {
+  let raw: string;
+  try {
+    raw = await readFile(indexPath, 'utf8');
+  } catch {
+    return [];
+  }
+  let parsed: SessionsIndexFile;
+  try {
+    parsed = JSON.parse(raw) as SessionsIndexFile;
+  } catch (err) {
+    logger.warnOnce(
+      `sessions-index-malformed:${indexPath}`,
+      `sessions-index.json ${indexPath} is not valid JSON: ${(err as Error).message}; skipping`,
+    );
+    return [];
+  }
+  const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+  if (entries.length === 0) return [];
+
+  // Cache fileExists across entries to avoid stat-ing the same path twice
+  // when an index lists duplicates (rare but possible).
+  const existsCache = new Map<string, boolean>();
+  const checkExists = async (p: string): Promise<boolean> => {
+    const cached = existsCache.get(p);
+    if (cached !== undefined) return cached;
+    let ok = false;
+    try {
+      const st = await stat(p);
+      ok = st.isFile();
+    } catch {
+      ok = false;
+    }
+    existsCache.set(p, ok);
+    return ok;
+  };
+
+  const out: UnifiedSessionEntry[] = [];
+  for (const e of entries) {
+    if (!e || typeof e.sessionId !== 'string' || e.sessionId.length === 0) continue;
+    // If the transcript is still on disk, the regular walker will handle it.
+    if (typeof e.fullPath === 'string' && (await checkExists(e.fullPath))) continue;
+
+    const startedAt =
+      typeof e.created === 'string' ? Date.parse(e.created) : Number.NaN;
+    const updatedAt =
+      typeof e.modified === 'string' ? Date.parse(e.modified) : Number.NaN;
+    if (!Number.isFinite(startedAt) || !Number.isFinite(updatedAt)) continue;
+
+    const firstPrompt = typeof e.firstPrompt === 'string' ? e.firstPrompt : '';
+    const title =
+      firstPrompt.length > 0 ? truncate(firstPrompt, 80) : UNTITLED_SESSION;
+    const titleSource: 'first-prompt' | 'fallback' =
+      firstPrompt.length > 0 ? 'first-prompt' : 'fallback';
+
+    const cwd = typeof e.projectPath === 'string' ? e.projectPath : undefined;
+    const project =
+      cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
+
+    // messageCount is total (user + assistant). Approximate userTurns as the
+    // ceiling of half — better than 0 (which would imply "no user activity"
+    // and confuse downstream filters) and never more than the truth.
+    const userTurns =
+      typeof e.messageCount === 'number' && Number.isFinite(e.messageCount)
+        ? Math.max(1, Math.ceil(e.messageCount / 2))
+        : 0;
+
+    // Mirror firstPrompt into userTextSamples (single sample, ≤400 chars) so
+    // discoverNarratives gets clustering input from pruned sessions too.
+    const userTextSamples =
+      firstPrompt.length > 0 ? [firstPrompt.slice(0, 400)] : [];
+
+    const entry: UnifiedSessionEntry = {
+      id: e.sessionId,
+      source: sourceTag,
+      rawSessionId: e.sessionId,
+      startedAt,
+      updatedAt,
+      durationMs: Math.max(0, updatedAt - startedAt),
+      title,
+      titleSource,
+      preview: buildPreview(firstPrompt.length > 0 ? firstPrompt : null),
+      userTurns,
+      model: null,
+      cwdKind,
+      totalCostUsd: null,
+      ...(cwd !== undefined ? { cwd } : {}),
+      ...(project !== undefined && project.length > 0 ? { project } : {}),
+      ...(typeof e.fileMtime === 'number' ? { sourceMtimeMs: e.fileMtime } : {}),
+      ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
+      transcriptStatus: 'pruned',
+      // No transcriptPath / manifestPath / tokenTotals / topTools /
+      // subagentRollup — those would require a transcript that's gone.
+    };
+    out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * Convenience: walk every `<projectsRoot>/<projectDir>/sessions-index.json`
+ * and collect all pruned entries in one go. Caller passes the projects
+ * root (e.g. `~/.claude/projects`); we discover index files at depth-1.
+ *
+ * Returns `[]` when no project dirs exist or none carry an index file
+ * (the index is a relatively recent Anthropic addition; older project
+ * dirs simply don't have one).
+ */
+export async function collectPrunedEntries(
+  projectsRoot: string,
+  cwdKind: 'host',
+  sourceTag: 'cli-direct',
+  readdirFn: (p: string) => Promise<readonly string[]>,
+): Promise<readonly UnifiedSessionEntry[]> {
+  let projectDirs: readonly string[];
+  try {
+    projectDirs = await readdirFn(projectsRoot);
+  } catch {
+    return [];
+  }
+  const all: UnifiedSessionEntry[] = [];
+  for (const d of projectDirs) {
+    const indexPath = path.join(projectsRoot, d, 'sessions-index.json');
+    const entries = await readPrunedFromSessionsIndex(indexPath, cwdKind, sourceTag);
+    all.push(...entries);
+  }
+  return all;
+}

--- a/packages/exporter/src/lib/subagents.ts
+++ b/packages/exporter/src/lib/subagents.ts
@@ -1,0 +1,154 @@
+import { readdir } from 'node:fs/promises';
+import path from 'node:path';
+import type { TokenTotals } from '@chat-arch/schema';
+import { readJsonlLines } from './jsonl.js';
+import { countToolUsesInMessage } from './toolUses.js';
+
+/**
+ * Per-session subagent rollup. Cowork and host-CLI sessions can fan out to
+ * sub-agents (Task tool invocations); each sub-agent gets its own transcript
+ * under `<sessionDir>/.../subagents/agent-*.jsonl`. They typically run on a
+ * smaller/faster model (Haiku) and execute their own tool calls. Without
+ * walking them, parent-session `tokenTotals` / `topTools` / `modelsUsed`
+ * undercount heavy-fan-out sessions by 10x+.
+ *
+ * `count` is the number of subagent JSONL files (one file per Task invocation);
+ * `totalTokens` / `topTools` / `modelsUsed` are summed across all files.
+ */
+export interface SubagentRollup {
+  count: number;
+  totalTokens: TokenTotals;
+  modelsUsed: readonly string[];
+  topTools: Readonly<Record<string, number>>;
+}
+
+const SUBAGENT_FILE_RE = /^agent-.*\.jsonl$/i;
+
+/**
+ * Walk a `subagents/` directory and produce a rollup of all `agent-*.jsonl`
+ * sub-agent transcripts. Same JSONL-stream-and-accumulate pattern as
+ * `streamToolUses` (lib/toolUses.ts); reads each file once, constant memory.
+ *
+ * Returns `undefined` when the directory is missing — most sessions don't
+ * fan out, and that's not an error. Malformed lines and unreadable individual
+ * files are silently skipped so a single corrupt subagent doesn't lose the
+ * rest of the rollup.
+ */
+export async function aggregateSubagents(
+  subagentsDir: string,
+): Promise<SubagentRollup | undefined> {
+  let entries: string[];
+  try {
+    entries = await readdir(subagentsDir);
+  } catch {
+    return undefined;
+  }
+
+  const files = entries.filter((n) => SUBAGENT_FILE_RE.test(n));
+  if (files.length === 0) return undefined;
+
+  const totalTokens: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
+  const modelsSeen = new Set<string>();
+  const modelsOrdered: string[] = [];
+  const topTools: Record<string, number> = {};
+
+  for (const name of files) {
+    const filePath = path.join(subagentsDir, name);
+    try {
+      for await (const y of readJsonlLines<Record<string, unknown>>(filePath)) {
+        if (y.kind === 'error') continue;
+        const line = y.line;
+        if (line['type'] !== 'assistant') continue;
+        const msg = line['message'] as
+          | {
+              model?: unknown;
+              usage?: {
+                input_tokens?: unknown;
+                output_tokens?: unknown;
+                cache_creation_input_tokens?: unknown;
+                cache_read_input_tokens?: unknown;
+              };
+            }
+          | undefined;
+        if (msg && typeof msg.model === 'string' && msg.model.length > 0) {
+          if (!modelsSeen.has(msg.model)) {
+            modelsSeen.add(msg.model);
+            modelsOrdered.push(msg.model);
+          }
+        }
+        if (msg && msg.usage) {
+          const u = msg.usage;
+          if (typeof u.input_tokens === 'number' && Number.isFinite(u.input_tokens)) {
+            totalTokens.input += u.input_tokens;
+          }
+          if (typeof u.output_tokens === 'number' && Number.isFinite(u.output_tokens)) {
+            totalTokens.output += u.output_tokens;
+          }
+          if (
+            typeof u.cache_creation_input_tokens === 'number' &&
+            Number.isFinite(u.cache_creation_input_tokens)
+          ) {
+            totalTokens.cacheCreation += u.cache_creation_input_tokens;
+          }
+          if (
+            typeof u.cache_read_input_tokens === 'number' &&
+            Number.isFinite(u.cache_read_input_tokens)
+          ) {
+            totalTokens.cacheRead += u.cache_read_input_tokens;
+          }
+        }
+        countToolUsesInMessage(line['message'], topTools);
+      }
+    } catch {
+      // Single corrupt subagent file — skip it, keep the rest of the rollup.
+    }
+  }
+
+  return {
+    count: files.length,
+    totalTokens,
+    modelsUsed: modelsOrdered,
+    topTools,
+  };
+}
+
+/** Helper: sum two TokenTotals. Pure. */
+export function sumTokens(a: TokenTotals, b: TokenTotals): TokenTotals {
+  return {
+    input: a.input + b.input,
+    output: a.output + b.output,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    cacheRead: a.cacheRead + b.cacheRead,
+  };
+}
+
+/** Helper: sum two name→count histograms into a new object. Pure. */
+export function sumHistograms(
+  a: Record<string, number>,
+  b: Record<string, number>,
+): Record<string, number> {
+  const out: Record<string, number> = { ...a };
+  for (const [k, v] of Object.entries(b)) {
+    out[k] = (out[k] ?? 0) + v;
+  }
+  return out;
+}
+
+/** Helper: union arrays preserving insertion order of `a` first, then new from `b`. */
+export function uniqueModels(a: readonly string[], b: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of a) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      out.push(m);
+    }
+  }
+  for (const m of b) {
+    if (!seen.has(m)) {
+      seen.add(m);
+      out.push(m);
+    }
+  }
+  return out;
+}

--- a/packages/exporter/src/lib/wsl.ts
+++ b/packages/exporter/src/lib/wsl.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process';
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { logger } from './logger.js';
+
+/**
+ * Enumerate Windows-side CLI projects roots that live inside WSL distros.
+ *
+ * Returns absolute UNC paths of the form
+ *   `\\wsl.localhost\<distro>\home\<user>\.claude\projects`
+ * for every (distro, user) pair where that directory exists.
+ *
+ * Strategy:
+ *   1. Discover distros via `wsl --list --quiet` (UTF-16LE output, with a
+ *      blank-line / "Windows Subsystem" header that must be stripped).
+ *   2. Skip system distros (`docker-desktop` and friends) that never host
+ *      user Claude Code installs — checking them costs a stat per user
+ *      and they always return empty.
+ *   3. For each remaining distro, enumerate `\\wsl.localhost\<distro>\home`
+ *      and look for a `.claude/projects` dir under each user. UNC reads
+ *      work transparently from Windows node — verified empirically.
+ *
+ * Best-effort: any failure (no WSL installed, distro unreachable, perm
+ * errors) returns `[]` with a single warn-once. Never throws.
+ */
+export async function discoverWslCliProjectsRoots(): Promise<readonly string[]> {
+  if (process.platform !== 'win32') return [];
+
+  let distros: readonly string[];
+  try {
+    distros = listWslDistros();
+  } catch (err) {
+    logger.warnOnce(
+      'wsl-list-failed',
+      `[chat-arch] could not enumerate WSL distros (${(err as Error).message}); skipping WSL CLI scan`,
+    );
+    return [];
+  }
+
+  const roots: string[] = [];
+  for (const distro of distros) {
+    if (SYSTEM_DISTROS.has(distro)) continue;
+    const homeRoot = `\\\\wsl.localhost\\${distro}\\home`;
+    let users: readonly string[];
+    try {
+      users = await readdir(homeRoot);
+    } catch {
+      // Distro unreachable or no /home — skip silently.
+      continue;
+    }
+    for (const user of users) {
+      const projectsRoot = path.join(homeRoot, user, '.claude', 'projects');
+      try {
+        const st = await stat(projectsRoot);
+        if (st.isDirectory()) roots.push(projectsRoot);
+      } catch {
+        // No projects dir for this user — skip silently.
+      }
+    }
+  }
+  return roots;
+}
+
+/**
+ * System WSL distros that never carry user Claude Code data. Skipping
+ * them avoids spinning up Docker's WSL2 instance just to fail on `/home`.
+ */
+const SYSTEM_DISTROS = new Set<string>(['docker-desktop', 'docker-desktop-data']);
+
+/**
+ * Parse `wsl --list --quiet` output. Windows ships the output as
+ * UTF-16LE-encoded text with stray nulls on some hosts; we decode and
+ * strip non-printable characters, then drop empty lines and the legacy
+ * "Windows Subsystem for Linux Distributions:" header.
+ *
+ * Exported for tests; production callers should use the async wrapper.
+ */
+export function listWslDistros(): readonly string[] {
+  const buf = execFileSync('wsl.exe', ['--list', '--quiet'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  // wsl.exe emits UTF-16LE; decode and normalize.
+  const text = buf.toString('utf16le').replace(/\0/g, '');
+  return text
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('Windows Subsystem'))
+    // The default distro line carries a leading "*" in some locales,
+    // and may bracket the name with "(Default)". Normalize away.
+    .map((s) => s.replace(/^\*\s*/, '').replace(/\s*\(Default\)\s*$/, '').trim())
+    .filter((s) => s.length > 0);
+}

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -95,7 +95,18 @@ interface TranscriptAggregate {
    * tools — no extra read. See `lib/toolUses.ts`.
    */
   toolUses: Record<string, number>;
+  /**
+   * Up to {@link USER_TEXT_SAMPLES_MAX} extracted user-turn excerpts,
+   * captured AFTER the first user turn so they don't double-count with
+   * `preview` (which is sourced from `firstUserText`). Each ≤
+   * {@link USER_TEXT_SAMPLES_CHAR_CAP} chars. Drives analysis-grade
+   * inputs like `discoverNarratives` clustering.
+   */
+  userTextSamples: string[];
 }
+
+export const USER_TEXT_SAMPLES_MAX = 5;
+export const USER_TEXT_SAMPLES_CHAR_CAP = 400;
 
 function zeroAggregate(): TranscriptAggregate {
   return {
@@ -112,6 +123,7 @@ function zeroAggregate(): TranscriptAggregate {
     maxTimestamp: undefined,
     malformedLineCount: 0,
     toolUses: {},
+    userTextSamples: [],
   };
 }
 
@@ -477,6 +489,14 @@ export async function streamAggregate(transcriptPath: string): Promise<Transcrip
       if (agg.firstUserText === undefined) {
         const t = extractFirstUserText(line['message']);
         if (t !== undefined) agg.firstUserText = t;
+      } else if (agg.userTextSamples.length < USER_TEXT_SAMPLES_MAX) {
+        // Capture user turns 2…N+1 as `userTextSamples`. Turn 1 already feeds
+        // `preview` via `firstUserText`, so starting from turn 2 prevents the
+        // double-count that would skew narrative clustering toward duplicates.
+        const t = extractFirstUserText(line['message']);
+        if (t !== undefined && t.length > 0) {
+          agg.userTextSamples.push(t.slice(0, USER_TEXT_SAMPLES_CHAR_CAP));
+        }
       }
     } else if (type === 'assistant') {
       agg.assistantTurns += 1;
@@ -636,6 +656,7 @@ export function buildCliDirectEntry(
     // value to the current stat on the next rescan.
     sourceMtimeMs: fileMtimeMs,
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(agg.userTextSamples.length > 0 ? { userTextSamples: agg.userTextSamples } : {}),
     ...(subagentRollup ? { subagentRollup } : {}),
   };
   return entry;
@@ -715,6 +736,7 @@ export function enrichCliDesktopEntry(
     sourceMtimeMs: fileMtimeMs,
     ...(phase2Entry.manifestPath !== undefined ? { manifestPath: phase2Entry.manifestPath } : {}),
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(agg.userTextSamples.length > 0 ? { userTextSamples: agg.userTextSamples } : {}),
     ...(subagentRollup ? { subagentRollup } : {}),
   };
 

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -19,10 +19,11 @@ import {
 import { EXPORTER_VERSION } from '../analysis/index.js';
 
 /**
- * `<uuid>.jsonl` at the TOP LEVEL of a project dir. Sub-agent transcripts
- * under `<uuid>/` (a directory sibling) are intentionally OUT OF SCOPE —
- * D1 of the Phase 3 plan. They're inner-child retries from the primary
- * transcript and add no new signal for the viewer.
+ * `<uuid>.jsonl` at the TOP LEVEL of a project dir is a session transcript.
+ * Sub-agent transcripts under `<uuid>/subagents/agent-*.jsonl` are walked
+ * separately by `aggregateSubagents` (lib/subagents.ts) and rolled up into
+ * the parent entry's `subagentRollup` field — they are NOT emitted as
+ * separate UnifiedSessionEntry rows.
  */
 const UUID_JSONL_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i;
 
@@ -355,7 +356,8 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
  * Walk `<root>/<projectDir>/*.jsonl` at maxdepth 1 — D1. Skips:
  *  - non-directory entries at root,
  *  - files whose name is not `<uuid>.jsonl`,
- *  - sub-agent transcripts under `<projectDir>/<uuid>/...`.
+ *  - sub-agent transcripts under `<projectDir>/<uuid>/subagents/` (those are
+ *    handled by `aggregateSubagents`, not this walker).
  *
  * Returns absolute paths. Never throws on a missing root; returns [].
  */

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -9,6 +9,13 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { countToolUsesInMessage } from '../lib/toolUses.js';
+import {
+  aggregateSubagents,
+  type SubagentRollup,
+  sumHistograms,
+  sumTokens,
+  uniqueModels,
+} from '../lib/subagents.js';
 
 /**
  * `<uuid>.jsonl` at the TOP LEVEL of a project dir. Sub-agent transcripts
@@ -251,6 +258,13 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
       return;
     }
 
+    // Subagent rollup: <projectDir>/<uuid>/subagents/agent-*.jsonl. Host
+    // Claude Code uses the same layout as Cowork CLI; aggregateSubagents
+    // returns undefined when the dir doesn't exist (most sessions don't
+    // fan out).
+    const subagentsDir = path.join(path.dirname(transcriptPath), uuid, 'subagents');
+    const subagentRollup = await aggregateSubagents(subagentsDir);
+
     malformedLinesTotal += agg.malformedLineCount;
 
     let transcriptRel: string | undefined;
@@ -267,16 +281,18 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
     if (isDesktop) {
       const phase2Entry = phase2Entries.get(uuid);
       if (phase2Entry) {
-        entries.push(enrichCliDesktopEntry(phase2Entry, agg, transcriptRel, fileMtime));
+        entries.push(
+          enrichCliDesktopEntry(phase2Entry, agg, transcriptRel, fileMtime, subagentRollup),
+        );
         desktopCount += 1;
       } else {
         // UUID was reported by Phase 2 but the entry has vanished — should be
         // impossible since we read from the same file, but fall back to direct.
-        entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime));
+        entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime, subagentRollup));
         directCount += 1;
       }
     } else {
-      entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime));
+      entries.push(buildCliDirectEntry(agg, uuid, transcriptRel, fileMtime, subagentRollup));
       directCount += 1;
     }
   });
@@ -562,6 +578,7 @@ export function buildCliDirectEntry(
   uuid: string,
   transcriptRel: string | undefined,
   fileMtimeMs: number,
+  subagentRollup?: SubagentRollup | undefined,
 ): UnifiedSessionEntry {
   const { title, titleSource } = resolveTitle(agg);
 
@@ -572,11 +589,23 @@ export function buildCliDirectEntry(
   const cwd = agg.cwd;
   const project = cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
 
+  // Merge subagent rollup into the parent aggregate. Parent transcript and
+  // subagent transcripts are disjoint files, so summing tokens + tools never
+  // double-counts; model union preserves parent-first insertion order.
+  const mergedTokens = subagentRollup
+    ? sumTokens(agg.tokens, subagentRollup.totalTokens)
+    : agg.tokens;
+  const mergedTools = subagentRollup
+    ? sumHistograms(agg.toolUses, subagentRollup.topTools)
+    : agg.toolUses;
+  const mergedModels = subagentRollup
+    ? uniqueModels(agg.modelsUsed, subagentRollup.modelsUsed)
+    : agg.modelsUsed;
   const tokensHasAny =
-    agg.tokens.input > 0 ||
-    agg.tokens.output > 0 ||
-    agg.tokens.cacheCreation > 0 ||
-    agg.tokens.cacheRead > 0;
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
 
   const entry: UnifiedSessionEntry = {
     // REQUIRED
@@ -596,17 +625,18 @@ export function buildCliDirectEntry(
 
     // OPTIONAL (conditional spread — EOP discipline, R8)
     ...(agg.assistantTurns > 0 ? { assistantTurns: agg.assistantTurns } : {}),
-    ...(agg.modelsUsed.length > 0 ? { modelsUsed: agg.modelsUsed } : {}),
+    ...(mergedModels.length > 0 ? { modelsUsed: mergedModels } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(project !== undefined && project.length > 0 ? { project } : {}),
-    ...(tokensHasAny ? { tokenTotals: agg.tokens } : {}),
-    ...(Object.keys(agg.toolUses).length > 0 ? { topTools: agg.toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(Object.keys(mergedTools).length > 0 ? { topTools: mergedTools } : {}),
     // Cached source-file mtime: drives incremental rescan. Equal to
     // `fileMtimeMs` here because this entry was built from the file
     // whose mtime we just read; the reuse check compares this cached
     // value to the current stat on the next rescan.
     sourceMtimeMs: fileMtimeMs,
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
   return entry;
 }
@@ -630,6 +660,7 @@ export function enrichCliDesktopEntry(
   agg: TranscriptAggregate,
   transcriptRel: string | undefined,
   fileMtimeMs: number,
+  subagentRollup?: SubagentRollup | undefined,
 ): UnifiedSessionEntry {
   const startedAt = agg.minTimestamp ?? phase2Entry.startedAt ?? fileMtimeMs;
   const updatedAt = agg.maxTimestamp ?? phase2Entry.updatedAt ?? fileMtimeMs;
@@ -639,11 +670,22 @@ export function enrichCliDesktopEntry(
   const cwd = phase2Entry.cwd ?? agg.cwd;
   const project = cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
 
+  // Merge subagent rollup the same way buildCliDirectEntry does — see its
+  // comment for the disjointness rationale.
+  const mergedTokens = subagentRollup
+    ? sumTokens(agg.tokens, subagentRollup.totalTokens)
+    : agg.tokens;
+  const mergedTools = subagentRollup
+    ? sumHistograms(agg.toolUses, subagentRollup.topTools)
+    : agg.toolUses;
+  const mergedModels = subagentRollup
+    ? uniqueModels(agg.modelsUsed, subagentRollup.modelsUsed)
+    : agg.modelsUsed;
   const tokensHasAny =
-    agg.tokens.input > 0 ||
-    agg.tokens.output > 0 ||
-    agg.tokens.cacheCreation > 0 ||
-    agg.tokens.cacheRead > 0;
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
 
   const entry: UnifiedSessionEntry = {
     // REQUIRED — kept from Phase 2 except temporal/userTurns.
@@ -663,16 +705,17 @@ export function enrichCliDesktopEntry(
 
     // OPTIONAL
     ...(agg.assistantTurns > 0 ? { assistantTurns: agg.assistantTurns } : {}),
-    ...(agg.modelsUsed.length > 0 ? { modelsUsed: agg.modelsUsed } : {}),
+    ...(mergedModels.length > 0 ? { modelsUsed: mergedModels } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(project !== undefined && project.length > 0 ? { project } : {}),
-    ...(tokensHasAny ? { tokenTotals: agg.tokens } : {}),
-    ...(Object.keys(agg.toolUses).length > 0 ? { topTools: agg.toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(Object.keys(mergedTools).length > 0 ? { topTools: mergedTools } : {}),
     // Cached transcript mtime — drives incremental rescan (see
     // `runCliExport`'s fast-path guard).
     sourceMtimeMs: fileMtimeMs,
     ...(phase2Entry.manifestPath !== undefined ? { manifestPath: phase2Entry.manifestPath } : {}),
     ...(transcriptRel !== undefined ? { transcriptPath: transcriptRel } : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
 
   return entry;

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -16,6 +16,7 @@ import {
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
+import { EXPORTER_VERSION } from '../analysis/index.js';
 
 /**
  * `<uuid>.jsonl` at the TOP LEVEL of a project dir. Sub-agent transcripts
@@ -150,10 +151,18 @@ async function loadPreviousCliEntries(outDir: string): Promise<Map<string, Unifi
   } catch {
     return map;
   }
-  if (!Array.isArray(parsed)) return map;
-  for (const e of parsed as UnifiedSessionEntry[]) {
-    if (e && typeof e.id === 'string' && typeof e.source === 'string') {
-      map.set(`${e.source}:${e.id}`, e);
+  // Bare-array (pre-envelope) shape: do not reuse — entries were produced by
+  // a different exporter version with a different on-disk schema. They'll be
+  // rebuilt this run and re-written with the new envelope.
+  if (Array.isArray(parsed)) return map;
+  if (parsed && typeof parsed === 'object') {
+    const envelope = parsed as { __exporterVersion?: unknown; entries?: unknown };
+    if (envelope.__exporterVersion !== EXPORTER_VERSION) return map;
+    if (!Array.isArray(envelope.entries)) return map;
+    for (const e of envelope.entries as UnifiedSessionEntry[]) {
+      if (e && typeof e.id === 'string' && typeof e.source === 'string') {
+        map.set(`${e.source}:${e.id}`, e);
+      }
     }
   }
   return map;
@@ -313,7 +322,14 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
   entries.sort((a, b) => b.updatedAt - a.updatedAt);
 
   const outFile = path.join(outDir, 'cli-sessions.json');
-  await writeFile(outFile, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+  // Envelope so the loader can gate reuse on EXPORTER_VERSION — see
+  // `loadPreviousCliEntries`. Older bare-array shapes self-invalidate on
+  // first read.
+  await writeFile(
+    outFile,
+    JSON.stringify({ __exporterVersion: EXPORTER_VERSION, entries }, null, 2) + '\n',
+    'utf8',
+  );
 
   return {
     entries,
@@ -407,11 +423,24 @@ export async function loadCliDesktopIds(phase2CoworkJsonPath: string): Promise<{
     );
     return { desktopIds, phase2Entries };
   }
-  if (!Array.isArray(parsed)) {
-    logger.warn(`Phase 2 output ${phase2CoworkJsonPath} is not an array; ignoring`);
+  // Tolerate both shapes: legacy bare array (pre-envelope) and the
+  // EXPORTER_VERSION-tagged envelope written by `runCoworkExport`.
+  let entries: readonly UnifiedSessionEntry[];
+  if (Array.isArray(parsed)) {
+    entries = parsed as UnifiedSessionEntry[];
+  } else if (
+    parsed &&
+    typeof parsed === 'object' &&
+    Array.isArray((parsed as { entries?: unknown }).entries)
+  ) {
+    entries = (parsed as { entries: UnifiedSessionEntry[] }).entries;
+  } else {
+    logger.warn(
+      `Phase 2 output ${phase2CoworkJsonPath} is not an array or envelope; ignoring`,
+    );
     return { desktopIds, phase2Entries };
   }
-  for (const e of parsed as UnifiedSessionEntry[]) {
+  for (const e of entries) {
     if (e && e.source === 'cli-desktop' && typeof e.id === 'string') {
       desktopIds.add(e.id);
       phase2Entries.set(e.id, e);

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -16,6 +16,7 @@ import {
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
+import { collectPrunedEntries } from '../lib/sessionsIndex.js';
 import { EXPORTER_VERSION } from '../analysis/index.js';
 
 /**
@@ -46,6 +47,14 @@ export interface RunCliExportOptions {
   outDir: string;
   /** Defaults to `os.homedir() + /.claude/projects`. */
   projectsRoot?: string;
+  /**
+   * Additional CLI projects roots to walk alongside the primary one. Used
+   * by the WSL pipeline to feed `\\wsl.localhost\<distro>\home\<user>\
+   * .claude\projects\` directories without duplicating every other walker
+   * setup. Each extra root contributes its own transcripts AND its own
+   * `sessions-index.json`-derived pruned entries.
+   */
+  additionalProjectsRoots?: readonly string[];
   /** Defaults to `<outDir>/cowork-sessions.json` (Phase 2's output). */
   phase2CoworkJsonPath?: string;
 }
@@ -56,6 +65,12 @@ export interface CliExportResult {
   transcriptsCopied: number;
   transcriptsSkipped: number;
   malformedLinesTotal: number;
+  /**
+   * Pruned entries reconstructed from `sessions-index.json` — sessions
+   * Anthropic's CLI has already deleted from disk but the index still
+   * lists. See {@link readPrunedFromSessionsIndex}.
+   */
+  prunedCount: number;
   /**
    * Number of entries reused verbatim from the previous cli-sessions.json
    * (source mtime hadn't changed). Reported in the exporter summary so
@@ -181,7 +196,8 @@ async function loadPreviousCliEntries(outDir: string): Promise<Map<string, Unifi
  * stat calls when nothing has changed.
  */
 export async function runCliExport(opts: RunCliExportOptions): Promise<CliExportResult> {
-  const projectsRoot = opts.projectsRoot ?? path.join(os.homedir(), '.claude', 'projects');
+  const primaryRoot = opts.projectsRoot ?? path.join(os.homedir(), '.claude', 'projects');
+  const allRoots = [primaryRoot, ...(opts.additionalProjectsRoots ?? [])];
   const outDir = opts.outDir;
   const phase2Path = opts.phase2CoworkJsonPath ?? path.join(outDir, 'cowork-sessions.json');
 
@@ -193,7 +209,14 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
     recursive: true,
   });
 
-  const transcriptPaths = await findTranscriptPaths(projectsRoot);
+  // Walk every CLI projects root in parallel and concat. WSL roots reach
+  // \\wsl.localhost\<distro>\home\<user>\.claude\projects via UNC; macOS /
+  // Linux native runs would feed their own homedir here too. Failures
+  // (unreachable distro, permission errors) surface as empty lists, not
+  // exceptions — see `findTranscriptPaths`.
+  const transcriptPaths = (
+    await Promise.all(allRoots.map((r) => findTranscriptPaths(r)))
+  ).flat();
   const { desktopIds, phase2Entries } = await loadCliDesktopIds(phase2Path);
   const prevEntries = await loadPreviousCliEntries(outDir);
 
@@ -319,6 +342,32 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
     }
   });
 
+  // Pruned-session ingestion: every CLI projects root may carry
+  // `<projectDir>/sessions-index.json` files that list sessions whose
+  // `<uuid>.jsonl` Anthropic has already deleted. Reconstruct lightweight
+  // entries from the index metadata (firstPrompt, messageCount, etc.) and
+  // tag them transcriptStatus='pruned'. De-dup against the sessionIds the
+  // regular walker already emitted — when both exist (transcript on disk
+  // AND index entry), the transcript wins.
+  const emittedIds = new Set(entries.map((e) => e.id));
+  let prunedCount = 0;
+  for (const root of allRoots) {
+    const pruned = await collectPrunedEntries(root, 'host', 'cli-direct', async (p) => {
+      try {
+        return await readdir(p);
+      } catch {
+        return [];
+      }
+    });
+    for (const e of pruned) {
+      if (emittedIds.has(e.id)) continue;
+      emittedIds.add(e.id);
+      entries.push(e);
+      prunedCount += 1;
+      directCount += 1; // pruned entries are cli-direct-shaped
+    }
+  }
+
   // Stable order: updatedAt desc. Matches Phase 2 convention.
   entries.sort((a, b) => b.updatedAt - a.updatedAt);
 
@@ -345,6 +394,7 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
       'cli-direct': directReused,
       'cli-desktop': desktopReused,
     },
+    prunedCount,
   };
 }
 

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -16,12 +16,44 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { streamToolUses } from '../lib/toolUses.js';
+import { readJsonlLines } from '../lib/jsonl.js';
 import {
   aggregateSubagents,
   sumHistograms,
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
+import {
+  extractFirstUserText,
+  USER_TEXT_SAMPLES_CHAR_CAP,
+  USER_TEXT_SAMPLES_MAX,
+} from './cli.js';
+
+/**
+ * Walk a Cowork transcript JSONL and collect up to {@link USER_TEXT_SAMPLES_MAX}
+ * user-turn excerpts (≤ {@link USER_TEXT_SAMPLES_CHAR_CAP} chars each), starting
+ * at the FIRST user turn — Cowork's preview is sourced from `manifest.initialMessage`
+ * (not the transcript), so the first transcript user turn is not a double-count.
+ *
+ * Never throws. Returns `[]` for missing files / no user lines.
+ */
+async function streamUserTextSamples(transcriptPath: string): Promise<string[]> {
+  const out: string[] = [];
+  try {
+    for await (const y of readJsonlLines<Record<string, unknown>>(transcriptPath)) {
+      if (y.kind === 'error') continue;
+      const line = y.line;
+      if (line['type'] !== 'user') continue;
+      const t = extractFirstUserText(line['message']);
+      if (t === undefined || t.length === 0) continue;
+      out.push(t.slice(0, USER_TEXT_SAMPLES_CHAR_CAP));
+      if (out.length >= USER_TEXT_SAMPLES_MAX) break;
+    }
+  } catch {
+    // unreadable file — return whatever we collected (likely [])
+  }
+  return out;
+}
 // Note: `processDesktopCliManifest` (./desktop-cli) is no longer invoked
 // from here — both AppData roots are Cowork-shaped per Anthropic's rename
 // (anthropics/claude-code#29373, #27463). The Desktop-CLI module stays
@@ -506,6 +538,9 @@ async function processCoworkManifest(
   // of sessions) and keeps the extraction co-located with the other
   // sources via the shared `streamToolUses` helper.
   const toolUses = transcriptAbsTarget ? await streamToolUses(transcriptAbsTarget) : {};
+  const userTextSamples = transcriptAbsTarget
+    ? await streamUserTextSamples(transcriptAbsTarget)
+    : [];
 
   // Subagent rollup — walk <sessionDir>/.claude/projects/-sessions-<proc>/
   // <cliSessionId>/subagents/agent-*.jsonl for Task-tool sub-agents (often
@@ -603,6 +638,7 @@ async function processCoworkManifest(
     ...(typeof manifest.error === 'string' && manifest.error.length > 0
       ? { errorMessage: manifest.error }
       : {}),
+    ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
     ...(subagentRollup ? { subagentRollup } : {}),
   };
 

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -22,7 +22,10 @@ import {
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
-import { processDesktopCliManifest } from './desktop-cli.js';
+// Note: `processDesktopCliManifest` (./desktop-cli) is no longer invoked
+// from here — both AppData roots are Cowork-shaped per Anthropic's rename
+// (anthropics/claude-code#29373, #27463). The Desktop-CLI module stays
+// exported from `src/index.ts` for back-compat reads of legacy data only.
 
 /**
  * Pull parent-session TokenTotals from a Cowork audit's `modelUsage` map.
@@ -34,6 +37,20 @@ import { processDesktopCliManifest } from './desktop-cli.js';
  * Returns a zero TokenTotals when modelUsage is absent or empty — callers
  * decide whether to drop the field via a conditional spread.
  */
+/**
+ * Coerce Cowork's `enabledMcpTools` (typed loosely as Record<string, unknown>)
+ * to the unified entry's stricter `Record<string, boolean>`. In practice every
+ * value observed is a boolean — non-boolean entries are dropped rather than
+ * forced. Keeps the unified field's contract clean.
+ */
+function coerceMcpToolFlags(raw: Readonly<Record<string, unknown>>): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v === 'boolean') out[k] = v;
+  }
+  return out;
+}
+
 function modelUsageToTokens(modelUsage: Record<string, unknown> | undefined): TokenTotals {
   const totals: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
   if (!modelUsage) return totals;
@@ -165,18 +182,24 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   await mkdir(path.join(outDir, 'manifests', 'cli-desktop'), { recursive: true });
   await mkdir(path.join(outDir, 'local-transcripts', 'cowork'), { recursive: true });
 
-  const coworkRoot = path.join(appDataRoot, 'local-agent-mode-sessions');
-  const cliRoot = path.join(appDataRoot, 'claude-code-sessions');
-
-  const coworkManifestPaths = await findManifestPaths(coworkRoot);
-  const cliManifestPaths = await findManifestPaths(cliRoot);
+  // Both `local-agent-mode-sessions/` and `claude-code-sessions/` are Cowork-
+  // shaped per Anthropic's rename (refs anthropics/claude-code#29373, #27463).
+  // The Desktop-CLI walker block is gone; the desktop-cli manifest processor
+  // is kept for back-compat reads of older entries.
+  const coworkRoots = [
+    path.join(appDataRoot, 'local-agent-mode-sessions'),
+    path.join(appDataRoot, 'claude-code-sessions'),
+  ];
+  const coworkManifestPaths = (
+    await Promise.all(coworkRoots.map(findManifestPaths))
+  ).flat();
   const prevEntries = await loadPreviousCoworkEntries(outDir);
 
   let sessionsSkipped = 0;
   let transcriptsCopied = 0;
   let transcriptsMissing = 0;
   let coworkReused = 0;
-  let cliDesktopReused = 0;
+  const cliDesktopReused = 0;
 
   const coworkEntries: UnifiedSessionEntry[] = [];
   await runWithConcurrency(coworkManifestPaths, CONCURRENCY, async (manifestPath) => {
@@ -192,24 +215,6 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   });
 
   const cliEntries: UnifiedSessionEntry[] = [];
-  let desktopCliZeroTurns = 0;
-  await runWithConcurrency(cliManifestPaths, CONCURRENCY, async (manifestPath) => {
-    const res = await processDesktopCliManifest(manifestPath, outDir, prevEntries);
-    if (res === null) {
-      sessionsSkipped += 1;
-      return;
-    }
-    const { entry, reused } = res;
-    if (reused) cliDesktopReused += 1;
-    if (entry.userTurns === 0) desktopCliZeroTurns += 1;
-    cliEntries.push(entry);
-  });
-
-  if (desktopCliZeroTurns > 0) {
-    logger.warn(
-      `${desktopCliZeroTurns} Desktop-CLI sessions have userTurns=0 until Phase 3 transcript walk enriches them.`,
-    );
-  }
 
   // Sort entries deterministically by updatedAt desc for downstream stability.
   const entries = [...coworkEntries, ...cliEntries].sort((a, b) => b.updatedAt - a.updatedAt);
@@ -316,7 +321,21 @@ async function processCoworkManifest(
 
   // Validate minimum required fields.
   if (!isMinimallyValidCowork(parsed)) {
-    logger.warn(`Cowork manifest ${manifestPath} missing required minimum fields; skipping`);
+    // claude-code-sessions/ shape divergence: warn-once when a manifest
+    // there matches neither Cowork nor Desktop-CLI. This is the canary
+    // for Anthropic shipping yet another shape on top of the rename.
+    if (
+      manifestPath.includes(`${path.sep}claude-code-sessions${path.sep}`) &&
+      !isMinimallyValidDesktopCli(parsed)
+    ) {
+      logger.warnOnce(
+        `claude-code-sessions-unknown-shape:${manifestPath}`,
+        `[chat-arch] claude-code-sessions manifest ${manifestPath} matched neither ` +
+          `Cowork nor Desktop-CLI schema — Anthropic may have shipped a new shape`,
+      );
+    } else {
+      logger.warn(`Cowork manifest ${manifestPath} missing required minimum fields; skipping`);
+    }
     return null;
   }
 
@@ -578,7 +597,9 @@ async function processCoworkManifest(
       ? { userSelectedFolders: manifest.userSelectedFolders }
       : {}),
     ...(manifest.slashCommands ? { slashCommands: manifest.slashCommands } : {}),
-    ...(manifest.enabledMcpTools ? { enabledMcpTools: manifest.enabledMcpTools } : {}),
+    ...(manifest.enabledMcpTools
+      ? { enabledMcpTools: coerceMcpToolFlags(manifest.enabledMcpTools) }
+      : {}),
     ...(typeof manifest.error === 'string' && manifest.error.length > 0
       ? { errorMessage: manifest.error }
       : {}),

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -17,6 +17,7 @@ import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { streamToolUses } from '../lib/toolUses.js';
 import { readJsonlLines } from '../lib/jsonl.js';
+import { EXPORTER_VERSION } from '../analysis/index.js';
 import {
   aggregateSubagents,
   sumHistograms,
@@ -136,10 +137,18 @@ async function loadPreviousCoworkEntries(
   } catch {
     return map;
   }
-  if (!Array.isArray(parsed)) return map;
-  for (const e of parsed as UnifiedSessionEntry[]) {
-    if (e && typeof e.id === 'string' && typeof e.source === 'string') {
-      map.set(`${e.source}:${e.id}`, e);
+  // Bare-array (pre-envelope) shape: do not reuse — entries were written by
+  // an exporter version with a different on-disk schema. They'll get
+  // rewritten with the new envelope after this rescan.
+  if (Array.isArray(parsed)) return map;
+  if (parsed && typeof parsed === 'object') {
+    const envelope = parsed as { __exporterVersion?: unknown; entries?: unknown };
+    if (envelope.__exporterVersion !== EXPORTER_VERSION) return map;
+    if (!Array.isArray(envelope.entries)) return map;
+    for (const e of envelope.entries as UnifiedSessionEntry[]) {
+      if (e && typeof e.id === 'string' && typeof e.source === 'string') {
+        map.set(`${e.source}:${e.id}`, e);
+      }
     }
   }
   return map;
@@ -252,7 +261,14 @@ export async function runCoworkExport(opts: RunCoworkExportOptions): Promise<Cow
   const entries = [...coworkEntries, ...cliEntries].sort((a, b) => b.updatedAt - a.updatedAt);
 
   const outFile = path.join(outDir, 'cowork-sessions.json');
-  await writeFile(outFile, JSON.stringify(entries, null, 2) + '\n', 'utf8');
+  // Envelope so the loader can gate reuse on EXPORTER_VERSION — see
+  // `loadPreviousCoworkEntries`. Older bare-array shapes self-invalidate
+  // on first read.
+  await writeFile(
+    outFile,
+    JSON.stringify({ __exporterVersion: EXPORTER_VERSION, entries }, null, 2) + '\n',
+    'utf8',
+  );
 
   return {
     entries,

--- a/packages/exporter/src/sources/cowork.ts
+++ b/packages/exporter/src/sources/cowork.ts
@@ -5,6 +5,7 @@ import type {
   CoworkManifestRaw,
   DesktopCliManifestKnown,
   DesktopCliManifestRaw,
+  TokenTotals,
   UnifiedSessionEntry,
 } from '@chat-arch/schema';
 import { UNTITLED_SESSION } from '@chat-arch/schema';
@@ -15,7 +16,53 @@ import { buildPreview } from '../lib/preview.js';
 import { toPosixRelative } from '../lib/paths.js';
 import { logger } from '../lib/logger.js';
 import { streamToolUses } from '../lib/toolUses.js';
+import {
+  aggregateSubagents,
+  sumHistograms,
+  sumTokens,
+  uniqueModels,
+} from '../lib/subagents.js';
 import { processDesktopCliManifest } from './desktop-cli.js';
+
+/**
+ * Pull parent-session TokenTotals from a Cowork audit's `modelUsage` map.
+ * Cowork audit lines carry per-model `inputTokens` / `outputTokens` /
+ * `cacheCreationInputTokens` / `cacheReadInputTokens` — sum them up so the
+ * unified entry exposes a single TokenTotals to consumers (cost estimation,
+ * /chat answers).
+ *
+ * Returns a zero TokenTotals when modelUsage is absent or empty — callers
+ * decide whether to drop the field via a conditional spread.
+ */
+function modelUsageToTokens(modelUsage: Record<string, unknown> | undefined): TokenTotals {
+  const totals: TokenTotals = { input: 0, output: 0, cacheCreation: 0, cacheRead: 0 };
+  if (!modelUsage) return totals;
+  for (const v of Object.values(modelUsage)) {
+    if (!v || typeof v !== 'object') continue;
+    const u = v as {
+      inputTokens?: unknown;
+      outputTokens?: unknown;
+      cacheCreationInputTokens?: unknown;
+      cacheReadInputTokens?: unknown;
+    };
+    if (typeof u.inputTokens === 'number' && Number.isFinite(u.inputTokens)) {
+      totals.input += u.inputTokens;
+    }
+    if (typeof u.outputTokens === 'number' && Number.isFinite(u.outputTokens)) {
+      totals.output += u.outputTokens;
+    }
+    if (
+      typeof u.cacheCreationInputTokens === 'number' &&
+      Number.isFinite(u.cacheCreationInputTokens)
+    ) {
+      totals.cacheCreation += u.cacheCreationInputTokens;
+    }
+    if (typeof u.cacheReadInputTokens === 'number' && Number.isFinite(u.cacheReadInputTokens)) {
+      totals.cacheRead += u.cacheReadInputTokens;
+    }
+  }
+  return totals;
+}
 
 /**
  * Load the previous cowork-sessions.json (if present) and index by
@@ -279,8 +326,14 @@ async function processCoworkManifest(
   // Fast path: manifest mtime matches what we cached last run →
   // nothing changed since the last rescan. Reuse the entry verbatim.
   // Skips: drift warnings (already seen), audit.jsonl aggregation
-  // (biggest cost), transcript copy (unless outDir was wiped), and
-  // tool-use mining.
+  // (biggest cost), transcript copy (unless outDir was wiped),
+  // tool-use mining, and the subagents/ walk.
+  //
+  // Staleness window: subagent rollups refresh only when the manifest
+  // mtime changes. In practice Cowork rewrites the manifest on every
+  // activity tick (lastActivityAt updates in lock-step with audit +
+  // transcript), so a new subagent fan-out almost always trips the
+  // mtime check on the next rescan.
   const prev = prevEntries.get(`cowork:${cliSessionIdResolved}`);
   if (
     prev !== undefined &&
@@ -434,10 +487,55 @@ async function processCoworkManifest(
   // of sessions) and keeps the extraction co-located with the other
   // sources via the shared `streamToolUses` helper.
   const toolUses = transcriptAbsTarget ? await streamToolUses(transcriptAbsTarget) : {};
-  const hasTools = Object.keys(toolUses).length > 0;
+
+  // Subagent rollup — walk <sessionDir>/.claude/projects/-sessions-<proc>/
+  // <cliSessionId>/subagents/agent-*.jsonl for Task-tool sub-agents (often
+  // Haiku) whose tokens/tool calls would otherwise be invisible.
+  //
+  // Guard: cliSessionId may be null when CLI handoff crashed
+  // (transcriptStatus='crashed'). Only walk when both cliSessionId and
+  // processName are present; otherwise the path is invalid.
+  const subagentRollup =
+    typeof manifest.cliSessionId === 'string' &&
+    manifest.cliSessionId.length > 0 &&
+    typeof manifest.processName === 'string' &&
+    manifest.processName.length > 0
+      ? await aggregateSubagents(
+          path.join(
+            sessionDir,
+            '.claude',
+            'projects',
+            `-sessions-${manifest.processName}`,
+            manifest.cliSessionId,
+            'subagents',
+          ),
+        )
+      : undefined;
+
+  // Merge parent + subagent aggregates so downstream consumers see a single
+  // session-wide rollup. Tool counts come from disjoint transcripts (parent
+  // vs. subagent files) and add cleanly. Token totals follow the same merge
+  // — `audit.modelUsage` may or may not already include subagent tokens in
+  // a given session; either way summing here over-attributes at worst, and
+  // the standalone `subagentRollup` field below keeps the breakdown
+  // inspectable for callers that need to disambiguate.
+  const parentTokens = modelUsageToTokens(audit.modelUsage);
+  const mergedTokens = subagentRollup
+    ? sumTokens(parentTokens, subagentRollup.totalTokens)
+    : parentTokens;
+  const tokensHasAny =
+    mergedTokens.input > 0 ||
+    mergedTokens.output > 0 ||
+    mergedTokens.cacheCreation > 0 ||
+    mergedTokens.cacheRead > 0;
+  const mergedTools = subagentRollup ? sumHistograms(toolUses, subagentRollup.topTools) : toolUses;
+  const hasTools = Object.keys(mergedTools).length > 0;
 
   const modelsUsedArr = audit.modelUsage !== undefined ? Object.keys(audit.modelUsage) : [];
-  const modelsUsed: readonly string[] = modelsUsedArr.length > 0 ? modelsUsedArr : [manifest.model];
+  const baseModels: readonly string[] = modelsUsedArr.length > 0 ? modelsUsedArr : [manifest.model];
+  const modelsUsed: readonly string[] = subagentRollup
+    ? uniqueModels(baseModels, subagentRollup.modelsUsed)
+    : baseModels;
 
   // Build entry via R4 conditional-spread template.
   const entry: UnifiedSessionEntry = {
@@ -464,7 +562,8 @@ async function processCoworkManifest(
     ...(audit.assistantTurns > 0 ? { assistantTurns: audit.assistantTurns } : {}),
     ...(modelsUsed.length > 0 ? { modelsUsed } : {}),
     cwd: manifest.cwd,
-    ...(hasTools ? { topTools: toolUses } : {}),
+    ...(tokensHasAny ? { tokenTotals: mergedTokens } : {}),
+    ...(hasTools ? { topTools: mergedTools } : {}),
     // Cached manifest file mtime — drives the incremental-rescan
     // fast path. Updated every time we (re)process the manifest.
     ...(currentMtime > 0 ? { sourceMtimeMs: currentMtime } : {}),
@@ -474,6 +573,16 @@ async function processCoworkManifest(
     transcriptStatus,
     manifestPath: toPosixRelative(manifestOutAbs, outDir),
     // auditPath: omitted (Q1)
+    // Cowork manifest fields previously dropped — exposed for /chat answers.
+    ...(manifest.userSelectedFolders
+      ? { userSelectedFolders: manifest.userSelectedFolders }
+      : {}),
+    ...(manifest.slashCommands ? { slashCommands: manifest.slashCommands } : {}),
+    ...(manifest.enabledMcpTools ? { enabledMcpTools: manifest.enabledMcpTools } : {}),
+    ...(typeof manifest.error === 'string' && manifest.error.length > 0
+      ? { errorMessage: manifest.error }
+      : {}),
+    ...(subagentRollup ? { subagentRollup } : {}),
   };
 
   return { entry, transcriptCopied, reused: false };

--- a/packages/exporter/src/sources/desktop-cli.ts
+++ b/packages/exporter/src/sources/desktop-cli.ts
@@ -39,8 +39,14 @@ const DESKTOP_CLI_KNOWN_KEYS = new Set<string>([
  * `outDir/manifests/cli-desktop/<rawSessionId>.json`. Returns a
  * UnifiedSessionEntry or null if the manifest is unreadable / invalid.
  *
- * Phase 3 overwrites `userTurns` (currently 0) and sets `transcriptPath`
- * after walking `~/.claude/projects/`.
+ * The unified CLI walker (`runCliExport`) overwrites `userTurns`
+ * (initialized to 0 here) and sets `transcriptPath` once it has matched
+ * the manifest's `cliSessionId` to a transcript under
+ * `~/.claude/projects/`.
+ *
+ * Kept for back-compat reads of older `claude-code-sessions/` data — the
+ * Cowork walker no longer routes manifests through here directly
+ * (Anthropic's rename made both AppData roots Cowork-shaped).
  */
 export async function processDesktopCliManifest(
   manifestPath: string,
@@ -128,7 +134,7 @@ export async function processDesktopCliManifest(
     title: manifest.title || UNTITLED_SESSION,
     titleSource: 'manifest',
     preview: null, // Desktop-CLI has no initialMessage equivalent
-    userTurns: 0, // TODO(phase-3): overwrite with transcript-derived count
+    userTurns: 0, // overwritten by enrichCliDesktopEntry after transcript walk
     model: manifest.model, // verbatim, keep [1m] suffix
     cwdKind: 'host',
     totalCostUsd: null, // Desktop-CLI has no cost summary; Phase 4 merge may fill

--- a/packages/exporter/test/integration/cowork-integration.test.ts
+++ b/packages/exporter/test/integration/cowork-integration.test.ts
@@ -35,14 +35,18 @@ describe('cowork integration (fixture appdata → outDir)', () => {
     expect(Array.isArray(parsed)).toBe(true);
 
     // Manifest copies landed in the right subdirs with the R3 naming.
+    // Both AppData roots now feed the Cowork pipeline (Anthropic rename),
+    // so the two former-Desktop-CLI fixtures land in manifests/cowork/ too.
     const coworkManifests = await readdir(path.join(outDir, 'manifests', 'cowork'));
-    expect(coworkManifests).toHaveLength(4); // corrupt skipped
+    expect(coworkManifests).toHaveLength(6); // 4 + 2; corrupt skipped
     expect(coworkManifests.every((n) => /^local_[0-9a-f-]+\.json$/.test(n))).toBe(true);
 
     const cliManifests = await readdir(path.join(outDir, 'manifests', 'cli-desktop'));
-    expect(cliManifests).toHaveLength(2);
+    expect(cliManifests).toHaveLength(0); // walker removed
 
     // Transcripts: mid + new + scheduled (3); old had no cliSessionId.
+    // claude-code-sessions/ fixtures lack `processName`, so no transcript
+    // copies for them.
     const transcripts = await readdir(path.join(outDir, 'local-transcripts', 'cowork'));
     expect(transcripts).toHaveLength(3);
 

--- a/packages/exporter/test/integration/cowork-integration.test.ts
+++ b/packages/exporter/test/integration/cowork-integration.test.ts
@@ -29,10 +29,12 @@ describe('cowork integration (fixture appdata → outDir)', () => {
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
 
-    // Output file exists and is parseable.
+    // Output file exists and is parseable. Envelope shape since the
+    // cache-bust envelope was introduced.
     const file = path.join(outDir, 'cowork-sessions.json');
     const parsed = JSON.parse(await readFile(file, 'utf8'));
-    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toMatchObject({ __exporterVersion: expect.any(String) });
+    expect(Array.isArray(parsed.entries)).toBe(true);
 
     // Manifest copies landed in the right subdirs with the R3 naming.
     // Both AppData roots now feed the Cowork pipeline (Anthropic rename),

--- a/packages/exporter/test/lib/sessionsIndex.test.ts
+++ b/packages/exporter/test/lib/sessionsIndex.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  readPrunedFromSessionsIndex,
+  collectPrunedEntries,
+} from '../../src/lib/sessionsIndex.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(os.tmpdir(), 'chat-arch-sessions-index-'));
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('readPrunedFromSessionsIndex', () => {
+  it('returns [] for a missing index file', async () => {
+    const res = await readPrunedFromSessionsIndex(
+      path.join(tmp, 'nope.json'),
+      'host',
+      'cli-direct',
+    );
+    expect(res).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON (logs a warn-once, does not throw)', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(p, '{ not valid json', 'utf8');
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toEqual([]);
+  });
+
+  it('reconstructs entries whose fullPath transcript is missing on disk', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'pruned-uuid-1111',
+            fullPath: path.join(tmp, 'does-not-exist-1.jsonl'),
+            fileMtime: 1700000000000,
+            firstPrompt: 'You are acting as a senior maintainer creating a public toolkit.',
+            messageCount: 30,
+            created: '2026-01-22T18:26:44.673Z',
+            modified: '2026-01-23T01:10:23.841Z',
+            gitBranch: 'main',
+            projectPath: 'C:\\Users\\Bryce\\Projects\\bryce-labs-toolkit',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toHaveLength(1);
+    const e = res[0]!;
+    expect(e.id).toBe('pruned-uuid-1111');
+    expect(e.source).toBe('cli-direct');
+    expect(e.transcriptStatus).toBe('pruned');
+    expect(e.title).toBe('You are acting as a senior maintainer creating a public toolkit.');
+    expect(e.titleSource).toBe('first-prompt');
+    expect(e.cwdKind).toBe('host');
+    expect(e.cwd).toBe('C:\\Users\\Bryce\\Projects\\bryce-labs-toolkit');
+    expect(e.project).toBe('bryce-labs-toolkit');
+    // messageCount=30 → userTurns ~= ceil(30/2) = 15
+    expect(e.userTurns).toBe(15);
+    expect(e.startedAt).toBe(Date.parse('2026-01-22T18:26:44.673Z'));
+    expect(e.updatedAt).toBe(Date.parse('2026-01-23T01:10:23.841Z'));
+    expect(e.userTextSamples).toEqual([
+      'You are acting as a senior maintainer creating a public toolkit.',
+    ]);
+    expect(e.transcriptPath).toBeUndefined();
+    expect(e.tokenTotals).toBeUndefined();
+    expect(e.subagentRollup).toBeUndefined();
+  });
+
+  it('skips entries whose fullPath transcript IS still on disk (avoid double-emit)', async () => {
+    // Create an actual transcript file the index points to.
+    const transcript = path.join(tmp, 'live.jsonl');
+    await writeFile(transcript, '{"type":"user","message":{"content":"hi"}}\n', 'utf8');
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'live-uuid',
+            fullPath: transcript,
+            firstPrompt: 'still on disk',
+            messageCount: 4,
+            created: '2026-04-01T00:00:00.000Z',
+            modified: '2026-04-01T00:30:00.000Z',
+            projectPath: 'C:\\proj',
+          },
+          {
+            sessionId: 'pruned-uuid',
+            fullPath: path.join(tmp, 'gone.jsonl'),
+            firstPrompt: 'long since deleted',
+            messageCount: 12,
+            created: '2026-01-01T00:00:00.000Z',
+            modified: '2026-01-01T01:00:00.000Z',
+            projectPath: 'C:\\proj',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    // Only the pruned one is emitted; live is left to the transcript walker.
+    expect(res).toHaveLength(1);
+    expect(res[0]!.id).toBe('pruned-uuid');
+  });
+
+  it('drops entries with unparseable created/modified timestamps', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'no-dates',
+            fullPath: path.join(tmp, 'never.jsonl'),
+            firstPrompt: 'has no created field',
+            messageCount: 3,
+            projectPath: 'C:\\proj',
+          },
+          {
+            sessionId: 'bad-dates',
+            fullPath: path.join(tmp, 'never2.jsonl'),
+            firstPrompt: 'gibberish date',
+            messageCount: 3,
+            created: 'not-a-date',
+            modified: 'also-bad',
+            projectPath: 'C:\\proj',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toEqual([]);
+  });
+
+  it('falls back to UNTITLED_SESSION when firstPrompt is missing', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'titleless',
+            fullPath: path.join(tmp, 'gone.jsonl'),
+            messageCount: 2,
+            created: '2026-01-01T00:00:00.000Z',
+            modified: '2026-01-01T00:30:00.000Z',
+            projectPath: 'C:\\proj',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toHaveLength(1);
+    expect(res[0]!.title).toBe('Untitled session');
+    expect(res[0]!.titleSource).toBe('fallback');
+    expect(res[0]!.userTextSamples).toBeUndefined();
+  });
+});
+
+describe('collectPrunedEntries', () => {
+  it('walks every project dir and aggregates pruned entries', async () => {
+    const projectsRoot = tmp;
+    await mkdir(path.join(projectsRoot, 'proj-a'));
+    await mkdir(path.join(projectsRoot, 'proj-b'));
+    await writeFile(
+      path.join(projectsRoot, 'proj-a', 'sessions-index.json'),
+      JSON.stringify({
+        entries: [
+          {
+            sessionId: 'pruned-a',
+            fullPath: path.join(projectsRoot, 'proj-a', 'gone.jsonl'),
+            firstPrompt: 'A',
+            messageCount: 2,
+            created: '2026-01-01T00:00:00.000Z',
+            modified: '2026-01-01T00:30:00.000Z',
+            projectPath: 'C:\\a',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    await writeFile(
+      path.join(projectsRoot, 'proj-b', 'sessions-index.json'),
+      JSON.stringify({
+        entries: [
+          {
+            sessionId: 'pruned-b',
+            fullPath: path.join(projectsRoot, 'proj-b', 'gone.jsonl'),
+            firstPrompt: 'B',
+            messageCount: 4,
+            created: '2026-02-01T00:00:00.000Z',
+            modified: '2026-02-01T01:00:00.000Z',
+            projectPath: 'C:\\b',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    // proj-c has no index file — should be ignored silently.
+    await mkdir(path.join(projectsRoot, 'proj-c'));
+
+    const { readdir } = await import('node:fs/promises');
+    const res = await collectPrunedEntries(projectsRoot, 'host', 'cli-direct', readdir);
+    expect(res.map((e) => e.id).sort()).toEqual(['pruned-a', 'pruned-b']);
+  });
+
+  it('returns [] for a non-existent projects root', async () => {
+    const { readdir } = await import('node:fs/promises');
+    const res = await collectPrunedEntries(
+      path.join(tmp, 'nope'),
+      'host',
+      'cli-direct',
+      readdir,
+    );
+    expect(res).toEqual([]);
+  });
+});

--- a/packages/exporter/test/lib/subagents.test.ts
+++ b/packages/exporter/test/lib/subagents.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  aggregateSubagents,
+  sumTokens,
+  sumHistograms,
+  uniqueModels,
+} from '../../src/lib/subagents.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(os.tmpdir(), 'chat-arch-subagents-'));
+});
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('aggregateSubagents', () => {
+  it('returns undefined when the subagents directory does not exist', async () => {
+    expect(await aggregateSubagents(path.join(tmp, 'nope'))).toBeUndefined();
+  });
+
+  it('returns undefined when the directory exists but is empty', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    expect(await aggregateSubagents(dir)).toBeUndefined();
+  });
+
+  it('walks two agent files, sums tokens, unions models, tallies tools', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+
+    const fileA = path.join(dir, 'agent-aaa.jsonl');
+    await writeFile(
+      fileA,
+      [
+        JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: 'run task' },
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            model: 'claude-haiku-4-5-20251001',
+            content: [
+              { type: 'text', text: 'ok' },
+              { type: 'tool_use', id: 't1', name: 'Bash' },
+            ],
+            usage: {
+              input_tokens: 10,
+              output_tokens: 20,
+              cache_creation_input_tokens: 100,
+              cache_read_input_tokens: 50,
+            },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const fileB = path.join(dir, 'agent-bbb.jsonl');
+    await writeFile(
+      fileB,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            model: 'claude-sonnet-4-6',
+            content: [
+              { type: 'tool_use', id: 't2', name: 'Bash' },
+              { type: 'tool_use', id: 't3', name: 'Read' },
+            ],
+            usage: {
+              input_tokens: 5,
+              output_tokens: 7,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+            },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const rollup = await aggregateSubagents(dir);
+    expect(rollup).toBeDefined();
+    expect(rollup!.count).toBe(2);
+    expect(rollup!.totalTokens).toEqual({
+      input: 15,
+      output: 27,
+      cacheCreation: 100,
+      cacheRead: 50,
+    });
+    expect([...rollup!.modelsUsed].sort()).toEqual([
+      'claude-haiku-4-5-20251001',
+      'claude-sonnet-4-6',
+    ]);
+    expect(rollup!.topTools).toEqual({ Bash: 2, Read: 1 });
+  });
+
+  it('skips non-agent-*.jsonl files in the directory', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    await writeFile(path.join(dir, 'agent-aaa.meta.json'), '{}', 'utf8');
+    await writeFile(path.join(dir, 'README.md'), 'hi', 'utf8');
+    // The .meta.json is metadata, not a JSONL transcript, so it must be ignored.
+    // With no agent-*.jsonl files, rollup is undefined.
+    expect(await aggregateSubagents(dir)).toBeUndefined();
+  });
+
+  it('silently skips malformed JSONL lines but keeps counting valid ones', async () => {
+    const dir = path.join(tmp, 'subagents');
+    await mkdir(dir);
+    const file = path.join(dir, 'agent-xxx.jsonl');
+    await writeFile(
+      file,
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            model: 'claude-haiku-4-5-20251001',
+            content: [{ type: 'tool_use', id: 'a', name: 'Bash' }],
+            usage: { input_tokens: 1, output_tokens: 2 },
+          },
+        }),
+        '{ not valid json',
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            model: 'claude-haiku-4-5-20251001',
+            content: [{ type: 'tool_use', id: 'b', name: 'Edit' }],
+            usage: { input_tokens: 3, output_tokens: 4 },
+          },
+        }),
+      ].join('\n') + '\n',
+      'utf8',
+    );
+    const rollup = await aggregateSubagents(dir);
+    expect(rollup!.count).toBe(1);
+    expect(rollup!.totalTokens.input).toBe(4);
+    expect(rollup!.totalTokens.output).toBe(6);
+    expect(rollup!.topTools).toEqual({ Bash: 1, Edit: 1 });
+  });
+});
+
+describe('helpers', () => {
+  it('sumTokens adds the four counters', () => {
+    expect(
+      sumTokens(
+        { input: 1, output: 2, cacheCreation: 3, cacheRead: 4 },
+        { input: 10, output: 20, cacheCreation: 30, cacheRead: 40 },
+      ),
+    ).toEqual({ input: 11, output: 22, cacheCreation: 33, cacheRead: 44 });
+  });
+
+  it('sumHistograms adds matching keys, preserves unique keys', () => {
+    expect(sumHistograms({ Bash: 1, Edit: 2 }, { Bash: 4, Read: 3 })).toEqual({
+      Bash: 5,
+      Edit: 2,
+      Read: 3,
+    });
+  });
+
+  it('uniqueModels preserves a-first insertion order and adds new from b', () => {
+    expect(uniqueModels(['opus', 'sonnet'], ['sonnet', 'haiku'])).toEqual([
+      'opus',
+      'sonnet',
+      'haiku',
+    ]);
+  });
+});

--- a/packages/exporter/test/lib/wsl.test.ts
+++ b/packages/exporter/test/lib/wsl.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { discoverWslCliProjectsRoots } from '../../src/lib/wsl.js';
+
+describe('discoverWslCliProjectsRoots', () => {
+  it('returns [] on non-Windows platforms (early exit)', async () => {
+    // The function gates on process.platform === 'win32'. On the test
+    // runner this will be 'win32' on the live dev host but other CI
+    // environments may differ; in either case the function must not
+    // throw. Just exercise it and assert it returns an array.
+    const res = await discoverWslCliProjectsRoots();
+    expect(Array.isArray(res)).toBe(true);
+    for (const r of res) {
+      // Every returned root must end with .claude\projects under wsl.localhost.
+      expect(r).toMatch(/wsl\.localhost[\\/].+[\\/]home[\\/].+[\\/]\.claude[\\/]projects$/);
+    }
+  });
+});

--- a/packages/exporter/test/sources/cli.test.ts
+++ b/packages/exporter/test/sources/cli.test.ts
@@ -678,11 +678,11 @@ describe('runCliExport (hermetic)', () => {
     expect(result.counts['cli-desktop']).toBe(0);
     expect(result.transcriptsCopied).toBe(2);
 
-    // cli-sessions.json on disk parses and matches.
-    const parsed = JSON.parse(
+    // cli-sessions.json on disk parses and matches (envelope shape).
+    const envelope = JSON.parse(
       await readFile(path.join(outDir, 'cli-sessions.json'), 'utf8'),
-    ) as UnifiedSessionEntry[];
-    expect(parsed).toHaveLength(2);
+    ) as { __exporterVersion: string; entries: UnifiedSessionEntry[] };
+    expect(envelope.entries).toHaveLength(2);
 
     // Transcripts copied to cli-direct subdir.
     const copiedA = path.join(outDir, 'local-transcripts', 'cli-direct', `${UUID_A}.jsonl`);

--- a/packages/exporter/test/sources/cli.test.ts
+++ b/packages/exporter/test/sources/cli.test.ts
@@ -394,7 +394,7 @@ describe('findTranscriptPaths', () => {
     expect(warnings.some((w) => w.includes('not found'))).toBe(true);
   });
 
-  it('returns top-level <uuid>.jsonl files but skips sub-agent subdirs (D1)', async () => {
+  it('returns top-level <uuid>.jsonl files but skips sub-agent subdirs', async () => {
     const p1 = await writeTranscript('proj-a', UUID_A, [userLine('x')]);
     const p2 = await writeTranscript('proj-a', UUID_B, [userLine('x')]);
     // Sub-agent dir — should NOT be returned.
@@ -408,6 +408,26 @@ describe('findTranscriptPaths', () => {
     await writeFile(path.join(projectsRoot, 'proj-a', 'README.md'), '# not a transcript', 'utf8');
     const found = await findTranscriptPaths(projectsRoot);
     expect(found.sort()).toEqual([p1, p2].sort());
+  });
+
+  it('aggregateSubagents reads from <uuid>/subagents/agent-*.jsonl, not findTranscriptPaths', async () => {
+    // Sanity-check the boundary: findTranscriptPaths must NOT walk into
+    // subagents/ even when an `agent-*.jsonl` exists there; that path is
+    // owned by `aggregateSubagents`.
+    await writeTranscript('proj-a', UUID_A, [userLine('x')]);
+    const subagentsDir = path.join(projectsRoot, 'proj-a', UUID_A, 'subagents');
+    await mkdir(subagentsDir, { recursive: true });
+    await writeFile(
+      path.join(subagentsDir, 'agent-abc.jsonl'),
+      JSON.stringify(userLine('sub')) + '\n',
+      'utf8',
+    );
+    const { aggregateSubagents } = await import('../../src/lib/subagents.js');
+    const rollup = await aggregateSubagents(subagentsDir);
+    expect(rollup?.count).toBe(1);
+    const transcripts = await findTranscriptPaths(projectsRoot);
+    // Only the top-level <UUID_A>.jsonl is returned; the subagent file is not.
+    expect(transcripts.filter((p) => p.includes('agent-abc'))).toHaveLength(0);
   });
 
   it('picks up case-variant sibling dirs (Windows quirk)', async () => {

--- a/packages/exporter/test/sources/cli.test.ts
+++ b/packages/exporter/test/sources/cli.test.ts
@@ -350,6 +350,36 @@ describe('streamAggregate', () => {
     const agg = await streamAggregate(file);
     expect(agg.toolUses).toEqual({});
   });
+
+  it('captures user-text samples starting from turn 2 (turn 1 already feeds preview)', async () => {
+    const file = await writeTranscript('proj-a', UUID_A, [
+      userLine('first prompt — should NOT appear in samples (it is the preview source)'),
+      assistantLine('m'),
+      userLine('second prompt'),
+      userLine('third prompt'),
+      userLine('fourth prompt'),
+    ]);
+    const agg = await streamAggregate(file);
+    expect(agg.firstUserText).toContain('first prompt');
+    expect(agg.userTextSamples).toEqual(['second prompt', 'third prompt', 'fourth prompt']);
+  });
+
+  it('caps userTextSamples at 5 entries and truncates each to 400 chars', async () => {
+    const long = 'x'.repeat(500);
+    const file = await writeTranscript('proj-a', UUID_A, [
+      userLine('preview source'),
+      userLine(long),
+      userLine('two'),
+      userLine('three'),
+      userLine('four'),
+      userLine('five'),
+      userLine('six — should be dropped, cap is 5'),
+    ]);
+    const agg = await streamAggregate(file);
+    expect(agg.userTextSamples).toHaveLength(5);
+    expect(agg.userTextSamples[0]).toHaveLength(400);
+    expect(agg.userTextSamples).not.toContain('six — should be dropped, cap is 5');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -532,6 +562,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: 2,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, 0);
     expect(e.project).toBe('my.dotted.site');
@@ -553,6 +584,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: undefined,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, mtime);
     expect(e.startedAt).toBe(mtime);
@@ -575,6 +607,7 @@ describe('buildCliDirectEntry', () => {
       maxTimestamp: undefined,
       malformedLineCount: 0,
       toolUses: {},
+      userTextSamples: [],
     };
     const e = buildCliDirectEntry(agg, UUID_A, undefined, 1_000);
     const errors = validateEntries([e]);

--- a/packages/exporter/test/sources/cowork.test.ts
+++ b/packages/exporter/test/sources/cowork.test.ts
@@ -48,9 +48,15 @@ describe('runCoworkExport (fixture)', () => {
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
     const file = path.join(outDir, 'cowork-sessions.json');
-    const roundtripped = JSON.parse(await readFile(file, 'utf8')) as UnifiedSessionEntry[];
-    expect(roundtripped).toHaveLength(result.entries.length);
-    expect(roundtripped.map((e) => e.id).sort()).toEqual(result.entries.map((e) => e.id).sort());
+    const envelope = JSON.parse(await readFile(file, 'utf8')) as {
+      __exporterVersion: string;
+      entries: UnifiedSessionEntry[];
+    };
+    expect(typeof envelope.__exporterVersion).toBe('string');
+    expect(envelope.entries).toHaveLength(result.entries.length);
+    expect(envelope.entries.map((e) => e.id).sort()).toEqual(
+      result.entries.map((e) => e.id).sort(),
+    );
   });
 
   it('falls back to stripped sessionId for entry id when manifest has no cliSessionId (old-schema Cowork)', async () => {

--- a/packages/exporter/test/sources/cowork.test.ts
+++ b/packages/exporter/test/sources/cowork.test.ts
@@ -27,15 +27,17 @@ afterEach(async () => {
 });
 
 describe('runCoworkExport (fixture)', () => {
-  it('walks both roots and emits one entry per valid manifest', async () => {
+  it('walks both AppData roots and emits one Cowork entry per valid manifest', async () => {
     const result = await runCoworkExport({
       outDir,
       appDataClaudeRoot: FIXTURE_APPDATA,
     });
-    // 5 Cowork manifests on disk: old/mid/new/corrupt/scheduled. The corrupt
-    // one is skipped, so 4 entries. 2 Desktop-CLI entries. Total 6.
-    expect(result.counts.cowork).toBe(4);
-    expect(result.counts['cli-desktop']).toBe(2);
+    // Post-Anthropic-rename: both `local-agent-mode-sessions/` and
+    // `claude-code-sessions/` feed the same Cowork pipeline. Fixture has
+    // 5 manifests under local-agent-mode-sessions (one corrupt → skipped)
+    // and 2 under claude-code-sessions, all Cowork-shape-valid. Total 6.
+    expect(result.counts.cowork).toBe(6);
+    expect(result.counts['cli-desktop']).toBe(0);
     expect(result.entries.length).toBe(6);
     expect(result.sessionsSkipped).toBe(1);
   });

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -309,12 +309,20 @@ export interface UnifiedSessionEntry {
    *                 wasn't on disk at scan time (deleted, aborted, or
    *                 cleaned up by the upstream tool between session end
    *                 and exporter scan).
+   *   - 'pruned'  — entry was reconstructed from `sessions-index.json`
+   *                 metadata (`firstPrompt`, `messageCount`, etc.) for
+   *                 a session whose transcript Anthropic's CLI has
+   *                 already deleted. The session is real but the
+   *                 conversation body is gone forever. `userTurns` is a
+   *                 best-effort estimate from `messageCount`; tokens /
+   *                 tool histograms are absent.
    *
    * Drives the SCANNED panel's split note ("X missing on disk · Y CLI
-   * crashed") so the user can tell apart recoverable-but-not-recovered
-   * errors from genuinely-gone transcripts.
+   * crashed · Z pruned") so the user can tell apart recoverable-but-not-
+   * recovered errors from genuinely-gone transcripts and from pre-pruned
+   * historical records.
    */
-  transcriptStatus?: 'ok' | 'crashed' | 'missing';
+  transcriptStatus?: 'ok' | 'crashed' | 'missing' | 'pruned';
 
   /** Output-relative path to the source manifest (Cowork, Desktop-CLI only). */
   manifestPath?: string;

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -316,6 +316,49 @@ export interface UnifiedSessionEntry {
 
   /** Output-relative path to the Cowork audit log. */
   auditPath?: string;
+
+  // ---- Analysis-grade enrichments ----
+
+  /**
+   * Up to 5 user-turn excerpts (≤400 chars each), captured AFTER the
+   * preview-source turn so they don't double-count with `preview`.
+   * Populated by all sources (local + cloud).
+   * Analysis pipelines (e.g. discoverNarratives) read this for richer
+   * clustering input than the 200-char preview alone. The viewer ignores
+   * this field — it's an analysis-grade input, not a display string.
+   */
+  userTextSamples?: readonly string[];
+
+  /** Cowork-only: host folders mounted into the VM workspace. */
+  userSelectedFolders?: readonly string[];
+
+  /** Cowork-only: skill/command IDs available to the session. Source-name match. */
+  slashCommands?: readonly string[];
+
+  /** Cowork-only: MCP tools enabled at session start. Source-name + shape match. */
+  enabledMcpTools?: Readonly<Record<string, boolean>>;
+
+  /**
+   * Cowork-only: human-readable error message from the source manifest's
+   * `error` field. Complements `transcriptStatus` (categorical) with the
+   * verbose form. Renamed to `errorMessage` to avoid name-collision risk
+   * with any consumer's idiomatic `entry.error` slot.
+   */
+  errorMessage?: string;
+
+  /**
+   * Subagent rollup, populated by `aggregateSubagents` for Cowork and host
+   * CLI sources. Absent when the session had no subagent fan-out.
+   * `tokenTotals`/`topTools`/`modelsUsed` on the entry are merged values
+   * (parent + subagents); this field keeps the subagent-only breakdown
+   * inspectable.
+   */
+  subagentRollup?: {
+    count: number;
+    totalTokens: TokenTotals;
+    modelsUsed: readonly string[];
+    topTools: Readonly<Record<string, number>>;
+  };
 }
 
 export interface SessionManifest {

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -79,6 +79,10 @@ export interface UnifiedSessionEntry {
    *
    * Populating this in the manifest avoids forcing the viewer to eager-fetch
    * per-session chunks for card previews (~11 MB saved at 1033 sessions).
+   *
+   * For analysis-grade input (e.g. discoverNarratives clustering),
+   * `userTextSamples` carries longer multi-turn excerpts in addition to
+   * this 200-char preview.
    */
   preview: string | null;
 
@@ -297,9 +301,10 @@ export interface UnifiedSessionEntry {
    *   - 'ok'      — transcript was copied (transcriptPath present).
    *   - 'crashed' — upstream session metadata was incomplete (e.g.
    *                 Cowork CLI handoff failed: no `cliSessionId`, often
-   *                 with an `error` field set on the source manifest).
-   *                 User-side prompts may still exist in audit.jsonl —
-   *                 future recovery work can mine those.
+   *                 with an `error` field set on the source manifest —
+   *                 mirrored on the entry as `errorMessage` in verbose
+   *                 form). User-side prompts may still exist in
+   *                 audit.jsonl — future recovery work can mine those.
    *   - 'missing' — pointers were complete but the transcript file
    *                 wasn't on disk at scan time (deleted, aborted, or
    *                 cleaned up by the upstream tool between session end


### PR DESCRIPTION
Stacked on #37. Adds two new scan-coverage sources after we discovered local data the original scan was missing.

## Summary
- **`sessions-index.json` ingestion** — Anthropic's CLI keeps a per-project index file that survives transcript auto-pruning. The walker now reads it and reconstructs `UnifiedSessionEntry`s for pruned sessions (`firstPrompt` → `userTextSamples`, `messageCount` → `userTurns`, `gitBranch` / `projectPath` retained). New `transcriptStatus: 'pruned'` distinguishes them from `'ok'` / `'missing'` / `'crashed'`.
- **WSL CLI scanning (Windows host)** — discovers WSL distros via `wsl --list --quiet`, skips system distros (`docker-desktop`, `docker-desktop-data`), and walks `\wsl.localhost\<distro>\home\<user>\.claude\projects\` for every user via UNC. No subprocess-per-file: Windows node reads UNC paths directly.
- **`runCliExport.additionalProjectsRoots`** — the option WSL discovery feeds; available to future macOS / Linux native scans too.

## Measured impact (local rescan)
| | Before this PR | After |
|---|---|---|
| cli-direct entries | 144 | **232** (+88: 86 pruned, +2 from WSL/host edges) |
| Date floor | 2026-04-12 | **2026-01-06** |
| Range span | 33 days | **129 days** |
| transcriptStatus distribution | n/a | ok=272, missing=87, crashed=14, **pruned=86** |

## Test plan
- [x] `pnpm lint` / `pnpm test` / `pnpm build` green (854 tests pass, 4 skipped — same skip set as baseline).
- [x] 8 new tests for `sessions-index.json` walker (missing file, malformed JSON, transcript-still-on-disk skip, bad-dates skip, fallback title path, multi-project aggregation).
- [x] 1 sanity test for WSL discovery (returns array, valid UNC shape).
- [x] Local rescan: 86 pruned entries recovered (2026-01-06 → 2026-02-05); 1 WSL session captured (`/mnt/c/Users/Bryce/Projects/brycewatson.com`).
- [x] Sample pruned entry: `2026-02-05 · 5 turns · "You are working in ShopSmith_v2. Goal - Fix the Deliverables…"` — proves firstPrompt → title cascade works.

## Cache impact
- `EXPORTER_VERSION` bumped 0.9.0 → 0.10.0 to trigger the per-source cache-bust shipped in #37. First rescan post-merge rebuilds all entries with the v0.10 shape (no stale legacy entries floating around).

## Out of scope (worth follow-up issues if you want them filed)
- **Cowork sessions-index equivalent** — Cowork manifests carry their own metadata, so the same fix would apply differently. Not needed today since Cowork retention is longer than CLI retention.
- **Cross-machine merge** — your earlier WSL CLI history from 2025 (~700 of 761 startups) is genuinely lost from disk. No code can recover what Anthropic deleted.
- **`~/.claude.json` `projects[*]` mining** — that field has `lastSessionId` + last-session token totals per project but no historical sessions. Marginal value, not worth a walker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)