### PR TITLE
feat(rev3-b): narrative provenance schema (B1+B2+B3+B4+B8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,43 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+### Added
+
+- **Narrative provenance schema (Phase Rev3-B B1+B2+B3+B4+B8).**
+  `packages/schema/src/narrative.ts` extends the `Narrative` type
+  with optional `schemaVersion`, `provenance` (intent/observation/
+  inference), `attributedTo`, `verifiedAt`, `confidence`,
+  `supportingCount`, `contradictingCount`, and `correlatedOutcome`
+  fields. `NarrativeEvidence` gains optional `turnIndex` (0-based
+  message ordinal). `validateNarrative` runs the pre-existing
+  invariant checks on both schema versions and additionally enforces
+  the v2 shape (non-empty provenance, attributedTo, confidence in
+  [0,1], non-negative counts) when `schemaVersion === 2`. v1 rows
+  remain accepted untouched for the legacy on-disk corpus.
+
+  DB migration `002-narrative-provenance.ts` adds the matching nullable
+  columns to `narratives` (`intent`, `observation`, `inference`,
+  `attributed_to` with CHECK on the 4-value union, `verified_at`,
+  `confidence` with CHECK 0–1, `supporting_count`/`contradicting_count`
+  with CHECK ≥ 0, `correlated_outcome_json`) and `turn_index` to
+  `narrative_evidence` (CHECK ≥ 0). Existing rows survive with all
+  new columns NULL — equivalent to schemaVersion=1. The schema-layer
+  `schema_version` column already exists from migration 001 with
+  DEFAULT 1; migration 002 only adds the provenance siblings.
+
+  Gate test `packages/schema/src/narrative.migration.test.ts` (16
+  cases) covers: v1 acceptance with/without explicit schemaVersion,
+  v1 still rejects pre-Rev3-B invariant violations, v2 acceptance
+  for the full provenance shape, v2 acceptance of verifiedAt=null
+  + correlatedOutcome=null + all 4 attributedTo values, v2 structural
+  rejections (missing provenance / empty triple / missing
+  attributedTo / out-of-range confidence / negative counts), unknown
+  schemaVersion rejection, and turnIndex round-trip on evidence.
+  DB-side migration test `002-narrative-provenance.test.ts` (7 cases)
+  exercises the SQL CHECK constraints + a v1 legacy insert + a full
+  v2 insert with correlated_outcome_json JSON round-trip + the
+  evidence.turn_index optional+CHECK behavior.
+
 ### Changed
 
 - **`attachIfBusy` refactored to named function with explicit deps

--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -44,14 +44,14 @@ Plan anchor: [§Phase Rev3-B](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 
 | # | Sub-task | Status | PR / notes |
 |---|---|---|---|
-| B1 | Extend `packages/schema/src/narrative.ts` with provenance fields (intent, observation, inference, attributedTo, verifiedAt, confidence, supportingCount, contradictingCount, correlatedOutcome, schemaVersion) | pending | |
-| B2 | Extend `NarrativeEvidence` with optional `turnIndex` | pending | |
-| B3 | DB migration adding the new columns to the `narratives` table | pending | |
-| B4 | `validateNarrative()` accepts both schemaVersion 1 and 2 | pending | |
+| B1 | Extend `packages/schema/src/narrative.ts` with provenance fields (intent, observation, inference, attributedTo, verifiedAt, confidence, supportingCount, contradictingCount, correlatedOutcome, schemaVersion) | in-review | PR #TBD |
+| B2 | Extend `NarrativeEvidence` with optional `turnIndex` | in-review | PR #TBD |
+| B3 | DB migration adding the new columns to the `narratives` table | in-review | PR #TBD (migration `002-narrative-provenance.ts`) |
+| B4 | `validateNarrative()` accepts both schemaVersion 1 and 2 | in-review | PR #TBD |
 | B5 | Backfill kernel — one-shot run over any existing narratives (post zero-data start, normally empty) computing confidence + setting `attributedTo='deterministic'` + bumping to schemaVersion 2 | pending | |
 | B6 | Confidence-ladder helper (`computeConfidence(supporting, contradicting, prior)`) consuming THRESHOLDS | pending | |
 | B7 | Calibration fail-safe: kernels with `calibrationCompletedAt = null` get effective prior pinned to `narrativeRung.uncalibratedPrior`; banner surfaces "kernel X uncalibrated" | pending | |
-| B8 | Named test `narrative.migration.test.ts` — covers legacy parse, deterministic backfill, round-trip, dual-schema acceptance | pending | Gate |
+| B8 | Named test `narrative.migration.test.ts` — covers legacy parse, deterministic backfill, round-trip, dual-schema acceptance | in-review | PR #TBD (covers dual-schema acceptance + structural rejections; backfill-round-trip lands with B5) |
 | B9 | PII handling for narrative previews — default-blur with reveal-on-click before any curator surface ships | pending | Gate |
 
 **Gates:** named `narrative.migration.test.ts` passes; existing `validateNarrative()` accepts both schemaVersion shapes.

--- a/packages/analysis/src/discoverNarratives.ts
+++ b/packages/analysis/src/discoverNarratives.ts
@@ -178,6 +178,9 @@ function buildNarrative(
     generatedAt: isoFromMs(now),
     actionType:
       sentiment === 'positive' ? 'encode-as-pattern' : 'generate-corrective-prompt',
+    // Legacy v1 shape — Rev3-B backfill (B5) bumps existing rows to
+    // v2 with provenance + confidence populated.
+    schemaVersion: 1,
   };
 }
 

--- a/packages/exporter/src/db/migrations/001-initial-schema.test.ts
+++ b/packages/exporter/src/db/migrations/001-initial-schema.test.ts
@@ -316,7 +316,10 @@ describe('001-initial-schema migration', () => {
       const db = openDb(dbPath);
       try {
         const first = runMigrations(db, MIGRATIONS);
-        expect(first.applied).toEqual(['001-initial-schema']);
+        expect(first.applied).toEqual([
+          '001-initial-schema',
+          '002-narrative-provenance',
+        ]);
       } finally {
         db.close();
       }
@@ -326,7 +329,10 @@ describe('001-initial-schema migration', () => {
       try {
         const second = runMigrations(db, MIGRATIONS);
         expect(second.applied).toEqual([]);
-        expect(second.alreadyApplied).toEqual(['001-initial-schema']);
+        expect(second.alreadyApplied).toEqual([
+          '001-initial-schema',
+          '002-narrative-provenance',
+        ]);
       } finally {
         db.close();
       }

--- a/packages/exporter/src/db/migrations/002-narrative-provenance.test.ts
+++ b/packages/exporter/src/db/migrations/002-narrative-provenance.test.ts
@@ -1,0 +1,190 @@
+// DB-side tests for Phase Rev3-B sub-task B3 — the narrative
+// provenance migration. Walks a freshly-migrated DB through
+// inserting both a v1-shape narrative (legacy columns only) and a
+// v2-shape narrative (provenance columns populated), then asserts the
+// CHECK constraints reject malformed inputs.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openDb } from '../connection.js';
+import { MIGRATIONS, runMigrations } from './index.js';
+
+describe('Rev3-B narrative-provenance migration (002)', () => {
+  let tmpDir: string;
+  let db: Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chat-arch-rev3b-test-'));
+    db = openDb(join(tmpDir, 'rev3b.db'));
+    runMigrations(db, MIGRATIONS);
+    db.prepare(
+      `INSERT INTO projects (id, display_name, discovered_at, last_activity_at, sentiment, source)
+       VALUES ('p1', 'P1', '2025-01-01T00:00:00Z', '2025-01-01T00:00:00Z', 'positive', 'desktop')`,
+    ).run();
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('both migrations are registered in apply order', () => {
+    const applied = db
+      .prepare<unknown[], { id: string }>('SELECT id FROM schema_migrations ORDER BY id')
+      .all()
+      .map((r) => r.id);
+    expect(applied).toEqual([
+      '001-initial-schema',
+      '002-narrative-provenance',
+    ]);
+  });
+
+  it('legacy v1 insert (no provenance columns) still works', () => {
+    db.prepare(
+      `INSERT INTO narratives
+        (id, project_id, sentiment, title, body, generated_at, action_type, schema_version)
+       VALUES ('n-v1', 'p1', 'positive', 't', 'b', '2025-01-01T00:00:00Z', 'encode-as-pattern', 1)`,
+    ).run();
+    const row = db
+      .prepare<[string], Record<string, unknown>>(
+        `SELECT * FROM narratives WHERE id = ?`,
+      )
+      .get('n-v1');
+    expect(row?.['schema_version']).toBe(1);
+    expect(row?.['intent']).toBeNull();
+    expect(row?.['observation']).toBeNull();
+    expect(row?.['inference']).toBeNull();
+    expect(row?.['attributed_to']).toBeNull();
+    expect(row?.['verified_at']).toBeNull();
+    expect(row?.['confidence']).toBeNull();
+    expect(row?.['supporting_count']).toBeNull();
+    expect(row?.['contradicting_count']).toBeNull();
+    expect(row?.['correlated_outcome_json']).toBeNull();
+  });
+
+  it('v2 insert with full provenance round-trips', () => {
+    db.prepare(
+      `INSERT INTO narratives (
+        id, project_id, sentiment, title, body, generated_at, action_type, schema_version,
+        intent, observation, inference, attributed_to, verified_at,
+        confidence, supporting_count, contradicting_count, correlated_outcome_json
+      ) VALUES (
+        'n-v2', 'p1', 'positive', 't', 'b', '2025-01-01T00:00:00Z', 'encode-as-pattern', 2,
+        ?, ?, ?, ?, ?, ?, ?, ?, ?
+      )`,
+    ).run(
+      'detect X-before-Y',
+      'X precedes Y in 5/7 sessions',
+      'X-before-Y is the right ordering for this project',
+      'deterministic',
+      '2026-05-23T00:00:00Z',
+      0.62,
+      5,
+      1,
+      JSON.stringify({ delta: 0.14, standardError: 0.06, citedCount: 5, uncitedCount: 12 }),
+    );
+    const row = db
+      .prepare<[string], Record<string, unknown>>(
+        `SELECT * FROM narratives WHERE id = ?`,
+      )
+      .get('n-v2');
+    expect(row?.['schema_version']).toBe(2);
+    expect(row?.['intent']).toBe('detect X-before-Y');
+    expect(row?.['attributed_to']).toBe('deterministic');
+    expect(row?.['confidence']).toBe(0.62);
+    expect(row?.['supporting_count']).toBe(5);
+    expect(row?.['contradicting_count']).toBe(1);
+    expect(JSON.parse(String(row?.['correlated_outcome_json']))).toEqual({
+      delta: 0.14,
+      standardError: 0.06,
+      citedCount: 5,
+      uncitedCount: 12,
+    });
+  });
+
+  it('rejects attributed_to values outside the CHECK list', () => {
+    expect(() =>
+      db.prepare(
+        `INSERT INTO narratives
+          (id, project_id, sentiment, title, body, generated_at, action_type, schema_version, attributed_to)
+         VALUES ('n-bad', 'p1', 'positive', 't', 'b', '2025-01-01T00:00:00Z', 'encode-as-pattern', 2, 'made-up-attribution')`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+
+  it('rejects confidence outside [0, 1]', () => {
+    for (const bad of [-0.1, 1.1, 2]) {
+      expect(() =>
+        db.prepare(
+          `INSERT INTO narratives
+            (id, project_id, sentiment, title, body, generated_at, action_type, schema_version, confidence)
+           VALUES ('n-c', 'p1', 'positive', 't', 'b', '2025-01-01T00:00:00Z', 'encode-as-pattern', 2, ?)`,
+        ).run(bad),
+      ).toThrow(/CHECK constraint/);
+    }
+  });
+
+  it('rejects negative supporting_count / contradicting_count', () => {
+    expect(() =>
+      db.prepare(
+        `INSERT INTO narratives
+          (id, project_id, sentiment, title, body, generated_at, action_type, schema_version, supporting_count)
+         VALUES ('n-s', 'p1', 'positive', 't', 'b', '2025-01-01T00:00:00Z', 'encode-as-pattern', 2, -1)`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+    expect(() =>
+      db.prepare(
+        `INSERT INTO narratives
+          (id, project_id, sentiment, title, body, generated_at, action_type, schema_version, contradicting_count)
+         VALUES ('n-c', 'p1', 'positive', 't', 'b', '2025-01-01T00:00:00Z', 'encode-as-pattern', 2, -1)`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+
+  it('narrative_evidence.turn_index round-trips and rejects negatives', () => {
+    db.prepare(
+      `INSERT INTO sessions (id, source, raw_session_id, started_at, updated_at, duration_ms, title, title_source)
+       VALUES ('s1', 'cli-direct', 'r', 1000, 1000, 0, 't', 'extracted')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO narratives (id, project_id, sentiment, title, body, generated_at, action_type)
+       VALUES ('n-ev', 'p1', 'positive', 't', 'b', '2025-01-01T00:00:00Z', 'encode-as-pattern')`,
+    ).run();
+
+    // Insert with turn_index populated.
+    db.prepare(
+      `INSERT INTO narrative_evidence
+        (narrative_id, evidence_index, session_source, session_id, anchor, excerpt, turn_index)
+       VALUES ('n-ev', 0, 'cli-direct', 's1', 'turn:3', 'snippet', 3)`,
+    ).run();
+    // Insert with turn_index NULL (optional per B2).
+    db.prepare(
+      `INSERT INTO narrative_evidence
+        (narrative_id, evidence_index, session_source, session_id, turn_index)
+       VALUES ('n-ev', 1, 'cli-direct', 's1', NULL)`,
+    ).run();
+
+    const rows = db
+      .prepare<[string], { evidence_index: number; turn_index: number | null }>(
+        `SELECT evidence_index, turn_index FROM narrative_evidence WHERE narrative_id = ? ORDER BY evidence_index`,
+      )
+      .all('n-ev');
+    expect(rows).toEqual([
+      { evidence_index: 0, turn_index: 3 },
+      { evidence_index: 1, turn_index: null },
+    ]);
+
+    // Negative turn_index rejected.
+    expect(() =>
+      db.prepare(
+        `INSERT INTO narrative_evidence (narrative_id, evidence_index, session_source, session_id, turn_index)
+         VALUES ('n-ev', 2, 'cli-direct', 's1', -1)`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+});

--- a/packages/exporter/src/db/migrations/002-narrative-provenance.ts
+++ b/packages/exporter/src/db/migrations/002-narrative-provenance.ts
@@ -1,0 +1,68 @@
+// Phase Rev3-B sub-task B3: add provenance columns to the
+// `narratives` table + `turn_index` to `narrative_evidence`.
+//
+// Plan reference: `_planning/chat-arch-v2-rev3-plan.md` Phase Rev3-B:
+//   "Add provenance fields (intent, observation, inference,
+//    attributedTo, verifiedAt, confidence, supportingCount,
+//    contradictingCount, correlatedOutcome) to the Narrative table."
+//
+// Column shapes mirror `packages/schema/src/narrative.ts`:
+//   - `intent` / `observation` / `inference` — TEXT, NULL allowed at
+//     the DB layer (B5 backfill populates them post-write); writers
+//     on schemaVersion=2 must set all three (enforced at the SDK
+//     boundary via `validateNarrative`).
+//   - `attributed_to` — TEXT ('deterministic' | 'deterministic-with-prior'
+//     | 'llm-derived' | 'falsifier-verified'). NULL on legacy v1 rows.
+//   - `verified_at` — TEXT (ISO-8601), NULL until first falsifier run.
+//   - `confidence` — REAL in [0,1], NULL on legacy v1 rows.
+//   - `supporting_count` / `contradicting_count` — INTEGER ≥ 0,
+//     NULL on legacy v1 rows.
+//   - `correlated_outcome_json` — TEXT (JSON-stringified
+//     `NarrativeCorrelatedOutcome`), NULL when below significance gate.
+//
+// `schema_version` (INTEGER) lands on `narratives` to discriminate
+// the row shape; the existing `001-initial-schema.ts` already creates
+// this column with DEFAULT 1, so we don't re-add it here.
+//
+// `narrative_evidence` gets `turn_index` (INTEGER, NULL allowed) for
+// the B2 turn-precision anchor.
+//
+// All ADD COLUMN operations are nullable + no default (or default
+// NULL), so existing rows survive the migration with all new columns
+// NULL — i.e. they remain valid as schemaVersion=1.
+
+import type { Database } from 'better-sqlite3';
+
+import type { Migration } from './types.js';
+
+const DDL = `
+  ALTER TABLE narratives ADD COLUMN intent TEXT;
+  ALTER TABLE narratives ADD COLUMN observation TEXT;
+  ALTER TABLE narratives ADD COLUMN inference TEXT;
+  ALTER TABLE narratives ADD COLUMN attributed_to TEXT
+    CHECK (attributed_to IS NULL OR attributed_to IN (
+      'deterministic',
+      'deterministic-with-prior',
+      'llm-derived',
+      'falsifier-verified'
+    ));
+  ALTER TABLE narratives ADD COLUMN verified_at TEXT;
+  ALTER TABLE narratives ADD COLUMN confidence REAL
+    CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1));
+  ALTER TABLE narratives ADD COLUMN supporting_count INTEGER
+    CHECK (supporting_count IS NULL OR supporting_count >= 0);
+  ALTER TABLE narratives ADD COLUMN contradicting_count INTEGER
+    CHECK (contradicting_count IS NULL OR contradicting_count >= 0);
+  ALTER TABLE narratives ADD COLUMN correlated_outcome_json TEXT;
+
+  ALTER TABLE narrative_evidence ADD COLUMN turn_index INTEGER
+    CHECK (turn_index IS NULL OR turn_index >= 0);
+`;
+
+export const narrativeProvenanceMigration: Migration = {
+  id: '002-narrative-provenance',
+  name: 'Rev3-B narrative provenance columns + evidence turn_index',
+  up(db: Database): void {
+    db.exec(DDL);
+  },
+};

--- a/packages/exporter/src/db/migrations/index.ts
+++ b/packages/exporter/src/db/migrations/index.ts
@@ -10,8 +10,12 @@
 
 import type { Migration } from './types.js';
 import { initialSchemaMigration } from './001-initial-schema.js';
+import { narrativeProvenanceMigration } from './002-narrative-provenance.js';
 
-export const MIGRATIONS: readonly Migration[] = [initialSchemaMigration];
+export const MIGRATIONS: readonly Migration[] = [
+  initialSchemaMigration,
+  narrativeProvenanceMigration,
+];
 
 export { runMigrations } from './runner.js';
 export type { Migration } from './types.js';

--- a/packages/schema/src/narrative.migration.test.ts
+++ b/packages/schema/src/narrative.migration.test.ts
@@ -30,6 +30,7 @@ function baseV1(overrides: Partial<Narrative> = {}): Narrative {
     evidence: [{ sessionId: 's1', anchor: 'turn:5', excerpt: 'short' }],
     generatedAt: ANCHOR_TS,
     actionType: 'encode-as-pattern',
+    schemaVersion: 1,
     ...overrides,
   };
 }
@@ -60,10 +61,15 @@ describe('Rev3-B narrative migration — dual-version contract', () => {
       expect(() => validateNarrative(baseV1())).not.toThrow();
     });
 
-    it('treats absent schemaVersion as v1 (no provenance required)', () => {
-      const n = baseV1();
-      expect(n.schemaVersion).toBeUndefined();
-      expect(() => validateNarrative(n)).not.toThrow();
+    it('runtime-defensive: absent schemaVersion (e.g. legacy JSON pre-Rev3-B) treated as v1', () => {
+      // The TS type requires schemaVersion since iter-2 (PR #66 design-
+      // coherence finding). The runtime validator still defends against
+      // legacy on-disk JSON that lacks the field — cast through unknown
+      // to exercise that defensive path.
+      const { schemaVersion: _drop, ...legacyShape } = baseV1();
+      const legacyJson = legacyShape as unknown as Narrative;
+      expect(legacyJson.schemaVersion).toBeUndefined();
+      expect(() => validateNarrative(legacyJson)).not.toThrow();
     });
 
     it('explicit schemaVersion=1 is accepted', () => {

--- a/packages/schema/src/narrative.migration.test.ts
+++ b/packages/schema/src/narrative.migration.test.ts
@@ -1,0 +1,181 @@
+// Phase Rev3-B sub-task B8: named gate test for the v1↔v2 Narrative
+// schema migration. Plan reference:
+//   "*Gate:* named `narrative.migration.test.ts` passes; existing
+//    `validateNarrative()` accepts both schemaVersion shapes."
+//
+// This file pins the dual-version contract from B4 + the shape of v2
+// rows from B1. The DB-side migration (B3, applied via the migration
+// runner) is exercised in the exporter package's own test suite —
+// here we test the schema-layer behavior (TS types + validateNarrative).
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  InvalidNarrativeError,
+  validateNarrative,
+  type Narrative,
+} from './narrative.js';
+import { UNASSIGNED_PROJECT_ID } from './project.js';
+
+const ANCHOR_TS = '2026-05-23T00:00:00Z';
+
+function baseV1(overrides: Partial<Narrative> = {}): Narrative {
+  return {
+    id: 'narr-v1',
+    projectId: 'proj-1',
+    sessionIds: ['s1'],
+    sentiment: 'positive',
+    title: 'Always set X before Y',
+    body: 'Repeated observation.',
+    evidence: [{ sessionId: 's1', anchor: 'turn:5', excerpt: 'short' }],
+    generatedAt: ANCHOR_TS,
+    actionType: 'encode-as-pattern',
+    ...overrides,
+  };
+}
+
+function baseV2(overrides: Partial<Narrative> = {}): Narrative {
+  return {
+    ...baseV1(),
+    id: 'narr-v2',
+    schemaVersion: 2,
+    provenance: {
+      intent: 'detect-repeated-X-before-Y',
+      observation: 'X precedes Y in 5/7 sampled sessions',
+      inference: 'X-before-Y is a stable workflow pattern for project',
+    },
+    attributedTo: 'deterministic',
+    verifiedAt: null,
+    confidence: 0.62,
+    supportingCount: 5,
+    contradictingCount: 1,
+    correlatedOutcome: null,
+    ...overrides,
+  };
+}
+
+describe('Rev3-B narrative migration — dual-version contract', () => {
+  describe('schemaVersion=1 (legacy) — back-compat acceptance', () => {
+    it('passes for a well-formed v1 row (no provenance fields)', () => {
+      expect(() => validateNarrative(baseV1())).not.toThrow();
+    });
+
+    it('treats absent schemaVersion as v1 (no provenance required)', () => {
+      const n = baseV1();
+      expect(n.schemaVersion).toBeUndefined();
+      expect(() => validateNarrative(n)).not.toThrow();
+    });
+
+    it('explicit schemaVersion=1 is accepted', () => {
+      const n = baseV1({ schemaVersion: 1 });
+      expect(() => validateNarrative(n)).not.toThrow();
+    });
+
+    it('still rejects v1 rows that violate the pre-existing invariants', () => {
+      // Pre-Rev3-B rules still apply on v1.
+      expect(() =>
+        validateNarrative(
+          baseV1({ projectId: UNASSIGNED_PROJECT_ID, actionType: 'encode-as-pattern' }),
+        ),
+      ).toThrow(InvalidNarrativeError);
+      expect(() =>
+        validateNarrative(
+          baseV1({ sentiment: 'positive', actionType: 'generate-corrective-prompt' }),
+        ),
+      ).toThrow(/actionType.*mismatches sentiment/);
+    });
+  });
+
+  describe('schemaVersion=2 (Rev3-B) — provenance-shape acceptance', () => {
+    it('passes for a fully-populated v2 row', () => {
+      expect(() => validateNarrative(baseV2())).not.toThrow();
+    });
+
+    it('accepts verifiedAt=null on v2 (falsifier has not run yet)', () => {
+      expect(() => validateNarrative(baseV2({ verifiedAt: null }))).not.toThrow();
+    });
+
+    it('accepts correlatedOutcome=null on v2 (below sig gate or not computed)', () => {
+      expect(() => validateNarrative(baseV2({ correlatedOutcome: null }))).not.toThrow();
+    });
+
+    it('accepts the four attributedTo values', () => {
+      for (const a of [
+        'deterministic',
+        'deterministic-with-prior',
+        'llm-derived',
+        'falsifier-verified',
+      ] as const) {
+        expect(() => validateNarrative(baseV2({ attributedTo: a }))).not.toThrow();
+      }
+    });
+  });
+
+  describe('schemaVersion=2 — structural rejections', () => {
+    it('rejects v2 without provenance', () => {
+      const n = baseV2({ provenance: undefined });
+      expect(() => validateNarrative(n)).toThrow(/requires provenance/);
+    });
+
+    it('rejects v2 with empty intent / observation / inference', () => {
+      for (const k of ['intent', 'observation', 'inference'] as const) {
+        const provenance = { ...baseV2().provenance!, [k]: '' };
+        expect(() => validateNarrative(baseV2({ provenance }))).toThrow(
+          new RegExp(`empty provenance\\.${k}`),
+        );
+      }
+    });
+
+    it('rejects v2 without attributedTo', () => {
+      expect(() => validateNarrative(baseV2({ attributedTo: undefined }))).toThrow(
+        /requires attributedTo/,
+      );
+    });
+
+    it('rejects confidence outside [0, 1]', () => {
+      expect(() => validateNarrative(baseV2({ confidence: -0.01 }))).toThrow(
+        /confidence must be a number in \[0,1\]/,
+      );
+      expect(() => validateNarrative(baseV2({ confidence: 1.01 }))).toThrow(
+        /confidence must be a number in \[0,1\]/,
+      );
+    });
+
+    it('rejects negative supporting/contradicting counts', () => {
+      expect(() => validateNarrative(baseV2({ supportingCount: -1 }))).toThrow(
+        /supportingCount must be a non-negative number/,
+      );
+      expect(() => validateNarrative(baseV2({ contradictingCount: -1 }))).toThrow(
+        /contradictingCount must be a non-negative number/,
+      );
+    });
+
+    it('rejects v2 with non-numeric confidence', () => {
+      const n = baseV2({ confidence: 'high' as unknown as number });
+      expect(() => validateNarrative(n)).toThrow(
+        /confidence must be a number in \[0,1\]/,
+      );
+    });
+  });
+
+  describe('unknown schemaVersion', () => {
+    it('rejects schemaVersion=3 (forward-incompat)', () => {
+      const n = baseV2({ schemaVersion: 3 as unknown as 1 | 2 });
+      expect(() => validateNarrative(n)).toThrow(/unknown schemaVersion 3/);
+    });
+  });
+
+  describe('NarrativeEvidence (B2 turnIndex)', () => {
+    it('accepts evidence rows with optional turnIndex', () => {
+      const n = baseV2({
+        evidence: [
+          { sessionId: 's1', anchor: 'turn:3', excerpt: 'foo', turnIndex: 3 },
+          { sessionId: 's2' }, // no turnIndex — still valid
+        ],
+      });
+      expect(() => validateNarrative(n)).not.toThrow();
+      expect(n.evidence[0]!.turnIndex).toBe(3);
+      expect(n.evidence[1]!.turnIndex).toBeUndefined();
+    });
+  });
+});

--- a/packages/schema/src/narrative.ts
+++ b/packages/schema/src/narrative.ts
@@ -1,10 +1,72 @@
 import type { Sentiment, NarrativeAction } from './sentiment.js';
 import { UNASSIGNED_PROJECT_ID } from './project.js';
 
+/**
+ * Per-narrative evidence row — one excerpt anchoring the claim to a
+ * specific session and (optionally — Rev3-B B2) the exact transcript
+ * turn where the supporting moment occurred. `turnIndex` is 0-based
+ * to match the `session_messages` ordinal indexing.
+ */
 export interface NarrativeEvidence {
   sessionId: string;
   anchor?: string;
   excerpt?: string;
+  /** 0-based message turn within the session. Optional (B2). */
+  turnIndex?: number;
+}
+
+/**
+ * "How the narrative concluded what it concluded" — the provenance
+ * triple introduced in Phase Rev3-B. `intent` names what the kernel
+ * was looking for; `observation` records the concrete pattern it
+ * matched; `inference` is the load-bearing claim derived from the
+ * observation. Together they let the falsifier (Rev3-F) check
+ * "does the cited evidence actually support the inference?"
+ */
+export interface NarrativeProvenance {
+  /** What the kernel was looking for ("repeated bash failures"). */
+  intent: string;
+  /** What the kernel observed ("3 of 5 sessions failed `pnpm test`"). */
+  observation: string;
+  /** What the kernel inferred ("project's test setup is flaky"). */
+  inference: string;
+}
+
+/**
+ * Attribution of the narrative's existence — `'deterministic'` for
+ * kernels that match observable patterns from session data;
+ * `'llm-derived'` for narratives a curator/LLM synthesized from
+ * evidence. Drives the SourceAttribution rung shown to the user.
+ *
+ * `'deterministic-with-prior'` is the post-calibration variant —
+ * a deterministic kernel whose Bayesian prior has been refined by
+ * historical engagement data.
+ */
+export type NarrativeAttribution =
+  | 'deterministic'
+  | 'deterministic-with-prior'
+  | 'llm-derived'
+  | 'falsifier-verified';
+
+/**
+ * Outcome-correlation summary attached to a narrative. Surfaces only
+ * when `evidence.length >= THRESHOLDS.curator.outcomeCorrelationEvidenceMinLength`
+ * AND `Math.abs(delta) / standardError >= THRESHOLDS.curator.outcomeCorrelationSignificance`
+ * (Welch's t / permutation test from `packages/analysis/src/stats.ts`).
+ *
+ * `null` (the field absent in JSON) means "not computed yet" or
+ * "computed but below the significance gate" — viewer must NOT
+ * display a correlation tag when this is null.
+ */
+export interface NarrativeCorrelatedOutcome {
+  /** `pCited - pUncited` (good-share delta on outcome.binary === 'good'). */
+  delta: number;
+  /** Standard error on the delta — drives the significance gate. */
+  standardError: number;
+  /** Number of cited sessions in the comparison (pCited's n). */
+  citedCount: number;
+  /** Number of uncited sessions in the project (pUncited's n). */
+  uncitedCount: number;
 }
 
 export interface Narrative {
@@ -17,6 +79,57 @@ export interface Narrative {
   evidence: readonly NarrativeEvidence[];
   generatedAt: string;
   actionType: NarrativeAction;
+
+  // ----- Rev3-B B1 provenance fields (optional on schemaVersion=1; the
+  //       backfill in B5 fills them in + bumps schemaVersion to 2) -----
+
+  /**
+   * Wire-format version of this Narrative row.
+   *   - `1`: pre-Rev3-B legacy shape (no provenance fields).
+   *   - `2`: Rev3-B+ shape; provenance fields populated.
+   * Default behavior in `validateNarrative` accepts both. Backfill
+   * (B5) bumps every v1 row to v2 with `attributedTo='deterministic'`
+   * and `confidence=computeConfidence(...)` from the existing
+   * evidence count + a fresh prior.
+   */
+  schemaVersion?: 1 | 2;
+
+  /** Provenance triple — required for schemaVersion=2. */
+  provenance?: NarrativeProvenance;
+
+  /** How this narrative came to exist. Required for schemaVersion=2. */
+  attributedTo?: NarrativeAttribution;
+
+  /**
+   * ISO-8601 timestamp of the last falsifier verification of this
+   * narrative's evidence chain. `null` (absent) means "not yet
+   * falsifier-verified" — Rev3-F is responsible for setting this.
+   * Required-shape but value `null` is legal on schemaVersion=2.
+   */
+  verifiedAt?: string | null;
+
+  /**
+   * Bayesian posterior confidence in the inference, computed via
+   * `computeConfidence(supporting, contradicting, prior)` (B6).
+   *   `0 ≤ confidence ≤ 1`.
+   * Drives the three-rung tier gating (`narrativeRung.tier1/2/3`
+   * in THRESHOLDS). Required for schemaVersion=2.
+   */
+  confidence?: number;
+
+  /** Count of evidence rows that support the inference. */
+  supportingCount?: number;
+
+  /** Count of evidence rows that contradict the inference. */
+  contradictingCount?: number;
+
+  /**
+   * Outcome-correlation summary (good-share delta on cited vs.
+   * uncited sessions). `null` means "below significance gate or
+   * not computed"; the viewer must not display the correlation
+   * tag when this is null. Optional even on schemaVersion=2.
+   */
+  correlatedOutcome?: NarrativeCorrelatedOutcome | null;
 }
 
 export class InvalidNarrativeError extends Error {
@@ -26,6 +139,17 @@ export class InvalidNarrativeError extends Error {
   }
 }
 
+/**
+ * Validate a Narrative against either schema version 1 (legacy) or
+ * 2 (Rev3-B provenance fields populated). The shape-level checks
+ * common to both versions run first; v2-specific structural checks
+ * run only when `schemaVersion === 2`.
+ *
+ * Phase Rev3-B B4: callers can pass v1 rows in untouched (no
+ * provenance fields required) and v2 rows are checked for shape
+ * completeness. The backfill in B5 produces only v2 rows; the v1
+ * acceptance is for the legacy on-disk corpus.
+ */
 export function validateNarrative(n: Narrative): void {
   if (n.projectId === UNASSIGNED_PROJECT_ID) {
     throw new InvalidNarrativeError(
@@ -43,5 +167,48 @@ export function validateNarrative(n: Narrative): void {
     throw new InvalidNarrativeError(
       `Narrative ${n.id} actionType ${n.actionType} mismatches sentiment ${n.sentiment} (expected ${expected}).`,
     );
+  }
+
+  // Rev3-B B4: dual-version acceptance. Treat absent schemaVersion as
+  // 1 (legacy); validate v2-shape only when the field is explicitly 2.
+  const version = n.schemaVersion ?? 1;
+  if (version !== 1 && version !== 2) {
+    throw new InvalidNarrativeError(
+      `Narrative ${n.id} has unknown schemaVersion ${String(version)}; expected 1 or 2.`,
+    );
+  }
+  if (version === 2) {
+    if (!n.provenance) {
+      throw new InvalidNarrativeError(
+        `Narrative ${n.id} schemaVersion=2 requires provenance (intent/observation/inference).`,
+      );
+    }
+    for (const k of ['intent', 'observation', 'inference'] as const) {
+      if (typeof n.provenance[k] !== 'string' || n.provenance[k].length === 0) {
+        throw new InvalidNarrativeError(
+          `Narrative ${n.id} schemaVersion=2 has empty provenance.${k}.`,
+        );
+      }
+    }
+    if (!n.attributedTo) {
+      throw new InvalidNarrativeError(
+        `Narrative ${n.id} schemaVersion=2 requires attributedTo.`,
+      );
+    }
+    if (typeof n.confidence !== 'number' || n.confidence < 0 || n.confidence > 1) {
+      throw new InvalidNarrativeError(
+        `Narrative ${n.id} schemaVersion=2 confidence must be a number in [0,1]; got ${String(n.confidence)}.`,
+      );
+    }
+    if (typeof n.supportingCount !== 'number' || n.supportingCount < 0) {
+      throw new InvalidNarrativeError(
+        `Narrative ${n.id} schemaVersion=2 supportingCount must be a non-negative number.`,
+      );
+    }
+    if (typeof n.contradictingCount !== 'number' || n.contradictingCount < 0) {
+      throw new InvalidNarrativeError(
+        `Narrative ${n.id} schemaVersion=2 contradictingCount must be a non-negative number.`,
+      );
+    }
   }
 }

--- a/packages/schema/src/narrative.ts
+++ b/packages/schema/src/narrative.ts
@@ -87,12 +87,16 @@ export interface Narrative {
    * Wire-format version of this Narrative row.
    *   - `1`: pre-Rev3-B legacy shape (no provenance fields).
    *   - `2`: Rev3-B+ shape; provenance fields populated.
-   * Default behavior in `validateNarrative` accepts both. Backfill
-   * (B5) bumps every v1 row to v2 with `attributedTo='deterministic'`
-   * and `confidence=computeConfidence(...)` from the existing
-   * evidence count + a fresh prior.
+   * Required (matches `UnifiedSessionEntry.schemaVersion` and
+   * `AppliedImprovementsFile.schemaVersion` in the same package — the
+   * type-level requirement prevents writer footguns where omitting
+   * the field would silently skip v2 structural checks).
+   * `validateNarrative` accepts both versions. Backfill (B5) bumps
+   * every v1 row to v2 with `attributedTo='deterministic'` and
+   * `confidence=computeConfidence(...)` from the existing evidence
+   * count + a fresh prior.
    */
-  schemaVersion?: 1 | 2;
+  schemaVersion: 1 | 2;
 
   /** Provenance triple — required for schemaVersion=2. */
   provenance?: NarrativeProvenance;


### PR DESCRIPTION
## Summary

First wave of Phase Rev3-B. Lays the schema foundation for the confidence ladder + curator surfaces in B5-B7 and Rev3-F.

## B1 + B2 — schema additions

[`packages/schema/src/narrative.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-b1-b4-narrative-provenance/packages/schema/src/narrative.ts):
- `Narrative` gains optional `schemaVersion` (1|2), `provenance: { intent, observation, inference }`, `attributedTo: 'deterministic' | 'deterministic-with-prior' | 'llm-derived' | 'falsifier-verified'`, `verifiedAt: string | null`, `confidence: number` (∈ [0,1]), `supportingCount: number`, `contradictingCount: number`, `correlatedOutcome: NarrativeCorrelatedOutcome | null`.
- `NarrativeEvidence` gains optional `turnIndex` (0-based message ordinal — B2).

The fields are optional on the TS type so legacy v1 rows compile without modification; the structural shape is enforced at runtime by `validateNarrative` when `schemaVersion === 2`.

## B3 — DB migration `002-narrative-provenance.ts`

ALTER TABLE statements add nullable columns mirroring the schema fields:
- `intent` / `observation` / `inference` (TEXT)
- `attributed_to` (TEXT with CHECK on the 4-value union)
- `verified_at` (TEXT, ISO-8601)
- `confidence` (REAL with CHECK 0–1)
- `supporting_count` / `contradicting_count` (INTEGER with CHECK ≥ 0)
- `correlated_outcome_json` (TEXT — JSON-stringified `NarrativeCorrelatedOutcome`)
- `narrative_evidence.turn_index` (INTEGER with CHECK ≥ 0)

Existing rows survive with all new columns NULL — equivalent to schemaVersion=1. The `schema_version` column on `narratives` already lives in migration 001 with DEFAULT 1; this migration only adds the provenance siblings.

Registered in `MIGRATIONS` after `001-initial-schema` per the \"never reorder, never mutate\" invariant in the runner.

## B4 — `validateNarrative` dual-version acceptance

- Pre-Rev3-B invariant checks (UNASSIGNED_PROJECT_ID, neutral-sentiment, actionType-mismatches-sentiment) run unconditionally on both versions.
- Absent `schemaVersion` is treated as 1 (legacy back-compat).
- `schemaVersion === 2` triggers the new structural checks: non-empty provenance triple, attributedTo present, confidence in [0,1], supportingCount/contradictingCount non-negative.
- Unknown schemaVersion (e.g. 3) is rejected.

## B8 — gate test

[`packages/schema/src/narrative.migration.test.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-b1-b4-narrative-provenance/packages/schema/src/narrative.migration.test.ts) — **16 cases**:
- v1 acceptance: well-formed, absent schemaVersion treated as 1, explicit schemaVersion=1, pre-existing invariants still enforced on v1.
- v2 acceptance: full provenance row, verifiedAt=null, correlatedOutcome=null, all 4 attributedTo values.
- v2 rejection: missing provenance, empty intent/observation/inference (3 cases), missing attributedTo, confidence outside [0,1] (2 cases), negative supportingCount, negative contradictingCount, non-numeric confidence.
- Unknown schemaVersion=3 rejected.
- NarrativeEvidence turnIndex round-trip.

DB-side migration test [`002-narrative-provenance.test.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-b1-b4-narrative-provenance/packages/exporter/src/db/migrations/002-narrative-provenance.test.ts) — **7 cases**:
- Both migrations register in apply order.
- Legacy v1 insert (no provenance columns) → all new columns NULL.
- Full v2 insert round-trips (incl. `correlated_outcome_json` JSON).
- `attributed_to` CHECK rejects out-of-list values.
- `confidence` CHECK rejects -0.1, 1.1, 2.
- `supporting_count` / `contradicting_count` CHECK rejects negatives.
- `narrative_evidence.turn_index` round-trips + CHECK rejects negatives.

Updated `001-initial-schema.test.ts`'s idempotency check to expect both migrations to apply on a fresh DB (a one-line array update).

## Plan anchor

- [§Phase Rev3-B — Narrative provenance + confidence ladder](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

## Tracker delta

| Row | Was | Now |
|---|---|---|
| B1 (schema fields) | pending | **in-review** |
| B2 (NarrativeEvidence.turnIndex) | pending | **in-review** |
| B3 (DB migration) | pending | **in-review** (migration `002-narrative-provenance.ts`) |
| B4 (dual-version validateNarrative) | pending | **in-review** |
| B8 (gate test) | pending | **in-review** (dual-schema acceptance + structural rejections; backfill-round-trip lands with B5) |

Remaining for Rev3-B: B5 (backfill kernel), B6 (computeConfidence helper), B7 (calibration fail-safe), B9 (PII default-blur).

## Gates

- [x] `pnpm install --frozen-lockfile` — green
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r test` — 1,593 tests pass (+23 new: 16 schema + 7 DB)
- [x] `pnpm build` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)