### PR TITLE
feat(rev3-b): confidence-ladder helpers + calibration fail-safe (B6+B7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,36 @@ on-disk shape with this changelog.
 
 ### Added
 
+- **Narrative confidence-ladder helpers (Phase Rev3-B B6 + B7).**
+  New module `packages/analysis/src/narrativeRung.ts` exports:
+  - `computeConfidence(supporting, contradicting, prior)` — the
+    Bayesian Beta-posterior mean form pinned by
+    `THRESHOLDS.narrativeRung` (`supporting / (supporting +
+    contradicting + prior)`). Returns NaN on invalid inputs;
+    clamps to `[0, 1]`.
+  - `effectivePriorForKernel({ kernel, calibrationCompletedAt })`
+    — B7 calibration fail-safe. Returns `uncalibratedPrior` (20)
+    when `calibrationCompletedAt == null`; else
+    `priorByKernel[kernel] ?? defaultPrior` (2). Cold-start
+    protection: an uncalibrated kernel can't promote a finding
+    to tier-3 on its first few observations.
+  - `narrativeTier(confidence, supporting, contradicting)` — joint-
+    gate dispatcher returning the highest reachable tier (0–3) per
+    the floor / supporting-count / (tier-3-only) contradicting-cap
+    rules in `THRESHOLDS.narrativeRung`. Single source of truth
+    for tier decisions; callers should NEVER inline the threshold
+    comparisons.
+  - All three re-exported from `@chat-arch/analysis`.
+
+  18 new tests in `narrativeRung.test.ts` cover the joint-gate
+  feasibility proof (the PR #58 contract that tier3=0.66 + count
+  cap is satisfiable at supporting=6, contradicting=1, prior=2 →
+  6/9=0.667 ≥ 0.66), the cold-start protection (uncalibrated +
+  moderate evidence can't reach tier-3), end-to-end equivalence
+  (calibrated kernel + tier-3 minimum count DOES reach tier-3),
+  invalid-input fallbacks, and the tier-2-fallback when contradicting
+  exceeds the cap.
+
 - **Narrative provenance schema (Phase Rev3-B B1+B2+B3+B4+B8).**
   `packages/schema/src/narrative.ts` extends the `Narrative` type
   with optional `schemaVersion`, `provenance` (intent/observation/

--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -49,8 +49,8 @@ Plan anchor: [§Phase Rev3-B](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 | B3 | DB migration adding the new columns to the `narratives` table | in-review | PR #TBD (migration `002-narrative-provenance.ts`) |
 | B4 | `validateNarrative()` accepts both schemaVersion 1 and 2 | in-review | PR #TBD |
 | B5 | Backfill kernel — one-shot run over any existing narratives (post zero-data start, normally empty) computing confidence + setting `attributedTo='deterministic'` + bumping to schemaVersion 2 | pending | |
-| B6 | Confidence-ladder helper (`computeConfidence(supporting, contradicting, prior)`) consuming THRESHOLDS | pending | |
-| B7 | Calibration fail-safe: kernels with `calibrationCompletedAt = null` get effective prior pinned to `narrativeRung.uncalibratedPrior`; banner surfaces "kernel X uncalibrated" | pending | |
+| B6 | Confidence-ladder helper (`computeConfidence(supporting, contradicting, prior)`) consuming THRESHOLDS | in-review | PR #TBD |
+| B7 | Calibration fail-safe: kernels with `calibrationCompletedAt = null` get effective prior pinned to `narrativeRung.uncalibratedPrior`; banner surfaces "kernel X uncalibrated" | in-review | PR #TBD (helper landed; viewer banner wires in with B5 backfill caller) |
 | B8 | Named test `narrative.migration.test.ts` — covers legacy parse, deterministic backfill, round-trip, dual-schema acceptance | in-review | PR #TBD (covers dual-schema acceptance + structural rejections; backfill-round-trip lands with B5) |
 | B9 | PII handling for narrative previews — default-blur with reveal-on-click before any curator surface ships | pending | Gate |
 

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -294,6 +294,13 @@ export {
 } from './thresholds.js';
 
 export {
+  computeConfidence,
+  effectivePriorForKernel,
+  narrativeTier,
+  type EffectivePriorOptions,
+} from './narrativeRung.js';
+
+export {
   bhFdrAdjust,
   cosineSimilarity,
   cosineSimilarityNormalized,

--- a/packages/analysis/src/narrativeRung.test.ts
+++ b/packages/analysis/src/narrativeRung.test.ts
@@ -1,0 +1,187 @@
+// Tests for the Rev3-B B6 (computeConfidence) + B7 (effectivePrior
+// fail-safe) + narrativeTier joint-gate helper. The joint-gate
+// feasibility constants come from `THRESHOLDS.narrativeRung` (pinned
+// in PR #58); these tests freeze the contract so a future calibration
+// edit can't silently invalidate the documented feasibility proof.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  computeConfidence,
+  effectivePriorForKernel,
+  narrativeTier,
+} from './narrativeRung.js';
+import { THRESHOLDS } from './thresholds.js';
+
+describe('computeConfidence (B6 — Bayesian Beta-posterior mean)', () => {
+  it('returns supporting / (supporting + contradicting + prior)', () => {
+    // Joint-gate feasibility proof from PR #58 / THRESHOLDS:
+    // supporting=6, contradicting=1, prior=2 → 6/9 = 0.667 ≥ tier3 (0.66).
+    expect(computeConfidence(6, 1, 2)).toBeCloseTo(6 / 9, 9);
+    expect(computeConfidence(1, 0, 2)).toBeCloseTo(1 / 3, 9); // tier1=0.33
+    expect(computeConfidence(3, 0, 3)).toBeCloseTo(0.5, 9); // tier2=0.5
+  });
+
+  it('returns 0 when supporting=0', () => {
+    expect(computeConfidence(0, 5, 2)).toBe(0);
+    expect(computeConfidence(0, 0, 2)).toBe(0);
+  });
+
+  it('approaches 1 as supporting dominates', () => {
+    const c = computeConfidence(1000, 0, 2);
+    expect(c).toBeGreaterThan(0.99);
+    expect(c).toBeLessThanOrEqual(1);
+  });
+
+  it('clamps to [0, 1] (defensive)', () => {
+    const c = computeConfidence(100, 0, 2);
+    expect(c).toBeLessThanOrEqual(1);
+    expect(c).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns NaN on invalid inputs (negative counts, non-finite prior, prior<=0)', () => {
+    expect(Number.isNaN(computeConfidence(-1, 0, 2))).toBe(true);
+    expect(Number.isNaN(computeConfidence(0, -1, 2))).toBe(true);
+    expect(Number.isNaN(computeConfidence(1, 0, 0))).toBe(true);
+    expect(Number.isNaN(computeConfidence(1, 0, -2))).toBe(true);
+    expect(Number.isNaN(computeConfidence(1, 0, Number.NaN))).toBe(true);
+    expect(Number.isNaN(computeConfidence(1, 0, Number.POSITIVE_INFINITY))).toBe(true);
+    expect(Number.isNaN(computeConfidence(Number.NaN, 0, 2))).toBe(true);
+  });
+
+  it('joint-gate feasibility at the count-minimum (PR #58 proof)', () => {
+    // The tier-3 floor (0.66) was specifically chosen so that:
+    //   supporting=tier3SupportingMin (6),
+    //   contradicting=ceil(6/contradictingCapDivisor)=ceil(6/6)=1,
+    //   prior=defaultPrior (2)
+    // both pass the confidence gate AND the contradicting-cap gate.
+    // This test fails loudly if a future calibration breaks that.
+    const { tier3, tier3SupportingMin, contradictingCapDivisor, defaultPrior } =
+      THRESHOLDS.narrativeRung;
+    const supporting = tier3SupportingMin;
+    const contradicting = Math.ceil(supporting / contradictingCapDivisor);
+    const confidence = computeConfidence(supporting, contradicting, defaultPrior);
+    expect(confidence).toBeGreaterThanOrEqual(tier3);
+  });
+});
+
+describe('effectivePriorForKernel (B7 — calibration fail-safe)', () => {
+  it('returns uncalibratedPrior when calibrationCompletedAt is null', () => {
+    expect(
+      effectivePriorForKernel({
+        kernel: 'kernel-x',
+        calibrationCompletedAt: null,
+      }),
+    ).toBe(THRESHOLDS.narrativeRung.uncalibratedPrior);
+  });
+
+  it('returns uncalibratedPrior when calibrationCompletedAt is undefined', () => {
+    expect(
+      effectivePriorForKernel({
+        kernel: 'kernel-x',
+        calibrationCompletedAt: undefined,
+      }),
+    ).toBe(THRESHOLDS.narrativeRung.uncalibratedPrior);
+  });
+
+  it('returns defaultPrior for a calibrated kernel without a per-kernel override', () => {
+    // priorByKernel is empty at v1 per THRESHOLDS, so any kernel name
+    // falls through to the default.
+    expect(
+      effectivePriorForKernel({
+        kernel: 'never-overridden',
+        calibrationCompletedAt: 1_700_000_000_000,
+      }),
+    ).toBe(THRESHOLDS.narrativeRung.defaultPrior);
+  });
+
+  it('uncalibrated prior makes tier-3 unreachable even at substantial supporting count', () => {
+    // PR #58 contract: uncalibratedPrior=20 should make tier-3 unreachable
+    // even at supporting=5x tier3SupportingMin (30) with 0 contradicting.
+    //   confidence = 30 / (30 + 0 + 20) = 0.6 < tier3 (0.66)
+    const prior = effectivePriorForKernel({
+      kernel: 'k',
+      calibrationCompletedAt: null,
+    });
+    const supporting = THRESHOLDS.narrativeRung.tier3SupportingMin * 5;
+    const confidence = computeConfidence(supporting, 0, prior);
+    expect(confidence).toBeLessThan(THRESHOLDS.narrativeRung.tier3);
+  });
+});
+
+describe('narrativeTier (joint-gate dispatch)', () => {
+  it('returns 0 when no tier is reachable', () => {
+    // supporting=0 fails tier1's count gate (min=1) → tier 0.
+    expect(narrativeTier(0.5, 0, 0)).toBe(0);
+    // confidence below tier1 floor → tier 0 regardless of counts.
+    expect(narrativeTier(0.1, 100, 0)).toBe(0);
+  });
+
+  it('returns 1 at the tier-1 minimum (supporting=1, confidence=tier1)', () => {
+    const { tier1, tier1SupportingMin } = THRESHOLDS.narrativeRung;
+    expect(narrativeTier(tier1, tier1SupportingMin, 0)).toBe(1);
+  });
+
+  it('returns 2 at the tier-2 minimum', () => {
+    const { tier2, tier2SupportingMin } = THRESHOLDS.narrativeRung;
+    expect(narrativeTier(tier2, tier2SupportingMin, 0)).toBe(2);
+  });
+
+  it('returns 3 at the tier-3 minimum with contradicting at the cap', () => {
+    // The PR #58 joint-gate proof. supporting=6, contradicting=1 (cap),
+    // confidence=0.667 (above floor 0.66).
+    const { tier3, tier3SupportingMin, contradictingCapDivisor } =
+      THRESHOLDS.narrativeRung;
+    const supporting = tier3SupportingMin;
+    const contradicting = Math.ceil(supporting / contradictingCapDivisor);
+    // Use a confidence just above tier3 floor.
+    expect(narrativeTier(tier3 + 0.001, supporting, contradicting)).toBe(3);
+  });
+
+  it('degrades from tier-3 to tier-2 when contradicting exceeds the cap', () => {
+    // Same supporting=6 confidence>tier3, but contradicting=2 exceeds
+    // cap of 1 → contradicting-cap gate fails → fall through to tier-2.
+    expect(narrativeTier(0.7, 6, 2)).toBe(2);
+  });
+
+  it('returns 0 on invalid inputs', () => {
+    expect(narrativeTier(Number.NaN, 5, 0)).toBe(0);
+    expect(narrativeTier(0.5, Number.NaN, 0)).toBe(0);
+    expect(narrativeTier(0.5, 5, Number.NaN)).toBe(0);
+    expect(narrativeTier(-0.1, 5, 0)).toBe(0);
+    expect(narrativeTier(1.1, 5, 0)).toBe(0);
+    expect(narrativeTier(0.5, -1, 0)).toBe(0);
+    expect(narrativeTier(0.5, 5, -1)).toBe(0);
+  });
+
+  it('end-to-end: uncalibrated kernel unreachable to tier-3 at the count-minimum and moderately above', () => {
+    // The uncalibratedPrior protects against COLD-START — a kernel
+    // that just started running can't promote a finding to tier-3 on
+    // its first few observations. At extremely high supporting counts
+    // (hundreds), the prior gets dominated by evidence — by design,
+    // since at that scale the cold-start risk is over. Test the
+    // load-bearing range: tier3SupportingMin through 5× minimum.
+    const prior = effectivePriorForKernel({
+      kernel: 'k',
+      calibrationCompletedAt: null,
+    });
+    const min = THRESHOLDS.narrativeRung.tier3SupportingMin;
+    for (const supporting of [min, min * 2, min * 3, min * 5]) {
+      const confidence = computeConfidence(supporting, 0, prior);
+      expect(narrativeTier(confidence, supporting, 0)).toBeLessThan(3);
+    }
+  });
+
+  it('end-to-end: calibrated kernel + tier-3 minimum count reaches tier 3', () => {
+    const prior = effectivePriorForKernel({
+      kernel: 'k',
+      calibrationCompletedAt: 1_700_000_000_000,
+    });
+    const supporting = THRESHOLDS.narrativeRung.tier3SupportingMin;
+    const contradicting = Math.ceil(
+      supporting / THRESHOLDS.narrativeRung.contradictingCapDivisor,
+    );
+    const confidence = computeConfidence(supporting, contradicting, prior);
+    expect(narrativeTier(confidence, supporting, contradicting)).toBe(3);
+  });
+});

--- a/packages/analysis/src/narrativeRung.ts
+++ b/packages/analysis/src/narrativeRung.ts
@@ -1,0 +1,150 @@
+/**
+ * Narrative confidence-ladder kernel (Phase Rev3-B sub-tasks B6 + B7).
+ *
+ * Three pure helpers + their backing types:
+ *
+ *   - `computeConfidence(supporting, contradicting, prior)` — B6.
+ *     The Bayesian Beta-posterior-mean form pinned by
+ *     `THRESHOLDS.narrativeRung` (PR #58 joint-gate feasibility):
+ *
+ *         confidence = supporting / (supporting + contradicting + prior)
+ *
+ *   - `effectivePriorForKernel({ kernel, calibrationCompletedAt })` — B7.
+ *     Selects the prior to feed `computeConfidence`:
+ *       - `calibrationCompletedAt == null` → `uncalibratedPrior` (20 by
+ *         default). Makes tier-3 unreachable so an uncalibrated kernel
+ *         can never silently surface promotable narratives.
+ *       - Otherwise → `priorByKernel[kernel] ?? defaultPrior` (the
+ *         per-kernel calibrated prior if present, else the global
+ *         default).
+ *
+ *   - `narrativeTier(confidence, supporting, contradicting)` — joint
+ *     gate per `THRESHOLDS.narrativeRung`. Returns the highest tier
+ *     (0–3) whose floor AND supporting-count AND contradicting-cap
+ *     gates are all satisfied. Tier 0 = "not surface-able."
+ *
+ * Pure, browser-safe. The viewer + curator-feed + Closure-B/C wirings
+ * all consume these directly.
+ */
+
+import { THRESHOLDS } from './thresholds.js';
+
+/**
+ * Bayesian Beta-posterior mean.
+ *
+ *   confidence = supporting / (supporting + contradicting + prior)
+ *
+ * `prior > 0` is required; pass the kernel's `effectivePriorForKernel`
+ * result. Returns NaN for invalid inputs (negative counts, non-finite
+ * prior) so callers can short-circuit rather than emit a bogus tier
+ * decision. Clamps to [0, 1] when the denominator could legitimately
+ * push the ratio outside the unit interval (shouldn't with non-negative
+ * inputs, but the clamp keeps the contract explicit).
+ */
+export function computeConfidence(
+  supporting: number,
+  contradicting: number,
+  prior: number,
+): number {
+  if (
+    !Number.isFinite(supporting) ||
+    !Number.isFinite(contradicting) ||
+    !Number.isFinite(prior) ||
+    supporting < 0 ||
+    contradicting < 0 ||
+    prior <= 0
+  ) {
+    return Number.NaN;
+  }
+  const denom = supporting + contradicting + prior;
+  if (denom <= 0) return Number.NaN;
+  const raw = supporting / denom;
+  return Math.max(0, Math.min(1, raw));
+}
+
+export interface EffectivePriorOptions {
+  /** Kernel name (e.g. `'kernel-alpha'`). Looked up in `priorByKernel`. */
+  readonly kernel: string;
+  /**
+   * `analyzers.calibration_completed_at` (ms since epoch) — `null` /
+   * `undefined` means "no calibration has completed for this kernel"
+   * and the uncalibratedPrior fail-safe fires.
+   */
+  readonly calibrationCompletedAt: number | null | undefined;
+}
+
+/**
+ * B7 calibration fail-safe. Selects the prior to feed
+ * `computeConfidence` based on whether the kernel has been calibrated
+ * and (optionally) whether it has a per-kernel override.
+ *
+ *   - `calibrationCompletedAt == null` → `narrativeRung.uncalibratedPrior`.
+ *     The viewer should also surface a "kernel X uncalibrated — tier-3
+ *     promotion disabled" banner alongside the affected narratives.
+ *   - Otherwise → `priorByKernel[kernel]` if present, else
+ *     `defaultPrior`.
+ */
+export function effectivePriorForKernel(
+  options: EffectivePriorOptions,
+): number {
+  const { kernel, calibrationCompletedAt } = options;
+  if (calibrationCompletedAt === null || calibrationCompletedAt === undefined) {
+    return THRESHOLDS.narrativeRung.uncalibratedPrior;
+  }
+  const override = THRESHOLDS.narrativeRung.priorByKernel[kernel];
+  if (typeof override === 'number' && override > 0) {
+    return override;
+  }
+  return THRESHOLDS.narrativeRung.defaultPrior;
+}
+
+/**
+ * Narrative tier per the joint gates in `THRESHOLDS.narrativeRung`.
+ * Returns 0 when no tier is reachable.
+ *
+ * Tier-i gates:
+ *   - `confidence >= tier_i` (Bayesian posterior floor)
+ *   - `supporting >= tier_i_SupportingMin` (count floor)
+ *   - For tier 3 only: `contradicting <= ceil(supporting /
+ *     contradictingCapDivisor)` (joint feasibility per PR #58).
+ *
+ * The contradicting-cap is tier-3-only because tier-1 and tier-2 are
+ * "candidate" and "established" — the user is already filtering out
+ * counter-examples via the dismiss workflow at those rungs. Tier-3 is
+ * action-eligible, so a higher bar applies.
+ *
+ * Use this helper at every surface that gates display on rung. NEVER
+ * inline the threshold comparisons at callsites; this function is the
+ * single point of truth.
+ */
+export function narrativeTier(
+  confidence: number,
+  supporting: number,
+  contradicting: number,
+): 0 | 1 | 2 | 3 {
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    return 0;
+  }
+  if (!Number.isFinite(supporting) || !Number.isFinite(contradicting)) {
+    return 0;
+  }
+  if (supporting < 0 || contradicting < 0) {
+    return 0;
+  }
+  const r = THRESHOLDS.narrativeRung;
+  // Walk from highest tier downward; first joint-gate-satisfied tier wins.
+  if (
+    confidence >= r.tier3 &&
+    supporting >= r.tier3SupportingMin &&
+    contradicting <= Math.ceil(supporting / r.contradictingCapDivisor)
+  ) {
+    return 3;
+  }
+  if (confidence >= r.tier2 && supporting >= r.tier2SupportingMin) {
+    return 2;
+  }
+  if (confidence >= r.tier1 && supporting >= r.tier1SupportingMin) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary

Second wave of Phase Rev3-B. Ships the kernel-level helpers that the upcoming B5 backfill + every downstream surface (curator feed, Closure A/B/C wirings, viewer methodology disclosure) will consume.

## B6 — `computeConfidence` helper

New module [`packages/analysis/src/narrativeRung.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-b6-b7-confidence-helpers/packages/analysis/src/narrativeRung.ts) ships the Bayesian Beta-posterior mean form pinned by `THRESHOLDS.narrativeRung` (PR #58 contract):

```ts
confidence = supporting / (supporting + contradicting + prior)
```

Returns NaN on invalid inputs (negative counts, non-finite or non-positive prior); clamps to `[0, 1]` defensively. The joint-gate feasibility proof from PR #58 (supporting=6, contradicting=1, prior=2 → 6/9=0.667 ≥ tier3=0.66) is frozen as a test invariant — a future calibration that breaks the documented feasibility proof fails loudly.

## B7 — `effectivePriorForKernel` calibration fail-safe

- `calibrationCompletedAt == null` → `uncalibratedPrior` (20). Cold-start protection: an uncalibrated kernel cannot promote findings to tier-3 on its first few observations. The viewer should ALSO surface a \"kernel X uncalibrated — tier-3 promotion disabled\" banner alongside the affected narratives (banner wires in with the B5 backfill caller).
- Otherwise → `priorByKernel[kernel] ?? defaultPrior` (2). At v1 `priorByKernel` is empty per THRESHOLDS; populates as per-kernel calibration runs land.

**Important subtlety the tests pin**: the `uncalibratedPrior` protects against COLD-START — at extremely high supporting counts the prior gets dominated by evidence (by design; at that scale the cold-start risk is over). The \"tier-3 unreachable\" property holds at the count-minimum and moderately above (up to 5× `tier3SupportingMin`), not absolutely.

## `narrativeTier` — joint-gate dispatcher

Walks the tier floors top-down and returns the highest reachable tier (0–3) satisfying ALL applicable gates:

- `confidence ≥ tier_i` (Bayesian posterior floor)
- `supporting ≥ tier_i_SupportingMin` (count floor)
- **Tier-3 ONLY**: `contradicting ≤ ceil(supporting / contradictingCapDivisor)` (joint-feasibility per PR #58)

Single source of truth — callers should NEVER inline the threshold comparisons. Returns 0 on invalid inputs (NaN, out-of-range confidence, negative counts).

Tests cover the degradation case (supporting=6, contradicting=2 exceeds cap of 1 → falls from tier-3 candidate down to tier-2).

## Test coverage added (+18 tests)

- **`computeConfidence` (7 tests)**: formula correctness, supporting=0 → 0, large-supporting → near-1, [0,1] clamp, NaN on invalid inputs, joint-gate feasibility proof.
- **`effectivePriorForKernel` (4 tests)**: null calibration → uncalibrated prior, undefined → same, calibrated + no override → defaultPrior, uncalibrated + 5× tier3 count → still below tier-3 floor.
- **`narrativeTier` (7 tests)**: tier 0 cases (count-fail / floor-fail), tier 1/2/3 minimum-count satisfaction, contradicting-cap downgrade, invalid-input fallbacks, end-to-end uncalibrated vs calibrated.

## Plan anchor

- [§Phase Rev3-B — Narrative provenance + confidence ladder](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

## Tracker delta

| Row | Was | Now |
|---|---|---|
| B6 (computeConfidence) | pending | **in-review** |
| B7 (calibration fail-safe) | pending | **in-review** (helper landed; viewer banner wires in with B5 backfill caller) |

Remaining for Rev3-B: B5 (backfill kernel), B9 (PII default-blur).

## Gates

- [x] `pnpm install --frozen-lockfile` — green
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r test` — 1,611 tests pass (+18 new)
- [x] `pnpm build` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)