### PR TITLE
feat(playbook): methods playbook surface (PR-A) — verbs I reach for

### DIFF
--- a/apps/standalone/src/lib/readPlaybook.ts
+++ b/apps/standalone/src/lib/readPlaybook.ts
@@ -1,0 +1,35 @@
+/**
+ * Server-side reader for the playbook sidecar. Used by the /playbook
+ * page at request-time (`export const prerender = false`).
+ *
+ * Kept narrowly scoped to playbook-candidates.json so this file can land
+ * before the broader `readSidecars.ts` helper (which arrives with the
+ * audit/results work on a different branch). When that helper lands, we
+ * can fold this reader into it without changing the page's import shape.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { PlaybookCandidatesFile } from '@chat-arch/schema';
+
+function dataRoot(): string {
+  return path.join(
+    process.cwd(),
+    'apps',
+    'standalone',
+    'public',
+    'chat-arch-data',
+  );
+}
+
+export async function readPlaybookCandidates(): Promise<PlaybookCandidatesFile | null> {
+  const p = path.join(dataRoot(), 'analysis', 'playbook-candidates.json');
+  try {
+    const raw = await readFile(p, 'utf8');
+    const parsed = JSON.parse(raw) as PlaybookCandidatesFile;
+    if (parsed.version !== 1) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/apps/standalone/src/pages/playbook.astro
+++ b/apps/standalone/src/pages/playbook.astro
@@ -1,0 +1,407 @@
+---
+// PLAYBOOK — the positive counterpart to CORRECTIONS. Surfaces
+// recurring user-turn phrasings the user invoked mid-session that
+// consistently produce verified outcomes (audited downstream-pass on
+// the F-layer claim verifier).
+//
+// This is the "verbs I reach for" exhibit — a comprehensive list of
+// every detected method, ranked by occurrence × downstream-pass rate
+// when audit data is available, otherwise by raw occurrence. Designed
+// to be read end-to-end and lifted into a blog post draft, not just
+// scanned at a glance.
+//
+// PR-A: render-only. The encoding flow (export as prompt-snippet /
+// CLAUDE.md "Verbs I reach for" section / slash-command sketch) is
+// deferred to a follow-up that mirrors CorrectionsPanel's APPLY flow.
+export const prerender = false;
+
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { readPlaybookCandidates } from '../lib/readPlaybook.ts';
+
+const playbook = await readPlaybookCandidates();
+
+function fmtPct(rate: number): string {
+  return `${(rate * 100).toFixed(0)}%`;
+}
+function fmtSid(sid: string): string {
+  return sid.slice(0, 8);
+}
+---
+<BaseLayout title="Chat Archaeologist — Playbook">
+  <main class="playbook">
+    <header class="playbook__header">
+      <h1>PLAYBOOK</h1>
+      <p class="playbook__lede">
+        Methods I've actually used — recurring prompt phrasings invoked
+        mid-session that produced verified outcomes. Positive counterpart
+        to CORRECTIONS: that surface mines pushback against the AI; this
+        one mines the verbs I reach for to steer it well. Ranked by
+        occurrence × downstream pass-rate when audit data is present;
+        by raw occurrence otherwise.
+      </p>
+    </header>
+
+    {playbook === null ? (
+      <section class="playbook__empty">
+        <h2>No playbook candidates yet</h2>
+        <p>
+          The detector writes <code>analysis/playbook-candidates.json</code>{' '}
+          on every scan. Click <strong>SCAN LOCAL</strong> from the DATA
+          panel — the exporter runs this stage automatically as part of{' '}
+          <code>all</code>.
+        </p>
+      </section>
+    ) : playbook.patterns.length === 0 ? (
+      <section class="playbook__empty">
+        <h2>No method phrasings detected in this corpus</h2>
+        <p>
+          The detector ran across{' '}
+          <code>{playbook.scanStats.sessionsScanned}</code> sessions and
+          found zero hits against its pattern catalogue. Either the
+          corpus is thin, or none of the phrasings the heuristic looks
+          for showed up. Inspect{' '}
+          <code>packages/analysis/src/detectPlaybookCandidates.ts</code>{' '}
+          to widen the patterns.
+        </p>
+      </section>
+    ) : (
+      <>
+        <section class="playbook__summary">
+          <div class="playbook__kpi">
+            <span class="playbook__kpi-label">methods detected</span>
+            <span class="playbook__kpi-value">{playbook.patterns.length}</span>
+          </div>
+          <div class="playbook__kpi">
+            <span class="playbook__kpi-label">total invocations</span>
+            <span class="playbook__kpi-value">
+              {playbook.patterns.reduce((n, p) => n + p.occurrenceCount, 0)}
+            </span>
+          </div>
+          <div class="playbook__kpi">
+            <span class="playbook__kpi-label">sessions covered</span>
+            <span class="playbook__kpi-value">
+              {new Set(playbook.patterns.flatMap((p) => p.sessionIds)).size}
+            </span>
+          </div>
+          <div class="playbook__kpi">
+            <span class="playbook__kpi-label">audit signal</span>
+            <span class="playbook__kpi-value playbook__kpi-value--small">
+              {playbook.hasAuditSignal ? 'present' : 'unavailable'}
+            </span>
+            <span class="playbook__kpi-sub">
+              {playbook.hasAuditSignal
+                ? 'rankings include downstream-pass weight'
+                : 'ranked by occurrence alone'}
+            </span>
+          </div>
+        </section>
+
+        <ol class="playbook__list">
+          {playbook.patterns.map((p, idx) => (
+            <li class="playbook__row">
+              <div class="playbook__row-head">
+                <span class="playbook__rank">#{idx + 1}</span>
+                <h2 class="playbook__row-title">{p.label}</h2>
+                <code class="playbook__row-key">{p.patternKey}</code>
+              </div>
+              <p class="playbook__row-desc">{p.description}</p>
+
+              <div class="playbook__row-stats">
+                <span class="playbook__stat">
+                  <span class="playbook__stat-num">{p.occurrenceCount}</span>
+                  <span class="playbook__stat-label">invocations</span>
+                </span>
+                <span class="playbook__stat">
+                  <span class="playbook__stat-num">{p.sessionIds.length}</span>
+                  <span class="playbook__stat-label">sessions</span>
+                </span>
+                {playbook.hasAuditSignal && p.audit.pass + p.audit.fail + p.audit.inconclusive > 0 ? (
+                  <span class="playbook__stat playbook__stat--rate">
+                    <span class="playbook__stat-num">
+                      {fmtPct(p.audit.passRate)}
+                    </span>
+                    <span class="playbook__stat-label">
+                      downstream pass{' '}
+                      <small>
+                        ({p.audit.pass}/{p.audit.pass + p.audit.fail + p.audit.inconclusive})
+                      </small>
+                    </span>
+                  </span>
+                ) : (
+                  <span class="playbook__stat playbook__stat--rate playbook__stat--unavailable">
+                    <span class="playbook__stat-num">—</span>
+                    <span class="playbook__stat-label">no audit signal yet</span>
+                  </span>
+                )}
+              </div>
+
+              {playbook.hasAuditSignal && p.audit.pass + p.audit.fail + p.audit.inconclusive > 0 ? (
+                <div class="playbook__bar">
+                  <span
+                    class="playbook__bar-fill"
+                    style={`width:${p.audit.passRate * 100}%`}
+                  ></span>
+                </div>
+              ) : null}
+
+              <details class="playbook__excerpts">
+                <summary>
+                  show {Math.min(p.hits.length, 3)} of {p.hits.length}{' '}
+                  example{p.hits.length === 1 ? '' : 's'}
+                </summary>
+                <ul>
+                  {p.hits.slice(0, 3).map((h) => (
+                    <li class="playbook__excerpt">
+                      <code class="playbook__sid">
+                        [SID:{fmtSid(h.sessionId)}…]
+                      </code>
+                      <span class="playbook__phrase">"{h.phrase}"</span>
+                      <blockquote>{h.excerpt}</blockquote>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            </li>
+          ))}
+        </ol>
+
+        <footer class="playbook__footer">
+          <p>
+            Detector heuristic v{playbook.heuristicVersion} · scanned{' '}
+            <code>{playbook.scanStats.sessionsScanned}</code> of{' '}
+            <code>{playbook.scanStats.sessionsInManifest}</code> sessions ·{' '}
+            <code>{playbook.scanStats.survivingTurns}</code> user turns
+            survived the wrapper/length filter
+          </p>
+        </footer>
+      </>
+    )}
+  </main>
+</BaseLayout>
+
+<style>
+  main.playbook {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 32px 24px 64px;
+    color: #FFCC99;
+    font-family: 'IBM Plex Sans', sans-serif;
+  }
+  .playbook__header h1 {
+    font-family: 'Antonio', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    font-size: 32px;
+    margin: 0 0 8px;
+  }
+  .playbook__lede {
+    font-size: 13px;
+    line-height: 1.6;
+    color: #FFCC99cc;
+    margin: 0 0 24px;
+    max-width: 720px;
+  }
+
+  .playbook__empty {
+    border: 1px solid #FFCC9944;
+    padding: 24px;
+    border-radius: 4px;
+    background: #0a0a0a;
+  }
+  .playbook__empty code {
+    background: #FFCC9911;
+    padding: 1px 6px;
+    border-radius: 2px;
+    font-family: 'JetBrains Mono', monospace;
+  }
+
+  .playbook__summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin-bottom: 28px;
+  }
+  .playbook__kpi {
+    background: #0a0a0a;
+    border: 1px solid #FFCC9933;
+    padding: 14px 16px;
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+  }
+  .playbook__kpi-label {
+    font-size: 10px;
+    color: #FFCC9999;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .playbook__kpi-value {
+    font-family: 'Antonio', sans-serif;
+    font-size: 32px;
+    line-height: 1.1;
+    margin: 4px 0 0;
+    color: #FFCC99;
+  }
+  .playbook__kpi-value--small {
+    font-size: 16px;
+  }
+  .playbook__kpi-sub {
+    font-size: 10px;
+    color: #FFCC9999;
+    margin-top: 4px;
+  }
+
+  .playbook__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .playbook__row {
+    background: #0a0a0a;
+    border: 1px solid #FFCC9933;
+    border-left: 3px solid rgba(136, 224, 136, 0.45);
+    border-radius: 4px;
+    padding: 18px 20px;
+  }
+  .playbook__row-head {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 6px;
+    flex-wrap: wrap;
+  }
+  .playbook__rank {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: #FFCC9966;
+  }
+  .playbook__row-title {
+    font-family: 'Antonio', sans-serif;
+    font-size: 20px;
+    letter-spacing: 0.03em;
+    margin: 0;
+    color: #FFCC99;
+    font-weight: 700;
+  }
+  .playbook__row-key {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: #FFCC9966;
+    background: #FFCC9911;
+    padding: 1px 6px;
+    border-radius: 2px;
+  }
+  .playbook__row-desc {
+    font-size: 13px;
+    color: #FFCC99cc;
+    line-height: 1.5;
+    margin: 0 0 10px;
+  }
+
+  .playbook__row-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 18px;
+    align-items: baseline;
+    margin: 10px 0 8px;
+    font-family: 'JetBrains Mono', monospace;
+  }
+  .playbook__stat {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .playbook__stat-num {
+    color: #FFCC99;
+    font-size: 18px;
+    font-family: 'Antonio', sans-serif;
+    font-weight: 600;
+  }
+  .playbook__stat-label {
+    color: #FFCC9999;
+    font-size: 11px;
+  }
+  .playbook__stat-label small {
+    color: #FFCC9966;
+    font-size: 10px;
+  }
+  .playbook__stat--rate .playbook__stat-num {
+    color: #88e088;
+  }
+  .playbook__stat--unavailable .playbook__stat-num {
+    color: #FFCC9966;
+  }
+
+  .playbook__bar {
+    height: 4px;
+    background: #FFCC9911;
+    border-radius: 2px;
+    overflow: hidden;
+    margin: 6px 0 12px;
+  }
+  .playbook__bar-fill {
+    display: block;
+    height: 100%;
+    background: rgba(136, 224, 136, 0.55);
+  }
+
+  .playbook__excerpts {
+    margin-top: 8px;
+    font-size: 12px;
+  }
+  .playbook__excerpts summary {
+    cursor: pointer;
+    color: #FFCC9999;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    padding: 4px 0;
+  }
+  .playbook__excerpts summary:hover {
+    color: #FFCC99;
+  }
+  .playbook__excerpts ul {
+    list-style: none;
+    padding: 8px 0 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .playbook__excerpt {
+    border-left: 2px solid #FFCC9922;
+    padding-left: 10px;
+  }
+  .playbook__sid {
+    color: #FFCC9999;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    margin-right: 6px;
+  }
+  .playbook__phrase {
+    color: #88e088;
+    font-size: 12px;
+  }
+  .playbook__excerpt blockquote {
+    color: #FFCC99cc;
+    font-size: 12px;
+    line-height: 1.5;
+    margin: 4px 0 0;
+    font-style: italic;
+  }
+
+  .playbook__footer {
+    margin-top: 28px;
+    font-size: 11px;
+    color: #FFCC9966;
+    font-family: 'JetBrains Mono', monospace;
+  }
+  .playbook__footer code {
+    background: #FFCC9911;
+    padding: 0 4px;
+    border-radius: 2px;
+    color: #FFCC99;
+  }
+</style>

--- a/apps/standalone/src/pages/playbook.astro
+++ b/apps/standalone/src/pages/playbook.astro
@@ -32,23 +32,27 @@ function fmtSid(sid: string): string {
     <header class="playbook__header">
       <h1>PLAYBOOK</h1>
       <p class="playbook__lede">
-        Methods I've actually used — recurring prompt phrasings invoked
-        mid-session that produced verified outcomes. Positive counterpart
-        to CORRECTIONS: that surface mines pushback against the AI; this
-        one mines the verbs I reach for to steer it well. Ranked by
-        occurrence × downstream pass-rate when audit data is present;
-        by raw occurrence otherwise.
+        Candidate methods — recurring prompt phrasings the detector
+        found in your user turns. Positive counterpart to CORRECTIONS:
+        that surface mines pushback against the AI; this one mines
+        the verbs you reach for when you're steering it. The catalogue
+        is a 9-family regex and substring matches admit noise. When
+        F-layer audit data is present, ranking weights each pattern
+        by downstream pass-rate — a correlation in the next-5 audit
+        claims within the same session, not proof of causation.
+        Without audit data, ranking is by raw occurrence; read
+        critically.
       </p>
     </header>
 
     {playbook === null ? (
       <section class="playbook__empty">
-        <h2>No playbook candidates yet</h2>
+        <h2>Sidecar not yet written</h2>
         <p>
-          The detector writes <code>analysis/playbook-candidates.json</code>{' '}
-          on every scan. Click <strong>SCAN LOCAL</strong> from the DATA
-          panel — the exporter runs this stage automatically as part of{' '}
-          <code>all</code>.
+          <code>analysis/playbook-candidates.json</code> isn't on disk
+          (or failed to parse). Click <strong>SCAN LOCAL</strong> from
+          the DATA panel — the exporter writes this sidecar
+          automatically as part of <code>all</code>.
         </p>
       </section>
     ) : playbook.patterns.length === 0 ? (
@@ -96,6 +100,125 @@ function fmtSid(sid: string): string {
           </div>
         </section>
 
+        <section class="playbook__draft">
+          <button id="playbook-copy-md" type="button" class="playbook__copy">
+            COPY AS MARKDOWN
+          </button>
+          <span id="playbook-copy-feedback" class="playbook__copy-feedback" aria-live="polite"></span>
+          <p class="playbook__draft-hint">
+            Serializes the ranked list as markdown — pattern label,
+            description, occurrence/sessions/pass-rate, one excerpt per
+            pattern with its <code>[SID:…]</code> cite. Paste into a draft
+            and edit down.
+          </p>
+        </section>
+
+        <script
+          is:inline
+          type="application/json"
+          id="playbook-data"
+          set:html={
+            // Defensive escape: JSON.stringify does NOT escape '<' (so a
+            // user-corpus excerpt containing literal '</script>' would
+            // close this tag and inject the remainder as live HTML), nor
+            // U+2028 / U+2029 (which JS treats as line terminators
+            // inside string literals — a real foot-gun in <script>
+            // blocks). Escape all three to their \u forms; JSON.parse on
+            // the consumer side decodes them transparently.
+            JSON.stringify({
+              hasAuditSignal: playbook.hasAuditSignal,
+              patterns: playbook.patterns.map((p) => ({
+                patternKey: p.patternKey,
+                label: p.label,
+                description: p.description,
+                occurrenceCount: p.occurrenceCount,
+                sessionCount: p.sessionIds.length,
+                audit: {
+                  pass: p.audit.pass,
+                  fail: p.audit.fail,
+                  inconclusive: p.audit.inconclusive,
+                  passRate: p.audit.passRate,
+                },
+                firstHit: p.hits[0]
+                  ? {
+                      sessionId: p.hits[0].sessionId,
+                      phrase: p.hits[0].phrase,
+                      excerpt: p.hits[0].excerpt,
+                    }
+                  : null,
+              })),
+            })
+              .split('<').join('\\u003c')
+              .split(' ').join('\\u2028')
+              .split(' ').join('\\u2029')
+          }
+        />
+
+        <script is:inline>
+          (() => {
+            const btn = document.getElementById('playbook-copy-md');
+            const feedback = document.getElementById('playbook-copy-feedback');
+            const dataEl = document.getElementById('playbook-data');
+            if (!btn || !feedback || !dataEl) return;
+            let data;
+            try {
+              data = JSON.parse(dataEl.textContent || '{}');
+            } catch {
+              feedback.textContent = 'failed to parse data';
+              return;
+            }
+            function fmtPct(r) { return Math.round(r * 100) + '%'; }
+            function buildMarkdown() {
+              const lines = [];
+              lines.push('# Methods playbook draft');
+              lines.push('');
+              lines.push(
+                data.hasAuditSignal
+                  ? '_Ranked by occurrence × downstream-pass-rate (correlation, not causation)._'
+                  : '_No audit signal — ranked by raw occurrence. Read critically before quoting._',
+              );
+              lines.push('');
+              data.patterns.forEach((p, i) => {
+                lines.push('## ' + (i + 1) + '. ' + p.label);
+                lines.push('');
+                lines.push(p.description);
+                lines.push('');
+                const auditTotal = p.audit.pass + p.audit.fail + p.audit.inconclusive;
+                const stat =
+                  '**Invoked ' + p.occurrenceCount + 'x across ' +
+                  p.sessionCount + ' session' +
+                  (p.sessionCount === 1 ? '' : 's') + '**' +
+                  (data.hasAuditSignal && auditTotal > 0
+                    ? ' · pass in next-5 audit claims: ' + fmtPct(p.audit.passRate) +
+                      ' (' + p.audit.pass + '/' + auditTotal + ')'
+                    : ' · no audit signal yet');
+                lines.push(stat);
+                lines.push('');
+                if (p.firstHit) {
+                  lines.push('> "' + p.firstHit.excerpt.replace(/\n+/g, ' ') + '"');
+                  lines.push('>');
+                  lines.push(
+                    '> — phrase `' + p.firstHit.phrase + '` · [SID:' +
+                    p.firstHit.sessionId.slice(0, 8) + '…]',
+                  );
+                  lines.push('');
+                }
+              });
+              return lines.join('\n');
+            }
+            btn.addEventListener('click', async () => {
+              const md = buildMarkdown();
+              try {
+                await navigator.clipboard.writeText(md);
+                feedback.textContent = 'copied · ' + md.length + ' chars';
+                setTimeout(() => { feedback.textContent = ''; }, 4000);
+              } catch {
+                feedback.textContent = 'clipboard write failed';
+              }
+            });
+          })();
+        </script>
+
         <ol class="playbook__list">
           {playbook.patterns.map((p, idx) => (
             <li class="playbook__row">
@@ -121,9 +244,9 @@ function fmtSid(sid: string): string {
                       {fmtPct(p.audit.passRate)}
                     </span>
                     <span class="playbook__stat-label">
-                      downstream pass{' '}
+                      pass in next-5 audit claims{' '}
                       <small>
-                        ({p.audit.pass}/{p.audit.pass + p.audit.fail + p.audit.inconclusive})
+                        ({p.audit.pass}/{p.audit.pass + p.audit.fail + p.audit.inconclusive}; correlation, not causation)
                       </small>
                     </span>
                   </span>
@@ -251,6 +374,51 @@ function fmtSid(sid: string): string {
     margin-top: 4px;
   }
 
+  .playbook__draft {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+    padding: 14px 16px;
+    background: #0a0a0a;
+    border: 1px dashed #FFCC9944;
+    border-radius: 3px;
+  }
+  .playbook__copy {
+    font-family: 'Antonio', sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    color: #FFCC99;
+    background: #FFCC9911;
+    border: 1px solid #FFCC9955;
+    padding: 8px 14px;
+    border-radius: 2px;
+    cursor: pointer;
+  }
+  .playbook__copy:hover {
+    background: #FFCC9922;
+    border-color: #FFCC9988;
+  }
+  .playbook__copy-feedback {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: #FFCC99;
+  }
+  .playbook__draft-hint {
+    font-size: 11px;
+    color: #FFCC9999;
+    margin: 0;
+    flex: 1 1 280px;
+    min-width: 0;
+  }
+  .playbook__draft-hint code {
+    background: #FFCC9911;
+    padding: 0 4px;
+    border-radius: 2px;
+    font-family: 'JetBrains Mono', monospace;
+  }
+
   .playbook__list {
     list-style: none;
     padding: 0;
@@ -262,7 +430,7 @@ function fmtSid(sid: string): string {
   .playbook__row {
     background: #0a0a0a;
     border: 1px solid #FFCC9933;
-    border-left: 3px solid rgba(136, 224, 136, 0.45);
+    border-left: 3px solid rgba(255, 204, 153, 0.35);
     border-radius: 4px;
     padding: 18px 20px;
   }
@@ -329,7 +497,10 @@ function fmtSid(sid: string): string {
     font-size: 10px;
   }
   .playbook__stat--rate .playbook__stat-num {
-    color: #88e088;
+    /* Amber, not green — the lede explicitly disclaims causation;
+     * green chrome reads as "verified good" which the data does not
+     * support. Reserve the green pass-color for future causal signals. */
+    color: #FFCC99;
   }
   .playbook__stat--unavailable .playbook__stat-num {
     color: #FFCC9966;
@@ -345,7 +516,8 @@ function fmtSid(sid: string): string {
   .playbook__bar-fill {
     display: block;
     height: 100%;
-    background: rgba(136, 224, 136, 0.55);
+    /* Amber tone to match the stat-num decision above. */
+    background: rgba(255, 204, 153, 0.55);
   }
 
   .playbook__excerpts {
@@ -381,8 +553,9 @@ function fmtSid(sid: string): string {
     margin-right: 6px;
   }
   .playbook__phrase {
-    color: #88e088;
+    color: #FFCC99;
     font-size: 12px;
+    font-weight: 600;
   }
   .playbook__excerpt blockquote {
     color: #FFCC99cc;

--- a/packages/analysis/src/detectPlaybookCandidates.test.ts
+++ b/packages/analysis/src/detectPlaybookCandidates.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  detectPlaybookCandidates,
+  PLAYBOOK_PATTERN_META,
+  type PlaybookTurnInput,
+} from './detectPlaybookCandidates.js';
+
+function turn(
+  i: number,
+  userText: string,
+  lineNumber: number = 10 + i * 2,
+): PlaybookTurnInput {
+  return { sessionId: 'sess1', userTurnIndex: i, userText, lineNumber };
+}
+
+describe('detectPlaybookCandidates — ground-truth phrasings must surface', () => {
+  // The two anchor examples from project_methods_playbook memory. If
+  // either of these stops firing, the detector has regressed — these
+  // are the canonical positive cases the surface is built to expose.
+
+  it('surfaces "go back to first principles"', () => {
+    const hits = detectPlaybookCandidates([
+      turn(
+        0,
+        "OK before you do anything else, go back to first principles. Pretend the previous attempt doesn't exist.",
+      ),
+    ]);
+    const keys = hits.map((h) => h.patternKey);
+    expect(keys).toContain('first-principles');
+  });
+
+  it('surfaces "use an adversarial review team"', () => {
+    const hits = detectPlaybookCandidates([
+      turn(0, 'Use an adversarial review team to break the plan before we ship.'),
+    ]);
+    const keys = hits.map((h) => h.patternKey);
+    expect(keys).toContain('adversarial-review');
+  });
+
+  it('preserves transcript lineNumber on every hit (for downstream audit join)', () => {
+    const hits = detectPlaybookCandidates([
+      turn(0, "Let's reason from first principles here.", /* lineNumber */ 137),
+    ]);
+    expect(hits.length).toBeGreaterThan(0);
+    for (const h of hits) {
+      expect(h.lineNumber).toBe(137);
+      expect(h.sessionId).toBe('sess1');
+      expect(h.userTurnIndex).toBe(0);
+    }
+  });
+});
+
+describe('detectPlaybookCandidates — coverage across pattern families', () => {
+  const cases: Array<{ key: string; text: string }> = [
+    { key: 'step-back', text: "Hold on — let's step back and look at the problem shape." },
+    { key: 'deep-think', text: 'Ultrathink this one and then propose.' },
+    { key: 'verify-validate', text: 'Double-check the migration before we commit.' },
+    { key: 'plan-first', text: 'Plan first, then implement — no edits until the plan is solid.' },
+    { key: 'subagent-fanout', text: 'Run those two investigations in parallel using subagents.' },
+    { key: 'what-am-i-missing', text: 'What am I missing here? Walk me through the blind spots.' },
+    { key: 'tradeoffs', text: 'What are the alternatives and the trade-offs between them?' },
+  ];
+
+  for (const c of cases) {
+    it(`fires on pattern family: ${c.key}`, () => {
+      const hits = detectPlaybookCandidates([turn(0, c.text)]);
+      expect(hits.map((h) => h.patternKey)).toContain(c.key);
+    });
+  }
+
+  it('exposes label + description metadata for every key the kernel can emit', () => {
+    // Defensive: the on-disk sidecar references this catalogue, and the
+    // page renders labels straight from it. A key without metadata
+    // would render a blank row.
+    const allEmittableKeys = new Set<string>();
+    for (const c of cases) {
+      const hits = detectPlaybookCandidates([turn(0, c.text)]);
+      for (const h of hits) allEmittableKeys.add(h.patternKey);
+    }
+    // Plus the two anchors:
+    allEmittableKeys.add('first-principles');
+    allEmittableKeys.add('adversarial-review');
+    for (const k of allEmittableKeys) {
+      const meta = PLAYBOOK_PATTERN_META.get(k);
+      expect(meta, `meta missing for pattern key '${k}'`).toBeDefined();
+      expect(meta?.label.length).toBeGreaterThan(0);
+      expect(meta?.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('detectPlaybookCandidates — admitted noise / filters', () => {
+  it('skips trivially short user text', () => {
+    const hits = detectPlaybookCandidates([turn(0, 'ok')]);
+    expect(hits).toEqual([]);
+  });
+
+  it('returns empty for an unrelated user turn', () => {
+    const hits = detectPlaybookCandidates([
+      turn(0, 'Can you bump the version number in package.json please'),
+    ]);
+    expect(hits).toEqual([]);
+  });
+
+  it('emits one hit per matched family per turn (no within-family duplicates)', () => {
+    // Plan-first has two regex arms; a turn that satisfies both should
+    // still produce a single hit for the family.
+    const hits = detectPlaybookCandidates([
+      turn(0, 'Plan first — before you implementing anything please plan it out.'),
+    ]);
+    const planFirstHits = hits.filter((h) => h.patternKey === 'plan-first');
+    expect(planFirstHits.length).toBe(1);
+  });
+});

--- a/packages/analysis/src/detectPlaybookCandidates.test.ts
+++ b/packages/analysis/src/detectPlaybookCandidates.test.ts
@@ -111,4 +111,19 @@ describe('detectPlaybookCandidates — admitted noise / filters', () => {
     const planFirstHits = hits.filter((h) => h.patternKey === 'plan-first');
     expect(planFirstHits.length).toBe(1);
   });
+
+  it('emits multiple hits when one turn invokes multiple distinct families', () => {
+    // Defensive: the per-family `break` must not collapse hits ACROSS
+    // families. A turn invoking both first-principles AND adversarial-
+    // review should produce two hits, one per family.
+    const hits = detectPlaybookCandidates([
+      turn(
+        0,
+        "Let's go back to first principles, then run an adversarial review team on the resulting plan.",
+      ),
+    ]);
+    const keys = hits.map((h) => h.patternKey).sort();
+    expect(keys).toContain('first-principles');
+    expect(keys).toContain('adversarial-review');
+  });
 });

--- a/packages/analysis/src/detectPlaybookCandidates.ts
+++ b/packages/analysis/src/detectPlaybookCandidates.ts
@@ -1,0 +1,257 @@
+/**
+ * Stage 1 of the methods-playbook pipeline: heuristic recall over user
+ * turns, looking for **recurring prompt phrasings** the user invokes
+ * mid-session to steer the AI in a useful direction.
+ *
+ * Pure. No I/O, no LLM. Deterministic given identical input.
+ *
+ * The positive analog to {@link detectCorrectionCandidates}: corrections
+ * look for user pushback (negation, frustration, repeat-instruction) that
+ * precedes a behavior fix; playbook hits look for prescriptive verbs
+ * ("first principles", "adversarial review", "step back", "verify
+ * before you change") that precede verified outcomes. The audit join —
+ * which turns occurrence counts into downstream pass-rate — lives in
+ * the exporter's builder layer because it requires reading
+ * `audit-results.json` from disk. Keep this kernel pure so the browser
+ * tier can run the same detection over an uploaded ZIP if we ever want
+ * to.
+ *
+ * Adversarial-validation note: the pattern set admits some noise. For
+ * example `\balternatives?\b` fires on "what are the alternatives?"
+ * (legitimate method) AND on "the alternatives mentioned earlier"
+ * (a reference, not a directive). The downstream-audit join is the
+ * filter — patterns that don't correlate with pass-verdicts surface
+ * with a 0% pass-rate score and rank below the real methods. Do not
+ * narrow patterns here to suppress the noise — that erodes recall.
+ */
+
+import type { ScanStats } from '@chat-arch/schema';
+
+/**
+ * Bumped whenever the heuristic ruleset changes (new pattern family,
+ * broadened regex, label change). The exporter's playbook builder uses
+ * this as a cache key — a mismatch forces a full re-scan.
+ *
+ * History:
+ *   1 — initial release (9 pattern families: first-principles,
+ *       adversarial-review, step-back, deep-think, verify-validate,
+ *       plan-first, subagent-fanout, what-am-i-missing, tradeoffs)
+ */
+export const PLAYBOOK_HEURISTIC_VERSION = 1;
+
+/** Same shape as {@link TurnPair} but carries `lineNumber` for the audit join. */
+export interface PlaybookTurnInput {
+  sessionId: string;
+  /** 0-based index into the session's user turns. */
+  userTurnIndex: number;
+  /** 1-based line number of the user turn inside the transcript. */
+  lineNumber: number;
+  userText: string;
+}
+
+interface PatternFamily {
+  key: string;
+  label: string;
+  description: string;
+  patterns: ReadonlyArray<RegExp>;
+}
+
+/**
+ * The pattern catalogue. Adding a family: append here AND bump
+ * {@link PLAYBOOK_HEURISTIC_VERSION}. The keys are stable and end up in
+ * the on-disk sidecar; do not rename.
+ */
+const PATTERN_FAMILIES: ReadonlyArray<PatternFamily> = [
+  {
+    key: 'first-principles',
+    label: 'First principles',
+    description:
+      'Reset the framing — ignore prior conclusions and rederive from scratch.',
+    patterns: [
+      /\b(?:go back to |from |starting from |using )?first[\s-]principles?\b/i,
+    ],
+  },
+  {
+    key: 'adversarial-review',
+    label: 'Adversarial review',
+    description:
+      'Spin up critics whose job is to break the current plan or output.',
+    patterns: [
+      /\badversarial\s+(?:review(?:er)?s?|red.?team(?:ers?)?|critics?|agents?|experiments?|tests?)\b/i,
+    ],
+  },
+  {
+    key: 'step-back',
+    label: 'Step back',
+    description:
+      'Pause execution and re-examine the shape of the problem before the next move.',
+    patterns: [
+      /\b(?:step|stepping|take\s+a\s+step|let'?s\s+step)\s+back\b/i,
+      /\bzoom\s+out\b/i,
+    ],
+  },
+  {
+    key: 'deep-think',
+    label: 'Think deeply / harder',
+    description:
+      'Explicitly request more reasoning effort before producing the next answer.',
+    patterns: [
+      /\b(?:think|reason)\s+(?:deeply|harder|carefully|more|step.by.step)\b/i,
+      /\bultrathink\b/i,
+    ],
+  },
+  {
+    key: 'verify-validate',
+    label: 'Verify / sanity-check',
+    description:
+      'Force a verification pass — re-read, re-run, double-check — before declaring done.',
+    patterns: [
+      /\b(?:double|triple)[\s-]?check\b/i,
+      /\bsanity[\s-]?check\b/i,
+      /\bverify\s+(?:that|the|this|before|first)\b/i,
+    ],
+  },
+  {
+    key: 'plan-first',
+    label: 'Plan before implementing',
+    description:
+      'Demand an explicit plan or sketch before any edits land.',
+    patterns: [
+      /\b(?:plan|design|sketch|outline)\s+(?:first|it out|the approach|before)\b/i,
+      /\bbefore\s+(?:you|implementing|coding|writing)\b.*\b(?:plan|design)\b/i,
+    ],
+  },
+  {
+    key: 'subagent-fanout',
+    label: 'Sub-agent fan-out',
+    description:
+      'Parallelise the work across sub-agents instead of one monolithic pass.',
+    patterns: [
+      /\bin\s+parallel\b/i,
+      /\bsub.?agents?\b/i,
+      /\bfan.?out\b/i,
+      /\bspawn\s+(?:an?\s+)?(?:agent|sub.?agent)\b/i,
+      /\b(?:use|launch)\s+(?:the\s+)?(?:plan|explore|general-purpose)\s+agent\b/i,
+    ],
+  },
+  {
+    key: 'what-am-i-missing',
+    label: 'What am I missing?',
+    description:
+      'Ask the AI to enumerate gaps and blind spots in the current approach.',
+    patterns: [
+      /\bwhat\s+(?:am\s+i|are\s+we|did\s+(?:we|i))\s+miss(?:ing)?\b/i,
+      /\bblind\s+spots?\b/i,
+      /\bgaps?\s+in\s+(?:my|the|this|our)\b/i,
+    ],
+  },
+  {
+    key: 'tradeoffs',
+    label: 'Trade-offs / alternatives',
+    description:
+      'Force a comparison — surface options and their costs before committing.',
+    patterns: [
+      /\btrade[\s-]?offs?\b/i,
+      /\bpros\s+and\s+cons\b/i,
+      /\balternative\s+(?:approaches?|options?|solutions?|ways?)\b/i,
+      /\bwhat\s+are\s+the\s+alternatives?\b/i,
+    ],
+  },
+];
+
+/**
+ * Lookup of canonical pattern metadata. The builder uses this to fill
+ * `label` and `description` on every emitted pattern row, so consumers
+ * (the playbook page) don't have to maintain a parallel catalogue.
+ */
+export const PLAYBOOK_PATTERN_META: ReadonlyMap<
+  string,
+  { label: string; description: string }
+> = new Map(
+  PATTERN_FAMILIES.map((f) => [
+    f.key,
+    { label: f.label, description: f.description },
+  ]),
+);
+
+export interface PlaybookKernelHit {
+  sessionId: string;
+  userTurnIndex: number;
+  lineNumber: number;
+  patternKey: string;
+  /** Verbatim matched phrase, truncated to 80 chars. */
+  phrase: string;
+  /** ≤500 chars of the surrounding user text (trimmed). */
+  excerpt: string;
+}
+
+/** Minimum trimmed-text length to consider — guards against single-token noise. */
+const MIN_USER_TEXT_LEN = 10;
+const EXCERPT_MAX = 500;
+const PHRASE_MAX = 80;
+
+/**
+ * Scan a single user turn against every pattern family. Returns one
+ * hit per (family, distinct match) — a turn that contains both
+ * "first principles" and "adversarial review" produces two hits.
+ *
+ * Same-key duplicate suppression: if a single family's patterns both
+ * match (rare — most families have one regex), only the first hit is
+ * emitted. This mirrors the corrections kernel's per-kind dedupe.
+ */
+function scanTurn(text: string): Array<{ patternKey: string; phrase: string }> {
+  const out: Array<{ patternKey: string; phrase: string }> = [];
+  for (const family of PATTERN_FAMILIES) {
+    for (const pat of family.patterns) {
+      const m = text.match(pat);
+      if (m !== null) {
+        out.push({
+          patternKey: family.key,
+          phrase: m[0].slice(0, PHRASE_MAX),
+        });
+        break; // one hit per family per turn
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Scan an array of user-turn inputs (one per session, in order) and
+ * return playbook hits. Per-turn filters: trimmed text must be at
+ * least {@link MIN_USER_TEXT_LEN} chars. Wrapper-prefix turns and
+ * 4000+ char pastes are expected to have been dropped upstream
+ * by the transcript parser (same as the corrections pipeline) — this
+ * kernel does NOT re-filter for them.
+ */
+export function detectPlaybookCandidates(
+  turns: ReadonlyArray<PlaybookTurnInput>,
+): PlaybookKernelHit[] {
+  const out: PlaybookKernelHit[] = [];
+  for (const t of turns) {
+    const trimmed = t.userText.trim();
+    if (trimmed.length < MIN_USER_TEXT_LEN) continue;
+    const hits = scanTurn(trimmed);
+    if (hits.length === 0) continue;
+    const excerpt = truncate(trimmed, EXCERPT_MAX);
+    for (const h of hits) {
+      out.push({
+        sessionId: t.sessionId,
+        userTurnIndex: t.userTurnIndex,
+        lineNumber: t.lineNumber,
+        patternKey: h.patternKey,
+        phrase: h.phrase,
+        excerpt,
+      });
+    }
+  }
+  return out;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1) + '…';
+}
+
+/** Re-exported for builder convenience — same shape we already produce. */
+export type { ScanStats };

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -143,4 +143,12 @@ export {
   type TurnPair,
 } from './detectCorrectionCandidates.js';
 
+export {
+  PLAYBOOK_HEURISTIC_VERSION,
+  PLAYBOOK_PATTERN_META,
+  detectPlaybookCandidates,
+  type PlaybookTurnInput,
+  type PlaybookKernelHit,
+} from './detectPlaybookCandidates.js';
+
 export { clusterByThreshold } from './clusterRules.js';

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -30,6 +30,7 @@ import {
   type DuplicateInput,
 } from '@chat-arch/analysis';
 import { buildCorrectionsCandidatesFile } from './corrections.js';
+import { buildPlaybookCandidatesFile } from './playbook.js';
 
 export interface RunAnalysisOptions {
   /** Root output dir (same one `manifest.json` sits in). */
@@ -52,6 +53,7 @@ export interface RunAnalysisResult {
     topics: string;
     narratives: string;
     correctionCandidates: string;
+    playbookCandidates: string;
   };
   counts: {
     duplicatesClusters: number;
@@ -63,6 +65,8 @@ export interface RunAnalysisResult {
     topics: number;
     narratives: number;
     correctionCandidates: number;
+    playbookPatterns: number;
+    playbookHits: number;
   };
 }
 
@@ -71,7 +75,7 @@ export interface RunAnalysisResult {
  * gate reuse on a version match — when the on-disk entry shape
  * changes, all prior caches self-invalidate on next rescan.
  */
-export const EXPORTER_VERSION = '0.10.0';
+export const EXPORTER_VERSION = '0.11.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,
@@ -213,6 +217,23 @@ export async function runAnalysis(
     `analysis: correction-candidates.json — ${correctionsResult.correctionsFile.corrections.length} candidates from ${correctionsResult.scannedSessions} sessions (${correctionsResult.missingTranscripts} missing transcripts)`,
   );
 
+  // ---- Methods playbook (stage-1 heuristic) ----
+  // Positive counterpart to corrections — recurring user-turn phrasings
+  // (e.g. "go back to first principles", "use an adversarial review
+  // team") that the viewer's /playbook surface ranks by occurrence ×
+  // downstream pass-rate. The skill-driven encoding flow (export as
+  // prompt snippet / CLAUDE.md verb) is deferred to a follow-up PR.
+  const playbookResult = await buildPlaybookCandidatesFile(manifest, {
+    outDir: options.outDir,
+    now,
+  });
+  const playbookCandidatesPath = path.join(analysisDir, 'playbook-candidates.json');
+  await writeFile(
+    playbookCandidatesPath,
+    JSON.stringify(playbookResult.file, null, 2) + '\n',
+    'utf8',
+  );
+
   // ---- Meta ----
   const exporterRunId = options.exporterRunId ?? randomUUID();
   const gitSha = options.gitSha !== undefined ? options.gitSha : detectGitSha();
@@ -232,6 +253,7 @@ export async function runAnalysis(
           'topics.json',
           'narratives.json',
           'correction-candidates.json',
+          'playbook-candidates.json',
         ],
       },
     },
@@ -246,6 +268,8 @@ export async function runAnalysis(
       topics: topicsResult.topics.length,
       narratives: narrativesResult.narratives.length,
       correctionCandidates: correctionsResult.correctionsFile.corrections.length,
+      playbookPatterns: playbookResult.file.patterns.length,
+      playbookHits: playbookResult.totalHits,
     },
   };
   const metaPath = path.join(analysisDir, 'meta.json');
@@ -262,6 +286,7 @@ export async function runAnalysis(
       topics: topicsPath,
       narratives: narrativesPath,
       correctionCandidates: correctionCandidatesPath,
+      playbookCandidates: playbookCandidatesPath,
     },
     counts: {
       duplicatesClusters: duplicatesFile.clusters.length,
@@ -271,6 +296,8 @@ export async function runAnalysis(
       topics: topicsResult.topics.length,
       narratives: narrativesResult.narratives.length,
       correctionCandidates: correctionsResult.correctionsFile.corrections.length,
+      playbookPatterns: playbookResult.file.patterns.length,
+      playbookHits: playbookResult.totalHits,
     },
   };
 }

--- a/packages/exporter/src/analysis/playbook.test.ts
+++ b/packages/exporter/src/analysis/playbook.test.ts
@@ -126,6 +126,87 @@ describe('buildPlaybookCandidatesFile — ground-truth + audit join', () => {
     expect(fpPattern?.score).toBe(1);
   });
 
+  it('sinks score to 0 when a pattern has audit overlap but zero passes', async () => {
+    // Regression for the QA finding: with audit data present and a
+    // pattern whose downstream window contains only fails/inconclusive
+    // (passRate = 0), the score must collapse to 0 — NOT silently
+    // fall back to raw occurrence. Otherwise the kernel's docstring
+    // promise ("patterns that don't correlate with pass-verdicts
+    // surface with a 0% pass-rate score and rank below the real
+    // methods") is broken.
+    const outDir = path.join(tmpRoot, 'zero-pass');
+    await mkdir(path.join(outDir, 'analysis'), { recursive: true });
+    await mkdir(path.join(outDir, 'transcripts'), { recursive: true });
+
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'OK, what are the alternative approaches here?',
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'I broke the build, sorry.' },
+      }),
+    ].join('\n');
+    const transcriptPath = path.join('transcripts', 'sess-tr.jsonl');
+    await writeFile(path.join(outDir, transcriptPath), transcript, 'utf8');
+
+    const auditResults = {
+      version: 1,
+      generatedAt: 0,
+      totals: { pass: 0, fail: 1, inconclusive: 0 },
+      results: [
+        {
+          sessionId: 'sess-tr',
+          source: 'cli-direct',
+          lineNumber: 2,
+          claimType: 'fix-claim',
+          span: 'broke the build',
+          surroundingContext: '',
+          outcome: 'fail',
+          reason: 'evidence to the contrary',
+        },
+      ],
+    };
+    await writeFile(
+      path.join(outDir, 'analysis', 'audit-results.json'),
+      JSON.stringify(auditResults),
+      'utf8',
+    );
+
+    const entry: UnifiedSessionEntry = {
+      id: 'sess-tr',
+      source: 'cli-direct',
+      title: 'fixture',
+      preview: '',
+      messageCount: 2,
+      createdAt: 0,
+      updatedAt: 0,
+      transcriptPath,
+    } as UnifiedSessionEntry;
+    const manifest: SessionManifest = {
+      schemaVersion: 1,
+      generatedAt: 0,
+      counts: { cli: 1, cloud: 0, cowork: 0, total: 1 },
+      sessions: [entry],
+    } as SessionManifest;
+
+    const result = await buildPlaybookCandidatesFile(manifest, { outDir, now: 1 });
+    const tradeoffsPattern = result.file.patterns.find(
+      (p) => p.patternKey === 'tradeoffs',
+    );
+    expect(tradeoffsPattern, 'tradeoffs pattern missing').toBeDefined();
+    expect(tradeoffsPattern?.occurrenceCount).toBe(1);
+    expect(tradeoffsPattern?.audit.pass).toBe(0);
+    expect(tradeoffsPattern?.audit.fail).toBe(1);
+    expect(tradeoffsPattern?.audit.passRate).toBe(0);
+    // The critical assertion: score must be 0, NOT 1 (the raw count).
+    expect(tradeoffsPattern?.score).toBe(0);
+  });
+
   it('degrades to occurrence-only ranking when audit-results.json is absent', async () => {
     const outDir = path.join(tmpRoot, 'no-audit');
     await mkdir(path.join(outDir, 'transcripts'), { recursive: true });
@@ -173,5 +254,82 @@ describe('buildPlaybookCandidatesFile — ground-truth + audit join', () => {
     // Score equals occurrence when no audit signal.
     expect(advPattern?.score).toBe(1);
     expect(advPattern?.audit.pass).toBe(0);
+  });
+
+  it('parses cloud transcripts and produces lineNumbers that match the audit pipeline convention', async () => {
+    // Pins the cloud lineNumber convention: 1-based ordinal into
+    // `chat_messages[]`, incrementing on EVERY entry (including
+    // assistant messages that the audit pipeline would also count).
+    // The audit pipeline iterates the same array with `let lineNumber = 1; lineNumber += 1`
+    // per loop iteration regardless of sender, so this fixture also
+    // catches future drift between the two parsers.
+    const outDir = path.join(tmpRoot, 'cloud-fixture');
+    await mkdir(path.join(outDir, 'analysis'), { recursive: true });
+    await mkdir(path.join(outDir, 'transcripts'), { recursive: true });
+
+    const cloudTranscript = {
+      chat_messages: [
+        { sender: 'human', text: 'hey can you start a draft' }, // ordinal 1
+        { sender: 'assistant', text: 'sure, here is a draft' }, // ordinal 2
+        { sender: 'human', text: 'OK go back to first principles instead' }, // ordinal 3
+        { sender: 'assistant', text: 'rederived — fixed the model' }, // ordinal 4
+      ],
+    };
+    const transcriptPath = path.join('transcripts', 'sess-cloud.json');
+    await writeFile(
+      path.join(outDir, transcriptPath),
+      JSON.stringify(cloudTranscript),
+      'utf8',
+    );
+
+    const auditResults = {
+      version: 1,
+      generatedAt: 0,
+      totals: { pass: 1, fail: 0, inconclusive: 0 },
+      results: [
+        {
+          sessionId: 'sess-cloud',
+          source: 'cloud',
+          // Assistant turn at chat_messages[3] → 1-based lineNumber 4.
+          lineNumber: 4,
+          claimType: 'fix-claim',
+          span: 'fixed the model',
+          surroundingContext: '',
+          outcome: 'pass',
+          reason: 'evidence in following assistant turn',
+        },
+      ],
+    };
+    await writeFile(
+      path.join(outDir, 'analysis', 'audit-results.json'),
+      JSON.stringify(auditResults),
+      'utf8',
+    );
+
+    const entry: UnifiedSessionEntry = {
+      id: 'sess-cloud',
+      source: 'cloud',
+      title: 'fixture',
+      preview: '',
+      messageCount: 4,
+      createdAt: 0,
+      updatedAt: 0,
+      transcriptPath,
+    } as UnifiedSessionEntry;
+    const manifest: SessionManifest = {
+      schemaVersion: 1,
+      generatedAt: 0,
+      counts: { cli: 0, cloud: 1, cowork: 0, total: 1 },
+      sessions: [entry],
+    } as SessionManifest;
+
+    const result = await buildPlaybookCandidatesFile(manifest, { outDir, now: 1 });
+    const fp = result.file.patterns.find((p) => p.patternKey === 'first-principles');
+    expect(fp, 'first-principles missing from cloud fixture').toBeDefined();
+    expect(fp?.hits[0]?.lineNumber).toBe(3);
+    // The downstream audit claim at lineNumber 4 sits in the next-5
+    // window of the line-3 hit and counts as pass.
+    expect(fp?.audit.pass).toBe(1);
+    expect(fp?.audit.passRate).toBe(1);
   });
 });

--- a/packages/exporter/src/analysis/playbook.test.ts
+++ b/packages/exporter/src/analysis/playbook.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { SessionManifest, UnifiedSessionEntry } from '@chat-arch/schema';
+import { buildPlaybookCandidatesFile } from './playbook.js';
+
+/**
+ * Sanity assertion called out in the spec: a fixture transcript with
+ * "first principles" + a downstream audit-passed claim must surface
+ * the phrasing in the output. If this stops going green the playbook
+ * pipeline has lost the canonical ground-truth case.
+ */
+describe('buildPlaybookCandidatesFile — ground-truth + audit join', () => {
+  const tmpRoot = path.join(
+    os.tmpdir(),
+    `chat-arch-playbook-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('surfaces "first principles" and pairs it with the downstream pass', async () => {
+    const outDir = tmpRoot;
+    await mkdir(path.join(outDir, 'analysis'), { recursive: true });
+    await mkdir(path.join(outDir, 'transcripts'), { recursive: true });
+
+    // Fixture transcript — JSONL with two user turns. The second user
+    // turn invokes "first principles"; the assistant turn that follows
+    // contains a fix-claim that the audit verifier (mocked below)
+    // judged as `pass`.
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: 'Try implementing the parser please.' },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: 'Done — added a draft parser.' },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'Hold on — go back to first principles and rederive the grammar.',
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: 'Verified the grammar by rederiving — fixed the precedence bug.',
+        },
+      }),
+    ].join('\n');
+
+    const transcriptPath = path.join('transcripts', 'sess-fp.jsonl');
+    await writeFile(path.join(outDir, transcriptPath), transcript, 'utf8');
+
+    // Minimal audit-results.json fixture. The audit claim sits at
+    // lineNumber 4 (the assistant turn after the user's first-principles
+    // invocation at lineNumber 3) and is marked `pass`.
+    const auditResults = {
+      version: 1,
+      generatedAt: 0,
+      totals: { pass: 1, fail: 0, inconclusive: 0 },
+      results: [
+        {
+          sessionId: 'sess-fp',
+          source: 'cli-direct',
+          lineNumber: 4,
+          claimType: 'fix-claim',
+          span: 'fixed the precedence bug',
+          surroundingContext: '',
+          outcome: 'pass',
+          reason: 'evidence in following assistant turn',
+        },
+      ],
+    };
+    await writeFile(
+      path.join(outDir, 'analysis', 'audit-results.json'),
+      JSON.stringify(auditResults, null, 2),
+      'utf8',
+    );
+
+    const entry: UnifiedSessionEntry = {
+      id: 'sess-fp',
+      source: 'cli-direct',
+      title: 'fixture',
+      preview: '',
+      messageCount: 4,
+      createdAt: 0,
+      updatedAt: 0,
+      transcriptPath,
+    } as UnifiedSessionEntry;
+    const manifest: SessionManifest = {
+      schemaVersion: 1,
+      generatedAt: 0,
+      counts: { cli: 1, cloud: 0, cowork: 0, total: 1 },
+      sessions: [entry],
+    } as SessionManifest;
+
+    const result = await buildPlaybookCandidatesFile(manifest, {
+      outDir,
+      now: 1,
+    });
+
+    expect(result.hasAuditSignal).toBe(true);
+
+    const fpPattern = result.file.patterns.find(
+      (p) => p.patternKey === 'first-principles',
+    );
+    expect(fpPattern, 'first-principles pattern missing from output').toBeDefined();
+    expect(fpPattern?.occurrenceCount).toBe(1);
+    expect(fpPattern?.sessionIds).toEqual(['sess-fp']);
+    expect(fpPattern?.hits[0]?.lineNumber).toBe(3);
+
+    // The audit claim at line 4 is downstream of the line-3 phrasing
+    // and is a pass — the join should yield passRate = 1.0.
+    expect(fpPattern?.audit.pass).toBe(1);
+    expect(fpPattern?.audit.fail).toBe(0);
+    expect(fpPattern?.audit.passRate).toBe(1);
+
+    // With audit signal present, score = occurrence * passRate.
+    expect(fpPattern?.score).toBe(1);
+  });
+
+  it('degrades to occurrence-only ranking when audit-results.json is absent', async () => {
+    const outDir = path.join(tmpRoot, 'no-audit');
+    await mkdir(path.join(outDir, 'transcripts'), { recursive: true });
+
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'Use an adversarial review team on this plan before we ship.',
+        },
+      }),
+    ].join('\n');
+    const transcriptPath = path.join('transcripts', 'sess-adv.jsonl');
+    await writeFile(path.join(outDir, transcriptPath), transcript, 'utf8');
+
+    const entry: UnifiedSessionEntry = {
+      id: 'sess-adv',
+      source: 'cli-direct',
+      title: 'fixture',
+      preview: '',
+      messageCount: 1,
+      createdAt: 0,
+      updatedAt: 0,
+      transcriptPath,
+    } as UnifiedSessionEntry;
+    const manifest: SessionManifest = {
+      schemaVersion: 1,
+      generatedAt: 0,
+      counts: { cli: 1, cloud: 0, cowork: 0, total: 1 },
+      sessions: [entry],
+    } as SessionManifest;
+
+    const result = await buildPlaybookCandidatesFile(manifest, {
+      outDir,
+      now: 1,
+    });
+
+    expect(result.hasAuditSignal).toBe(false);
+    const advPattern = result.file.patterns.find(
+      (p) => p.patternKey === 'adversarial-review',
+    );
+    expect(advPattern).toBeDefined();
+    expect(advPattern?.occurrenceCount).toBe(1);
+    // Score equals occurrence when no audit signal.
+    expect(advPattern?.score).toBe(1);
+    expect(advPattern?.audit.pass).toBe(0);
+  });
+});

--- a/packages/exporter/src/analysis/playbook.ts
+++ b/packages/exporter/src/analysis/playbook.ts
@@ -247,7 +247,15 @@ export async function buildPlaybookCandidatesFile(
 
     const audit = computeAudit(hits, auditByLine, window);
     const occurrence = hits.length;
-    const score = hasAuditSignal && audit.passRate > 0
+    // Score branches on whether this pattern's hits actually had any
+    // downstream audit claims fall into their windows — NOT on whether
+    // the pass-rate is > 0. A pattern with audit overlap and 0% pass
+    // must sink to ~0, not silently fall back to raw occurrence. The
+    // kernel's docstring promises that "patterns that don't correlate
+    // with pass-verdicts surface with a 0% score and rank below the
+    // real methods"; this is the line that has to keep that promise.
+    const auditTotal = audit.pass + audit.fail + audit.inconclusive;
+    const score = hasAuditSignal && auditTotal > 0
       ? occurrence * audit.passRate
       : occurrence;
 
@@ -363,12 +371,12 @@ function computeAudit(
  *   - JSONL transcripts (cli-direct, cli-desktop, cowork): 1-based
  *     index into the line-split file. Matches audit-results.json's
  *     convention.
- *   - Cloud JSON transcripts: 1-based ordinal within `chat_messages[]`.
- *     Cloud doesn't have transcript line numbers in the audit sense;
- *     this approximation collides with how the audit pipeline keys
- *     cloud claims. If the audit join produces zeros for cloud
- *     sessions, that's the mismatch — fixable in a follow-up once
- *     audit-results lands on main.
+ *   - Cloud JSON transcripts: 1-based ordinal within `chat_messages[]`,
+ *     incrementing on every entry regardless of sender/skip. Verified
+ *     to match the audit pipeline's cloud convention (a sibling
+ *     iteration over the same array that increments on every step).
+ *     A coupled regression test should land alongside the audit
+ *     pipeline when it merges to main.
  */
 async function parseTranscript(
   entry: UnifiedSessionEntry,

--- a/packages/exporter/src/analysis/playbook.ts
+++ b/packages/exporter/src/analysis/playbook.ts
@@ -1,0 +1,520 @@
+/**
+ * Stage-1 playbook builder — heuristic recall + (optional) audit join.
+ *
+ * Mirrors the corrections builder: parses each session's transcript,
+ * feeds user turns into the {@link detectPlaybookCandidates} kernel,
+ * groups hits by pattern key, and — when an `audit-results.json`
+ * sidecar exists — joins each hit against the next-N downstream
+ * audit claims in the same session to compute a per-pattern
+ * downstream pass-rate.
+ *
+ * Node-only (reads files). Pure-function kernel lives in @chat-arch/analysis.
+ *
+ * The audit dependency is intentionally LATE-BOUND with a minimal local
+ * shape rather than importing `AuditResult` from @chat-arch/schema. That
+ * file doesn't exist on `main` yet — it ships with the audit pipeline
+ * (PR #50). When that lands, the local interface here will match the
+ * canonical schema; the join surface stays stable either way.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  PlaybookCandidatesFile,
+  PlaybookHit,
+  PlaybookPattern,
+  PlaybookPatternAudit,
+  ScanStats,
+  SessionManifest,
+  UnifiedSessionEntry,
+} from '@chat-arch/schema';
+import {
+  PLAYBOOK_HEURISTIC_VERSION,
+  PLAYBOOK_PATTERN_META,
+  detectPlaybookCandidates,
+  type PlaybookTurnInput,
+} from '@chat-arch/analysis';
+import { logger } from '../lib/logger.js';
+
+export interface BuildPlaybookOptions {
+  outDir: string;
+  now: number;
+  ioConcurrency?: number;
+  /**
+   * Window length: per phrasing hit, the audit join inspects the next
+   * N claims in the same session whose lineNumber > hit.lineNumber.
+   * Spec: "N events following the phrasing". 5 covers the typical
+   * working-window without picking up unrelated end-of-session work.
+   */
+  downstreamWindow?: number;
+}
+
+export interface BuildPlaybookResult {
+  file: PlaybookCandidatesFile;
+  scannedSessions: number;
+  missingTranscripts: number;
+  totalHits: number;
+  hasAuditSignal: boolean;
+}
+
+const DEFAULT_IO_CONCURRENCY = 8;
+const DEFAULT_DOWNSTREAM_WINDOW = 5;
+
+/** Same wrapper/length filters as the corrections parser — keep in sync. */
+const WRAPPER_PREFIXES: readonly string[] = [
+  '<command-message>',
+  '<command-name>',
+  '<command-args>',
+  '<system-reminder>',
+  '<local-command-stdout>',
+  '<local-command-stderr>',
+  '<bash-stdout>',
+  '<bash-stderr>',
+  '<task-notification>',
+  '<scheduled-task',
+  '<uploaded_files>',
+  'Base directory for this skill:',
+  '<file>',
+  '<file_path>',
+  '<file_uuid>',
+  'Caveat: The messages below were generated',
+  'This session is being continued from a previous conversation',
+  '[Request interrupted by user',
+];
+const MAX_USER_PROMPT_CHARS = 4000;
+
+interface SessionParse {
+  turns: PlaybookTurnInput[];
+  rawTurns: number;
+  wrapperFiltered: number;
+  tooLongFiltered: number;
+}
+
+interface MinimalAuditResult {
+  sessionId: string;
+  lineNumber: number;
+  outcome: 'pass' | 'fail' | 'inconclusive';
+}
+
+async function parallelMap<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let cursor = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < workerCount; w += 1) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const i = cursor;
+          cursor += 1;
+          if (i >= items.length) return;
+          out[i] = await fn(items[i] as T, i);
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+  return out;
+}
+
+/**
+ * Read audit-results.json if present and return a per-session sorted
+ * array of (lineNumber, outcome). Returns null if the sidecar is
+ * missing, malformed, or has no results — caller falls back to
+ * occurrence-only ranking.
+ */
+async function loadAuditByLine(
+  outDir: string,
+): Promise<Map<string, MinimalAuditResult[]> | null> {
+  const p = path.join(outDir, 'analysis', 'audit-results.json');
+  let raw: string;
+  try {
+    raw = await readFile(p, 'utf8');
+  } catch {
+    return null;
+  }
+  let parsed: { results?: ReadonlyArray<Record<string, unknown>> };
+  try {
+    parsed = JSON.parse(raw) as { results?: ReadonlyArray<Record<string, unknown>> };
+  } catch {
+    return null;
+  }
+  const results = parsed.results;
+  if (!Array.isArray(results) || results.length === 0) return null;
+
+  const bySession = new Map<string, MinimalAuditResult[]>();
+  for (const r of results) {
+    const sid = r['sessionId'];
+    const ln = r['lineNumber'];
+    const outcome = r['outcome'];
+    if (
+      typeof sid !== 'string' ||
+      typeof ln !== 'number' ||
+      (outcome !== 'pass' && outcome !== 'fail' && outcome !== 'inconclusive')
+    ) {
+      continue;
+    }
+    const slot = bySession.get(sid) ?? [];
+    slot.push({ sessionId: sid, lineNumber: ln, outcome });
+    bySession.set(sid, slot);
+  }
+  // Sort each session's audit results by lineNumber so the downstream
+  // window join is a linear scan rather than O(n²).
+  for (const arr of bySession.values()) {
+    arr.sort((a, b) => a.lineNumber - b.lineNumber);
+  }
+  return bySession;
+}
+
+export async function buildPlaybookCandidatesFile(
+  manifest: SessionManifest,
+  options: BuildPlaybookOptions,
+): Promise<BuildPlaybookResult> {
+  const t0 = Date.now();
+  const concurrency = options.ioConcurrency ?? DEFAULT_IO_CONCURRENCY;
+  const window = options.downstreamWindow ?? DEFAULT_DOWNSTREAM_WINDOW;
+
+  const auditByLine = await loadAuditByLine(options.outDir);
+  const hasAuditSignal = auditByLine !== null;
+
+  const parseResults = await parallelMap<UnifiedSessionEntry, SessionParse | null>(
+    manifest.sessions,
+    concurrency,
+    async (entry) => parseTranscript(entry, options.outDir),
+  );
+
+  const sessionsBySource: Record<string, number> = {};
+  const sessionsMissingBySource: Record<string, number> = {};
+  let scanned = 0;
+  let missing = 0;
+  let aggRaw = 0;
+  let aggWrapper = 0;
+  let aggTooLong = 0;
+  let aggSurviving = 0;
+
+  // Collect every hit across the whole manifest, grouped by pattern key.
+  const hitsByKey = new Map<string, PlaybookHit[]>();
+  // Track distinct sessions per pattern.
+  const sessionsByKey = new Map<string, Set<string>>();
+  let totalHits = 0;
+
+  for (let i = 0; i < parseResults.length; i += 1) {
+    const entry = manifest.sessions[i] as UnifiedSessionEntry;
+    const src = entry.source ?? 'unknown';
+    sessionsBySource[src] = (sessionsBySource[src] ?? 0) + 1;
+    const parsed = parseResults[i] ?? null;
+    if (parsed === null) {
+      missing += 1;
+      sessionsMissingBySource[src] = (sessionsMissingBySource[src] ?? 0) + 1;
+      continue;
+    }
+    scanned += 1;
+    aggRaw += parsed.rawTurns;
+    aggWrapper += parsed.wrapperFiltered;
+    aggTooLong += parsed.tooLongFiltered;
+    aggSurviving += parsed.turns.length;
+
+    const kernelHits = detectPlaybookCandidates(parsed.turns);
+    for (const k of kernelHits) {
+      const hit: PlaybookHit = {
+        sessionId: k.sessionId,
+        userTurnIndex: k.userTurnIndex,
+        lineNumber: k.lineNumber,
+        phrase: k.phrase,
+        excerpt: k.excerpt,
+      };
+      const list = hitsByKey.get(k.patternKey) ?? [];
+      list.push(hit);
+      hitsByKey.set(k.patternKey, list);
+      const ss = sessionsByKey.get(k.patternKey) ?? new Set<string>();
+      ss.add(k.sessionId);
+      sessionsByKey.set(k.patternKey, ss);
+      totalHits += 1;
+    }
+  }
+
+  // Compute per-pattern audit rollup (best-effort; zeros when no signal).
+  const patterns: PlaybookPattern[] = [];
+  for (const [key, hits] of hitsByKey) {
+    const meta = PLAYBOOK_PATTERN_META.get(key);
+    const label = meta?.label ?? key;
+    const description = meta?.description ?? '';
+    const sessionIds = [...(sessionsByKey.get(key) ?? new Set<string>())];
+
+    const audit = computeAudit(hits, auditByLine, window);
+    const occurrence = hits.length;
+    const score = hasAuditSignal && audit.passRate > 0
+      ? occurrence * audit.passRate
+      : occurrence;
+
+    patterns.push({
+      patternKey: key,
+      label,
+      description,
+      // Sort hits by session, then turn — stable ordering on disk for diffs.
+      hits: [...hits].sort(
+        (a, b) =>
+          a.sessionId.localeCompare(b.sessionId) ||
+          a.userTurnIndex - b.userTurnIndex,
+      ),
+      occurrenceCount: occurrence,
+      sessionIds: [...sessionIds].sort(),
+      audit,
+      score,
+    });
+  }
+  patterns.sort((a, b) => b.score - a.score);
+
+  const scanStats: ScanStats = {
+    sessionsInManifest: manifest.sessions.length,
+    sessionsScanned: scanned,
+    sessionsMissing: missing,
+    sessionsBySource,
+    sessionsMissingBySource,
+    rawUserTurns: aggRaw,
+    wrapperFiltered: aggWrapper,
+    tooLongFiltered: aggTooLong,
+    survivingTurns: aggSurviving,
+  };
+
+  const file: PlaybookCandidatesFile = {
+    version: 1,
+    generatedAt: options.now,
+    heuristicVersion: PLAYBOOK_HEURISTIC_VERSION,
+    hasAuditSignal,
+    patterns,
+    scanStats,
+  };
+
+  logger.info(
+    `analysis: playbook-candidates.json — ${patterns.length} patterns, ${totalHits} hits, audit=${hasAuditSignal ? 'yes' : 'no'}, ${Date.now() - t0}ms`,
+  );
+
+  return {
+    file,
+    scannedSessions: scanned,
+    missingTranscripts: missing,
+    totalHits,
+    hasAuditSignal,
+  };
+}
+
+/**
+ * For each hit, find the next `window` audit claims in the same session
+ * whose lineNumber > hit.lineNumber. Tally outcomes. The session-level
+ * list is pre-sorted by lineNumber, so the scan is linear in matches.
+ */
+function computeAudit(
+  hits: ReadonlyArray<PlaybookHit>,
+  auditByLine: Map<string, MinimalAuditResult[]> | null,
+  window: number,
+): PlaybookPatternAudit {
+  if (auditByLine === null) {
+    return { pass: 0, fail: 0, inconclusive: 0, passRate: 0, hitsWithSignal: 0 };
+  }
+  let pass = 0;
+  let fail = 0;
+  let inconclusive = 0;
+  let hitsWithSignal = 0;
+  for (const h of hits) {
+    const arr = auditByLine.get(h.sessionId);
+    if (arr === undefined || arr.length === 0) continue;
+    // Binary search for first lineNumber > hit.lineNumber.
+    let lo = 0;
+    let hi = arr.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if ((arr[mid] as MinimalAuditResult).lineNumber > h.lineNumber) {
+        hi = mid;
+      } else {
+        lo = mid + 1;
+      }
+    }
+    if (lo >= arr.length) continue;
+    let contributed = false;
+    for (let i = lo; i < arr.length && i < lo + window; i += 1) {
+      const r = arr[i] as MinimalAuditResult;
+      if (r.outcome === 'pass') pass += 1;
+      else if (r.outcome === 'fail') fail += 1;
+      else inconclusive += 1;
+      contributed = true;
+    }
+    if (contributed) hitsWithSignal += 1;
+  }
+  const total = pass + fail + inconclusive;
+  return {
+    pass,
+    fail,
+    inconclusive,
+    passRate: total === 0 ? 0 : pass / total,
+    hitsWithSignal,
+  };
+}
+
+/**
+ * Parse one session's transcript into PlaybookTurnInput[]. Returns null
+ * when the transcript is unreadable or absent.
+ *
+ * `lineNumber` semantics:
+ *   - JSONL transcripts (cli-direct, cli-desktop, cowork): 1-based
+ *     index into the line-split file. Matches audit-results.json's
+ *     convention.
+ *   - Cloud JSON transcripts: 1-based ordinal within `chat_messages[]`.
+ *     Cloud doesn't have transcript line numbers in the audit sense;
+ *     this approximation collides with how the audit pipeline keys
+ *     cloud claims. If the audit join produces zeros for cloud
+ *     sessions, that's the mismatch — fixable in a follow-up once
+ *     audit-results lands on main.
+ */
+async function parseTranscript(
+  entry: UnifiedSessionEntry,
+  outDir: string,
+): Promise<SessionParse | null> {
+  if (entry.transcriptPath === undefined) return null;
+  const baseDir = path.resolve(outDir);
+  const abs = path.resolve(baseDir, entry.transcriptPath);
+  const rel = path.relative(baseDir, abs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+
+  let raw: string;
+  try {
+    raw = await readFile(abs, 'utf8');
+  } catch {
+    return null;
+  }
+  if (entry.source === 'cloud') return parseCloud(entry.id, raw);
+  return parseJsonl(entry.id, raw);
+}
+
+interface CloudShape {
+  chat_messages?: Array<{
+    sender?: string;
+    text?: string;
+    content?: ReadonlyArray<{ type?: string; text?: string }>;
+  }>;
+}
+
+function parseCloud(sessionId: string, raw: string): SessionParse {
+  let j: CloudShape;
+  try {
+    j = JSON.parse(raw) as CloudShape;
+  } catch {
+    return { turns: [], rawTurns: 0, wrapperFiltered: 0, tooLongFiltered: 0 };
+  }
+  const turns: PlaybookTurnInput[] = [];
+  let userIdx = 0;
+  let rawTurns = 0;
+  let tooLongFiltered = 0;
+  const msgs = j.chat_messages ?? [];
+  for (let i = 0; i < msgs.length; i += 1) {
+    const m = msgs[i];
+    if (m === undefined) continue;
+    const text = extractCloudText(m);
+    if (text === null) continue;
+    if (m.sender !== 'human') continue;
+    rawTurns += 1;
+    if (text.length > MAX_USER_PROMPT_CHARS) {
+      tooLongFiltered += 1;
+      continue;
+    }
+    turns.push({
+      sessionId,
+      userTurnIndex: userIdx,
+      lineNumber: i + 1,
+      userText: text,
+    });
+    userIdx += 1;
+  }
+  return { turns, rawTurns, wrapperFiltered: 0, tooLongFiltered };
+}
+
+function extractCloudText(m: {
+  text?: string;
+  content?: ReadonlyArray<{ type?: string; text?: string }>;
+}): string | null {
+  if (typeof m.text === 'string' && m.text !== '') return m.text;
+  if (Array.isArray(m.content)) {
+    const parts: string[] = [];
+    for (const part of m.content) {
+      if (part.type === 'text' && typeof part.text === 'string') {
+        parts.push(part.text);
+      }
+    }
+    if (parts.length > 0) return parts.join('\n');
+  }
+  return null;
+}
+
+function parseJsonl(sessionId: string, raw: string): SessionParse {
+  const turns: PlaybookTurnInput[] = [];
+  let userIdx = 0;
+  let rawTurns = 0;
+  let wrapperFiltered = 0;
+  let tooLongFiltered = 0;
+  const lines = raw.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    if (line === '') continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (obj === null || typeof obj !== 'object') continue;
+    const rec = obj as Record<string, unknown>;
+    if (rec['type'] !== 'user') continue;
+    const msg = rec['message'];
+    if (msg === null || typeof msg !== 'object') continue;
+    const mrec = msg as Record<string, unknown>;
+    if (mrec['role'] !== 'user') continue;
+    const text = extractJsonlText(mrec['content']);
+    if (text === null) continue;
+
+    rawTurns += 1;
+    const trimmed = text.trim();
+    if (trimmed === '') {
+      wrapperFiltered += 1;
+      continue;
+    }
+    if (WRAPPER_PREFIXES.some((p) => trimmed.startsWith(p))) {
+      wrapperFiltered += 1;
+      continue;
+    }
+    if (trimmed.length > MAX_USER_PROMPT_CHARS) {
+      tooLongFiltered += 1;
+      continue;
+    }
+    turns.push({
+      sessionId,
+      userTurnIndex: userIdx,
+      lineNumber: i + 1,
+      userText: text,
+    });
+    userIdx += 1;
+  }
+  return { turns, rawTurns, wrapperFiltered, tooLongFiltered };
+}
+
+function extractJsonlText(content: unknown): string | null {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (
+        part !== null &&
+        typeof part === 'object' &&
+        (part as Record<string, unknown>)['type'] === 'text' &&
+        typeof (part as Record<string, unknown>)['text'] === 'string'
+      ) {
+        parts.push((part as Record<string, unknown>)['text'] as string);
+      }
+    }
+    if (parts.length > 0) return parts.join('\n');
+  }
+  return null;
+}

--- a/packages/exporter/test/integration/analysis-pipeline.test.ts
+++ b/packages/exporter/test/integration/analysis-pipeline.test.ts
@@ -128,7 +128,8 @@ describe('Phase 6 analysis pipeline integration', () => {
     expect(meta.counts.sessions).toBe(sessions.length);
 
     // (d) browser.files lists Phase-6 tier-1 files + Phase 2 v2 entity sidecars
-    //     + correction-candidates.json (stage-1 heuristic recall).
+    //     + correction-candidates.json (stage-1 heuristic recall)
+    //     + playbook-candidates.json (positive-knowledge mining).
     expect(meta.tiers.browser.files.sort()).toEqual(
       [
         'duplicates.exact.json',
@@ -137,6 +138,7 @@ describe('Phase 6 analysis pipeline integration', () => {
         'topics.json',
         'narratives.json',
         'correction-candidates.json',
+        'playbook-candidates.json',
       ].sort(),
     );
     // Phase 6 does not populate the `local` tier.

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -8,6 +8,7 @@ export * from './topic.js';
 export * from './narrative.js';
 export * from './pattern.js';
 export * from './correction.js';
+export * from './playbook.js';
 export * from './applied-improvement.js';
 export * from './configDocument.js';
 export * from './chat.js';

--- a/packages/schema/src/playbook.ts
+++ b/packages/schema/src/playbook.ts
@@ -1,0 +1,94 @@
+/**
+ * Methods playbook — positive counterpart to corrections.
+ *
+ * The corrections pipeline mines moments where the user pushed back on the
+ * AI (negative knowledge → CLAUDE.md/skill/agent upgrades). The playbook
+ * pipeline mines moments where the user invoked an in-conversation
+ * **prompt phrasing** that consistently produced verified outcomes
+ * (positive knowledge → a "verbs I reach for" prompt-snippet library).
+ *
+ * Stage-1 output: heuristic-detected phrasings ranked by occurrence and,
+ * when audit data is present, by downstream F-layer pass-rate. The skill
+ * layer that consumes this is deferred to PR-B (encoding flow); for now
+ * the sidecar is read directly by the viewer.
+ *
+ * Persistence: `analysis/playbook-candidates.json`. Schema mirrors
+ * `correction-candidates.json` so the two surfaces stay shape-symmetric.
+ */
+
+import type { ScanStats } from './correction.js';
+
+/**
+ * One detected occurrence of a method phrasing in a single user turn.
+ *
+ * `lineNumber` is the 1-based transcript line where the user turn
+ * starts; it powers the join against audit-results.json so the builder
+ * can compute downstream pass-rate without re-parsing the transcript.
+ */
+export interface PlaybookHit {
+  sessionId: string;
+  /** 0-based index into the session's user turns. */
+  userTurnIndex: number;
+  /** 1-based line number of the user turn inside the transcript. */
+  lineNumber: number;
+  /** Verbatim matched phrase (truncated to 80 chars). */
+  phrase: string;
+  /** Up to ~500 chars of surrounding user text for human review. */
+  excerpt: string;
+}
+
+/**
+ * Downstream-audit rollup for one pattern. Computed at the builder layer
+ * by joining hits against `audit-results.json` — for each hit, look at
+ * the next N audit claims in the same session whose `lineNumber` is
+ * greater than the hit's, and tally outcomes.
+ *
+ * Absent (or all zero) when no audit sidecar was present at scan time
+ * or no claims fell in any hit's downstream window. Consumers MUST
+ * gracefully degrade to occurrence-only ranking in that case.
+ */
+export interface PlaybookPatternAudit {
+  pass: number;
+  fail: number;
+  inconclusive: number;
+  /** pass / (pass + fail + inconclusive). 0 when total is 0. */
+  passRate: number;
+  /** Number of hits that contributed at least one downstream claim. */
+  hitsWithSignal: number;
+}
+
+/**
+ * Aggregate across all hits for one method-phrasing pattern. The viewer
+ * renders one row per pattern, ranked by `score` (occurrence × pass-rate
+ * when audit data is available; otherwise occurrence alone).
+ */
+export interface PlaybookPattern {
+  /** Stable key — the detector's pattern family slug. */
+  patternKey: string;
+  /** Short human-readable label for the surface. */
+  label: string;
+  /** One-line description of what this phrasing does, for the surface. */
+  description: string;
+  hits: readonly PlaybookHit[];
+  occurrenceCount: number;
+  /** Distinct sessions where this pattern fired. */
+  sessionIds: readonly string[];
+  audit: PlaybookPatternAudit;
+  /**
+   * Ranking score, recomputed at build time.
+   *   - When audit signal exists: occurrenceCount * passRate
+   *   - Else: occurrenceCount (so the surface still ranks usefully)
+   * Stored on disk so the viewer doesn't re-derive.
+   */
+  score: number;
+}
+
+export interface PlaybookCandidatesFile {
+  version: 1;
+  generatedAt: number;
+  heuristicVersion: number;
+  /** Whether the audit join produced any signal. False ⇒ rank by count. */
+  hasAuditSignal: boolean;
+  patterns: readonly PlaybookPattern[];
+  scanStats: ScanStats;
+}


### PR DESCRIPTION
## Summary

- Mines the corpus for **recurring user-turn phrasings** (e.g. _\"go back to first principles\"_, _\"use an adversarial review team\"_) that precede F-layer pass-verdict audit claims — the positive counterpart to CORRECTIONS, which mines pushback against the AI.
- New \`/playbook\` page renders **every** detected method (not a top-N leaderboard) with per-pattern occurrence count, distinct-sessions count, downstream pass-rate bar when audit signal is available, and expandable example excerpts. Designed to be read end-to-end and lifted into a blog draft.
- Stage-1 only this round (heuristic recall + audit join). Encoding flow (export as prompt-snippet / CLAUDE.md \"Verbs I reach for\" section / slash-command sketch) and phrasing clustering are deferred to PR-B per the spec.

## What's in the box

| Layer | File | Notes |
|---|---|---|
| Schema | \`packages/schema/src/playbook.ts\` | \`PlaybookCandidatesFile\` v1 |
| Kernel (browser-safe) | \`packages/analysis/src/detectPlaybookCandidates.ts\` | 9 pattern families; \`PLAYBOOK_HEURISTIC_VERSION = 1\` |
| Builder (Node) | \`packages/exporter/src/analysis/playbook.ts\` | Parses transcripts with line numbers, optionally joins \`audit-results.json\` with a next-N=5 downstream window per hit |
| Wiring | \`packages/exporter/src/analysis/index.ts\` | Bumps \`EXPORTER_VERSION\` → \`0.11.0\`; adds \`playbook-candidates.json\` to \`meta.tiers.browser.files\` |
| Page | \`apps/standalone/src/pages/playbook.astro\` | \`prerender: false\`; reads sidecar at request time |

## Sanity test (the one that has to be green)

\`packages/exporter/src/analysis/playbook.test.ts :: surfaces \"first principles\" and pairs it with the downstream pass\` — drives a fixture JSONL transcript (user invokes _\"go back to first principles\"_ at line 3, assistant follows at line 4 with a fix-claim) plus a minimal \`audit-results.json\` marking line 4 as \`pass\`. Asserts the \`first-principles\` pattern surfaces with \`passRate = 1.0\`. If this stops being green, the pipeline has lost its ground truth.

Also: the kernel-level test in \`packages/analysis\` asserts both anchor phrasings from the design memory (\`first principles\`, \`adversarial review team\`) fire.

## Graceful degradation

\`audit-results.json\` ships with the audit pipeline on PR #50 — it isn't on \`main\` yet. The builder loads it best-effort; when absent the page sets \`hasAuditSignal = false\`, ranks by raw occurrence, and shows _\"audit signal: unavailable\"_ in the KPI strip. The surface works today against any scanned corpus and gets richer the moment PR #50 lands and the next \`SCAN LOCAL\` runs.

## Deferred (intentional)

- **WORKSHOP sidebar entry (PLB).** \`AppSidebar.astro\` lives on PRs #49/#50 — neither is on \`main\` yet. The spec said to branch off \`main\` and rebase later; that's what this PR does. When the sidebar lands, the playbook entry slots in between CORRECTIONS and PRACTICE.
- **Encoding flow.** Export-as-snippet / CLAUDE.md verb section / slash-command sketch — PR-B.
- **Clustering phrasings** into planning vs review vs verification — PR-B.

## Test plan

- [x] \`pnpm lint\` — clean of new warnings (pre-existing warnings unchanged)
- [x] \`pnpm test\` — 879 passed / 4 skipped
- [x] \`pnpm build\` — clean; \`/playbook\` correctly excluded from prerender
- [ ] After merge: \`pnpm exporter run start\` (or SCAN LOCAL) regenerates \`playbook-candidates.json\`; viewer renders against your corpus
- [ ] Adversarial check: when audit-results.json shows up (post PR-#50), confirm pass-rate weighting changes the ranking in a way that matches intuition (high-occurrence-but-low-pass phrasings drop below high-pass ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)