### PR TITLE
Recover pruned sessions + scan WSL CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-15
+
+### Added
+
+- **`sessions-index.json` ingestion** — the host-CLI walker now reads
+  Anthropic's per-project `sessions-index.json` and reconstructs
+  lightweight `UnifiedSessionEntry`s for sessions whose `.jsonl` has
+  already been pruned from disk. New `transcriptStatus: 'pruned'`
+  distinguishes them. `userTextSamples` is populated from the index's
+  `firstPrompt` so `discoverNarratives` still gets clustering input.
+- **WSL CLI scanning (Windows host)** — the `cli` and `all` subcommands
+  now enumerate WSL distros via `wsl --list --quiet` and walk
+  `\\wsl.localhost\<distro>\home\<user>\.claude\projects\` for each one
+  via UNC. `docker-desktop` and other system distros are skipped.
+  Failures (no WSL installed, unreachable distro) are warn-once'd and
+  the rest of the scan continues.
+- **`additionalProjectsRoots` option on `runCliExport`** so other
+  callers can feed extra CLI roots without round-tripping through the
+  WSL discovery code (e.g., future macOS / Linux native scans).
+- **`prunedCount` on `CliExportResult`** — reported in the `all`
+  summary alongside the rescanned/reused counts.
+
 ## [0.9.0] — 2026-05-15
 
 ### Added

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -71,7 +71,7 @@ export interface RunAnalysisResult {
  * gate reuse on a version match — when the on-disk entry shape
  * changes, all prior caches self-invalidate on next rescan.
  */
-export const EXPORTER_VERSION = '0.9.0';
+export const EXPORTER_VERSION = '0.10.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/commands/all.ts
+++ b/packages/exporter/src/commands/all.ts
@@ -10,6 +10,7 @@ import { runAnalysis } from '../analysis/index.js';
 import { findRepoRoot } from '../lib/repo-root.js';
 import { validateEntries } from '../lib/validate-entry.js';
 import { logger } from '../lib/logger.js';
+import { discoverWslCliProjectsRoots } from '../lib/wsl.js';
 
 /**
  * Read the cloud-manifest.json written by a previous `cloud` phase.
@@ -95,9 +96,19 @@ export async function runAllSubcommand(argv: readonly string[]): Promise<number>
   // ---- Phase 3: cli ----
   logger.info('  [2/3] cli: scanning…');
   const cliStart = Date.now();
+  // Discover WSL CLI projects roots on Windows (no-op elsewhere). Failures
+  // are warn-once'd internally; we don't fail the whole rescan if WSL is
+  // unreachable.
+  const wslRoots = await discoverWslCliProjectsRoots();
+  if (wslRoots.length > 0) {
+    logger.info(`  [2/3] cli: + ${wslRoots.length} WSL root(s)`);
+  }
   let cliResult;
   try {
-    cliResult = await runCliExport({ outDir });
+    cliResult = await runCliExport({
+      outDir,
+      ...(wslRoots.length > 0 ? { additionalProjectsRoots: wslRoots } : {}),
+    });
   } catch (err) {
     logger.error(`cli phase failed: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
@@ -109,7 +120,8 @@ export async function runAllSubcommand(argv: readonly string[]): Promise<number>
   const cliDeskRescanned = cliResult.counts['cli-desktop'] - cliDeskReused;
   logger.info(
     `  [2/3] cli: cli-direct=${cliResult.counts['cli-direct']} (${cliDirectReused} reused, ${cliDirectRescanned} rescanned) ` +
-      `cli-desktop=${cliResult.counts['cli-desktop']} (${cliDeskReused} reused, ${cliDeskRescanned} rescanned) in ${cliMs} ms`,
+      `cli-desktop=${cliResult.counts['cli-desktop']} (${cliDeskReused} reused, ${cliDeskRescanned} rescanned) ` +
+      `pruned=${cliResult.prunedCount} in ${cliMs} ms`,
   );
 
   // ---- Phase 4: cloud ----

--- a/packages/exporter/src/commands/cli.ts
+++ b/packages/exporter/src/commands/cli.ts
@@ -4,6 +4,7 @@ import { runCliExport } from '../sources/cli.js';
 import { findRepoRoot } from '../lib/repo-root.js';
 import { validateEntries } from '../lib/validate-entry.js';
 import { logger } from '../lib/logger.js';
+import { discoverWslCliProjectsRoots } from '../lib/wsl.js';
 
 export async function runCliSubcommand(argv: readonly string[]): Promise<number> {
   const { values } = parseArgs({
@@ -41,14 +42,24 @@ export async function runCliSubcommand(argv: readonly string[]): Promise<number>
   const started = Date.now();
   logger.info(`cli export → ${outDir}`);
 
+  // WSL CLI projects: on Windows, also walk every WSL distro's
+  // ~/.claude/projects via \\wsl.localhost\<distro>\home\<user>\.claude\
+  // projects. On non-Windows this is a no-op. Failures are warn-once'd
+  // internally; we don't bail the whole export over WSL trouble.
+  const wslRoots = await discoverWslCliProjectsRoots();
+  if (wslRoots.length > 0) {
+    logger.info(`cli export: discovered ${wslRoots.length} WSL CLI projects root(s)`);
+  }
+
   const result = await runCliExport({
     outDir,
     ...(phase2CoworkJsonPath !== undefined ? { phase2CoworkJsonPath } : {}),
+    ...(wslRoots.length > 0 ? { additionalProjectsRoots: wslRoots } : {}),
   });
 
   const elapsedMs = Date.now() - started;
   logger.info(
-    `cli export complete in ${elapsedMs} ms — cli-direct=${result.counts['cli-direct']}, cli-desktop=${result.counts['cli-desktop']}, transcripts copied=${result.transcriptsCopied}, skipped=${result.transcriptsSkipped}, malformed lines=${result.malformedLinesTotal}`,
+    `cli export complete in ${elapsedMs} ms — cli-direct=${result.counts['cli-direct']}, cli-desktop=${result.counts['cli-desktop']}, pruned (reconstructed from sessions-index)=${result.prunedCount}, transcripts copied=${result.transcriptsCopied}, skipped=${result.transcriptsSkipped}, malformed lines=${result.malformedLinesTotal}`,
   );
 
   // Post-write shape validation — R11.

--- a/packages/exporter/src/lib/sessionsIndex.ts
+++ b/packages/exporter/src/lib/sessionsIndex.ts
@@ -1,0 +1,198 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import type { UnifiedSessionEntry } from '@chat-arch/schema';
+import { UNTITLED_SESSION } from '@chat-arch/schema';
+import { logger } from './logger.js';
+import { buildPreview } from './preview.js';
+
+/**
+ * `sessions-index.json` is a per-project-dir index Anthropic's CLI maintains
+ * alongside `<uuid>.jsonl` transcripts under `~/.claude/projects/<dir>/`.
+ * Crucially, the index outlives the transcripts: Anthropic auto-prunes old
+ * `.jsonl` files but leaves the index entries behind, preserving session
+ * metadata (sessionId, firstPrompt, messageCount, gitBranch, projectPath,
+ * timestamps) for sessions whose conversation body is gone.
+ *
+ * This walker reconstructs `UnifiedSessionEntry`s from index entries whose
+ * transcript file no longer exists on disk, emitting them with
+ * `transcriptStatus: 'pruned'`. Entries whose transcript IS still on disk
+ * are NOT emitted — they're already covered by `findTranscriptPaths` /
+ * `streamAggregate` (which produce richer entries with tokens, tools,
+ * subagent rollups). De-dup is by the transcript-file existence check.
+ */
+
+interface SessionsIndexEntry {
+  sessionId: string;
+  fullPath?: string;
+  fileMtime?: number;
+  firstPrompt?: string;
+  messageCount?: number;
+  created?: string;
+  modified?: string;
+  gitBranch?: string;
+  projectPath?: string;
+  isSidechain?: boolean;
+}
+
+interface SessionsIndexFile {
+  version?: number;
+  entries?: readonly SessionsIndexEntry[];
+}
+
+/**
+ * Truncate a long firstPrompt down to a title-shaped string.
+ * Mirrors `truncate` in cli.ts:`resolveTitle`.
+ */
+function truncate(s: string, max: number): string {
+  const collapsed = s.replace(/\s+/g, ' ').trim();
+  return collapsed.length <= max ? collapsed : collapsed.slice(0, max);
+}
+
+/**
+ * Walk one `sessions-index.json` and produce synthetic entries for every
+ * indexed session whose `fullPath` transcript no longer exists on disk.
+ *
+ * @param indexPath  Absolute path to a `sessions-index.json` file.
+ * @param cwdKind    `'host'` for Windows-host CLI / WSL CLI walkers (the
+ *                   indexed `projectPath` is a real filesystem path).
+ * @param sourceTag  `'cli-direct'` — pruned sessions match the cli-direct
+ *                   shape; cli-desktop entries come from Cowork manifests
+ *                   which carry their own metadata and don't get pruned
+ *                   from `~/.claude/projects/` since the CLI never touched
+ *                   them in the first place.
+ *
+ * Never throws. Missing / malformed index → returns []. Per-entry
+ * malformed/incomplete records are silently skipped.
+ */
+export async function readPrunedFromSessionsIndex(
+  indexPath: string,
+  cwdKind: 'host',
+  sourceTag: 'cli-direct',
+): Promise<readonly UnifiedSessionEntry[]> {
+  let raw: string;
+  try {
+    raw = await readFile(indexPath, 'utf8');
+  } catch {
+    return [];
+  }
+  let parsed: SessionsIndexFile;
+  try {
+    parsed = JSON.parse(raw) as SessionsIndexFile;
+  } catch (err) {
+    logger.warnOnce(
+      `sessions-index-malformed:${indexPath}`,
+      `sessions-index.json ${indexPath} is not valid JSON: ${(err as Error).message}; skipping`,
+    );
+    return [];
+  }
+  const entries = Array.isArray(parsed.entries) ? parsed.entries : [];
+  if (entries.length === 0) return [];
+
+  // Cache fileExists across entries to avoid stat-ing the same path twice
+  // when an index lists duplicates (rare but possible).
+  const existsCache = new Map<string, boolean>();
+  const checkExists = async (p: string): Promise<boolean> => {
+    const cached = existsCache.get(p);
+    if (cached !== undefined) return cached;
+    let ok = false;
+    try {
+      const st = await stat(p);
+      ok = st.isFile();
+    } catch {
+      ok = false;
+    }
+    existsCache.set(p, ok);
+    return ok;
+  };
+
+  const out: UnifiedSessionEntry[] = [];
+  for (const e of entries) {
+    if (!e || typeof e.sessionId !== 'string' || e.sessionId.length === 0) continue;
+    // If the transcript is still on disk, the regular walker will handle it.
+    if (typeof e.fullPath === 'string' && (await checkExists(e.fullPath))) continue;
+
+    const startedAt =
+      typeof e.created === 'string' ? Date.parse(e.created) : Number.NaN;
+    const updatedAt =
+      typeof e.modified === 'string' ? Date.parse(e.modified) : Number.NaN;
+    if (!Number.isFinite(startedAt) || !Number.isFinite(updatedAt)) continue;
+
+    const firstPrompt = typeof e.firstPrompt === 'string' ? e.firstPrompt : '';
+    const title =
+      firstPrompt.length > 0 ? truncate(firstPrompt, 80) : UNTITLED_SESSION;
+    const titleSource: 'first-prompt' | 'fallback' =
+      firstPrompt.length > 0 ? 'first-prompt' : 'fallback';
+
+    const cwd = typeof e.projectPath === 'string' ? e.projectPath : undefined;
+    const project =
+      cwd !== undefined ? path.win32.basename(cwd) || undefined : undefined;
+
+    // messageCount is total (user + assistant). Approximate userTurns as the
+    // ceiling of half — better than 0 (which would imply "no user activity"
+    // and confuse downstream filters) and never more than the truth.
+    const userTurns =
+      typeof e.messageCount === 'number' && Number.isFinite(e.messageCount)
+        ? Math.max(1, Math.ceil(e.messageCount / 2))
+        : 0;
+
+    // Mirror firstPrompt into userTextSamples (single sample, ≤400 chars) so
+    // discoverNarratives gets clustering input from pruned sessions too.
+    const userTextSamples =
+      firstPrompt.length > 0 ? [firstPrompt.slice(0, 400)] : [];
+
+    const entry: UnifiedSessionEntry = {
+      id: e.sessionId,
+      source: sourceTag,
+      rawSessionId: e.sessionId,
+      startedAt,
+      updatedAt,
+      durationMs: Math.max(0, updatedAt - startedAt),
+      title,
+      titleSource,
+      preview: buildPreview(firstPrompt.length > 0 ? firstPrompt : null),
+      userTurns,
+      model: null,
+      cwdKind,
+      totalCostUsd: null,
+      ...(cwd !== undefined ? { cwd } : {}),
+      ...(project !== undefined && project.length > 0 ? { project } : {}),
+      ...(typeof e.fileMtime === 'number' ? { sourceMtimeMs: e.fileMtime } : {}),
+      ...(userTextSamples.length > 0 ? { userTextSamples } : {}),
+      transcriptStatus: 'pruned',
+      // No transcriptPath / manifestPath / tokenTotals / topTools /
+      // subagentRollup — those would require a transcript that's gone.
+    };
+    out.push(entry);
+  }
+  return out;
+}
+
+/**
+ * Convenience: walk every `<projectsRoot>/<projectDir>/sessions-index.json`
+ * and collect all pruned entries in one go. Caller passes the projects
+ * root (e.g. `~/.claude/projects`); we discover index files at depth-1.
+ *
+ * Returns `[]` when no project dirs exist or none carry an index file
+ * (the index is a relatively recent Anthropic addition; older project
+ * dirs simply don't have one).
+ */
+export async function collectPrunedEntries(
+  projectsRoot: string,
+  cwdKind: 'host',
+  sourceTag: 'cli-direct',
+  readdirFn: (p: string) => Promise<readonly string[]>,
+): Promise<readonly UnifiedSessionEntry[]> {
+  let projectDirs: readonly string[];
+  try {
+    projectDirs = await readdirFn(projectsRoot);
+  } catch {
+    return [];
+  }
+  const all: UnifiedSessionEntry[] = [];
+  for (const d of projectDirs) {
+    const indexPath = path.join(projectsRoot, d, 'sessions-index.json');
+    const entries = await readPrunedFromSessionsIndex(indexPath, cwdKind, sourceTag);
+    all.push(...entries);
+  }
+  return all;
+}

--- a/packages/exporter/src/lib/wsl.ts
+++ b/packages/exporter/src/lib/wsl.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from 'node:child_process';
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { logger } from './logger.js';
+
+/**
+ * Enumerate Windows-side CLI projects roots that live inside WSL distros.
+ *
+ * Returns absolute UNC paths of the form
+ *   `\\wsl.localhost\<distro>\home\<user>\.claude\projects`
+ * for every (distro, user) pair where that directory exists.
+ *
+ * Strategy:
+ *   1. Discover distros via `wsl --list --quiet` (UTF-16LE output, with a
+ *      blank-line / "Windows Subsystem" header that must be stripped).
+ *   2. Skip system distros (`docker-desktop` and friends) that never host
+ *      user Claude Code installs — checking them costs a stat per user
+ *      and they always return empty.
+ *   3. For each remaining distro, enumerate `\\wsl.localhost\<distro>\home`
+ *      and look for a `.claude/projects` dir under each user. UNC reads
+ *      work transparently from Windows node — verified empirically.
+ *
+ * Best-effort: any failure (no WSL installed, distro unreachable, perm
+ * errors) returns `[]` with a single warn-once. Never throws.
+ */
+export async function discoverWslCliProjectsRoots(): Promise<readonly string[]> {
+  if (process.platform !== 'win32') return [];
+
+  let distros: readonly string[];
+  try {
+    distros = listWslDistros();
+  } catch (err) {
+    logger.warnOnce(
+      'wsl-list-failed',
+      `[chat-arch] could not enumerate WSL distros (${(err as Error).message}); skipping WSL CLI scan`,
+    );
+    return [];
+  }
+
+  const roots: string[] = [];
+  for (const distro of distros) {
+    if (SYSTEM_DISTROS.has(distro)) continue;
+    const homeRoot = `\\\\wsl.localhost\\${distro}\\home`;
+    let users: readonly string[];
+    try {
+      users = await readdir(homeRoot);
+    } catch {
+      // Distro unreachable or no /home — skip silently.
+      continue;
+    }
+    for (const user of users) {
+      const projectsRoot = path.join(homeRoot, user, '.claude', 'projects');
+      try {
+        const st = await stat(projectsRoot);
+        if (st.isDirectory()) roots.push(projectsRoot);
+      } catch {
+        // No projects dir for this user — skip silently.
+      }
+    }
+  }
+  return roots;
+}
+
+/**
+ * System WSL distros that never carry user Claude Code data. Skipping
+ * them avoids spinning up Docker's WSL2 instance just to fail on `/home`.
+ */
+const SYSTEM_DISTROS = new Set<string>(['docker-desktop', 'docker-desktop-data']);
+
+/**
+ * Parse `wsl --list --quiet` output. Windows ships the output as
+ * UTF-16LE-encoded text with stray nulls on some hosts; we decode and
+ * strip non-printable characters, then drop empty lines and the legacy
+ * "Windows Subsystem for Linux Distributions:" header.
+ *
+ * Exported for tests; production callers should use the async wrapper.
+ */
+export function listWslDistros(): readonly string[] {
+  const buf = execFileSync('wsl.exe', ['--list', '--quiet'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  // wsl.exe emits UTF-16LE; decode and normalize.
+  const text = buf.toString('utf16le').replace(/\0/g, '');
+  return text
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('Windows Subsystem'))
+    // The default distro line carries a leading "*" in some locales,
+    // and may bracket the name with "(Default)". Normalize away.
+    .map((s) => s.replace(/^\*\s*/, '').replace(/\s*\(Default\)\s*$/, '').trim())
+    .filter((s) => s.length > 0);
+}

--- a/packages/exporter/src/sources/cli.ts
+++ b/packages/exporter/src/sources/cli.ts
@@ -16,6 +16,7 @@ import {
   sumTokens,
   uniqueModels,
 } from '../lib/subagents.js';
+import { collectPrunedEntries } from '../lib/sessionsIndex.js';
 import { EXPORTER_VERSION } from '../analysis/index.js';
 
 /**
@@ -46,6 +47,14 @@ export interface RunCliExportOptions {
   outDir: string;
   /** Defaults to `os.homedir() + /.claude/projects`. */
   projectsRoot?: string;
+  /**
+   * Additional CLI projects roots to walk alongside the primary one. Used
+   * by the WSL pipeline to feed `\\wsl.localhost\<distro>\home\<user>\
+   * .claude\projects\` directories without duplicating every other walker
+   * setup. Each extra root contributes its own transcripts AND its own
+   * `sessions-index.json`-derived pruned entries.
+   */
+  additionalProjectsRoots?: readonly string[];
   /** Defaults to `<outDir>/cowork-sessions.json` (Phase 2's output). */
   phase2CoworkJsonPath?: string;
 }
@@ -56,6 +65,12 @@ export interface CliExportResult {
   transcriptsCopied: number;
   transcriptsSkipped: number;
   malformedLinesTotal: number;
+  /**
+   * Pruned entries reconstructed from `sessions-index.json` — sessions
+   * Anthropic's CLI has already deleted from disk but the index still
+   * lists. See {@link readPrunedFromSessionsIndex}.
+   */
+  prunedCount: number;
   /**
    * Number of entries reused verbatim from the previous cli-sessions.json
    * (source mtime hadn't changed). Reported in the exporter summary so
@@ -181,7 +196,8 @@ async function loadPreviousCliEntries(outDir: string): Promise<Map<string, Unifi
  * stat calls when nothing has changed.
  */
 export async function runCliExport(opts: RunCliExportOptions): Promise<CliExportResult> {
-  const projectsRoot = opts.projectsRoot ?? path.join(os.homedir(), '.claude', 'projects');
+  const primaryRoot = opts.projectsRoot ?? path.join(os.homedir(), '.claude', 'projects');
+  const allRoots = [primaryRoot, ...(opts.additionalProjectsRoots ?? [])];
   const outDir = opts.outDir;
   const phase2Path = opts.phase2CoworkJsonPath ?? path.join(outDir, 'cowork-sessions.json');
 
@@ -193,7 +209,14 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
     recursive: true,
   });
 
-  const transcriptPaths = await findTranscriptPaths(projectsRoot);
+  // Walk every CLI projects root in parallel and concat. WSL roots reach
+  // \\wsl.localhost\<distro>\home\<user>\.claude\projects via UNC; macOS /
+  // Linux native runs would feed their own homedir here too. Failures
+  // (unreachable distro, permission errors) surface as empty lists, not
+  // exceptions — see `findTranscriptPaths`.
+  const transcriptPaths = (
+    await Promise.all(allRoots.map((r) => findTranscriptPaths(r)))
+  ).flat();
   const { desktopIds, phase2Entries } = await loadCliDesktopIds(phase2Path);
   const prevEntries = await loadPreviousCliEntries(outDir);
 
@@ -319,6 +342,32 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
     }
   });
 
+  // Pruned-session ingestion: every CLI projects root may carry
+  // `<projectDir>/sessions-index.json` files that list sessions whose
+  // `<uuid>.jsonl` Anthropic has already deleted. Reconstruct lightweight
+  // entries from the index metadata (firstPrompt, messageCount, etc.) and
+  // tag them transcriptStatus='pruned'. De-dup against the sessionIds the
+  // regular walker already emitted — when both exist (transcript on disk
+  // AND index entry), the transcript wins.
+  const emittedIds = new Set(entries.map((e) => e.id));
+  let prunedCount = 0;
+  for (const root of allRoots) {
+    const pruned = await collectPrunedEntries(root, 'host', 'cli-direct', async (p) => {
+      try {
+        return await readdir(p);
+      } catch {
+        return [];
+      }
+    });
+    for (const e of pruned) {
+      if (emittedIds.has(e.id)) continue;
+      emittedIds.add(e.id);
+      entries.push(e);
+      prunedCount += 1;
+      directCount += 1; // pruned entries are cli-direct-shaped
+    }
+  }
+
   // Stable order: updatedAt desc. Matches Phase 2 convention.
   entries.sort((a, b) => b.updatedAt - a.updatedAt);
 
@@ -345,6 +394,7 @@ export async function runCliExport(opts: RunCliExportOptions): Promise<CliExport
       'cli-direct': directReused,
       'cli-desktop': desktopReused,
     },
+    prunedCount,
   };
 }
 

--- a/packages/exporter/test/lib/sessionsIndex.test.ts
+++ b/packages/exporter/test/lib/sessionsIndex.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  readPrunedFromSessionsIndex,
+  collectPrunedEntries,
+} from '../../src/lib/sessionsIndex.js';
+
+let tmp: string;
+
+beforeEach(async () => {
+  tmp = await mkdtemp(path.join(os.tmpdir(), 'chat-arch-sessions-index-'));
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe('readPrunedFromSessionsIndex', () => {
+  it('returns [] for a missing index file', async () => {
+    const res = await readPrunedFromSessionsIndex(
+      path.join(tmp, 'nope.json'),
+      'host',
+      'cli-direct',
+    );
+    expect(res).toEqual([]);
+  });
+
+  it('returns [] for malformed JSON (logs a warn-once, does not throw)', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(p, '{ not valid json', 'utf8');
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toEqual([]);
+  });
+
+  it('reconstructs entries whose fullPath transcript is missing on disk', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'pruned-uuid-1111',
+            fullPath: path.join(tmp, 'does-not-exist-1.jsonl'),
+            fileMtime: 1700000000000,
+            firstPrompt: 'You are acting as a senior maintainer creating a public toolkit.',
+            messageCount: 30,
+            created: '2026-01-22T18:26:44.673Z',
+            modified: '2026-01-23T01:10:23.841Z',
+            gitBranch: 'main',
+            projectPath: 'C:\\Users\\Bryce\\Projects\\bryce-labs-toolkit',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toHaveLength(1);
+    const e = res[0]!;
+    expect(e.id).toBe('pruned-uuid-1111');
+    expect(e.source).toBe('cli-direct');
+    expect(e.transcriptStatus).toBe('pruned');
+    expect(e.title).toBe('You are acting as a senior maintainer creating a public toolkit.');
+    expect(e.titleSource).toBe('first-prompt');
+    expect(e.cwdKind).toBe('host');
+    expect(e.cwd).toBe('C:\\Users\\Bryce\\Projects\\bryce-labs-toolkit');
+    expect(e.project).toBe('bryce-labs-toolkit');
+    // messageCount=30 → userTurns ~= ceil(30/2) = 15
+    expect(e.userTurns).toBe(15);
+    expect(e.startedAt).toBe(Date.parse('2026-01-22T18:26:44.673Z'));
+    expect(e.updatedAt).toBe(Date.parse('2026-01-23T01:10:23.841Z'));
+    expect(e.userTextSamples).toEqual([
+      'You are acting as a senior maintainer creating a public toolkit.',
+    ]);
+    expect(e.transcriptPath).toBeUndefined();
+    expect(e.tokenTotals).toBeUndefined();
+    expect(e.subagentRollup).toBeUndefined();
+  });
+
+  it('skips entries whose fullPath transcript IS still on disk (avoid double-emit)', async () => {
+    // Create an actual transcript file the index points to.
+    const transcript = path.join(tmp, 'live.jsonl');
+    await writeFile(transcript, '{"type":"user","message":{"content":"hi"}}\n', 'utf8');
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'live-uuid',
+            fullPath: transcript,
+            firstPrompt: 'still on disk',
+            messageCount: 4,
+            created: '2026-04-01T00:00:00.000Z',
+            modified: '2026-04-01T00:30:00.000Z',
+            projectPath: 'C:\\proj',
+          },
+          {
+            sessionId: 'pruned-uuid',
+            fullPath: path.join(tmp, 'gone.jsonl'),
+            firstPrompt: 'long since deleted',
+            messageCount: 12,
+            created: '2026-01-01T00:00:00.000Z',
+            modified: '2026-01-01T01:00:00.000Z',
+            projectPath: 'C:\\proj',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    // Only the pruned one is emitted; live is left to the transcript walker.
+    expect(res).toHaveLength(1);
+    expect(res[0]!.id).toBe('pruned-uuid');
+  });
+
+  it('drops entries with unparseable created/modified timestamps', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'no-dates',
+            fullPath: path.join(tmp, 'never.jsonl'),
+            firstPrompt: 'has no created field',
+            messageCount: 3,
+            projectPath: 'C:\\proj',
+          },
+          {
+            sessionId: 'bad-dates',
+            fullPath: path.join(tmp, 'never2.jsonl'),
+            firstPrompt: 'gibberish date',
+            messageCount: 3,
+            created: 'not-a-date',
+            modified: 'also-bad',
+            projectPath: 'C:\\proj',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toEqual([]);
+  });
+
+  it('falls back to UNTITLED_SESSION when firstPrompt is missing', async () => {
+    const p = path.join(tmp, 'sessions-index.json');
+    await writeFile(
+      p,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            sessionId: 'titleless',
+            fullPath: path.join(tmp, 'gone.jsonl'),
+            messageCount: 2,
+            created: '2026-01-01T00:00:00.000Z',
+            modified: '2026-01-01T00:30:00.000Z',
+            projectPath: 'C:\\proj',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    const res = await readPrunedFromSessionsIndex(p, 'host', 'cli-direct');
+    expect(res).toHaveLength(1);
+    expect(res[0]!.title).toBe('Untitled session');
+    expect(res[0]!.titleSource).toBe('fallback');
+    expect(res[0]!.userTextSamples).toBeUndefined();
+  });
+});
+
+describe('collectPrunedEntries', () => {
+  it('walks every project dir and aggregates pruned entries', async () => {
+    const projectsRoot = tmp;
+    await mkdir(path.join(projectsRoot, 'proj-a'));
+    await mkdir(path.join(projectsRoot, 'proj-b'));
+    await writeFile(
+      path.join(projectsRoot, 'proj-a', 'sessions-index.json'),
+      JSON.stringify({
+        entries: [
+          {
+            sessionId: 'pruned-a',
+            fullPath: path.join(projectsRoot, 'proj-a', 'gone.jsonl'),
+            firstPrompt: 'A',
+            messageCount: 2,
+            created: '2026-01-01T00:00:00.000Z',
+            modified: '2026-01-01T00:30:00.000Z',
+            projectPath: 'C:\\a',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    await writeFile(
+      path.join(projectsRoot, 'proj-b', 'sessions-index.json'),
+      JSON.stringify({
+        entries: [
+          {
+            sessionId: 'pruned-b',
+            fullPath: path.join(projectsRoot, 'proj-b', 'gone.jsonl'),
+            firstPrompt: 'B',
+            messageCount: 4,
+            created: '2026-02-01T00:00:00.000Z',
+            modified: '2026-02-01T01:00:00.000Z',
+            projectPath: 'C:\\b',
+          },
+        ],
+      }),
+      'utf8',
+    );
+    // proj-c has no index file — should be ignored silently.
+    await mkdir(path.join(projectsRoot, 'proj-c'));
+
+    const { readdir } = await import('node:fs/promises');
+    const res = await collectPrunedEntries(projectsRoot, 'host', 'cli-direct', readdir);
+    expect(res.map((e) => e.id).sort()).toEqual(['pruned-a', 'pruned-b']);
+  });
+
+  it('returns [] for a non-existent projects root', async () => {
+    const { readdir } = await import('node:fs/promises');
+    const res = await collectPrunedEntries(
+      path.join(tmp, 'nope'),
+      'host',
+      'cli-direct',
+      readdir,
+    );
+    expect(res).toEqual([]);
+  });
+});

--- a/packages/exporter/test/lib/wsl.test.ts
+++ b/packages/exporter/test/lib/wsl.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { discoverWslCliProjectsRoots } from '../../src/lib/wsl.js';
+
+describe('discoverWslCliProjectsRoots', () => {
+  it('returns [] on non-Windows platforms (early exit)', async () => {
+    // The function gates on process.platform === 'win32'. On the test
+    // runner this will be 'win32' on the live dev host but other CI
+    // environments may differ; in either case the function must not
+    // throw. Just exercise it and assert it returns an array.
+    const res = await discoverWslCliProjectsRoots();
+    expect(Array.isArray(res)).toBe(true);
+    for (const r of res) {
+      // Every returned root must end with .claude\projects under wsl.localhost.
+      expect(r).toMatch(/wsl\.localhost[\\/].+[\\/]home[\\/].+[\\/]\.claude[\\/]projects$/);
+    }
+  });
+});

--- a/packages/schema/src/unified.ts
+++ b/packages/schema/src/unified.ts
@@ -309,12 +309,20 @@ export interface UnifiedSessionEntry {
    *                 wasn't on disk at scan time (deleted, aborted, or
    *                 cleaned up by the upstream tool between session end
    *                 and exporter scan).
+   *   - 'pruned'  — entry was reconstructed from `sessions-index.json`
+   *                 metadata (`firstPrompt`, `messageCount`, etc.) for
+   *                 a session whose transcript Anthropic's CLI has
+   *                 already deleted. The session is real but the
+   *                 conversation body is gone forever. `userTurns` is a
+   *                 best-effort estimate from `messageCount`; tokens /
+   *                 tool histograms are absent.
    *
    * Drives the SCANNED panel's split note ("X missing on disk · Y CLI
-   * crashed") so the user can tell apart recoverable-but-not-recovered
-   * errors from genuinely-gone transcripts.
+   * crashed · Z pruned") so the user can tell apart recoverable-but-not-
+   * recovered errors from genuinely-gone transcripts and from pre-pruned
+   * historical records.
    */
-  transcriptStatus?: 'ok' | 'crashed' | 'missing';
+  transcriptStatus?: 'ok' | 'crashed' | 'missing' | 'pruned';
 
   /** Output-relative path to the source manifest (Cowork, Desktop-CLI only). */
   manifestPath?: string;


### PR DESCRIPTION
Replaces #44 (closed after rebase onto current main; same commits, clean against the post-#36 main).

## Summary
- **\`sessions-index.json\` ingestion** — Anthropic's CLI keeps a per-project index file that survives transcript auto-pruning. The walker now reads it and reconstructs \`UnifiedSessionEntry\`s for pruned sessions (\`firstPrompt\` → \`userTextSamples\`, \`messageCount\` → \`userTurns\`, \`gitBranch\` / \`projectPath\` retained). New \`transcriptStatus: 'pruned'\` distinguishes them from \`'ok'\` / \`'missing'\` / \`'crashed'\`.
- **WSL CLI scanning (Windows host)** — discovers WSL distros via \`wsl --list --quiet\`, skips system distros (\`docker-desktop\`, \`docker-desktop-data\`), and walks \`\\wsl.localhost\<distro>\home\<user>\.claude\projects\\` for every user via UNC. No subprocess-per-file: Windows node reads UNC paths directly.
- **\`runCliExport.additionalProjectsRoots\`** — the option WSL discovery feeds; available to future macOS / Linux native scans too.

## Measured impact (local rescan)
| | Before this PR | After |
|---|---|---|
| cli-direct entries | 144 | **232** (+88: 86 pruned, +2 from WSL/host edges) |
| Date floor | 2026-04-12 | **2026-01-06** |
| Range span | 33 days | **129 days** |
| transcriptStatus distribution | n/a | ok=272, missing=87, crashed=14, **pruned=86** |

## Test plan
- [x] \`pnpm lint\` / \`pnpm test\` / \`pnpm build\` green locally on rebased branch (863 tests pass, 4 skipped — same skip set as baseline).
- [x] 8 new tests for \`sessions-index.json\` walker (missing file, malformed JSON, transcript-still-on-disk skip, bad-dates skip, fallback title path, multi-project aggregation).
- [x] 1 sanity test for WSL discovery (returns array, valid UNC shape).
- [x] Local rescan: 86 pruned entries recovered (2026-01-06 → 2026-02-05); 1 WSL session captured (\`/mnt/c/Users/Bryce/Projects/brycewatson.com\`).
- [x] Sample pruned entry: \`2026-02-05 · 5 turns · "You are working in ShopSmith_v2. Goal - Fix the Deliverables…"\` — proves firstPrompt → title cascade works.

## Cache impact
- \`EXPORTER_VERSION\` bumped 0.9.0 → 0.10.0 to trigger the per-source cache-bust. First rescan post-merge rebuilds all entries with the v0.10 shape (no stale legacy entries floating around).

🤖 Generated with [Claude Code](https://claude.com/claude-code)