### PR TITLE
fix(tech-debt): XN3 attachIfBusy refactor in index.astro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+### Changed
+
+- **`attachIfBusy` refactored to named function with explicit deps
+  object (tech-debt XN3).** The on-page-load handler that re-attaches
+  to in-flight mining runs in [`apps/standalone/src/pages/index.astro`]
+  was previously a 40-line IIFE closing over module-scope state. It's
+  now a named function (`attachIfBusy(deps)`) with dependencies
+  surfaced in one place — `showProgress`, `setButtonsDisabled`,
+  `startElapsedTicker`, `pollMineStatus`, `setStatus`, `hideProgress`,
+  `reloadSoon`, `setStatusPollTimer`, `clearStatusPollTimer`. The
+  script tag stays `is:inline` (Vite doesn't process inline scripts),
+  but the explicit-deps shape prepares a future module extraction to
+  lift the function verbatim. Same runtime behavior; no behavior
+  change.
+
 ### Added
 
 - **`cosineSimilarity` triplication consolidated (tech-debt D2).**

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -605,46 +605,68 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
     // progress instead of a stale UI. We can't re-attach to the
     // original POST's stream from a new connection, but the status
     // file gives us everything that matters.
-    (async function attachIfBusy() {
+    //
+    // XN3 refactor: named function with an explicit `deps` object
+    // (rather than the previous IIFE closing over module-scope state).
+    // Dependencies are surfaced in one place so a future Vite-bundled
+    // module extraction can lift this verbatim. The function is still
+    // invoked once at module-load time below.
+    async function attachIfBusy(deps) {
       try {
         const res = await fetch('/api/mine-corrections', { method: 'GET' });
         if (!res.ok) return;
         const body = await res.json();
         if (body && body.busy === true && typeof body.busyRequestId === 'string') {
-          showProgress('mine corrections (resumed)');
-          setButtonsDisabled(true);
-          startElapsedTicker(Date.now());
+          deps.showProgress('mine corrections (resumed)');
+          deps.setButtonsDisabled(true);
+          deps.startElapsedTicker(Date.now());
           const requestId = body.busyRequestId;
-          await pollMineStatus(requestId);
-          statusPollTimer = setInterval(async () => {
-            await pollMineStatus(requestId);
+          await deps.pollMineStatus(requestId);
+          deps.setStatusPollTimer(setInterval(async () => {
+            await deps.pollMineStatus(requestId);
             // When the status file flips to complete/error, refresh.
             try {
               const r = await fetch(`/chat-arch-data/analysis/correction-status-${requestId}.json`, { cache: 'no-store' });
               if (!r.ok) return;
               const s = await r.json();
               if (s && (s.status === 'complete' || s.status === 'error')) {
-                clearInterval(statusPollTimer);
-                statusPollTimer = null;
+                deps.clearStatusPollTimer();
                 if (s.status === 'complete') {
-                  setStatus('mine corrections complete — refreshing…', false);
-                  hideProgress();
-                  reloadSoon();
+                  deps.setStatus('mine corrections complete — refreshing…', false);
+                  deps.hideProgress();
+                  deps.reloadSoon();
                 } else {
-                  hideProgress();
-                  setButtonsDisabled(false);
-                  setStatus(`mine corrections failed${s.error ? ': ' + String(s.error).slice(0, 200) : ''}`, true);
+                  deps.hideProgress();
+                  deps.setButtonsDisabled(false);
+                  deps.setStatus(`mine corrections failed${s.error ? ': ' + String(s.error).slice(0, 200) : ''}`, true);
                 }
               }
             } catch {
               // Transient — keep polling.
             }
-          }, 1500);
+          }, 1500));
         }
       } catch {
         // No backend / network error — silently skip the attach.
       }
-    })();
+    }
+
+    void attachIfBusy({
+      showProgress,
+      setButtonsDisabled,
+      startElapsedTicker,
+      pollMineStatus,
+      setStatus,
+      hideProgress,
+      reloadSoon,
+      setStatusPollTimer: (handle) => { statusPollTimer = handle; },
+      clearStatusPollTimer: () => {
+        if (statusPollTimer !== null) {
+          clearInterval(statusPollTimer);
+          statusPollTimer = null;
+        }
+      },
+    });
   </script>
 </BaseLayout>
 


### PR DESCRIPTION
## Summary

Seventh and final tech-debt item. After this PR merges, all 7 items from the queued tech-debt list (T1-T5, D2, XN3) are closed, and the loop moves to Phase Rev3-B.

## XN3 — `attachIfBusy` refactor

[`apps/standalone/src/pages/index.astro`](https://github.com/BryceEWatson/chat-arch/blob/main/apps/standalone/src/pages/index.astro) previously had a 40-line IIFE that re-attached to in-flight mining runs on page load. It closed over module-scope state (`showProgress`, `setButtonsDisabled`, `startElapsedTicker`, `pollMineStatus`, `setStatus`, `hideProgress`, `reloadSoon`, `statusPollTimer`) implicitly via closure.

Refactor:
- Convert IIFE → named `async function attachIfBusy(deps)` defined above the explicit invocation.
- Dependencies passed in via an explicit `deps` object — surfaces the contract in one place rather than implicit closure capture.
- Added two thin wrapper deps (`setStatusPollTimer`, `clearStatusPollTimer`) so the function never mutates module-scope state directly — the polling-handle lifecycle is owned by the callsite, not by `attachIfBusy`.

## Why not extract to a separate module file?

The script tag remains `is:inline` — Astro doesn't run Vite over `is:inline` scripts, so a true module extraction (e.g. to `apps/standalone/src/lib/attachIfBusy.ts`) would require also switching the script's bundling mode. That's a larger architectural change with init-order risk (`is:inline` runs synchronously at parse time; a Vite-bundled module runs after the bundle loads). The explicit-deps shape prepares a future extraction to lift the function verbatim, but doesn't take that step here.

Same runtime behavior — pure refactor.

## Tech-debt sweep complete

All 7 queued items are now merged:

| Item | What | PR |
|---|---|---|
| T1 | BH-FDR in ITS | #61 |
| T2 | McNemar in computeReflexive | #62 |
| T3 | Fisher's exact in surface-comparison | #63 |
| T4 | trended-AR(1) detrending | #62 |
| T5 | silhouette gate in detectArchetypes | #61 |
| D2 | cosineSimilarity triplication | #64 |
| XN3 | attachIfBusy refactor | **this PR** |

Plus a bonus normalCdf bug fix surfaced during T1 (#61).

**Next:** Phase Rev3-B (Narrative provenance + confidence ladder).

## CHANGELOG

Added `[Unreleased]` entry for XN3 under a new `### Changed` section (first non-`### Added` entry in the unreleased block).

## Gates

- [x] `pnpm install --frozen-lockfile` — green
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r test` — 1,570 tests pass (no count change — pure runtime-equivalent refactor of a 40-line IIFE with no existing test coverage; would need Vite-bundled module extraction first)
- [x] `pnpm build` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)