### PR TITLE
feat(rev3-a): THRESHOLDS additions for confidence ladder + clear-endpoint test coverage (A7)

### DIFF
--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -28,7 +28,7 @@ Plan anchor: [§Phase Rev3-A](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 | A4 | Create `packages/exporter/src/db/migrations/` with migration framework (`schema_migrations` table, idempotent migration runner) — moved from `packages/schema/` since `better-sqlite3` is a Node native module and `packages/schema/` must stay browser-safe | complete-and-merged | PR #57 |
 | A5 | Initial migration: tables for `projects`, `topics`, `sessions`, `session_messages`, `session_revisions`, `narratives`, `narrative_evidence`, `narrative_sessions`, `patterns`, `project_sessions`, `project_topics`, `topic_sessions`, `findings`, `analyzers` (13 entity + 1 generic findings) | complete-and-merged | PR #57 |
 | A6 | Enable WAL mode + `synchronous=NORMAL` + `foreign_keys=ON`; document `BEGIN IMMEDIATE` single-writer contract with 50ms→1s exponential backoff retry | complete-and-merged | PR #57 |
-| A7 | THRESHOLDS additions in `packages/analysis/src/thresholds.ts`: `narrativeRung.*`, `curator.*`, `closureC.*` | in-review | PR #TBD |
+| A7 | THRESHOLDS additions in `packages/analysis/src/thresholds.ts`: `narrativeRung.*`, `curator.*`, `appliedRuleWatcher.*` | in-review | PR #58 |
 | A8 | SDK skeleton in `packages/exporter/src/db/` exposing typed query/write methods over the new tables | pending | |
 | A9 | Extend `NuclearReset` to sweep orphan JSON files under `chat-arch-data/analysis/` | complete-and-merged | PR #53 (outcome-substrate roadmap shipped the NuclearReset extension as Phase 4 work) |
 | A10 | "NO DATA YET" landing screen renders correctly against empty DB | pending | Existing screen — verify |

--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -25,10 +25,10 @@ Plan anchor: [§Phase Rev3-A](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 | A1 | Amend `chat-arch-v2-spec.md` §13 (SQLite substrate) and §16 (curator/falsifier/MCP in scope) | complete-and-merged | PR #54 (+ PR #56 extended §5 to 7-surface IA per Rev3 D1) |
 | A2 | Add `*.db / *.db-wal / *.db-shm` to `.gitignore` | complete-and-merged | PR #55 |
 | A3 | Add `better-sqlite3` + `sqlite-vec` deps; CI spike confirming prebuilt binaries on Ubuntu runner | complete-and-merged | PR #55 |
-| A4 | Create `packages/exporter/src/db/migrations/` with migration framework (`schema_migrations` table, idempotent migration runner) — moved from `packages/schema/` since `better-sqlite3` is a Node native module and `packages/schema/` must stay browser-safe | in-review | PR #57 |
-| A5 | Initial migration: tables for `projects`, `topics`, `sessions`, `session_messages`, `session_revisions`, `narratives`, `narrative_evidence`, `narrative_sessions`, `patterns`, `project_sessions`, `project_topics`, `topic_sessions`, `findings`, `analyzers` (13 entity + 1 generic findings) | in-review | PR #57 |
-| A6 | Enable WAL mode + `synchronous=NORMAL` + `foreign_keys=ON`; document `BEGIN IMMEDIATE` single-writer contract with 50ms→1s exponential backoff retry | in-review | PR #57 |
-| A7 | THRESHOLDS additions in `packages/analysis/src/thresholds.ts`: `narrativeRung.*`, `curator.*`, `closureC.*` | pending | All values centralized |
+| A4 | Create `packages/exporter/src/db/migrations/` with migration framework (`schema_migrations` table, idempotent migration runner) — moved from `packages/schema/` since `better-sqlite3` is a Node native module and `packages/schema/` must stay browser-safe | complete-and-merged | PR #57 |
+| A5 | Initial migration: tables for `projects`, `topics`, `sessions`, `session_messages`, `session_revisions`, `narratives`, `narrative_evidence`, `narrative_sessions`, `patterns`, `project_sessions`, `project_topics`, `topic_sessions`, `findings`, `analyzers` (13 entity + 1 generic findings) | complete-and-merged | PR #57 |
+| A6 | Enable WAL mode + `synchronous=NORMAL` + `foreign_keys=ON`; document `BEGIN IMMEDIATE` single-writer contract with 50ms→1s exponential backoff retry | complete-and-merged | PR #57 |
+| A7 | THRESHOLDS additions in `packages/analysis/src/thresholds.ts`: `narrativeRung.*`, `curator.*`, `closureC.*` | in-review | PR #TBD |
 | A8 | SDK skeleton in `packages/exporter/src/db/` exposing typed query/write methods over the new tables | pending | |
 | A9 | Extend `NuclearReset` to sweep orphan JSON files under `chat-arch-data/analysis/` | complete-and-merged | PR #53 (outcome-substrate roadmap shipped the NuclearReset extension as Phase 4 work) |
 | A10 | "NO DATA YET" landing screen renders correctly against empty DB | pending | Existing screen — verify |

--- a/apps/standalone/src/lib/clearDataDir.ts
+++ b/apps/standalone/src/lib/clearDataDir.ts
@@ -1,0 +1,187 @@
+// Data-dir wipe helpers, factored out of `/api/clear` so they can be
+// unit-tested without standing up the full Astro request pipeline.
+//
+// Rev3-A.A9 (orphan-sweep): the kitchen-sink wipe already removes
+// everything under `chat-arch-data/` except `.gitkeep`, which means
+// the future SQLite DB family (`*.db`, `*.db-wal`, `*.db-shm`) and
+// orphan JSON sidecars under `analysis/` are swept on the same code
+// path. The partial-source wipe always removes the `analysis/`
+// subdirectory — those files are derived from the manifest and stale
+// the moment any session disappears.
+//
+// Forward-compat note (Rev3): once the SQLite SDK (A8) starts writing
+// to `chat-arch-data/chat-arch.db`, the kitchen-sink wipe handles it
+// automatically (covered by the `name !== .gitkeep` filter). For
+// partial-source deletes, the SDK will need its own row-level delete
+// path (DELETE FROM sessions WHERE source = ?) — but that lands with
+// the SDK in A8, not here.
+
+import { readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export const ALL_SOURCES = [
+  'cli-direct',
+  'cli-desktop',
+  'cowork',
+  'cloud',
+] as const;
+export type SourceName = (typeof ALL_SOURCES)[number];
+
+export interface ManifestSession {
+  id: string;
+  source: string;
+  transcriptPath?: string;
+  [k: string]: unknown;
+}
+
+export interface Manifest {
+  schemaVersion: number;
+  generatedAt: number;
+  counts: Record<string, number>;
+  sessions: ManifestSession[];
+}
+
+export async function readManifest(dir: string): Promise<Manifest | null> {
+  try {
+    const raw = await readFile(join(dir, 'manifest.json'), 'utf8');
+    const m = JSON.parse(raw) as Manifest;
+    if (!m || !Array.isArray(m.sessions)) return null;
+    return m;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Kitchen-sink mode — wipe the entire data dir except `.gitkeep`.
+ *
+ * Sweeps in one pass:
+ *   - `manifest.json` (current source of truth)
+ *   - `analysis/` (derived JSON sidecars, including future orphans
+ *     once the SQLite substrate becomes the new source of truth)
+ *   - `cloud-conversations/`, `exports/`, the `.demo` sentinel
+ *   - Future: `chat-arch.db`, `chat-arch.db-wal`, `chat-arch.db-shm`
+ *     (Rev3-A SQLite substrate; A8 SDK writes here)
+ *
+ * The `.gitkeep` exception preserves the directory itself so the
+ * empty-state path still works on fresh clones.
+ */
+export async function wipeAll(dir: string): Promise<{ removed: number }> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  let removed = 0;
+  await Promise.all(
+    entries.map(async (e) => {
+      if (e.name === '.gitkeep') return;
+      await rm(join(dir, e.name), { recursive: true, force: true });
+      removed += 1;
+    }),
+  );
+  return { removed };
+}
+
+/**
+ * Partial-source mode — filter the manifest, delete the transcript
+ * files belonging to removed sessions, sweep the `analysis/`
+ * directory (always — its contents are derived from the manifest
+ * and any source removal invalidates them), and remove the
+ * `cloud-conversations/` directory if cloud was selected.
+ *
+ * Returns per-source removal tallies so the UI can render "X sessions
+ * removed from cli-direct".
+ */
+export async function wipeSources(
+  dir: string,
+  selected: Set<SourceName>,
+): Promise<{ removed: number; bySources: Record<string, number> }> {
+  const manifest = await readManifest(dir);
+  const bySources: Record<string, number> = {};
+  let fileRemovals = 0;
+
+  if (manifest) {
+    const kept: ManifestSession[] = [];
+    const toDelete: ManifestSession[] = [];
+    for (const s of manifest.sessions) {
+      if (selected.has(s.source as SourceName)) {
+        toDelete.push(s);
+        bySources[s.source] = (bySources[s.source] ?? 0) + 1;
+      } else {
+        kept.push(s);
+      }
+    }
+
+    // Unlink the transcript files belonging to removed sessions.
+    await Promise.all(
+      toDelete.map(async (s) => {
+        if (!s.transcriptPath) return;
+        // Guard: resolve against `dir` and reject any path that
+        // escapes. Mirrors the path-traversal check in the exporter.
+        const resolved = resolve(dir, s.transcriptPath);
+        if (!resolved.startsWith(resolve(dir))) return;
+        try {
+          await rm(resolved, { force: true });
+          fileRemovals += 1;
+        } catch {
+          /* best-effort — manifest rewrite is the source of truth */
+        }
+      }),
+    );
+
+    // Rewrite the manifest with the filtered session list and
+    // recomputed counts. Touch `generatedAt` so cache-busts land.
+    const counts: Record<string, number> = {
+      cloud: 0,
+      cowork: 0,
+      'cli-direct': 0,
+      'cli-desktop': 0,
+    };
+    for (const s of kept) counts[s.source] = (counts[s.source] ?? 0) + 1;
+    const next: Manifest = {
+      ...manifest,
+      generatedAt: Date.now(),
+      counts,
+      sessions: kept,
+    };
+    await writeFile(
+      join(dir, 'manifest.json'),
+      JSON.stringify(next, null, 2) + '\n',
+    );
+  }
+
+  // Cloud conversations live under a top-level folder — wipe the
+  // whole folder when cloud is selected (in case the manifest
+  // missed some orphaned JSONs).
+  if (selected.has('cloud')) {
+    try {
+      await rm(join(dir, 'cloud-conversations'), {
+        recursive: true,
+        force: true,
+      });
+    } catch {
+      /* ignore */
+    }
+    // Demo-data sentinel is paired with a demo-seeded manifest;
+    // if cloud is being pruned, the sentinel no longer reflects
+    // reality and should drop.
+    try {
+      await rm(join(dir, '.demo'), { force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // Always wipe derived analysis files — they are a function of the
+  // manifest, and any source change invalidates them. This is the
+  // Rev3-A.A9 orphan-sweep: when the SQLite substrate (Rev3-A.A8)
+  // becomes the source of truth for kernel outputs, the JSON sidecars
+  // under `analysis/` are orphan, and partial-source wipes continue
+  // to remove them via this same rm-call.
+  try {
+    await rm(join(dir, 'analysis'), { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+
+  const removed =
+    fileRemovals + Object.values(bySources).reduce((a, b) => a + b, 0);
+  return { removed, bySources };
+}

--- a/apps/standalone/src/pages/api/clear.ts
+++ b/apps/standalone/src/pages/api/clear.ts
@@ -1,7 +1,13 @@
 import type { APIRoute } from 'astro';
-import { readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve, join } from 'node:path';
+import { dirname, resolve } from 'node:path';
+
+import {
+  ALL_SOURCES,
+  type SourceName,
+  wipeAll,
+  wipeSources,
+} from '../../lib/clearDataDir.js';
 
 /**
  * Selective-delete endpoint — the UI dropdown posts one or more source
@@ -38,8 +44,6 @@ export const prerender = false;
 
 const REQUIRED_HEADER = 'chat-arch-clear';
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
-const ALL_SOURCES = ['cli-direct', 'cli-desktop', 'cowork', 'cloud'] as const;
-type SourceName = (typeof ALL_SOURCES)[number];
 
 function isLocalOrigin(origin: string | null): boolean {
   if (!origin) return false;
@@ -63,136 +67,6 @@ function csrfReject(reason: string): Response {
 function dataDir(): string {
   const here = dirname(fileURLToPath(import.meta.url));
   return resolve(here, '..', '..', '..', 'public', 'chat-arch-data');
-}
-
-interface ManifestSession {
-  id: string;
-  source: string;
-  transcriptPath?: string;
-  [k: string]: unknown;
-}
-interface Manifest {
-  schemaVersion: number;
-  generatedAt: number;
-  counts: Record<string, number>;
-  sessions: ManifestSession[];
-}
-
-async function readManifest(dir: string): Promise<Manifest | null> {
-  try {
-    const raw = await readFile(join(dir, 'manifest.json'), 'utf8');
-    const m = JSON.parse(raw) as Manifest;
-    if (!m || !Array.isArray(m.sessions)) return null;
-    return m;
-  } catch {
-    return null;
-  }
-}
-
-/** Wipe the entire data dir except `.gitkeep` — kitchen-sink mode. */
-async function wipeAll(dir: string): Promise<{ removed: number }> {
-  const entries = await readdir(dir, { withFileTypes: true });
-  let removed = 0;
-  await Promise.all(
-    entries.map(async (e) => {
-      if (e.name === '.gitkeep') return;
-      await rm(join(dir, e.name), { recursive: true, force: true });
-      removed += 1;
-    }),
-  );
-  return { removed };
-}
-
-/**
- * Delete the sessions belonging to `selected` sources, rewrite the
- * manifest without them, and drop derived state (analysis files,
- * demo sentinel if cloud is touched). Returns per-source tallies so
- * the UI can render "X sessions removed from cli-direct".
- */
-async function wipeSources(
-  dir: string,
-  selected: Set<SourceName>,
-): Promise<{ removed: number; bySources: Record<string, number> }> {
-  const manifest = await readManifest(dir);
-  const bySources: Record<string, number> = {};
-  let fileRemovals = 0;
-
-  if (manifest) {
-    const kept: ManifestSession[] = [];
-    const toDelete: ManifestSession[] = [];
-    for (const s of manifest.sessions) {
-      if (selected.has(s.source as SourceName)) {
-        toDelete.push(s);
-        bySources[s.source] = (bySources[s.source] ?? 0) + 1;
-      } else {
-        kept.push(s);
-      }
-    }
-
-    // Unlink the transcript files belonging to removed sessions.
-    await Promise.all(
-      toDelete.map(async (s) => {
-        if (!s.transcriptPath) return;
-        // Guard: resolve against `dir` and reject any path that
-        // escapes. Mirrors the path-traversal check in the exporter.
-        const resolved = resolve(dir, s.transcriptPath);
-        if (!resolved.startsWith(resolve(dir))) return;
-        try {
-          await rm(resolved, { force: true });
-          fileRemovals += 1;
-        } catch {
-          /* best-effort — manifest rewrite is the source of truth */
-        }
-      }),
-    );
-
-    // Rewrite the manifest with the filtered session list and
-    // recomputed counts. Touch `generatedAt` so cache-busts land.
-    const counts: Record<string, number> = {
-      cloud: 0,
-      cowork: 0,
-      'cli-direct': 0,
-      'cli-desktop': 0,
-    };
-    for (const s of kept) counts[s.source] = (counts[s.source] ?? 0) + 1;
-    const next: Manifest = {
-      ...manifest,
-      generatedAt: Date.now(),
-      counts,
-      sessions: kept,
-    };
-    await writeFile(join(dir, 'manifest.json'), JSON.stringify(next, null, 2) + '\n');
-  }
-
-  // Cloud conversations live under a top-level folder — wipe the
-  // whole folder when cloud is selected (in case the manifest
-  // missed some orphaned JSONs).
-  if (selected.has('cloud')) {
-    try {
-      await rm(join(dir, 'cloud-conversations'), { recursive: true, force: true });
-    } catch {
-      /* ignore */
-    }
-    // Demo-data sentinel is paired with a demo-seeded manifest;
-    // if cloud is being pruned, the sentinel no longer reflects
-    // reality and should drop.
-    try {
-      await rm(join(dir, '.demo'), { force: true });
-    } catch {
-      /* ignore */
-    }
-  }
-
-  // Always wipe derived analysis files — they are a function of the
-  // manifest, and any source change invalidates them.
-  try {
-    await rm(join(dir, 'analysis'), { recursive: true, force: true });
-  } catch {
-    /* ignore */
-  }
-
-  const removed = fileRemovals + Object.values(bySources).reduce((a, b) => a + b, 0);
-  return { removed, bySources };
 }
 
 export const POST: APIRoute = async ({ request }) => {

--- a/apps/standalone/test/lib/clearDataDir.test.ts
+++ b/apps/standalone/test/lib/clearDataDir.test.ts
@@ -1,0 +1,155 @@
+// Tests for the data-dir wipe helpers. Covers the Rev3-A.A9
+// orphan-sweep contract: both kitchen-sink and partial-source modes
+// remove derived `analysis/` JSONs (Rev3-A.A8 SQLite SDK arrival
+// makes those orphans; the wipe path stays the same).
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { wipeAll, wipeSources } from '../../src/lib/clearDataDir.js';
+
+async function seedDir(dir: string): Promise<void> {
+  // Mimic a populated chat-arch-data/ tree with manifest, analysis
+  // sidecars, cloud-conversations, a .demo sentinel, and a future-
+  // SQLite-DB sibling so the orphan-sweep assertions are concrete.
+  await writeFile(join(dir, '.gitkeep'), '');
+  await writeFile(
+    join(dir, 'manifest.json'),
+    JSON.stringify({
+      schemaVersion: 4,
+      generatedAt: 1000,
+      counts: { cloud: 1, cowork: 1, 'cli-direct': 1, 'cli-desktop': 0 },
+      sessions: [
+        { id: 's1', source: 'cloud' },
+        { id: 's2', source: 'cowork' },
+        { id: 's3', source: 'cli-direct' },
+      ],
+    }),
+  );
+  await mkdir(join(dir, 'analysis'), { recursive: true });
+  await writeFile(join(dir, 'analysis', 'composite-outcomes.json'), '{}');
+  await writeFile(join(dir, 'analysis', 'narratives.json'), '[]');
+  await writeFile(join(dir, 'analysis', 'patterns.json'), '[]');
+  await mkdir(join(dir, 'cloud-conversations'), { recursive: true });
+  await writeFile(join(dir, 'cloud-conversations', 'c1.json'), '{}');
+  await writeFile(join(dir, '.demo'), '');
+  // Future SQLite substrate file — kitchen-sink mode must wipe it.
+  await writeFile(join(dir, 'chat-arch.db'), 'binary');
+  await writeFile(join(dir, 'chat-arch.db-wal'), 'binary');
+}
+
+describe('wipeAll (kitchen-sink mode)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'chat-arch-clear-all-'));
+    await seedDir(dir);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('removes everything except .gitkeep', async () => {
+    const result = await wipeAll(dir);
+
+    // Counted at least the eight top-level entries we seeded (manifest,
+    // analysis dir, cloud-conversations dir, .demo, .db, .db-wal).
+    expect(result.removed).toBeGreaterThanOrEqual(6);
+
+    expect(existsSync(join(dir, '.gitkeep'))).toBe(true);
+    expect(existsSync(join(dir, 'manifest.json'))).toBe(false);
+    expect(existsSync(join(dir, 'analysis'))).toBe(false);
+    expect(existsSync(join(dir, 'cloud-conversations'))).toBe(false);
+    expect(existsSync(join(dir, '.demo'))).toBe(false);
+  });
+
+  it('sweeps the SQLite substrate family — Rev3-A forward-compat', async () => {
+    // The plan calls out `*.db`, `*.db-wal`, `*.db-shm` explicitly;
+    // verify kitchen-sink picks them up via the .gitkeep-only filter.
+    await wipeAll(dir);
+    expect(existsSync(join(dir, 'chat-arch.db'))).toBe(false);
+    expect(existsSync(join(dir, 'chat-arch.db-wal'))).toBe(false);
+  });
+
+  it('sweeps orphan analysis sidecars (Rev3-A.A9 orphan-sweep contract)', async () => {
+    await wipeAll(dir);
+    // The analysis subdir is gone entirely — composite-outcomes,
+    // narratives, patterns all swept regardless of whether they
+    // were live (manifest-derived JSON) or orphan (post-SQLite).
+    expect(existsSync(join(dir, 'analysis'))).toBe(false);
+  });
+});
+
+describe('wipeSources (partial-source mode)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'chat-arch-clear-partial-'));
+    await seedDir(dir);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('filters manifest sessions by source and recomputes counts', async () => {
+    const result = await wipeSources(dir, new Set(['cloud']));
+
+    expect(result.bySources).toEqual({ cloud: 1 });
+
+    const remaining = JSON.parse(
+      await readFile(join(dir, 'manifest.json'), 'utf8'),
+    );
+    expect(remaining.sessions).toHaveLength(2);
+    expect(remaining.sessions.every((s: { source: string }) => s.source !== 'cloud')).toBe(true);
+    expect(remaining.counts.cloud).toBe(0);
+    expect(remaining.counts.cowork).toBe(1);
+    expect(remaining.counts['cli-direct']).toBe(1);
+  });
+
+  it('always wipes the analysis/ subdirectory (orphan-sweep contract)', async () => {
+    // Partial-source wipes — even when 'cloud' isn't selected — must
+    // still drop the analysis dir because its contents are manifest-
+    // derived and stale the moment any session disappears. This is
+    // the load-bearing claim from clear.ts:188-198.
+    expect(existsSync(join(dir, 'analysis'))).toBe(true);
+    await wipeSources(dir, new Set(['cowork']));
+    expect(existsSync(join(dir, 'analysis'))).toBe(false);
+  });
+
+  it('removes cloud-conversations/ + .demo only when cloud is in the selection', async () => {
+    // First: partial wipe NOT including cloud — those two artifacts
+    // survive because they're cloud-rooted.
+    await wipeSources(dir, new Set(['cowork']));
+    expect(existsSync(join(dir, 'cloud-conversations'))).toBe(true);
+    expect(existsSync(join(dir, '.demo'))).toBe(true);
+  });
+
+  it('removes cloud-conversations/ + .demo when cloud IS in the selection', async () => {
+    await wipeSources(dir, new Set(['cloud']));
+    expect(existsSync(join(dir, 'cloud-conversations'))).toBe(false);
+    expect(existsSync(join(dir, '.demo'))).toBe(false);
+  });
+
+  it('returns aggregate "removed" tally including transcript-file unlinks', async () => {
+    // No transcriptPath in the seeded sessions, so removed === count
+    // of manifest sessions in the selection.
+    const result = await wipeSources(dir, new Set(['cloud', 'cowork']));
+    expect(result.removed).toBe(2);
+  });
+
+  it('handles missing manifest gracefully (degraded state)', async () => {
+    await rm(join(dir, 'manifest.json'));
+    const result = await wipeSources(dir, new Set(['cloud']));
+    // No sessions counted, but analysis/ + cloud-conversations are
+    // still swept on the cloud-selection path.
+    expect(result.removed).toBe(0);
+    expect(existsSync(join(dir, 'analysis'))).toBe(false);
+    expect(existsSync(join(dir, 'cloud-conversations'))).toBe(false);
+  });
+});

--- a/packages/analysis/src/thresholds.test.ts
+++ b/packages/analysis/src/thresholds.test.ts
@@ -1,7 +1,7 @@
 // Tests for Rev3 THRESHOLDS additions (sub-task A7 — narrativeRung,
-// curator, closureC). The plan pins specific values for stat-rigor
-// reasons; these tests freeze that contract so a casual edit doesn't
-// silently break the joint-gate feasibility proof.
+// curator, appliedRuleWatcher). The plan pins specific values for
+// stat-rigor reasons; these tests freeze that contract so a casual
+// edit doesn't silently break the joint-gate feasibility proof.
 
 import { describe, expect, it } from 'vitest';
 
@@ -117,10 +117,10 @@ describe('THRESHOLDS.curator (Rev3 curator / falsifier metrics)', () => {
   });
 });
 
-describe('THRESHOLDS.closureC (Rev3 applied-rule outcome watcher)', () => {
+describe('THRESHOLDS.appliedRuleWatcher (Rev3 applied-rule outcome watcher — Closure C)', () => {
   it('watcher caps are positive: N sessions, wall-clock days, stale-project days', () => {
     const { watcherSessionsN, watcherWallClockDays, staleProjectDays } =
-      THRESHOLDS.closureC;
+      THRESHOLDS.appliedRuleWatcher;
     expect(watcherSessionsN).toBeGreaterThan(0);
     expect(watcherWallClockDays).toBeGreaterThan(0);
     expect(staleProjectDays).toBeGreaterThan(0);
@@ -129,7 +129,7 @@ describe('THRESHOLDS.closureC (Rev3 applied-rule outcome watcher)', () => {
   it('staleProjectDays < watcherWallClockDays (stale-out must precede wall-clock close)', () => {
     // Otherwise a project that goes idle at day 31 still has the
     // watcher running until day 60 — no early-invalidation.
-    const { watcherWallClockDays, staleProjectDays } = THRESHOLDS.closureC;
+    const { watcherWallClockDays, staleProjectDays } = THRESHOLDS.appliedRuleWatcher;
     expect(staleProjectDays).toBeLessThan(watcherWallClockDays);
   });
 });

--- a/packages/analysis/src/thresholds.test.ts
+++ b/packages/analysis/src/thresholds.test.ts
@@ -1,0 +1,135 @@
+// Tests for Rev3 THRESHOLDS additions (sub-task A7 — narrativeRung,
+// curator, closureC). The plan pins specific values for stat-rigor
+// reasons; these tests freeze that contract so a casual edit doesn't
+// silently break the joint-gate feasibility proof.
+
+import { describe, expect, it } from 'vitest';
+
+import { THRESHOLDS } from './thresholds.js';
+
+describe('THRESHOLDS.narrativeRung (Rev3 confidence ladder)', () => {
+  it('exposes the three rung confidence floors in ascending order', () => {
+    const { tier1, tier2, tier3 } = THRESHOLDS.narrativeRung;
+    expect(tier1).toBeLessThan(tier2);
+    expect(tier2).toBeLessThan(tier3);
+    expect(tier1).toBeGreaterThan(0);
+    expect(tier3).toBeLessThan(1);
+  });
+
+  it('exposes ascending supporting-count gates per rung', () => {
+    const { tier1SupportingMin, tier2SupportingMin, tier3SupportingMin } =
+      THRESHOLDS.narrativeRung;
+    expect(tier1SupportingMin).toBeLessThanOrEqual(tier2SupportingMin);
+    expect(tier2SupportingMin).toBeLessThanOrEqual(tier3SupportingMin);
+    expect(tier1SupportingMin).toBeGreaterThanOrEqual(1);
+  });
+
+  it('tier-3 confidence + contradicting-cap gates are jointly satisfiable at the count-minimum', () => {
+    // Plan §Confidence ladder: tier3 uses 0.66 (not 0.75) so the
+    // confidence gate AND the contradicting cap are both satisfiable
+    // at supporting=6, contradicting=1 with defaultPrior=2.
+    //   confidence = 6 / (6 + 1 + 2) = 6/9 = 0.667
+    //   contradicting cap = ceil(6 / contradictingCapDivisor)
+    const {
+      tier3,
+      tier3SupportingMin,
+      contradictingCapDivisor,
+      defaultPrior,
+    } = THRESHOLDS.narrativeRung;
+    const supporting = tier3SupportingMin;
+    const contradictingCap = Math.ceil(supporting / contradictingCapDivisor);
+    const confidence = supporting / (supporting + contradictingCap + defaultPrior);
+    expect(confidence).toBeGreaterThanOrEqual(tier3);
+    // And the cap must allow ≥ 1 contradicting at the minimum
+    // supporting — otherwise tier-3 is unreachable for any kernel
+    // that ever surfaces a single counter-example.
+    expect(contradictingCap).toBeGreaterThanOrEqual(1);
+  });
+
+  it('uncalibratedPrior makes tier-3 unreachable until a kernel is calibrated', () => {
+    const { tier3, tier3SupportingMin, uncalibratedPrior } =
+      THRESHOLDS.narrativeRung;
+    // Even with maximum-feasible supporting and zero contradicting,
+    // confidence = s / (s + 0 + uncalibratedPrior) must fall below
+    // tier3. Test at supporting = 5 × tier3SupportingMin to give the
+    // kernel substantial headroom.
+    const supporting = tier3SupportingMin * 5;
+    const confidence = supporting / (supporting + 0 + uncalibratedPrior);
+    expect(confidence).toBeLessThan(tier3);
+  });
+
+  it('dismissDecay > 1 (re-emergence requires growth, not just stasis)', () => {
+    expect(THRESHOLDS.narrativeRung.dismissDecay).toBeGreaterThan(1);
+  });
+
+  it('maxDismissals + maxRepromotionAttempts are positive ints', () => {
+    const { maxDismissals, maxRepromotionAttempts, repromotionPenalty } =
+      THRESHOLDS.narrativeRung;
+    expect(Number.isInteger(maxDismissals) && maxDismissals > 0).toBe(true);
+    expect(
+      Number.isInteger(maxRepromotionAttempts) && maxRepromotionAttempts > 0,
+    ).toBe(true);
+    expect(repromotionPenalty).toBeGreaterThanOrEqual(0);
+  });
+
+  it('priorByKernel + minSessionsByKernel are empty at v1 (calibration not yet run)', () => {
+    expect(Object.keys(THRESHOLDS.narrativeRung.priorByKernel)).toEqual([]);
+    expect(Object.keys(THRESHOLDS.narrativeRung.minSessionsByKernel)).toEqual([]);
+  });
+});
+
+describe('THRESHOLDS.curator (Rev3 curator / falsifier metrics)', () => {
+  it('precision@k has a positive k and horizon, target in (0, 1)', () => {
+    const { precisionAtKWindow, precisionAtKHorizonDays, precisionAtKTarget } =
+      THRESHOLDS.curator;
+    expect(precisionAtKWindow).toBeGreaterThan(0);
+    expect(precisionAtKHorizonDays).toBeGreaterThan(0);
+    expect(precisionAtKTarget).toBeGreaterThan(0);
+    expect(precisionAtKTarget).toBeLessThan(1);
+  });
+
+  it('falsifierRejectionBracket is a [lo, hi] tuple with lo < hi, both in (0, 1)', () => {
+    const [lo, hi] = THRESHOLDS.curator.falsifierRejectionBracket;
+    expect(lo).toBeGreaterThan(0);
+    expect(lo).toBeLessThan(hi);
+    expect(hi).toBeLessThan(1);
+  });
+
+  it('falsifier accuracy floor is in (0.5, 1) — under-the-coin-flip floors are nonsense', () => {
+    const { falsifierAccuracyFloor } = THRESHOLDS.curator;
+    expect(falsifierAccuracyFloor).toBeGreaterThan(0.5);
+    expect(falsifierAccuracyFloor).toBeLessThan(1);
+  });
+
+  it('outcome-correlation significance is the two-sided α=0.05 z-critical or stricter', () => {
+    // 1.96 is the two-sided α=0.05 normal critical value. Anything
+    // smaller would let noise slip through to the SourceAttribution
+    // tag and undermine the "correlation, not causation" disclosure.
+    expect(
+      THRESHOLDS.curator.outcomeCorrelationSignificance,
+    ).toBeGreaterThanOrEqual(1.96);
+  });
+
+  it('outcome-correlation evidence-length floor is at least 5 (per iter-1 finding)', () => {
+    expect(
+      THRESHOLDS.curator.outcomeCorrelationEvidenceMinLength,
+    ).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('THRESHOLDS.closureC (Rev3 applied-rule outcome watcher)', () => {
+  it('watcher caps are positive: N sessions, wall-clock days, stale-project days', () => {
+    const { watcherSessionsN, watcherWallClockDays, staleProjectDays } =
+      THRESHOLDS.closureC;
+    expect(watcherSessionsN).toBeGreaterThan(0);
+    expect(watcherWallClockDays).toBeGreaterThan(0);
+    expect(staleProjectDays).toBeGreaterThan(0);
+  });
+
+  it('staleProjectDays < watcherWallClockDays (stale-out must precede wall-clock close)', () => {
+    // Otherwise a project that goes idle at day 31 still has the
+    // watcher running until day 60 — no early-invalidation.
+    const { watcherWallClockDays, staleProjectDays } = THRESHOLDS.closureC;
+    expect(staleProjectDays).toBeLessThan(watcherWallClockDays);
+  });
+});

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -162,6 +162,194 @@ export const THRESHOLDS = {
     /** Minimum user-turn count to flag a session as a turn-outlier. */
     turnOutlierMin: 50,
   },
+  /**
+   * Rev3 confidence ladder for Narratives. Bayesian smoothing per the
+   * formula `confidence = supporting / (supporting + contradicting +
+   * prior)`. Three rungs (tier1=candidate, tier2=established,
+   * tier3=promotable) gate visibility, curator-feed eligibility, and
+   * `encode-as-pattern` action eligibility respectively.
+   *
+   * Joint-gate feasibility: tier3 uses 0.66 (not 0.75) so the
+   * confidence gate + contradicting-cap are jointly satisfiable at
+   * the count-minimum `supporting=6, contradicting=1` (with
+   * defaultPrior=2 → 6/(6+1+2)=0.667 ≥ 0.66 ✓ AND 1 ≤ ceil(6/6)=1 ✓).
+   * Iter-1 stat-rigor finding #001 demonstrated 0.75 + count cap was
+   * infeasible.
+   *
+   * Calibration plan: hand-label n ≥ 100 narratives per kernel, ≥30
+   * held-out, MDE ±0.10 false-promotion-rate at 80% power α=0.05.
+   * Refit defaultPrior + per-kernel priors as Bayesian updates of
+   * the prior itself; document the resulting credible interval, not
+   * a point estimate. Track calibration history alongside
+   * `composite.weights`.
+   *
+   * Pre-launch placeholders below — re-calibrate when corpus has the
+   * first 100 narratives in a candidate kernel.
+   */
+  narrativeRung: {
+    /** Tier-1 (candidate) confidence floor. */
+    tier1: 0.33,
+    /** Tier-2 (established) confidence floor — curator-feed eligible. */
+    tier2: 0.5,
+    /** Tier-3 (promotable) confidence floor — action eligible. */
+    tier3: 0.66,
+    /** Tier-1 additional gate: minimum supporting evidence count. */
+    tier1SupportingMin: 1,
+    /** Tier-2 additional gate: minimum supporting evidence count. */
+    tier2SupportingMin: 2,
+    /** Tier-3 additional gate: minimum supporting evidence count. */
+    tier3SupportingMin: 6,
+    /**
+     * Tier-3 additional gate: contradicting ≤ ceil(supporting /
+     * contradictingCapDivisor). At divisor=6, supporting=6 allows
+     * contradicting≤1, supporting=12 allows ≤2, etc.
+     */
+    contradictingCapDivisor: 6,
+    /**
+     * Default Bayesian prior when a kernel doesn't override it via
+     * `priorByKernel`. From the ShopForge precedent — light prior so
+     * a kernel with 1 supporting and 0 contradicting lands at
+     * confidence 1/(1+0+2)=0.33, exactly the tier-1 floor.
+     */
+    defaultPrior: 2,
+    /**
+     * Calibration fail-safe: a kernel whose
+     * `analyzers.calibration_completed_at` is NULL has its effective
+     * prior pinned to this very-high value, making tier-3 unreachable
+     * (1/(1+0+20)=0.048 ≪ tier3). Banner-state surfaces "kernel X
+     * uncalibrated — tier-3 promotion disabled" so the missing
+     * calibration is visible, not silent.
+     */
+    uncalibratedPrior: 20,
+    /**
+     * Per-kernel prior overrides. Empty at v1; populated after
+     * per-kernel calibration. Lookup falls back to `defaultPrior`
+     * when the kernel name isn't present.
+     */
+    priorByKernel: {} as Readonly<Record<string, number>>,
+    /**
+     * Per-kernel minimum-sessions floor for cold-start honesty.
+     * Kernels report "uncalibrated" when corpus < their floor; their
+     * findings cannot exceed tier-1 until the threshold is met.
+     * Empty at v1; populated as kernel-specific calibration runs
+     * inform the floor.
+     */
+    minSessionsByKernel: {} as Readonly<Record<string, number>>,
+    /**
+     * Closure B saturation: per-Narrative growth-multiplier multiplier
+     * applied on each user dismissal. Default doubling per dismissal —
+     * a 2× multiplier becomes 4× after first dismissal, 8× after the
+     * second, 16× after the third. Closes the iter-1 unbounded-nag
+     * failure mode.
+     */
+    dismissDecay: 2,
+    /**
+     * Cap on user dismissals before a Narrative is shelved
+     * permanently. After this many dismissals the item is visible
+     * only via an explicit "show shelved" affordance.
+     */
+    maxDismissals: 4,
+    /**
+     * Closure B family-wise correction: per-Narrative prior increases
+     * by this value on each dismissal. Each re-emergence is a re-test
+     * of the same hypothesis; raising the prior makes subsequent
+     * re-promotion attempts face a stiffer Bayesian threshold.
+     */
+    repromotionPenalty: 1,
+    /**
+     * Cap on re-promotion attempts. Document the resulting family-
+     * wise α inflation in the curator-surface methodology disclosure.
+     */
+    maxRepromotionAttempts: 3,
+  },
+  /**
+   * Rev3 curator / falsifier metrics and gates. Used by the
+   * `/curate` and `/falsify` skills (Rev3-F) and consumed by the
+   * curator-surface methodology disclosure.
+   */
+  curator: {
+    /**
+     * Precision@k window — the top-k items the curator surfaces
+     * whose engagement is tallied. k=10 per plan §Validation metrics.
+     */
+    precisionAtKWindow: 10,
+    /**
+     * Engagement horizon: a surfaced item counts as a "hit" only if
+     * a user action (star / explicit-action / engagedAt event)
+     * occurs within this many days of first surfacing. Items whose
+     * window hasn't closed are excluded from both numerator and
+     * denominator (per iter-1 stat-rigor finding #006).
+     */
+    precisionAtKHorizonDays: 7,
+    /**
+     * Precision@k success threshold. Re-calibrate after the first
+     * calibration window once empirical engagement data lands.
+     */
+    precisionAtKTarget: 0.3,
+    /**
+     * Falsifier rejection-rate acceptance bracket — pre-launch
+     * placeholder. 4-week empirical calibration window analogous to
+     * `CHATARCH_THRASH_DETECT`; re-derive from observed data.
+     * Rejection rate below `[0]` = falsifier under-rejecting (false
+     * negatives leak); above `[1]` = over-rejecting (good findings
+     * killed). `as const` tuple so consumers see a fixed shape.
+     */
+    falsifierRejectionBracket: [0.2, 0.5] as readonly [number, number],
+    /**
+     * Falsifier meta-accuracy floor. Triggered on rolling 4-week
+     * window (n=40 verdicts re-judged by user or different model
+     * role). Banner-state fires when Wilson lower bound drops below
+     * this value. NOT a point estimate on n=10/week — that fires
+     * ~26% of weeks on noise at true accuracy 0.9 (iter-1 finding
+     * stat-rigor #003).
+     */
+    falsifierAccuracyFloor: 0.8,
+    /** Rolling-window length for falsifier meta-accuracy in weeks. */
+    falsifierAccuracyWindowWeeks: 4,
+    /** Rolling-window N (verdicts spot-checked) for falsifier meta-accuracy. */
+    falsifierAccuracyWindowN: 40,
+    /**
+     * Outcome-correlation significance gate. `|Δ|/SE` (Welch's t /
+     * permutation difference) must exceed this value before the
+     * correlation tag is visible in the SourceAttribution
+     * side-column. Pre-launch placeholder ≈ 1.96 (two-sided α=0.05);
+     * calibrate empirically after first ~50 correlations are
+     * computed.
+     */
+    outcomeCorrelationSignificance: 1.96,
+    /**
+     * Outcome-correlation evidence-length floor. Tie-breaker is
+     * gated on `evidence.length ≥ outcomeCorrelationEvidenceMinLength`
+     * — below this the SE on the cited-side mean dominates and the
+     * ranking becomes noise (iter-1 stat-rigor #004).
+     */
+    outcomeCorrelationEvidenceMinLength: 5,
+  },
+  /**
+   * Rev3 Closure C — applied-rule outcome watcher. After a Pattern
+   * is `encode-as-pattern`'d and (optionally) appended to CLAUDE.md,
+   * the next-sessions watcher activates. Closes on whichever fires
+   * first: (a) N sessions observed in the target project,
+   * (b) wall-clock elapsed, (c) explicit user-side close. Project
+   * inactivity ≥ staleProjectDays before N is reached invalidates
+   * the watch entirely; a fresh watcher starts on project re-entry.
+   */
+  closureC: {
+    /** Number of post-application sessions observed before closing. */
+    watcherSessionsN: 5,
+    /**
+     * Wall-clock cap. Timeout emits a `WATCH_INCONCLUSIVE` Narrative
+     * at low feed priority — not silence.
+     */
+    watcherWallClockDays: 60,
+    /**
+     * Project-inactivity threshold (days). If the target project
+     * goes this long without a session BEFORE watcherSessionsN is
+     * reached, the watcher is invalidated. A fresh watcher starts
+     * on project re-entry.
+     */
+    staleProjectDays: 30,
+  },
 } as const;
 
 export type Thresholds = typeof THRESHOLDS;

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -241,6 +241,14 @@ export const THRESHOLDS = {
      * a 2× multiplier becomes 4× after first dismissal, 8× after the
      * second, 16× after the third. Closes the iter-1 unbounded-nag
      * failure mode.
+     *
+     * Parallel mechanism — kept separate: knowledge-debt clusters use
+     * `actionBanner.knowledgeDebtRepromotionGrowthMultiplier` (also
+     * default 2) for the same saturation policy on a different entity
+     * domain (clusters vs Narratives). The two are intentionally
+     * NOT unified so per-domain calibration can tune each independently
+     * once empirical re-promotion data lands per entity type. A future
+     * audit should re-check whether they should converge.
      */
     dismissDecay: 2,
     /**
@@ -326,15 +334,21 @@ export const THRESHOLDS = {
     outcomeCorrelationEvidenceMinLength: 5,
   },
   /**
-   * Rev3 Closure C — applied-rule outcome watcher. After a Pattern
-   * is `encode-as-pattern`'d and (optionally) appended to CLAUDE.md,
-   * the next-sessions watcher activates. Closes on whichever fires
-   * first: (a) N sessions observed in the target project,
-   * (b) wall-clock elapsed, (c) explicit user-side close. Project
-   * inactivity ≥ staleProjectDays before N is reached invalidates
-   * the watch entirely; a fresh watcher starts on project re-entry.
+   * Rev3 applied-rule outcome watcher (plan §"Three closures" —
+   * Closure C). After a Pattern is `encode-as-pattern`'d and
+   * (optionally) appended to CLAUDE.md, the next-sessions watcher
+   * activates. Closes on whichever fires first: (a) N sessions
+   * observed in the target project, (b) wall-clock elapsed,
+   * (c) explicit user-side close. Project inactivity ≥
+   * staleProjectDays before N is reached invalidates the watch
+   * entirely; a fresh watcher starts on project re-entry.
+   *
+   * (Closures A and B don't get their own top-level key: A graduates
+   * Narratives across `narrativeRung.tier*`; B saturates via
+   * `narrativeRung.dismissDecay` + `maxDismissals` +
+   * `repromotionPenalty`.)
    */
-  closureC: {
+  appliedRuleWatcher: {
     /** Number of post-application sessions observed before closing. */
     watcherSessionsN: 5,
     /**


### PR DESCRIPTION
## Summary

Phase Rev3-A **sub-task A7** per [`_planning/chat-arch-v2-rev3-plan.md`](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md). Adds the three new top-level `THRESHOLDS` sections that downstream Rev3 phases (B/C/D/E/F/G) will consume. Bundles in a refactor + test coverage for the A9 orphan-sweep code path (which already landed via PR #53 but was missing dedicated test coverage).

## A7 — THRESHOLDS additions (primary deliverable)

Three new top-level keys in `packages/analysis/src/thresholds.ts`:

**`narrativeRung`** (14 fields) — three-rung Bayesian confidence ladder:
- `tier1: 0.33`, `tier2: 0.50`, `tier3: 0.66` with ascending supporting-count gates (1 / 2 / 6).
- **Joint-gate feasibility math pinned**: tier3=0.66 (not 0.75) so the confidence gate AND contradicting-cap are jointly satisfiable at the count-minimum (`supporting=6, contradicting=1, prior=2` → 6/9=0.667 ✓ AND 1 ≤ ceil(6/6)=1 ✓). Iter-1 stat-rigor finding #001 demonstrated 0.75 + count cap was infeasible.
- `dismissDecay: 2` (Closure B saturation — ×2/×4/×8/×16 per dismissal); `maxDismissals: 4` (cap K); `repromotionPenalty: 1` (per-Narrative prior += 1 on each dismissal — family-wise correction); `maxRepromotionAttempts: 3`.
- `defaultPrior: 2` (ShopForge precedent); `uncalibratedPrior: 20` (cold-start fail-safe — makes tier-3 unreachable for kernels with `analyzers.calibration_completed_at IS NULL`).
- Empty `priorByKernel` / `minSessionsByKernel` maps for per-kernel calibration.

**`curator`** (8 fields) — precision@k, falsifier rejection bracket + meta-accuracy floor, outcome-correlation significance:
- `precisionAtKWindow: 10`, `precisionAtKHorizonDays: 7`, `precisionAtKTarget: 0.30`.
- `falsifierRejectionBracket: [0.20, 0.50]` as readonly tuple; `falsifierAccuracyFloor: 0.8`; rolling window `4` weeks × `40` verdicts (per iter-1 stat-rigor #003 — n=10/week point-estimate fires ~26% of weeks on noise at true 0.9).
- `outcomeCorrelationSignificance: 1.96` (two-sided α=0.05); `outcomeCorrelationEvidenceMinLength: 5` (iter-1 finding #004).

**`closureC`** (3 fields) — applied-rule-outcome watcher caps:
- `watcherSessionsN: 5`, `watcherWallClockDays: 60`, `staleProjectDays: 30`.

**14 new tests** in `thresholds.test.ts` freeze the contract: ascending rung order, joint-gate feasibility proof at the count-minimum, uncalibrated-prior unreachability, bracket/target/significance bounds, `staleProjectDays < watcherWallClockDays` invariant.

## A9 follow-up — clear endpoint refactor + test coverage

A9 (orphan-sweep) already landed via PR #53 — `/api/clear` already wipes `analysis/` on both kitchen-sink and partial-source modes. This PR adds the test coverage that was missing on that code path:

- Extract `wipeAll` + `wipeSources` + `readManifest` from [`apps/standalone/src/pages/api/clear.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-a-thresholds-and-orphan-sweep/apps/standalone/src/pages/api/clear.ts) into a testable helper at [`apps/standalone/src/lib/clearDataDir.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-a-thresholds-and-orphan-sweep/apps/standalone/src/lib/clearDataDir.ts). The route handler keeps the CSRF gate + body parsing; pure wipe logic moves to the helper.
- New [`clearDataDir.test.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-a-thresholds-and-orphan-sweep/apps/standalone/test/lib/clearDataDir.test.ts) (9 cases): both modes, `.gitkeep` preservation, **SQLite-substrate forward-compat sweep** (`*.db`, `*.db-wal`), cloud-conversations + `.demo` conditional removal, manifest-rewrite + count recomputation, graceful degraded-manifest handling.
- Documentation in `clearDataDir.ts` makes the Rev3-A.A9 contract explicit: orphan JSON sidecars under `analysis/` are swept on both paths; future SQLite DB files are swept on kitchen-sink via the existing `name !== .gitkeep` filter; partial-source SQLite deletes will need their own row-level path landing with the A8 SDK.

## Plan anchor

- [§Confidence ladder](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#confidence-ladder-centralized-in-thresholds)
- [§Three closures](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#three-closures-mapped-onto-existing-infrastructure)
- [§Validation metrics](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#validation-metrics-pinned)

## Gates

- [x] All numeric values live in `packages/analysis/src/thresholds.ts` (the lint-enforced registry)
- [x] No inline literals introduced anywhere else
- [x] Tier-3 confidence + contradicting-cap gates jointly satisfiable at count-minimum (proven in test)
- [x] Uncalibrated-prior makes tier-3 unreachable until calibration lands (proven in test)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r test` — 1,473 tests pass (23 new)
- [x] `pnpm build` — all workspaces succeed

## Progress-tracker sub-tasks addressed

- **A7** — THRESHOLDS additions ✅
- **A4/A5/A6** — updated to `complete-and-merged` (PR #57 landed before this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)