### PR TITLE
Unify v2 page chrome under LCARS / Supergraphic Panel

### DIFF
--- a/apps/standalone/src/components/SectionBar.astro
+++ b/apps/standalone/src/components/SectionBar.astro
@@ -1,0 +1,50 @@
+---
+// LCARS mid-bar section header — a solid 22-26px chrome strip with
+// black Antonio caps label. Mirrors `.lcars-mid-bar` from
+// packages/viewer/src/styles.css (spec §6.6). Used as the section
+// header on the new v2-instrumented-loop pages so that headers read
+// as chrome rather than as plain prose <h2> caps.
+//
+// Props:
+//   label    — the header text (will be tracked-caps Antonio).
+//   tone     — palette role: 'butterscotch' (default), 'ice', 'peach',
+//              'violet', 'sunflower'. Maps to the LCARS named accents.
+//   id       — optional element id for in-page anchors.
+//   as       — the heading tag to render (h2 by default). Kept
+//              semantic — visual chrome doesn't excuse skipping
+//              heading levels.
+interface Props {
+  label: string;
+  tone?: 'butterscotch' | 'ice' | 'peach' | 'violet' | 'sunflower';
+  id?: string;
+  as?: 'h1' | 'h2' | 'h3';
+}
+const { label, tone = 'butterscotch', id, as = 'h2' } = Astro.props;
+const toneVar = `var(--lcars-${tone})`;
+const Tag = as;
+---
+<Tag id={id} class="lcars-mid-bar lcars-mid-bar--section" style={`background: ${toneVar};`}>
+  <span class="lcars-mid-bar__label">{label}</span>
+</Tag>
+<style>
+  /* Page-level mid-bar variant: full width, a touch taller than the
+     viewer's mid-bar (which sits inside a packed sidebar column),
+     and a top margin so it spaces sections. The radius matches the
+     LCARS pill rule (`13px` desktop, `10px` mobile) from the canonical
+     class.
+
+     The component reuses the viewer's `.lcars-mid-bar` class for the
+     base treatment, so dark-mode tokens, height stepping, and label
+     typography come for free. This style block only adds the page-
+     level layout concerns (margins, full width) that the original
+     class doesn't claim. */
+  .lcars-mid-bar.lcars-mid-bar--section {
+    margin: 28px 0 12px;
+    width: 100%;
+  }
+  /* The first mid-bar after the page <h1> gets less top margin —
+     the h1's own bottom margin already provides the separation. */
+  :global(h1) + .lcars-mid-bar.lcars-mid-bar--section {
+    margin-top: 16px;
+  }
+</style>

--- a/apps/standalone/src/components/TodayNav.astro
+++ b/apps/standalone/src/components/TodayNav.astro
@@ -10,7 +10,13 @@
 // peach-on-hover) plus the sidebar item's three-letter abbreviation
 // prefix (`CHT CHAT`, `COR CORRECTIONS`, etc.) so the visual vocabulary
 // is identical regardless of which surface you land on first.
-const { current } = Astro.props as { current: string };
+// `compact` suppresses the dot + "CHAT ARCHAEOLOGIST" title block.
+// On the viewer pages (`/sessions` `/projects` `/topics` `/practice`)
+// the React viewer renders its own `.lcars-top-bar` with the same
+// dot + title, so showing both stacks two identical title pills.
+// Compact mode keeps just the nav pills, sized to read as a
+// secondary cross-surface strip below the viewer's primary top bar.
+const { current, compact = false } = Astro.props as { current: string; compact?: boolean };
 const links: { href: string; short: string; label: string }[] = [
   { href: '/', short: 'TDY', label: 'TODAY' },
   { href: '/audit', short: 'AUD', label: 'AUDIT' },
@@ -19,11 +25,16 @@ const links: { href: string; short: string; label: string }[] = [
   { href: '/sessions', short: 'SES', label: 'SESSIONS' },
   { href: '/projects', short: 'PRJ', label: 'PROJECTS' },
   { href: '/topics', short: 'TOP', label: 'TOPICS' },
+  { href: '/practice', short: 'PRC', label: 'PRACTICE' },
 ];
 ---
-<nav class="today-nav" aria-label="Primary surfaces">
-  <span class="today-nav__dot" aria-hidden="true"></span>
-  <span class="today-nav__title">CHAT&nbsp;ARCHAEOLOGIST</span>
+<nav class={`today-nav ${compact ? 'today-nav--compact' : ''}`} aria-label="Primary surfaces">
+  {!compact ? (
+    <>
+      <span class="today-nav__dot" aria-hidden="true"></span>
+      <span class="today-nav__title">CHAT&nbsp;ARCHAEOLOGIST</span>
+    </>
+  ) : null}
   <ul class="today-nav__links">
     {links.map((l) => (
       <li>
@@ -123,5 +134,25 @@ const links: { href: string; short: string; label: string }[] = [
   @media (max-width: 700px) {
     .today-nav__item-label { display: none; }
     .today-nav__item { padding: 8px 10px; }
+  }
+  /* Compact mode — no dot + title, smaller padding. Sits *below*
+     the viewer's full top-bar on /sessions /projects /topics
+     /practice as a secondary cross-surface strip. Reading order:
+     primary top-bar (viewer) → compact TodayNav (cross-surface
+     pills) → sidebar + content. The strip itself stays on-brand
+     (butterscotch underline + sunflower-muted pills) so it reads as
+     part of the same chrome system. */
+  .today-nav--compact {
+    padding: 6px 12px;
+    gap: 0;
+    border-radius: 0 12px 12px 0;
+    margin: 4px 0 0;
+  }
+  .today-nav--compact .today-nav__links {
+    justify-content: flex-start;
+  }
+  .today-nav--compact .today-nav__item {
+    padding: 6px 12px;
+    font-size: 10px;
   }
 </style>

--- a/apps/standalone/src/pages/audit.astro
+++ b/apps/standalone/src/pages/audit.astro
@@ -1,8 +1,15 @@
 ---
+// LCARS chrome (post-unify): wraps `.lcars-root` and reuses the
+// viewer's tokens/class shapes so the page reads as the same
+// product as `/sessions` `/projects` `/topics`. Status badges remap
+// to the four named LCARS accents (ice / peach / violet) per spec
+// §3 — green/red RGB tints retired.
 export const prerender = false;
 
 import BaseLayout from '../layouts/BaseLayout.astro';
 import TodayNav from '../components/TodayNav.astro';
+import SectionBar from '../components/SectionBar.astro';
+import '@chat-arch/viewer/style.css';
 import { readAuditResults, readAuditSummary } from '../lib/readSidecars.ts';
 
 const results = await readAuditResults();
@@ -91,188 +98,418 @@ const claimTypes = [
 ---
 <BaseLayout title="Chat Archaeologist — Audit">
   <TodayNav current="AUDIT" />
-  <main class="audit">
-    <h1>AUDIT</h1>
-    {results === null ? (
-      <p class="audit__empty">
-        No <code>analysis/audit-results.json</code> on disk. Run
-        <code>pnpm exporter all</code> and reload.
-      </p>
-    ) : (
-      <>
-        <section class="audit__totals">
-          <span><strong>{results.totals.pass}</strong> pass</span>
-          <span><strong>{results.totals.fail}</strong> fail</span>
-          <span><strong>{results.totals.inconclusive}</strong> inconclusive</span>
-          {summary && summary.topFailureClaimTypes.length > 0 ? (
-            <span class="audit__top-fail">
-              top failures: {summary.topFailureClaimTypes
-                .map((t) => `${t.claimType} (${(t.failRate * 100).toFixed(0)}%)`)
-                .join(', ')}
+  <div class="lcars-root audit-root">
+    <main class="audit">
+      <h1>AUDIT</h1>
+      {results === null ? (
+        <p class="audit__empty">
+          No <code>analysis/audit-results.json</code> on disk. Run
+          <code>pnpm exporter all</code> and reload.
+        </p>
+      ) : (
+        <>
+          <section class="audit__totals">
+            <span class="audit__total audit__total--pass">
+              <strong>{results.totals.pass}</strong> pass
             </span>
-          ) : null}
-        </section>
-
-        {concernClusters.length > 0 ? (
-          <section class="audit__concerns">
-            <h2>TOP CONCERNS · {concernClusters.length} clusters</h2>
-            <p class="audit__concerns-hint">
-              Failures grouped by claim type, ranked by count. Each cluster's top sessions are the
-              ones most worth investigating — they accumulated the most fail verdicts of this kind.
-              Use the filter row below to drill into any one cluster.
-            </p>
-            <ul class="audit__concerns-list">
-              {concernClusters.map((c) => (
-                <li>
-                  <div class="audit__concerns-head">
-                    <code class="audit__concerns-type">{c.claimType}</code>
-                    <span class="audit__concerns-count">{c.failCount} fail{c.failCount === 1 ? '' : 's'}</span>
-                    <a class="audit__concerns-drill" href={`?outcome=fail&claimType=${c.claimType}`}>filter below →</a>
-                  </div>
-                  {c.topSessions.length > 0 ? (
-                    <ul class="audit__concerns-sessions">
-                      {c.topSessions.map((s) => (
-                        <li>
-                          <code>[SID:{s.sessionId.slice(0, 8)}…]</code>
-                          <span class="audit__concerns-x">{s.failsInSession}× </span>
-                          <span class="audit__concerns-span">"{s.sampleSpan.slice(0, 60)}"</span>
-                          <span class="audit__concerns-reason">— {s.sampleReason.slice(0, 80)}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
+            <span class="audit__total audit__total--fail">
+              <strong>{results.totals.fail}</strong> fail
+            </span>
+            <span class="audit__total audit__total--inconc">
+              <strong>{results.totals.inconclusive}</strong> inconclusive
+            </span>
+            {summary && summary.topFailureClaimTypes.length > 0 ? (
+              <span class="audit__top-fail">
+                top failures: {summary.topFailureClaimTypes
+                  .map((t) => `${t.claimType} (${(t.failRate * 100).toFixed(0)}%)`)
+                  .join(', ')}
+              </span>
+            ) : null}
           </section>
-        ) : null}
 
-        <form method="get" class="audit__filters">
-          <label>outcome
-            <select name="outcome">
-              <option value="all" selected={outcomeParam === 'all'}>all</option>
-              <option value="pass" selected={outcomeParam === 'pass'}>pass</option>
-              <option value="fail" selected={outcomeParam === 'fail'}>fail</option>
-              <option value="inconclusive" selected={outcomeParam === 'inconclusive'}>inconclusive</option>
-            </select>
-          </label>
-          <label>claim type
-            <select name="claimType">
-              {claimTypes.map((ct) => (
-                <option value={ct} selected={ct === claimTypeParam}>{ct}</option>
-              ))}
-            </select>
-          </label>
-          <label>session id contains
-            <input type="text" name="project" value={projectParam} placeholder="optional substring" />
-          </label>
-          <button type="submit">apply</button>
-        </form>
+          {concernClusters.length > 0 ? (
+            <>
+              <SectionBar label={`TOP CONCERNS · ${concernClusters.length} clusters`} tone="peach" />
+              <section class="audit__concerns">
+                <p class="audit__concerns-hint">
+                  Failures grouped by claim type, ranked by count. Each cluster's top sessions are the
+                  ones most worth investigating — they accumulated the most fail verdicts of this kind.
+                  Use the filter row below to drill into any one cluster.
+                </p>
+                <ul class="audit__concerns-list">
+                  {concernClusters.map((c) => (
+                    <li>
+                      <div class="audit__concerns-head">
+                        <code class="audit__concerns-type">{c.claimType}</code>
+                        <span class="audit__concerns-count">{c.failCount} fail{c.failCount === 1 ? '' : 's'}</span>
+                        <a class="audit__concerns-drill" href={`?outcome=fail&claimType=${c.claimType}`}>filter below →</a>
+                      </div>
+                      {c.topSessions.length > 0 ? (
+                        <ul class="audit__concerns-sessions">
+                          {c.topSessions.map((s) => (
+                            <li>
+                              <code>[SID:{s.sessionId.slice(0, 8)}…]</code>
+                              <span class="audit__concerns-x">{s.failsInSession}× </span>
+                              <span class="audit__concerns-span">"{s.sampleSpan.slice(0, 60)}"</span>
+                              <span class="audit__concerns-reason">— {s.sampleReason.slice(0, 80)}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            </>
+          ) : null}
 
-        <p class="audit__count">{displayed.length} result(s) · page {page} / {totalPages}</p>
+          <SectionBar label="FILTERS" tone="butterscotch" />
+          <form method="get" class="audit__filters">
+            <label>outcome
+              <select name="outcome">
+                <option value="all" selected={outcomeParam === 'all'}>all</option>
+                <option value="pass" selected={outcomeParam === 'pass'}>pass</option>
+                <option value="fail" selected={outcomeParam === 'fail'}>fail</option>
+                <option value="inconclusive" selected={outcomeParam === 'inconclusive'}>inconclusive</option>
+              </select>
+            </label>
+            <label>claim type
+              <select name="claimType">
+                {claimTypes.map((ct) => (
+                  <option value={ct} selected={ct === claimTypeParam}>{ct}</option>
+                ))}
+              </select>
+            </label>
+            <label>session id contains
+              <input type="text" name="project" value={projectParam} placeholder="optional substring" />
+            </label>
+            <button type="submit" class="audit__apply">apply</button>
+          </form>
 
-        <table class="audit__table">
-          <thead>
-            <tr>
-              <th>outcome</th>
-              <th>claim type</th>
-              <th>session</th>
-              <th>line</th>
-              <th>span</th>
-              <th>reason</th>
-            </tr>
-          </thead>
-          <tbody>
-            {slice.map((r) => (
+          <p class="audit__count">{displayed.length} result(s) · page {page} / {totalPages}</p>
+
+          <table class="audit__table">
+            <thead>
               <tr>
-                <td><span class={badgeClass(r.outcome)}>{r.outcome}</span></td>
-                <td><code>{r.claimType}</code></td>
-                <td><code>{r.sessionId}</code></td>
-                <td>{r.lineNumber}</td>
-                <td class="audit__span">{r.span}</td>
-                <td class="audit__reason">{r.reason}</td>
+                <th>outcome</th>
+                <th>claim type</th>
+                <th>session</th>
+                <th>line</th>
+                <th>span</th>
+                <th>reason</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {slice.map((r) => (
+                <tr>
+                  <td><span class={badgeClass(r.outcome)}>{r.outcome}</span></td>
+                  <td><code>{r.claimType}</code></td>
+                  <td><code>{r.sessionId}</code></td>
+                  <td>{r.lineNumber}</td>
+                  <td class="audit__span">{r.span}</td>
+                  <td class="audit__reason">{r.reason}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
 
-        <nav class="audit__pager">
-          {page > 1 ? (
-            <a href={`?page=${page - 1}&outcome=${outcomeParam}&claimType=${claimTypeParam}&project=${encodeURIComponent(projectParam)}`}>← prev</a>
-          ) : <span class="audit__pager--disabled">← prev</span>}
-          <span>page {page} / {totalPages}</span>
-          {page < totalPages ? (
-            <a href={`?page=${page + 1}&outcome=${outcomeParam}&claimType=${claimTypeParam}&project=${encodeURIComponent(projectParam)}`}>next →</a>
-          ) : <span class="audit__pager--disabled">next →</span>}
-        </nav>
-      </>
-    )}
-  </main>
+          <nav class="audit__pager">
+            {page > 1 ? (
+              <a href={`?page=${page - 1}&outcome=${outcomeParam}&claimType=${claimTypeParam}&project=${encodeURIComponent(projectParam)}`}>← prev</a>
+            ) : <span class="audit__pager--disabled">← prev</span>}
+            <span>page {page} / {totalPages}</span>
+            {page < totalPages ? (
+              <a href={`?page=${page + 1}&outcome=${outcomeParam}&claimType=${claimTypeParam}&project=${encodeURIComponent(projectParam)}`}>next →</a>
+            ) : <span class="audit__pager--disabled">next →</span>}
+          </nav>
+        </>
+      )}
+    </main>
+  </div>
 </BaseLayout>
 
 <style>
+  .audit-root { padding: 0; }
   main.audit {
     max-width: 1100px;
     margin: 0 auto;
-    padding: 32px 24px 64px;
-    color: #FFCC99;
-    font-family: 'IBM Plex Sans', sans-serif;
+    padding: 24px 24px 64px;
+    color: var(--lcars-text);
+    font-family: var(--lcars-font-prose);
   }
   main.audit h1 {
-    font-family: 'Antonio', sans-serif;
+    font-family: var(--lcars-font-chrome);
     font-weight: 700;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.16em;
     font-size: 32px;
     margin: 0 0 16px;
+    color: var(--lcars-sunflower);
   }
   .audit__empty code {
-    background: #FFCC9911;
+    background: rgba(255, 204, 153, 0.08);
+    color: var(--lcars-ice);
     padding: 1px 6px;
+    border: 1px solid rgba(255, 204, 153, 0.1);
     border-radius: 3px;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--lcars-font-mono);
   }
-  .audit__totals { display: flex; gap: 24px; font-size: 14px; margin-bottom: 16px; }
-  .audit__totals strong { font-family: 'Antonio', sans-serif; color: #FFCC99; }
-  .audit__top-fail { color: #FFCC9999; }
-  .audit__filters { display: flex; gap: 16px; align-items: end; margin-bottom: 16px; flex-wrap: wrap; }
-  .audit__filters label { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: #FFCC9999; }
-  .audit__filters select, .audit__filters input {
-    background: #0a0a0a; color: #FFCC99; border: 1px solid #FFCC9933; padding: 4px 8px; font-family: inherit;
+
+  /* Totals strip — counts colored by outcome role per spec §3
+     status alias map (pass→ice, fail→peach, inconc→violet). */
+  .audit__totals {
+    display: flex;
+    gap: 24px;
+    font-size: 13px;
+    margin-bottom: 16px;
+    align-items: baseline;
+    flex-wrap: wrap;
+    color: var(--lcars-butterscotch);
   }
-  .audit__filters button {
-    background: #FFCC99; color: #0a0a0a; border: none; padding: 6px 16px; font-family: 'Antonio', sans-serif;
-    letter-spacing: 0.08em; cursor: pointer;
+  .audit__total strong {
+    font-family: var(--lcars-font-chrome);
+    font-size: 18px;
+    letter-spacing: 0.06em;
   }
-  .audit__count { font-size: 12px; color: #FFCC9999; margin: 0 0 8px; }
-  .audit__table {
-    width: 100%; border-collapse: collapse; font-size: 12px; font-family: 'JetBrains Mono', monospace;
+  .audit__total--pass strong { color: var(--lcars-ice); }
+  .audit__total--fail strong { color: var(--lcars-peach); }
+  .audit__total--inconc strong { color: var(--lcars-violet); }
+  .audit__top-fail { color: var(--lcars-butterscotch); }
+
+  /* Concerns panel — bg-1 surface with 3px peach left-rule (matches
+     `.lcars-rescan-banner--error` pattern, spec §6.7). */
+  .audit__concerns {
+    margin: 0 0 24px;
+    padding: 14px 18px;
+    background: var(--lcars-bg-1);
+    border: 1px solid var(--lcars-divider);
+    border-left: 3px solid var(--lcars-peach);
+    border-radius: 0 8px 8px 0;
   }
-  .audit__table th, .audit__table td {
-    text-align: left; padding: 6px 10px; border-bottom: 1px solid #FFCC9922; vertical-align: top;
+  .audit__concerns-hint {
+    font-size: 12px;
+    color: var(--lcars-butterscotch);
+    margin: 0 0 12px;
+    line-height: 1.5;
   }
-  .audit__table th { color: #FFCC9999; font-weight: 600; font-family: 'Antonio', sans-serif; letter-spacing: 0.08em; }
-  .audit__span { color: #FFCC99; max-width: 240px; }
-  .audit__reason { color: #FFCC99cc; max-width: 360px; }
-  .badge { display: inline-block; padding: 2px 8px; border-radius: 3px; font-size: 11px; }
-  .badge--pass { background: #4caf5044; color: #88e088; }
-  .badge--fail { background: #c0393944; color: #f08080; }
-  .badge--inconc { background: #ffaa3344; color: #ffd680; }
-  .audit__pager { margin-top: 16px; display: flex; gap: 24px; font-size: 13px; color: #FFCC99cc; }
-  .audit__pager a { color: #FFCC99; text-decoration: none; border-bottom: 1px dashed #FFCC9955; }
-  .audit__pager--disabled { color: #FFCC9944; }
-  .audit__concerns { margin: 20px 0; padding: 16px 20px; background: #0a0a0a; border: 1px solid #FFCC9944; border-radius: 4px; }
-  .audit__concerns h2 { font-family: 'Antonio', sans-serif; letter-spacing: 0.12em; font-size: 14px; margin: 0 0 8px; color: #FFCC99; }
-  .audit__concerns-hint { font-size: 12px; color: #FFCC9999; margin: 0 0 12px; line-height: 1.5; }
   .audit__concerns-list { list-style: none; padding: 0; margin: 0; }
-  .audit__concerns-list > li { padding: 10px 0; border-bottom: 1px solid #FFCC9922; }
+  .audit__concerns-list > li {
+    padding: 10px 0;
+    border-bottom: 1px solid var(--lcars-divider);
+  }
   .audit__concerns-list > li:last-child { border-bottom: none; }
   .audit__concerns-head { display: flex; align-items: baseline; gap: 12px; }
-  .audit__concerns-type { font-family: 'JetBrains Mono', monospace; color: #ffd680; font-size: 12px; }
-  .audit__concerns-count { font-family: 'Antonio', sans-serif; color: #FFCC99; font-size: 14px; }
-  .audit__concerns-drill { color: #FFCC99; font-size: 11px; text-decoration: none; border-bottom: 1px dashed #FFCC9955; margin-left: auto; }
-  .audit__concerns-sessions { list-style: none; padding: 4px 0 0 12px; margin: 0; }
-  .audit__concerns-sessions li { padding: 3px 0; font-family: 'JetBrains Mono', monospace; font-size: 11px; color: #FFCC99cc; display: flex; flex-wrap: wrap; gap: 6px; align-items: baseline; }
-  .audit__concerns-x { color: #ffd680; }
-  .audit__concerns-span { color: #FFCC99; }
-  .audit__concerns-reason { color: #FFCC9999; }
+  .audit__concerns-type {
+    font-family: var(--lcars-font-mono);
+    color: var(--lcars-peach);
+    font-size: 12px;
+    background: rgba(255, 153, 51, 0.08);
+    padding: 1px 6px;
+    border-radius: 3px;
+    border: 1px solid rgba(255, 153, 51, 0.15);
+  }
+  .audit__concerns-count {
+    font-family: var(--lcars-font-chrome);
+    color: var(--lcars-sunflower);
+    font-size: 14px;
+    letter-spacing: 0.08em;
+  }
+  .audit__concerns-drill {
+    color: var(--lcars-sunflower);
+    font-size: 11px;
+    text-decoration: none;
+    border-bottom: 1px dashed var(--lcars-butterscotch);
+    margin-left: auto;
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.1em;
+  }
+  .audit__concerns-drill:hover {
+    color: var(--lcars-ice);
+    border-bottom-color: var(--lcars-ice);
+  }
+  .audit__concerns-sessions {
+    list-style: none;
+    padding: 4px 0 0 12px;
+    margin: 0;
+  }
+  .audit__concerns-sessions li {
+    padding: 3px 0;
+    font-family: var(--lcars-font-mono);
+    font-size: 11px;
+    color: var(--lcars-text);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: baseline;
+  }
+  .audit__concerns-sessions code {
+    color: var(--lcars-ice);
+    background: rgba(153, 204, 255, 0.06);
+    padding: 1px 4px;
+    border-radius: 2px;
+  }
+  .audit__concerns-x { color: var(--lcars-peach); }
+  .audit__concerns-span { color: var(--lcars-text); }
+  .audit__concerns-reason { color: var(--lcars-butterscotch); }
+
+  /* Filter row — selects/inputs use bg surface + divider border;
+     apply button is a butterscotch pill matching today__btn. */
+  .audit__filters {
+    display: flex;
+    gap: 16px;
+    align-items: end;
+    margin: 12px 0 16px;
+    flex-wrap: wrap;
+  }
+  .audit__filters label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 11px;
+    color: var(--lcars-butterscotch);
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+  .audit__filters select,
+  .audit__filters input {
+    background: var(--lcars-bg-1);
+    color: var(--lcars-text);
+    border: 1px solid var(--lcars-divider);
+    padding: 6px 8px;
+    font-family: var(--lcars-font-mono);
+    font-size: 12px;
+    border-radius: 4px;
+    min-width: 140px;
+  }
+  .audit__filters select:focus,
+  .audit__filters input:focus {
+    outline: none;
+    border-color: var(--lcars-sunflower);
+  }
+  .audit__apply {
+    display: inline-flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 14px;
+    background: rgba(255, 204, 153, 0.12);
+    color: var(--lcars-butterscotch);
+    border: 1.5px solid var(--lcars-butterscotch);
+    border-radius: 14px;
+    font-family: var(--lcars-font-chrome);
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    line-height: 1;
+    padding-bottom: 2px;
+    cursor: pointer;
+    transition: background 120ms, color 120ms;
+  }
+  .audit__apply:hover,
+  .audit__apply:focus-visible {
+    background: var(--lcars-butterscotch);
+    color: var(--lcars-bg);
+    outline: none;
+  }
+
+  .audit__count {
+    font-size: 12px;
+    color: var(--lcars-butterscotch);
+    margin: 0 0 8px;
+    font-family: var(--lcars-font-mono);
+  }
+
+  .audit__table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    font-family: var(--lcars-font-mono);
+  }
+  .audit__table th,
+  .audit__table td {
+    text-align: left;
+    padding: 6px 10px;
+    border-bottom: 1px solid var(--lcars-divider);
+    vertical-align: top;
+  }
+  .audit__table th {
+    color: var(--lcars-bg);
+    background: var(--lcars-butterscotch);
+    font-weight: 700;
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-size: 10px;
+    padding: 6px 10px;
+    line-height: 1;
+  }
+  .audit__table th:first-child { border-radius: 10px 0 0 10px; }
+  .audit__table th:last-child { border-radius: 0 10px 10px 0; }
+  .audit__table tbody tr:hover {
+    background: var(--lcars-bg-1);
+  }
+  .audit__table code {
+    color: var(--lcars-ice);
+    background: rgba(153, 204, 255, 0.06);
+    padding: 1px 4px;
+    border-radius: 2px;
+  }
+  .audit__span {
+    color: var(--lcars-text);
+    max-width: 240px;
+  }
+  .audit__reason {
+    color: var(--lcars-butterscotch);
+    max-width: 360px;
+  }
+
+  /* Status badges remapped to the four named LCARS accents per
+     spec §3 status alias map. Border + foreground color carry the
+     state (mirrors `.lcars-semantic-chip` pattern, spec §6.8) — no
+     RGB green/red. */
+  .badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 0 10px 10px 0;
+    font-size: 10px;
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-weight: 700;
+    border: 1px solid;
+  }
+  .badge--pass {
+    color: var(--lcars-ice);
+    border-color: var(--lcars-ice);
+    background: rgba(153, 204, 255, 0.1);
+  }
+  .badge--fail {
+    color: var(--lcars-peach);
+    border-color: var(--lcars-peach);
+    background: rgba(255, 153, 51, 0.1);
+  }
+  .badge--inconc {
+    color: var(--lcars-violet);
+    border-color: var(--lcars-violet);
+    background: rgba(204, 153, 204, 0.1);
+  }
+
+  .audit__pager {
+    margin-top: 16px;
+    display: flex;
+    gap: 24px;
+    font-size: 13px;
+    color: var(--lcars-butterscotch);
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.1em;
+  }
+  .audit__pager a {
+    color: var(--lcars-sunflower);
+    text-decoration: none;
+    border-bottom: 1px dashed var(--lcars-butterscotch);
+  }
+  .audit__pager a:hover {
+    color: var(--lcars-ice);
+    border-bottom-color: var(--lcars-ice);
+  }
+  .audit__pager--disabled { color: var(--lcars-dim); }
 </style>

--- a/apps/standalone/src/pages/blog-drafts/[slug].astro
+++ b/apps/standalone/src/pages/blog-drafts/[slug].astro
@@ -1,8 +1,15 @@
 ---
+// LCARS chrome (post-unify): wraps `.lcars-root` and uses LCARS
+// tokens. F-audit verdict pass/fail markers remap to spec §3
+// status alias colors (ice for pass, peach for fail). Notice
+// strip uses the rescan-banner pattern (butterscotch left-rule,
+// spec §6.7) — the "demo" / non-error chrome role.
 export const prerender = false;
 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import TodayNav from '../../components/TodayNav.astro';
+import SectionBar from '../../components/SectionBar.astro';
+import '@chat-arch/viewer/style.css';
 import { readBlogDraft, readAuditResults } from '../../lib/readSidecars.ts';
 
 const slug = Astro.params.slug ?? '';
@@ -62,87 +69,223 @@ const overallRate = overallTotal === 0 ? 0 : overallPass / overallTotal;
 ---
 <BaseLayout title={draft !== null ? `Draft — ${slug}` : 'Draft not found'}>
   <TodayNav current="DRAFTS" />
-  <main class="draft">
-    <p class="draft__crumb"><a href="/blog-drafts">← all drafts</a></p>
-    <h1>{slug || '(no slug)'}</h1>
+  <div class="lcars-root draft-root">
+    <main class="draft">
+      <p class="draft__crumb"><a href="/blog-drafts">← all drafts</a></p>
+      <h1>{slug || '(no slug)'}</h1>
 
-    {draft === null ? (
-      <p class="draft__empty">
-        No draft found at <code>analysis/blog-drafts/{slug}.md</code> (or
-        <code>{slug}.prompt.md</code>). Run a rescan first.
-      </p>
-    ) : (
-      <>
-        {draft.isPrompt ? (
-          <p class="draft__notice">
-            ⚠ This is the prompt scaffold, not the final draft. Invoke the
-            chat-answer skill in draft mode against the member sessions
-            below, then drop the produced markdown alongside this file as
-            <code>{slug}.md</code>. A rescan will pick it up.
-          </p>
-        ) : (
-          <section class="draft__audit">
-            <h2>F-AUDIT VERDICT</h2>
-            <p>
-              <strong>{(overallRate * 100).toFixed(0)}%</strong> claim-pass
-              rate ({overallPass}/{overallTotal} verified, {overallFail} failed,
-              {overallInc} inconclusive across {auditRows.length} cited session(s)).
-              {overallRate >= 0.8 ? (
-                <span class="draft__pass"> ✓ passes 80% bar</span>
-              ) : (
-                <span class="draft__fail"> ✗ below 80% bar</span>
-              )}
-            </p>
-            {auditRows.length > 0 ? (
-              <table class="draft__audit-table">
-                <thead><tr><th>session</th><th>pass</th><th>fail</th><th>inconc</th><th>rate</th></tr></thead>
-                <tbody>
-                  {auditRows.map((r) => (
-                    <tr>
-                      <td><code>{r.sessionId}</code></td>
-                      <td>{r.pass}</td>
-                      <td>{r.fail}</td>
-                      <td>{r.inconclusive}</td>
-                      <td>{(r.passRate * 100).toFixed(0)}%</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            ) : (
-              <p class="draft__no-cites">No audit data for the cited sessions yet.</p>
-            )}
+      {draft === null ? (
+        <p class="draft__empty">
+          No draft found at <code>analysis/blog-drafts/{slug}.md</code> (or
+          <code>{slug}.prompt.md</code>). Run a rescan first.
+        </p>
+      ) : (
+        <>
+          {draft.isPrompt ? (
+            <div class="draft__notice">
+              <span class="draft__notice-tag">PROMPT</span>
+              <span class="draft__notice-body">
+                This is the prompt scaffold, not the final draft. Invoke the
+                chat-answer skill in draft mode against the member sessions
+                below, then drop the produced markdown alongside this file as
+                <code>{slug}.md</code>. A rescan will pick it up.
+              </span>
+            </div>
+          ) : (
+            <>
+              <SectionBar label="F-AUDIT VERDICT" tone={overallRate >= 0.8 ? 'ice' : 'peach'} />
+              <section class="draft__audit">
+                <p class="draft__audit-summary">
+                  <strong>{(overallRate * 100).toFixed(0)}%</strong> claim-pass
+                  rate ({overallPass}/{overallTotal} verified, {overallFail} failed,
+                  {overallInc} inconclusive across {auditRows.length} cited session(s)).
+                  {overallRate >= 0.8 ? (
+                    <span class="draft__pass"> ✓ passes 80% bar</span>
+                  ) : (
+                    <span class="draft__fail"> ✗ below 80% bar</span>
+                  )}
+                </p>
+                {auditRows.length > 0 ? (
+                  <table class="draft__audit-table">
+                    <thead><tr><th>session</th><th>pass</th><th>fail</th><th>inconc</th><th>rate</th></tr></thead>
+                    <tbody>
+                      {auditRows.map((r) => (
+                        <tr>
+                          <td><code>{r.sessionId}</code></td>
+                          <td class="draft__num draft__num--pass">{r.pass}</td>
+                          <td class="draft__num draft__num--fail">{r.fail}</td>
+                          <td class="draft__num draft__num--inconc">{r.inconclusive}</td>
+                          <td><strong>{(r.passRate * 100).toFixed(0)}%</strong></td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                ) : (
+                  <p class="draft__no-cites">No audit data for the cited sessions yet.</p>
+                )}
+              </section>
+            </>
+          )}
+
+          <SectionBar label={draft.isPrompt ? 'DRAFT PROMPT' : 'DRAFT'} tone="butterscotch" />
+          <section class="draft__body">
+            <pre>{draft.markdown}</pre>
           </section>
-        )}
-
-        <section class="draft__body">
-          <h2>{draft.isPrompt ? 'DRAFT PROMPT' : 'DRAFT'}</h2>
-          <pre>{draft.markdown}</pre>
-        </section>
-      </>
-    )}
-  </main>
+        </>
+      )}
+    </main>
+  </div>
 </BaseLayout>
 
 <style>
-  main.draft { max-width: 880px; margin: 0 auto; padding: 32px 24px 64px; color: #FFCC99; font-family: 'IBM Plex Sans', sans-serif; }
-  main.draft h1 { font-family: 'Antonio', sans-serif; letter-spacing: 0.08em; font-size: 24px; margin: 0 0 16px; word-break: break-all; }
-  main.draft h2 { font-family: 'Antonio', sans-serif; letter-spacing: 0.1em; font-size: 14px; color: #FFCC99; margin: 20px 0 8px; }
-  .draft__crumb a { color: #FFCC99cc; text-decoration: none; font-size: 12px; }
-  .draft__notice { background: #ffaa3322; border: 1px solid #ffaa3388; padding: 12px 16px; border-radius: 4px; color: #ffd680; }
-  .draft__notice code { background: #00000044; padding: 1px 4px; border-radius: 2px; font-family: 'JetBrains Mono', monospace; }
-  .draft__audit { margin-top: 16px; }
-  .draft__pass { color: #88e088; }
-  .draft__fail { color: #f08080; }
-  .draft__audit-table { border-collapse: collapse; margin-top: 8px; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
-  .draft__audit-table th, .draft__audit-table td { padding: 4px 12px; text-align: left; border-bottom: 1px solid #FFCC9922; }
-  .draft__no-cites { color: #FFCC9999; font-style: italic; }
+  .draft-root { padding: 0; }
+  main.draft {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 24px 24px 64px;
+    color: var(--lcars-text);
+    font-family: var(--lcars-font-prose);
+  }
+  main.draft h1 {
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.12em;
+    font-size: 24px;
+    margin: 0 0 16px;
+    word-break: break-all;
+    color: var(--lcars-sunflower);
+    font-weight: 700;
+  }
+  .draft__crumb a {
+    color: var(--lcars-butterscotch);
+    text-decoration: none;
+    font-size: 12px;
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.1em;
+  }
+  .draft__crumb a:hover {
+    color: var(--lcars-ice);
+  }
+  .draft__empty code {
+    background: rgba(255, 204, 153, 0.08);
+    color: var(--lcars-ice);
+    padding: 1px 6px;
+    border: 1px solid rgba(255, 204, 153, 0.1);
+    border-radius: 3px;
+    font-family: var(--lcars-font-mono);
+  }
+
+  /* Notice strip — rescan-banner pattern (spec §6.7): bg-1 surface
+     with 3px butterscotch left-rule, semantic-chip tag at the start. */
+  .draft__notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    background: var(--lcars-bg-1);
+    border: 1px solid var(--lcars-divider);
+    border-left: 4px solid var(--lcars-butterscotch);
+    padding: 12px 16px;
+    margin: 16px 0;
+    border-radius: 0 8px 8px 0;
+    color: var(--lcars-text);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .draft__notice-tag {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    height: 18px;
+    padding: 0 8px 2px;
+    background: var(--lcars-butterscotch);
+    color: var(--lcars-bg);
+    font-family: var(--lcars-font-chrome);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    border-radius: 0 9px 9px 0;
+    margin-top: 1px;
+  }
+  .draft__notice-body { flex: 1 1 auto; }
+  .draft__notice code {
+    background: rgba(0, 0, 0, 0.3);
+    color: var(--lcars-ice);
+    padding: 1px 4px;
+    border-radius: 2px;
+    font-family: var(--lcars-font-mono);
+    font-size: 12px;
+  }
+
+  .draft__audit { margin-bottom: 8px; }
+  .draft__audit-summary {
+    font-family: var(--lcars-font-prose);
+    color: var(--lcars-text);
+    margin: 8px 0;
+  }
+  .draft__audit-summary strong {
+    font-family: var(--lcars-font-chrome);
+    font-size: 18px;
+    color: var(--lcars-sunflower);
+    letter-spacing: 0.06em;
+  }
+  .draft__pass {
+    color: var(--lcars-ice);
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.1em;
+    font-size: 12px;
+  }
+  .draft__fail {
+    color: var(--lcars-peach);
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.1em;
+    font-size: 12px;
+  }
+  .draft__audit-table {
+    border-collapse: collapse;
+    margin-top: 8px;
+    font-family: var(--lcars-font-mono);
+    font-size: 12px;
+    width: 100%;
+  }
+  .draft__audit-table th {
+    text-align: left;
+    padding: 6px 12px;
+    background: var(--lcars-butterscotch);
+    color: var(--lcars-bg);
+    font-family: var(--lcars-font-chrome);
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-size: 10px;
+    line-height: 1;
+  }
+  .draft__audit-table th:first-child { border-radius: 10px 0 0 10px; }
+  .draft__audit-table th:last-child { border-radius: 0 10px 10px 0; }
+  .draft__audit-table td {
+    padding: 6px 12px;
+    border-bottom: 1px solid var(--lcars-divider);
+    color: var(--lcars-text);
+  }
+  .draft__audit-table code {
+    color: var(--lcars-ice);
+    background: rgba(153, 204, 255, 0.06);
+    padding: 1px 4px;
+    border-radius: 2px;
+  }
+  .draft__num--pass { color: var(--lcars-ice); }
+  .draft__num--fail { color: var(--lcars-peach); }
+  .draft__num--inconc { color: var(--lcars-violet); }
+  .draft__no-cites {
+    color: var(--lcars-butterscotch);
+    font-style: italic;
+    font-size: 13px;
+  }
   .draft__body pre {
-    background: #0a0a0a;
-    border: 1px solid #FFCC9922;
+    background: var(--lcars-bg-1);
+    border: 1px solid var(--lcars-divider);
     padding: 16px 20px;
-    border-radius: 4px;
-    color: #FFCC99;
-    font-family: 'JetBrains Mono', monospace;
+    border-radius: 6px;
+    color: var(--lcars-text);
+    font-family: var(--lcars-font-mono);
     font-size: 13px;
     line-height: 1.7;
     overflow-x: auto;

--- a/apps/standalone/src/pages/blog-drafts/index.astro
+++ b/apps/standalone/src/pages/blog-drafts/index.astro
@@ -1,8 +1,15 @@
 ---
+// LCARS chrome (post-unify): wraps `.lcars-root` and uses LCARS
+// tokens. Pills remap to spec §3 status alias colors — prompt
+// scaffold → butterscotch (the "in-progress" role), final draft →
+// ice (the "open-PR / verified" role) — and use the half-pill
+// `0 14px 14px 0` geometry that defines the system.
 export const prerender = false;
 
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import TodayNav from '../../components/TodayNav.astro';
+import SectionBar from '../../components/SectionBar.astro';
+import '@chat-arch/viewer/style.css';
 import { listBlogDraftSlugs, readBlogCandidates } from '../../lib/readSidecars.ts';
 
 const slugs = await listBlogDraftSlugs();
@@ -12,54 +19,133 @@ for (const c of candidates?.candidates ?? []) candidateMap.set(c.id, c);
 ---
 <BaseLayout title="Chat Archaeologist — Blog Drafts">
   <TodayNav current="DRAFTS" />
-  <main class="drafts">
-    <h1>BLOG DRAFTS</h1>
-    {slugs.length === 0 ? (
-      <p class="drafts__empty">
-        No drafts on disk. The blog-candidate selector runs as part of
-        <code>pnpm exporter all</code>; top candidates land at
-        <code>analysis/blog-drafts/&#123;slug&#125;.prompt.md</code>. Invoke the
-        chat-answer skill in draft mode to produce the final markdown.
-      </p>
-    ) : (
-      <ul class="drafts__list">
-        {slugs.map((s) => {
-          const candidateId = s.slug.split('-').slice(-2).join('-');
-          const cand = candidateMap.get(`blog-candidate-${candidateId.split('-')[1] ?? '0'}`);
-          return (
-            <li>
-              <a href={`/blog-drafts/${s.slug}`}>
-                <span class={s.isPrompt ? 'drafts__pill drafts__pill--prompt' : 'drafts__pill drafts__pill--final'}>
-                  {s.isPrompt ? 'prompt' : 'draft'}
-                </span>
-                <code>{s.slug}</code>
-              </a>
-              {cand ? (
-                <p class="drafts__meta">
-                  score {cand.score.toFixed(3)} · {cand.clusterSessionIds.length} session(s) ·
-                  span {cand.spanDays.toFixed(1)}d ·
-                  novelty {cand.noveltyScore.toFixed(2)}
-                  {cand.meanAuditPassRate !== null ? ` · audit ${(cand.meanAuditPassRate * 100).toFixed(0)}%` : ''}
-                </p>
-              ) : null}
-            </li>
-          );
-        })}
-      </ul>
-    )}
-  </main>
+  <div class="lcars-root drafts-root">
+    <main class="drafts">
+      <h1>BLOG DRAFTS</h1>
+      {slugs.length === 0 ? (
+        <p class="drafts__empty">
+          No drafts on disk. The blog-candidate selector runs as part of
+          <code>pnpm exporter all</code>; top candidates land at
+          <code>analysis/blog-drafts/&#123;slug&#125;.prompt.md</code>. Invoke the
+          chat-answer skill in draft mode to produce the final markdown.
+        </p>
+      ) : (
+        <>
+          <SectionBar label={`${slugs.length} DRAFT${slugs.length === 1 ? '' : 'S'} ON DISK`} tone="ice" />
+          <ul class="drafts__list">
+            {slugs.map((s) => {
+              const candidateId = s.slug.split('-').slice(-2).join('-');
+              const cand = candidateMap.get(`blog-candidate-${candidateId.split('-')[1] ?? '0'}`);
+              return (
+                <li>
+                  <a href={`/blog-drafts/${s.slug}`}>
+                    <span class={s.isPrompt ? 'drafts__pill drafts__pill--prompt' : 'drafts__pill drafts__pill--final'}>
+                      {s.isPrompt ? 'PROMPT' : 'DRAFT'}
+                    </span>
+                    <code class="drafts__slug">{s.slug}</code>
+                  </a>
+                  {cand ? (
+                    <p class="drafts__meta">
+                      score <span class="drafts__meta-val">{cand.score.toFixed(3)}</span> ·
+                      <span class="drafts__meta-val"> {cand.clusterSessionIds.length}</span> session(s) ·
+                      span <span class="drafts__meta-val">{cand.spanDays.toFixed(1)}d</span> ·
+                      novelty <span class="drafts__meta-val">{cand.noveltyScore.toFixed(2)}</span>
+                      {cand.meanAuditPassRate !== null ? (
+                        <>
+                          {' · audit '}
+                          <span class="drafts__meta-val">{(cand.meanAuditPassRate * 100).toFixed(0)}%</span>
+                        </>
+                      ) : null}
+                    </p>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      )}
+    </main>
+  </div>
 </BaseLayout>
 
 <style>
-  main.drafts { max-width: 880px; margin: 0 auto; padding: 32px 24px 64px; color: #FFCC99; font-family: 'IBM Plex Sans', sans-serif; }
-  main.drafts h1 { font-family: 'Antonio', sans-serif; letter-spacing: 0.1em; font-size: 28px; margin: 0 0 16px; }
-  .drafts__empty code { background: #FFCC9911; padding: 1px 6px; border-radius: 3px; font-family: 'JetBrains Mono', monospace; }
+  .drafts-root { padding: 0; }
+  main.drafts {
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 24px 24px 64px;
+    color: var(--lcars-text);
+    font-family: var(--lcars-font-prose);
+  }
+  main.drafts h1 {
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.16em;
+    font-size: 28px;
+    margin: 0 0 16px;
+    color: var(--lcars-sunflower);
+    font-weight: 700;
+  }
+  .drafts__empty {
+    color: var(--lcars-text);
+    line-height: 1.6;
+  }
+  .drafts__empty code {
+    background: rgba(255, 204, 153, 0.08);
+    color: var(--lcars-ice);
+    padding: 1px 6px;
+    border: 1px solid rgba(255, 204, 153, 0.1);
+    border-radius: 3px;
+    font-family: var(--lcars-font-mono);
+  }
+
   .drafts__list { list-style: none; padding: 0; margin: 0; }
-  .drafts__list li { padding: 12px 0; border-bottom: 1px solid #FFCC9922; }
-  .drafts__list a { color: #FFCC99; text-decoration: none; display: inline-flex; align-items: center; gap: 12px; }
-  .drafts__list code { font-family: 'JetBrains Mono', monospace; font-size: 13px; }
-  .drafts__pill { padding: 2px 8px; border-radius: 3px; font-size: 11px; letter-spacing: 0.08em; }
-  .drafts__pill--prompt { background: #ffaa3344; color: #ffd680; }
-  .drafts__pill--final { background: #4caf5044; color: #88e088; }
-  .drafts__meta { font-size: 12px; color: #FFCC9999; margin: 4px 0 0; padding-left: 60px; font-family: 'JetBrains Mono', monospace; }
+  .drafts__list li {
+    padding: 12px 0;
+    border-bottom: 1px solid var(--lcars-divider);
+  }
+  .drafts__list a {
+    color: var(--lcars-sunflower);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .drafts__list a:hover .drafts__slug {
+    color: var(--lcars-ice);
+  }
+  .drafts__slug {
+    font-family: var(--lcars-font-mono);
+    font-size: 13px;
+    color: var(--lcars-sunflower);
+  }
+
+  /* Pill remapped to spec §3 status alias map and half-pill geometry
+     (`border-radius: 0 14px 14px 0`). butterscotch carries the
+     in-progress / prompt-scaffold role; ice carries the verified /
+     final-draft role. */
+  .drafts__pill {
+    padding: 3px 12px 3px 8px;
+    border-radius: 0 14px 14px 0;
+    font-family: var(--lcars-font-chrome);
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    font-weight: 700;
+    color: var(--lcars-bg);
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    height: 20px;
+    padding-bottom: 2px; /* Antonio baseline correction */
+  }
+  .drafts__pill--prompt { background: var(--lcars-butterscotch); }
+  .drafts__pill--final { background: var(--lcars-ice); }
+
+  .drafts__meta {
+    font-size: 12px;
+    color: var(--lcars-butterscotch);
+    margin: 4px 0 0;
+    padding-left: 86px;
+    font-family: var(--lcars-font-mono);
+  }
+  .drafts__meta-val { color: var(--lcars-ice); }
 </style>

--- a/apps/standalone/src/pages/health.astro
+++ b/apps/standalone/src/pages/health.astro
@@ -1,8 +1,13 @@
 ---
-export const prerender = false;
-
+// LCARS chrome (post-unify): wraps `.lcars-root` and reuses the
+// viewer's tokens/class shapes. Section headers use SectionBar
+// (mid-bar, spec §6.6). Metric tiles get the `.lcars-session-card`-
+// style left-rule treatment. Warnings panel uses the rescan-banner
+// pattern (peach left-rule, spec §6.7) when warnings are present.
 import BaseLayout from '../layouts/BaseLayout.astro';
 import TodayNav from '../components/TodayNav.astro';
+import SectionBar from '../components/SectionBar.astro';
+import '@chat-arch/viewer/style.css';
 import { readContinuumHealth } from '../lib/readSidecars.ts';
 
 const health = await readContinuumHealth();
@@ -13,103 +18,213 @@ function fmtPct(v: number): string {
 ---
 <BaseLayout title="Chat Archaeologist — Health">
   <TodayNav current="HEALTH" />
-  <main class="health">
-    <h1>CONTINUUM HEALTH</h1>
-    {health === null ? (
-      <p class="health__empty">
-        No <code>analysis/continuum-health.json</code> on disk yet. Run a
-        rescan and reload.
-      </p>
-    ) : (
-      <>
-        <section class="health__top">
-          <div class="health__metric">
-            <span class="health__metric-label">consecutive successes</span>
-            <span class="health__metric-value">{health.consecutiveSuccesses}</span>
-          </div>
-          <div class="health__metric">
-            <span class="health__metric-label">last scan</span>
-            <span class="health__metric-value">{health.lastScanAt}</span>
-          </div>
-          <div class="health__metric">
-            <span class="health__metric-label">last successful scan</span>
-            <span class="health__metric-value">{health.lastSuccessfulScanAt ?? '—'}</span>
-          </div>
-          <div class="health__metric">
-            <span class="health__metric-label">new since last scan</span>
-            <span class="health__metric-value">{health.newSessionsSinceLast}</span>
-          </div>
-        </section>
+  <div class="lcars-root health-root">
+    <main class="health">
+      <h1>CONTINUUM HEALTH</h1>
+      {health === null ? (
+        <p class="health__empty">
+          No <code>analysis/continuum-health.json</code> on disk yet. Run a
+          rescan and reload.
+        </p>
+      ) : (
+        <>
+          <SectionBar label="SNAPSHOT" tone="butterscotch" />
+          <section class="health__top">
+            <div class="health__metric" style="--metric-color: var(--lcars-ice)">
+              <span class="health__metric-label">consecutive successes</span>
+              <span class="health__metric-value">{health.consecutiveSuccesses}</span>
+            </div>
+            <div class="health__metric" style="--metric-color: var(--lcars-sunflower)">
+              <span class="health__metric-label">last scan</span>
+              <span class="health__metric-value health__metric-value--small">{health.lastScanAt}</span>
+            </div>
+            <div class="health__metric" style="--metric-color: var(--lcars-sunflower)">
+              <span class="health__metric-label">last successful scan</span>
+              <span class="health__metric-value health__metric-value--small">{health.lastSuccessfulScanAt ?? '—'}</span>
+            </div>
+            <div class="health__metric" style="--metric-color: var(--lcars-violet)">
+              <span class="health__metric-label">new since last scan</span>
+              <span class="health__metric-value">{health.newSessionsSinceLast}</span>
+            </div>
+          </section>
 
-        <section class="health__row">
-          <h2>SOURCES SCANNED</h2>
-          <p>{health.sourcesScanned.join(', ')}</p>
-        </section>
+          <SectionBar label="SOURCES SCANNED" tone="ice" />
+          <section class="health__row">
+            <p>{health.sourcesScanned.join(', ')}</p>
+          </section>
 
-        <section class="health__row">
-          <h2>ENTRIES BY STATUS</h2>
-          <table class="health__table">
-            <tbody>
-              <tr><th>ok</th><td>{health.entriesByStatus.ok}</td></tr>
-              <tr><th>missing</th><td>{health.entriesByStatus.missing}</td></tr>
-              <tr><th>crashed</th><td>{health.entriesByStatus.crashed}</td></tr>
-              <tr><th>pruned</th><td>{health.entriesByStatus.pruned}</td></tr>
-            </tbody>
-          </table>
-        </section>
+          <SectionBar label="ENTRIES BY STATUS" tone="ice" />
+          <section class="health__row">
+            <table class="health__table">
+              <tbody>
+                <tr><th>ok</th><td><code>{health.entriesByStatus.ok}</code></td></tr>
+                <tr><th>missing</th><td><code>{health.entriesByStatus.missing}</code></td></tr>
+                <tr><th>crashed</th><td><code>{health.entriesByStatus.crashed}</code></td></tr>
+                <tr><th>pruned</th><td><code>{health.entriesByStatus.pruned}</code></td></tr>
+              </tbody>
+            </table>
+          </section>
 
-        <section class="health__row">
-          <h2>WARNINGS {health.warnings.length === 0 ? '(none)' : `(${health.warnings.length})`}</h2>
-          {health.warnings.length === 0 ? (
-            <p class="health__nowarn">All sources under threshold.</p>
-          ) : (
-            <ul>
-              {health.warnings.map((w) => (
-                <li>
-                  <code>{w.source}</code> · {w.kind} =
-                  {' '}<strong>{typeof w.value === 'number' ? (w.kind.includes('rate') ? fmtPct(w.value) : w.value) : String(w.value)}</strong>
-                  {' '}(threshold {w.kind.includes('rate') ? fmtPct(w.threshold) : w.threshold})
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-      </>
-    )}
-  </main>
+          <SectionBar
+            label={`WARNINGS ${health.warnings.length === 0 ? '(none)' : `(${health.warnings.length})`}`}
+            tone={health.warnings.length === 0 ? 'sunflower' : 'peach'}
+          />
+          <section class={`health__row ${health.warnings.length > 0 ? 'health__row--warning' : ''}`}>
+            {health.warnings.length === 0 ? (
+              <p class="health__nowarn">All sources under threshold.</p>
+            ) : (
+              <ul>
+                {health.warnings.map((w) => (
+                  <li>
+                    <code>{w.source}</code> · {w.kind} =
+                    {' '}<strong>{typeof w.value === 'number' ? (w.kind.includes('rate') ? fmtPct(w.value) : w.value) : String(w.value)}</strong>
+                    {' '}(threshold {w.kind.includes('rate') ? fmtPct(w.threshold) : w.threshold})
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+    </main>
+  </div>
 </BaseLayout>
 
 <style>
+  .health-root { padding: 0; }
   main.health {
     max-width: 880px;
     margin: 0 auto;
-    padding: 32px 24px 64px;
-    color: #FFCC99;
-    font-family: 'IBM Plex Sans', sans-serif;
+    padding: 24px 24px 64px;
+    color: var(--lcars-text);
+    font-family: var(--lcars-font-prose);
   }
   main.health h1 {
-    font-family: 'Antonio', sans-serif;
+    font-family: var(--lcars-font-chrome);
     font-weight: 700;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.16em;
     font-size: 28px;
-    margin: 0 0 24px;
+    margin: 0 0 16px;
+    color: var(--lcars-sunflower);
   }
   .health__empty code {
-    background: #FFCC9911;
+    background: rgba(255, 204, 153, 0.08);
+    color: var(--lcars-ice);
     padding: 1px 6px;
+    border: 1px solid rgba(255, 204, 153, 0.1);
     border-radius: 3px;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--lcars-font-mono);
   }
-  .health__top { display: flex; gap: 24px; flex-wrap: wrap; margin-bottom: 32px; }
-  .health__metric { background: #0a0a0a; border: 1px solid #FFCC9933; padding: 12px 16px; border-radius: 4px; min-width: 200px; }
-  .health__metric-label { display: block; font-size: 11px; color: #FFCC9999; letter-spacing: 0.08em; }
-  .health__metric-value { display: block; font-size: 18px; font-family: 'JetBrains Mono', monospace; margin-top: 4px; }
-  .health__row h2 { font-family: 'Antonio', sans-serif; font-size: 14px; letter-spacing: 0.1em; color: #FFCC99; margin: 20px 0 8px; }
-  .health__row p { font-family: 'JetBrains Mono', monospace; font-size: 13px; margin: 0; }
-  .health__table { border-collapse: collapse; }
-  .health__table th { text-align: left; padding: 4px 16px 4px 0; color: #FFCC9999; font-weight: 400; font-family: 'JetBrains Mono', monospace; }
-  .health__table td { padding: 4px 0; font-family: 'JetBrains Mono', monospace; }
-  .health__nowarn { color: #88e088; }
-  .health__row ul { padding-left: 18px; font-family: 'JetBrains Mono', monospace; font-size: 13px; }
-  .health__row li { padding: 4px 0; color: #FFCC99cc; }
+
+  .health__top {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    margin-bottom: 8px;
+  }
+  /* Metric tile — mirrors `.lcars-session-card`: bg surface, 3px
+     left rule in `--metric-color`, half-pill right-corner radius. */
+  .health__metric {
+    --metric-color: var(--lcars-sunflower);
+    background: var(--lcars-bg);
+    border: 1px solid var(--lcars-divider);
+    border-left: 3px solid var(--metric-color);
+    padding: 12px 14px;
+    border-radius: 0 10px 10px 0;
+    transition: transform 120ms, background 120ms;
+  }
+  .health__metric:hover {
+    background: var(--lcars-bg-1);
+    transform: translateY(-1px);
+  }
+  .health__metric-label {
+    display: block;
+    font-family: var(--lcars-font-chrome);
+    font-size: 10px;
+    color: var(--lcars-butterscotch);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 700;
+  }
+  .health__metric-value {
+    display: block;
+    font-family: var(--lcars-font-chrome);
+    font-size: 28px;
+    line-height: 1.1;
+    margin-top: 6px;
+    color: var(--metric-color);
+    font-weight: 700;
+  }
+  .health__metric-value--small {
+    font-family: var(--lcars-font-mono);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--lcars-text);
+  }
+
+  .health__row { margin: 0 0 12px; }
+  .health__row p {
+    font-family: var(--lcars-font-mono);
+    font-size: 13px;
+    margin: 0;
+    color: var(--lcars-text);
+  }
+  /* Warnings panel reuses the rescan-banner error pattern (peach
+     left-rule, bg-1 surface), spec §6.7. */
+  .health__row--warning {
+    padding: 12px 16px;
+    background: var(--lcars-bg-1);
+    border: 1px solid var(--lcars-divider);
+    border-left: 3px solid var(--lcars-peach);
+    border-radius: 0 8px 8px 0;
+  }
+  .health__row--warning ul {
+    padding-left: 18px;
+    font-family: var(--lcars-font-mono);
+    font-size: 13px;
+    margin: 0;
+  }
+  .health__row--warning li {
+    padding: 4px 0;
+    color: var(--lcars-text);
+  }
+  .health__row--warning code {
+    color: var(--lcars-peach);
+    background: rgba(255, 153, 51, 0.08);
+    padding: 1px 4px;
+    border-radius: 2px;
+  }
+  .health__row--warning strong {
+    color: var(--lcars-peach);
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.06em;
+  }
+  .health__table {
+    border-collapse: collapse;
+    margin: 0;
+  }
+  .health__table th {
+    text-align: left;
+    padding: 4px 18px 4px 0;
+    color: var(--lcars-butterscotch);
+    font-weight: 700;
+    font-family: var(--lcars-font-chrome);
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  .health__table td {
+    padding: 4px 0;
+    font-family: var(--lcars-font-mono);
+  }
+  .health__table code {
+    color: var(--lcars-ice);
+    font-size: 13px;
+  }
+  .health__nowarn {
+    color: var(--lcars-ice);
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.1em;
+    font-size: 12px;
+  }
 </style>

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -4,10 +4,21 @@
 // CLAUDE.md / skills. Prove the loop closed." The hero panel is the
 // workshop-loop status (corrections to apply, applies made, loop
 // closure rate). Audit concerns + brief content are demoted below.
+//
+// LCARS chrome (post-unify): the page wraps in `.lcars-root` and
+// imports the viewer's canonical stylesheet so every `--lcars-*`
+// token resolves the same way it does on `/sessions` `/projects`
+// `/topics`. Section headers use the SectionBar mid-bar component
+// (mirrors `.lcars-mid-bar`, spec §6.6). Metric tiles use the
+// canonical 3px left-rule pattern from `.lcars-session-card`
+// (spec §6.4) — `--metric-color` is the per-tile role accent
+// (butterscotch / ice / peach / sunflower).
 export const prerender = false;
 
 import BaseLayout from '../layouts/BaseLayout.astro';
 import TodayNav from '../components/TodayNav.astro';
+import SectionBar from '../components/SectionBar.astro';
+import '@chat-arch/viewer/style.css';
 import {
   listBlogDraftSlugs,
   readContinuumHealth,
@@ -34,183 +45,188 @@ const workshopEmpty =
 ---
 <BaseLayout title="Chat Archaeologist — Today">
   <TodayNav current="TODAY" />
-  <main class="today">
-    <header class="today__header">
-      <h1>TODAY</h1>
-      <p class="today__date">
-        {new Date(NOW).toISOString().slice(0, 10)}
-        {brief !== null ? <span class="today__chip">brief at {brief.date}</span> : null}
-      </p>
-      <div class="today__actions">
-        <button id="action-rescan" type="button">RESCAN</button>
-        <button id="action-mine" type="button">MINE CORRECTIONS</button>
-        <button id="action-brief" type="button">REGEN BRIEF</button>
-        <span id="action-status" class="today__action-status"></span>
-      </div>
-    </header>
-
-    {/* ======================= WORKSHOP LOOP ======================= */}
-    <section class="today__hero">
-      <h2>WORKSHOP LOOP</h2>
-      {workshopEmpty ? (
-        <div class="today__empty">
-          <p><strong>No mined patterns yet.</strong> chat-arch has detected
-            <code>{1549}</code> correction candidates via heuristic recall, but
-            the <code>/mine-corrections</code> skill hasn't classified them into
-            actionable patterns yet.</p>
-          <p>
-            <strong>To populate the loop:</strong> from a fresh Claude Code session in this repo, run
-            <code>/mine-corrections</code>. It LLM-classifies the candidates,
-            clusters them, and emits <code>analysis/corrections.json</code>
-            with proposed CLAUDE.md / skill upgrades. Reload this page after.
-          </p>
-          <p class="today__empty-note">
-            The MINE CORRECTIONS button above tries the same via
-            <code>/api/mine-corrections</code> — currently broken on Windows
-            (CLI spawn quoting bug). Use the slash-command path until the
-            endpoint is patched.
-          </p>
-        </div>
-      ) : (
-        <div class="today__hero-grid">
-          <div class="today__metric today__metric--big">
-            <span class="today__metric-label">to APPLY</span>
-            <span class="today__metric-value">{workshop.unappliedPatternCount}</span>
-            <span class="today__metric-sub">new patterns waiting for review</span>
-          </div>
-          <div class="today__metric">
-            <span class="today__metric-label">applied total</span>
-            <span class="today__metric-value">{workshop.appliedPatternCount}</span>
-            <span class="today__metric-sub">CLAUDE.md / skill patches shipped</span>
-          </div>
-          <div class={`today__metric ${workshop.recurringAfterApplyCount > 0 ? 'today__metric--warn' : ''}`}>
-            <span class="today__metric-label">still recurring</span>
-            <span class="today__metric-value">{workshop.recurringAfterApplyCount}</span>
-            <span class="today__metric-sub">
-              {workshop.recurringAfterApplyCount > 0
-                ? 'rules patched but Claude still breaks them'
-                : 'no patched rule recurring'}
-            </span>
-          </div>
-          <div class="today__metric">
-            <span class="today__metric-label">loop closure</span>
-            <span class="today__metric-value">
-              {workshop.loopClosureRate === null
-                ? '—'
-                : `${(workshop.loopClosureRate * 100).toFixed(0)}%`}
-            </span>
-            <span class="today__metric-sub">
-              {workshop.loopClosureRate === null
-                ? 'no observed windows yet'
-                : 'patches that stuck (no recurrence in window)'}
-            </span>
-          </div>
-        </div>
-      )}
-
-      {workshop.topUnapplied.length > 0 ? (
-        <div class="today__queue">
-          <h3>NEXT TO REVIEW · top {workshop.topUnapplied.length} by confidence</h3>
-          <ul>
-            {workshop.topUnapplied.map((p) => (
-              <li>
-                <span class="today__confidence">
-                  {(p.confidence * 100).toFixed(0)}%
-                </span>
-                <span class="today__rule">{p.canonicalRule}</span>
-                <span class="today__scope">
-                  ({p.occurrenceCount}× · scope={p.scope.kind})
-                </span>
-                <a href={`/sessions#corrections`}>review →</a>
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-
-      {workshop.recentApplies.length > 0 ? (
-        <div class="today__applies">
-          <h3>RECENT APPLIES</h3>
-          <ul>
-            {workshop.recentApplies.map((a) => (
-              <li>
-                <code>{new Date(a.appliedAt).toISOString().slice(0, 10)}</code>
-                · {a.ruleSummary}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-    </section>
-
-    {/* ======================= DRAFTS READY ======================= */}
-    <section class="today__row">
-      <h2>BLOG DRAFTS</h2>
-      {drafts.length === 0 ? (
-        <p class="today__row-empty">
-          No drafts yet. The blog candidate selector ran but produced no
-          drafts because the <code>discoveryScore</code> threshold wasn't
-          met (or the chat-answer skill hasn't been invoked against the
-          prompt scaffolds). See <a href="/blog-drafts">/blog-drafts</a>.
+  <div class="lcars-root today-root">
+    <main class="today">
+      <header class="today__header">
+        <h1>TODAY</h1>
+        <p class="today__date">
+          <code class="today__date-code">{new Date(NOW).toISOString().slice(0, 10)}</code>
+          {brief !== null ? <span class="today__chip">brief at {brief.date}</span> : null}
         </p>
-      ) : (
+        <div class="today__actions">
+          <button id="action-rescan" class="today__btn" type="button">RESCAN</button>
+          <button id="action-mine" class="today__btn" type="button">MINE CORRECTIONS</button>
+          <button id="action-brief" class="today__btn" type="button">REGEN BRIEF</button>
+          <span id="action-status" class="today__action-status"></span>
+        </div>
+      </header>
+
+      {/* ======================= WORKSHOP LOOP ======================= */}
+      <SectionBar label="WORKSHOP LOOP" tone="butterscotch" />
+      <section class="today__hero">
+        {workshopEmpty ? (
+          <div class="today__empty">
+            <p><strong>No mined patterns yet.</strong> chat-arch has detected
+              <code>{1549}</code> correction candidates via heuristic recall, but
+              the <code>/mine-corrections</code> skill hasn't classified them into
+              actionable patterns yet.</p>
+            <p>
+              <strong>To populate the loop:</strong> from a fresh Claude Code session in this repo, run
+              <code>/mine-corrections</code>. It LLM-classifies the candidates,
+              clusters them, and emits <code>analysis/corrections.json</code>
+              with proposed CLAUDE.md / skill upgrades. Reload this page after.
+            </p>
+            <p class="today__empty-note">
+              The MINE CORRECTIONS button above tries the same via
+              <code>/api/mine-corrections</code> — currently broken on Windows
+              (CLI spawn quoting bug). Use the slash-command path until the
+              endpoint is patched.
+            </p>
+          </div>
+        ) : (
+          <div class="today__hero-grid">
+            <div class="today__metric today__metric--big" style="--metric-color: var(--lcars-butterscotch)">
+              <span class="today__metric-label">to APPLY</span>
+              <span class="today__metric-value">{workshop.unappliedPatternCount}</span>
+              <span class="today__metric-sub">new patterns waiting for review</span>
+            </div>
+            <div class="today__metric" style="--metric-color: var(--lcars-ice)">
+              <span class="today__metric-label">applied total</span>
+              <span class="today__metric-value">{workshop.appliedPatternCount}</span>
+              <span class="today__metric-sub">CLAUDE.md / skill patches shipped</span>
+            </div>
+            <div
+              class={`today__metric ${workshop.recurringAfterApplyCount > 0 ? 'today__metric--warn' : ''}`}
+              style={`--metric-color: ${workshop.recurringAfterApplyCount > 0 ? 'var(--lcars-peach)' : 'var(--lcars-sunflower)'}`}
+            >
+              <span class="today__metric-label">still recurring</span>
+              <span class="today__metric-value">{workshop.recurringAfterApplyCount}</span>
+              <span class="today__metric-sub">
+                {workshop.recurringAfterApplyCount > 0
+                  ? 'rules patched but Claude still breaks them'
+                  : 'no patched rule recurring'}
+              </span>
+            </div>
+            <div class="today__metric" style="--metric-color: var(--lcars-violet)">
+              <span class="today__metric-label">loop closure</span>
+              <span class="today__metric-value">
+                {workshop.loopClosureRate === null
+                  ? '—'
+                  : `${(workshop.loopClosureRate * 100).toFixed(0)}%`}
+              </span>
+              <span class="today__metric-sub">
+                {workshop.loopClosureRate === null
+                  ? 'no observed windows yet'
+                  : 'patches that stuck (no recurrence in window)'}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {workshop.topUnapplied.length > 0 ? (
+          <div class="today__queue">
+            <h3>NEXT TO REVIEW · top {workshop.topUnapplied.length} by confidence</h3>
+            <ul>
+              {workshop.topUnapplied.map((p) => (
+                <li>
+                  <span class="today__confidence">
+                    {(p.confidence * 100).toFixed(0)}%
+                  </span>
+                  <span class="today__rule">{p.canonicalRule}</span>
+                  <span class="today__scope">
+                    ({p.occurrenceCount}× · scope={p.scope.kind})
+                  </span>
+                  <a href={`/sessions#corrections`}>review →</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {workshop.recentApplies.length > 0 ? (
+          <div class="today__applies">
+            <h3>RECENT APPLIES</h3>
+            <ul>
+              {workshop.recentApplies.map((a) => (
+                <li>
+                  <code>{new Date(a.appliedAt).toISOString().slice(0, 10)}</code>
+                  · {a.ruleSummary}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </section>
+
+      {/* ======================= DRAFTS READY ======================= */}
+      <SectionBar label="BLOG DRAFTS" tone="ice" />
+      <section class="today__row">
+        {drafts.length === 0 ? (
+          <p class="today__row-empty">
+            No drafts yet. The blog candidate selector ran but produced no
+            drafts because the <code>discoveryScore</code> threshold wasn't
+            met (or the chat-answer skill hasn't been invoked against the
+            prompt scaffolds). See <a href="/blog-drafts">/blog-drafts</a>.
+          </p>
+        ) : (
+          <p class="today__row-summary">
+            <a href="/blog-drafts">
+              {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
+            </a>
+          </p>
+        )}
+      </section>
+
+      {/* ======================= AUDIT CONCERNS (demoted) ======================= */}
+      <SectionBar label={`AUDIT CONCERNS · top ${concerns.length}`} tone="peach" />
+      <section class="today__row">
+        {concerns.length === 0 ? (
+          <p class="today__row-empty">No F-layer concerns surfaced yet.</p>
+        ) : (
+          <ul class="today__concerns">
+            {concerns.map((c) => (
+              <li>
+                <code class="today__concern-type">{c.claimType}</code>
+                <span class="today__concern-span">claimed "{c.span}"</span>
+                <span class="today__concern-reason">— {c.reason}</span>
+                <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
+              </li>
+            ))}
+          </ul>
+        )}
         <p class="today__row-summary">
-          <a href="/blog-drafts">
-            {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
-          </a>
+          <a href="/audit">full audit table →</a>
         </p>
-      )}
-    </section>
+      </section>
 
-    {/* ======================= AUDIT CONCERNS (demoted) ======================= */}
-    <section class="today__row">
-      <h2>AUDIT CONCERNS · top {concerns.length}</h2>
-      {concerns.length === 0 ? (
-        <p class="today__row-empty">No F-layer concerns surfaced yet.</p>
-      ) : (
-        <ul class="today__concerns">
-          {concerns.map((c) => (
-            <li>
-              <code class="today__concern-type">{c.claimType}</code>
-              <span class="today__concern-span">claimed "{c.span}"</span>
-              <span class="today__concern-reason">— {c.reason}</span>
-              <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
-            </li>
-          ))}
-        </ul>
-      )}
-      <p class="today__row-summary">
-        <a href="/audit">full audit table →</a>
-      </p>
-    </section>
+      {/* ======================= CORPUS HEALTH (footer-y) ======================= */}
+      <SectionBar label="CORPUS HEALTH" tone="sunflower" />
+      <section class="today__row today__row--footer">
+        {health === null ? (
+          <p>No continuum snapshot.</p>
+        ) : (
+          <p>
+            <code>{health.consecutiveSuccesses}</code> consecutive successful scans ·
+            {' '}<code>{health.entriesByStatus.ok}</code> ok ·
+            {' '}<code>{health.entriesByStatus.missing}</code> missing ·
+            {' '}<code>{health.entriesByStatus.crashed}</code> crashed ·
+            {' '}<code>{health.entriesByStatus.pruned}</code> pruned
+            {health.warnings.length > 0 ? (
+              <span class="today__warn"> · {health.warnings.length} warning(s)</span>
+            ) : null}
+            {' · '}<a href="/health">/health →</a>
+          </p>
+        )}
+      </section>
 
-    {/* ======================= CORPUS HEALTH (footer-y) ======================= */}
-    <section class="today__row today__row--footer">
-      <h2>CORPUS HEALTH</h2>
-      {health === null ? (
-        <p>No continuum snapshot.</p>
-      ) : (
-        <p>
-          <code>{health.consecutiveSuccesses}</code> consecutive successful scans ·
-          {' '}<code>{health.entriesByStatus.ok}</code> ok ·
-          {' '}<code>{health.entriesByStatus.missing}</code> missing ·
-          {' '}<code>{health.entriesByStatus.crashed}</code> crashed ·
-          {' '}<code>{health.entriesByStatus.pruned}</code> pruned
-          {health.warnings.length > 0 ? (
-            <span class="today__warn"> · {health.warnings.length} warning(s)</span>
-          ) : null}
-          {' · '}<a href="/health">/health →</a>
-        </p>
-      )}
-    </section>
-
-    {brief !== null ? (
-      <details class="today__raw">
-        <summary>raw daily brief markdown</summary>
-        <pre>{brief.markdown}</pre>
-      </details>
-    ) : null}
-  </main>
+      {brief !== null ? (
+        <details class="today__raw">
+          <summary>raw daily brief markdown</summary>
+          <pre>{brief.markdown}</pre>
+        </details>
+      ) : null}
+    </main>
+  </div>
 
   <script is:inline>
     // Wire the action buttons. Each POSTs to the corresponding API
@@ -220,7 +236,8 @@ const workshopEmpty =
     function setStatus(text, isError) {
       if (!status) return;
       status.textContent = text;
-      status.style.color = isError ? '#f08080' : '#88e088';
+      // Ice for success, peach for error — staying on-palette.
+      status.style.color = isError ? '#ff9933' : '#99ccff';
     }
     async function callApi(url, header, label) {
       setStatus(`${label}…`, false);
@@ -253,114 +270,319 @@ const workshopEmpty =
 </BaseLayout>
 
 <style>
+  /* The page wraps in `.lcars-root` so `--lcars-*` tokens resolve.
+     Override the `.lcars-root` default 8–12px padding here — the
+     TodayNav already provides the chrome strip, and the page wants
+     a wider centered content column rather than the viewer's full-
+     bleed grid layout. */
+  .today-root {
+    padding: 0;
+  }
   main.today {
     max-width: 960px;
     margin: 0 auto;
-    padding: 32px 24px 64px;
-    color: #FFCC99;
-    font-family: 'IBM Plex Sans', sans-serif;
+    padding: 24px 24px 64px;
+    color: var(--lcars-text);
+    font-family: var(--lcars-font-prose);
   }
   .today__header h1 {
-    font-family: 'Antonio', sans-serif;
+    font-family: var(--lcars-font-chrome);
     font-weight: 700;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.16em;
     font-size: 32px;
     margin: 0 0 4px;
+    color: var(--lcars-sunflower);
   }
   .today__date {
-    font-size: 13px; color: #FFCC9999; margin: 0 0 16px;
-    display: flex; align-items: center; gap: 12px;
+    font-size: 13px;
+    color: var(--lcars-butterscotch);
+    margin: 0 0 16px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .today__date-code {
+    font-family: var(--lcars-font-mono);
+    color: var(--lcars-ice);
+    font-size: 12px;
   }
   .today__chip {
-    background: #FFCC9911; padding: 2px 8px; border-radius: 3px;
-    font-family: 'JetBrains Mono', monospace; font-size: 11px;
+    /* Sunflower-muted (#d9ad82) pre-composited bg with black text —
+       same role + contrast pattern as the LCARS sidebar item. */
+    background: var(--lcars-sunflower-muted);
+    color: var(--lcars-bg);
+    padding: 2px 10px;
+    /* Half-pill rounded on the right edge only — the signature LCARS
+       chip shape. */
+    border-radius: 0 14px 14px 0;
+    font-family: var(--lcars-font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
   }
-  .today__actions { display: flex; gap: 12px; align-items: center; margin-bottom: 32px; }
-  .today__actions button {
-    background: #FFCC99; color: #0a0a0a; border: none; padding: 8px 16px;
-    font-family: 'Antonio', sans-serif; letter-spacing: 0.08em; font-size: 12px;
-    cursor: pointer; border-radius: 2px;
+  .today__actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
   }
-  .today__actions button:hover { background: #ffd680; }
-  .today__action-status { font-size: 12px; font-family: 'JetBrains Mono', monospace; }
+  /* Action button mirrors `.lcars-top-bar__source-btn` on the mobile-
+     tier dark top bar: butterscotch border + butterscotch text on a
+     translucent sunflower fill, 14px four-corner radius. Hover fills
+     butterscotch with black text — the canonical LCARS pill swap. */
+  .today__btn {
+    display: inline-flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 14px;
+    background: rgba(255, 204, 153, 0.12);
+    color: var(--lcars-butterscotch);
+    border: 1.5px solid var(--lcars-butterscotch);
+    border-radius: 14px;
+    font-family: var(--lcars-font-chrome);
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    line-height: 1;
+    padding-bottom: 2px; /* Antonio baseline correction, see spec §5 */
+    cursor: pointer;
+    transition: background 120ms, color 120ms;
+  }
+  .today__btn:hover,
+  .today__btn:focus-visible {
+    background: var(--lcars-butterscotch);
+    color: var(--lcars-bg);
+    outline: none;
+  }
+  .today__action-status {
+    font-size: 12px;
+    font-family: var(--lcars-font-mono);
+    color: var(--lcars-ice);
+  }
 
+  /* Hero panel — `bg-1` card surface with `divider` hairline. Surface
+     stepping (bg → bg-1) carries the hierarchy per spec §8; no
+     drop shadows. */
   .today__hero {
-    border: 1px solid #FFCC9944;
-    background: linear-gradient(180deg, #0a0a0a, #050505);
-    padding: 24px;
-    border-radius: 4px;
-    margin-bottom: 32px;
-  }
-  .today__hero h2 {
-    font-family: 'Antonio', sans-serif; letter-spacing: 0.12em;
-    font-size: 14px; color: #FFCC99; margin: 0 0 16px;
+    background: var(--lcars-bg-1);
+    border: 1px solid var(--lcars-divider);
+    padding: 20px;
+    border-radius: 8px;
+    margin-bottom: 8px;
   }
   .today__hero-grid {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 16px; margin-bottom: 24px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin-bottom: 16px;
   }
+  /* Metric tile mirrors `.lcars-session-card` (spec §6.4) — 3px left
+     accent in `--metric-color`, `bg-1` surface, half-pill rounding on
+     the right corners. Hover lifts with translateY, never a shadow. */
   .today__metric {
-    background: #0a0a0a; border: 1px solid #FFCC9933; padding: 16px;
-    border-radius: 3px; display: flex; flex-direction: column;
+    --metric-color: var(--lcars-sunflower);
+    background: var(--lcars-bg);
+    border: 1px solid var(--lcars-divider);
+    border-left: 3px solid var(--metric-color);
+    padding: 12px 14px;
+    border-radius: 0 10px 10px 0;
+    display: flex;
+    flex-direction: column;
+    transition: transform 120ms, background 120ms;
   }
-  .today__metric--big { border-color: #FFCC9988; }
-  .today__metric--warn { border-color: #ffaa3388; }
-  .today__metric--warn .today__metric-value { color: #ffd680; }
-  .today__metric-label { font-size: 11px; color: #FFCC9999; letter-spacing: 0.08em; }
+  .today__metric:hover {
+    background: var(--lcars-bg-2);
+    transform: translateY(-1px);
+  }
+  .today__metric--big {
+    border-left-width: 4px;
+  }
+  .today__metric-label {
+    font-family: var(--lcars-font-chrome);
+    font-size: 10px;
+    color: var(--lcars-butterscotch);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 700;
+  }
   .today__metric-value {
-    font-family: 'Antonio', sans-serif; font-size: 36px; line-height: 1.1;
-    margin: 6px 0; color: #FFCC99;
+    font-family: var(--lcars-font-chrome);
+    font-size: 36px;
+    line-height: 1.1;
+    margin: 4px 0;
+    color: var(--metric-color);
+    font-weight: 700;
   }
-  .today__metric-sub { font-size: 11px; color: #FFCC9999; }
-
-  .today__empty { color: #FFCC99cc; font-size: 14px; line-height: 1.6; }
-  .today__empty code { background: #FFCC9911; padding: 1px 6px; border-radius: 2px; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
-  .today__empty-note { font-size: 12px; color: #FFCC9999; font-style: italic; margin-top: 12px; }
-
-  .today__queue, .today__applies { margin-top: 16px; }
-  .today__queue h3, .today__applies h3 {
-    font-family: 'Antonio', sans-serif; font-size: 12px; letter-spacing: 0.1em;
-    color: #FFCC9999; margin: 0 0 8px;
+  .today__metric-sub {
+    font-size: 11px;
+    color: var(--lcars-butterscotch);
+    font-family: var(--lcars-font-prose);
   }
-  .today__queue ul, .today__applies ul {
-    list-style: none; padding: 0; margin: 0; font-family: 'JetBrains Mono', monospace; font-size: 12px;
+
+  .today__empty {
+    color: var(--lcars-text);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+  .today__empty code,
+  .today__row code {
+    background: rgba(255, 204, 153, 0.08);
+    color: var(--lcars-ice);
+    padding: 1px 6px;
+    border: 1px solid rgba(255, 204, 153, 0.1);
+    border-radius: 3px;
+    font-family: var(--lcars-font-mono);
+    font-size: 12px;
+  }
+  .today__empty-note {
+    font-size: 12px;
+    color: var(--lcars-butterscotch);
+    font-style: italic;
+    margin-top: 12px;
+  }
+
+  .today__queue,
+  .today__applies {
+    margin-top: 16px;
+  }
+  .today__queue h3,
+  .today__applies h3 {
+    font-family: var(--lcars-font-chrome);
+    font-size: 11px;
+    letter-spacing: 0.16em;
+    color: var(--lcars-butterscotch);
+    margin: 0 0 8px;
+    text-transform: uppercase;
+  }
+  .today__queue ul,
+  .today__applies ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: var(--lcars-font-mono);
+    font-size: 12px;
   }
   .today__queue li {
-    padding: 6px 0; border-bottom: 1px solid #FFCC9922;
-    display: flex; align-items: baseline; gap: 12px;
+    padding: 6px 0;
+    border-bottom: 1px solid var(--lcars-divider);
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
   }
-  .today__queue li:last-child { border-bottom: none; }
-  .today__confidence { color: #FFCC99; font-weight: 600; min-width: 40px; }
-  .today__rule { flex: 1; color: #FFCC99cc; }
-  .today__scope { color: #FFCC9999; font-size: 11px; }
-  .today__queue a { color: #FFCC99; text-decoration: none; border-bottom: 1px dashed #FFCC9955; }
-  .today__applies li { padding: 4px 0; color: #FFCC99cc; }
-  .today__applies code { color: #FFCC9999; }
-
-  .today__row { margin-bottom: 28px; }
-  .today__row--footer { margin-top: 16px; padding-top: 16px; border-top: 1px dashed #FFCC9933; }
-  .today__row h2 {
-    font-family: 'Antonio', sans-serif; font-size: 13px; letter-spacing: 0.12em;
-    color: #FFCC99; margin: 0 0 8px;
+  .today__queue li:last-child {
+    border-bottom: none;
   }
-  .today__row code { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: #FFCC99; }
-  .today__row-empty { color: #FFCC9999; font-size: 13px; }
-  .today__row-summary { font-size: 13px; }
-  .today__row-summary a { color: #FFCC99; text-decoration: none; border-bottom: 1px dashed #FFCC9955; }
+  .today__confidence {
+    color: var(--lcars-ice);
+    font-weight: 700;
+    min-width: 44px;
+  }
+  .today__rule {
+    flex: 1;
+    color: var(--lcars-text);
+  }
+  .today__scope {
+    color: var(--lcars-butterscotch);
+    font-size: 11px;
+  }
+  .today__queue a {
+    color: var(--lcars-sunflower);
+    text-decoration: none;
+    border-bottom: 1px dashed var(--lcars-butterscotch);
+  }
+  .today__queue a:hover {
+    color: var(--lcars-ice);
+    border-bottom-color: var(--lcars-ice);
+  }
+  .today__applies li {
+    padding: 4px 0;
+    color: var(--lcars-text);
+  }
+  .today__applies code {
+    color: var(--lcars-ice);
+  }
 
-  .today__concerns { list-style: none; padding: 0; margin: 0; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
-  .today__concerns li { padding: 4px 0; color: #FFCC99cc; display: flex; flex-wrap: wrap; gap: 6px; align-items: baseline; }
-  .today__concern-type { color: #ffd680; font-size: 11px; }
-  .today__concern-span { color: #FFCC99; }
-  .today__concern-reason { color: #FFCC9999; }
-  .today__concern-sid { color: #FFCC9966; font-size: 11px; }
-  .today__warn { color: #ffd680; }
+  .today__row {
+    margin-bottom: 8px;
+  }
+  .today__row--footer {
+    margin-top: 8px;
+    padding-top: 8px;
+  }
+  .today__row-empty {
+    color: var(--lcars-butterscotch);
+    font-size: 13px;
+  }
+  .today__row-summary {
+    font-size: 13px;
+  }
+  .today__row-summary a {
+    color: var(--lcars-sunflower);
+    text-decoration: none;
+    border-bottom: 1px dashed var(--lcars-butterscotch);
+  }
+  .today__row-summary a:hover {
+    color: var(--lcars-ice);
+    border-bottom-color: var(--lcars-ice);
+  }
 
-  .today__raw { margin-top: 32px; font-size: 12px; color: #FFCC9999; }
-  .today__raw summary { cursor: pointer; padding: 6px 0; font-family: 'Antonio', sans-serif; letter-spacing: 0.1em; }
+  .today__concerns {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: var(--lcars-font-mono);
+    font-size: 12px;
+  }
+  .today__concerns li {
+    padding: 4px 0;
+    color: var(--lcars-text);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: baseline;
+  }
+  .today__concern-type {
+    color: var(--lcars-peach);
+    font-size: 11px;
+  }
+  .today__concern-span {
+    color: var(--lcars-text);
+  }
+  .today__concern-reason {
+    color: var(--lcars-butterscotch);
+  }
+  .today__concern-sid {
+    color: var(--lcars-dim);
+    font-size: 11px;
+  }
+  .today__warn {
+    color: var(--lcars-peach);
+  }
+
+  .today__raw {
+    margin-top: 32px;
+    font-size: 12px;
+    color: var(--lcars-butterscotch);
+  }
+  .today__raw summary {
+    cursor: pointer;
+    padding: 6px 0;
+    font-family: var(--lcars-font-chrome);
+    letter-spacing: 0.16em;
+    color: var(--lcars-sunflower);
+  }
   .today__raw pre {
-    background: #0a0a0a; border: 1px solid #FFCC9922; padding: 12px 16px;
-    margin-top: 8px; border-radius: 3px; font-family: 'JetBrains Mono', monospace;
-    font-size: 12px; line-height: 1.6; overflow-x: auto; white-space: pre-wrap;
+    background: var(--lcars-bg-1);
+    border: 1px solid var(--lcars-divider);
+    padding: 12px 16px;
+    margin-top: 8px;
+    border-radius: 6px;
+    font-family: var(--lcars-font-mono);
+    font-size: 12px;
+    line-height: 1.6;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    color: var(--lcars-text);
   }
 </style>

--- a/apps/standalone/src/pages/practice.astro
+++ b/apps/standalone/src/pages/practice.astro
@@ -1,9 +1,18 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import TodayNav from '../components/TodayNav.astro';
 import { ChatArchViewer } from '@chat-arch/viewer';
 import '@chat-arch/viewer/style.css';
 ---
 <BaseLayout title="Chat Archaeologist — Practice">
+  {/*
+    Hosts the PRACTICE four-lens dashboard inside the viewer island.
+    `compact` TodayNav strip mirrors the other viewer-island pages
+    (/sessions /projects /topics) — it gives users a path back to
+    TODAY / AUDIT / HEALTH / DRAFTS without double-stacking the
+    viewer's own `.lcars-top-bar` title pill.
+  */}
+  <TodayNav current="PRACTICE" compact />
   <script is:inline>
     if (typeof window !== 'undefined' && window.location.hash !== '#practice') {
       window.history.replaceState(null, '', window.location.pathname + '#practice');

--- a/apps/standalone/src/pages/projects.astro
+++ b/apps/standalone/src/pages/projects.astro
@@ -16,10 +16,11 @@ import '@chat-arch/viewer/style.css';
     v2-instrumented-loop chrome (TODAY / AUDIT / HEALTH / DRAFTS) and
     the legacy LCARS viewer surfaces works in both directions —
     otherwise clicking PROJECTS from the new pages stranded users here
-    with no path back. The strip lives ABOVE the viewer's full-height
-    chrome so it doesn't collide with the LCARS elbow geometry.
+    with no path back. The strip uses `compact` mode (no dot + title
+    block) because the viewer renders its own `.lcars-top-bar` with
+    the same title pill; stacking both was double-billing the chrome.
   */}
-  <TodayNav current="PROJECTS" />
+  <TodayNav current="PROJECTS" compact />
   <script is:inline>
     if (typeof window !== 'undefined' && window.location.hash !== '#projects') {
       window.history.replaceState(null, '', window.location.pathname + '#projects');

--- a/apps/standalone/src/pages/sessions.astro
+++ b/apps/standalone/src/pages/sessions.astro
@@ -11,9 +11,10 @@ import '@chat-arch/viewer/style.css';
     is the long-form session browser. The viewer's hash-state is reset
     pre-hydration so a fresh visit lands on SESSIONS rather than the
     last-used surface. TodayNav strip on top per the same back-link
-    rationale as /projects.astro.
+    rationale as /projects.astro — `compact` to avoid double-stacking
+    the title pill (the viewer's own top-bar carries the dot + title).
   */}
-  <TodayNav current="SESSIONS" />
+  <TodayNav current="SESSIONS" compact />
   <script is:inline>
     if (typeof window !== 'undefined' && window.location.hash !== '#sessions') {
       window.history.replaceState(null, '', window.location.pathname + '#sessions');

--- a/apps/standalone/src/pages/topics.astro
+++ b/apps/standalone/src/pages/topics.astro
@@ -9,10 +9,11 @@ import '@chat-arch/viewer/style.css';
     v2 spec §5.2 / decision D3: TOPICS index lives at /topics.
     Mirrors /projects.astro: pre-hydration script normalizes the
     hash so the viewer's hash listener picks `topics` on mount.
-    TodayNav strip on top per the same back-link rationale as
-    /projects.astro.
+    TodayNav strip on top in `compact` mode so the cross-surface
+    pills sit below the viewer's own top-bar without duplicating
+    the title pill.
   */}
-  <TodayNav current="TOPICS" />
+  <TodayNav current="TOPICS" compact />
   <script is:inline>
     if (typeof window !== 'undefined' && window.location.hash !== '#topics') {
       window.history.replaceState(null, '', window.location.pathname + '#topics');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.2.0
         version: 4.4.2(@types/node@22.19.17)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yaml@2.8.3)
+      '@chat-arch/analysis':
+        specifier: workspace:*
+        version: link:../../packages/analysis
       '@chat-arch/schema':
         specifier: workspace:*
         version: link:../../packages/schema


### PR DESCRIPTION
## Summary

Pulls `/`, `/audit`, `/health`, `/blog-drafts` (index + `[slug]`) into the **Supergraphic Panel** design system that already lives on `/sessions /projects /topics`. Closes the visual-cohesion gap identified in the audit run earlier this session — the app no longer reads as two stacked design systems.

This is Option C from that audit: keep dense data tabular, but propagate LCARS chrome primitives (mid-bar headers, sunflower-muted card surfaces, four-accent status palette, half-pill geometry) onto every page.

### What changed

- **New `SectionBar.astro`** — wraps `.lcars-mid-bar` (`design-system/spec.md` §6.6). Replaces every `<h2>` section header on the v2-instrumented-loop pages. Solid butterscotch / ice / peach / sunflower strips with black tracked-caps Antonio labels.
- **Metric tiles** — adopt the `.lcars-session-card` pattern (spec §6.4): 3px left-rule in role accent (butterscotch / ice / peach / violet / sunflower), `bg-1` surface, half-pill `0 14px 14px 0` right-corner radius, `translateY(-1px)` hover.
- **Audit status badges** — remapped to spec §3 status aliases: pass → ice, fail → peach, inconclusive → violet. RGB green/red retired (was off-palette).
- **Buttons** — mirror `.lcars-top-bar__source-btn` (butterscotch border + text on translucent sunflower, hover flips to filled butterscotch with black text, 14px pill, Antonio baseline correction).
- **Code chips / links** — use the canonical info-popover code treatment from the viewer (translucent sunflower bg, ice text, hairline border).
- **Double top-bar fix** — `TodayNav` gains a `compact` prop that drops the dot + "CHAT ARCHAEOLOGIST" title block. Used on `/sessions /projects /topics /practice` because the React viewer already renders its own `.lcars-top-bar` with the same title; stacking both was visual double-billing.
- **Missing TodayNav on `/practice`** — added (compact). Previously stranded users at the viewer with no path back to TODAY/AUDIT/etc. Also adds `PRC PRACTICE` to the link set.

### Files touched

- New: `apps/standalone/src/components/SectionBar.astro`
- Modified: `apps/standalone/src/components/TodayNav.astro` (compact prop, added Practice link)
- Modified: `apps/standalone/src/pages/{index,audit,health,practice,sessions,projects,topics}.astro`
- Modified: `apps/standalone/src/pages/blog-drafts/{index,[slug]}.astro`

No changes to: the viewer core stylesheet, `manifest.json` or any sidecar (PII), `/bench` (dev-only), `/design-system` (already canonical).

The workshop-loop hero on `/` is unchanged structurally (load-bearing per `research/refocus-plan.md` north star) — only its paint and geometry shifted.

## Test plan

- [x] `pnpm --filter @chat-arch/standalone build` — clean (the two `ts(6133)` warnings are pre-existing in `design-system/index.astro`, unrelated)
- [x] `pnpm --filter @chat-arch/standalone lint` — clean (one pre-existing unused-import warning unrelated to this change)
- [x] `pnpm --filter @chat-arch/standalone test --run` — 4 files / 51 tests pass
- [x] Dev server boots, every page renders, structural classes (`lcars-root`, `lcars-mid-bar`, `today-nav--compact`, the status badges) verified in served HTML
- [ ] Visual review in browser — recommend clicking through TODAY → AUDIT → HEALTH → DRAFTS → SESSIONS → PROJECTS → TOPICS → PRACTICE to confirm the chrome reads as one system and no double-top-bar remains on viewer pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)