### PR TITLE
feat(rev3-b): narrative provenance backfill kernel (B5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,35 @@ on-disk shape with this changelog.
 
 ### Added
 
+- **Narrative provenance backfill kernel (Phase Rev3-B B5).** New
+  module `packages/exporter/src/db/backfillNarrativeProvenance.ts`.
+  One-shot promotion of legacy schemaVersion=1 narrative rows to
+  schemaVersion=2 with provenance fields populated. For each v1 row:
+  - `supportingCount` = `COUNT(*)` of `narrative_evidence` rows.
+  - `contradictingCount` = 0 (no legacy contradiction info).
+  - `confidence` = `computeConfidence(supportingCount, 0,
+    THRESHOLDS.narrativeRung.defaultPrior)`.
+  - `attributedTo` = `'deterministic'` per plan §B5.
+  - `provenance` = synthesized placeholder (`intent:
+    'legacy-v1-backfill'`, `observation: title[0..200]`, `inference:
+    body[0..200]`). Future kernel re-runs overwrite with real
+    provenance.
+  - `schema_version` = 2.
+
+  All writes happen inside a single `withWriteTransaction` for
+  atomicity. Idempotent — second call promotes 0 (the `WHERE
+  schema_version = 1` filter excludes already-backfilled rows).
+  Pure (no `Date.now()` / PRNG / external I/O); same DB state in →
+  same DB state out.
+
+  7 new tests in `backfillNarrativeProvenance.test.ts` against the
+  PR #60 seeded fixture (4 v1 narratives + 1 v2 narrative): one-call
+  promotion, idempotency, provenance/attributedTo/confidence
+  population, supportingCount equals evidence-row count,
+  confidence matches computeConfidence formula, empty-DB no-op,
+  observation/inference truncation at 200 chars (placeholder
+  PII boundary).
+
 - **Narrative confidence-ladder helpers (Phase Rev3-B B6 + B7).**
   New module `packages/analysis/src/narrativeRung.ts` exports:
   - `computeConfidence(supporting, contradicting, prior)` — the

--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -48,7 +48,7 @@ Plan anchor: [§Phase Rev3-B](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 | B2 | Extend `NarrativeEvidence` with optional `turnIndex` | in-review | PR #TBD |
 | B3 | DB migration adding the new columns to the `narratives` table | in-review | PR #TBD (migration `002-narrative-provenance.ts`) |
 | B4 | `validateNarrative()` accepts both schemaVersion 1 and 2 | in-review | PR #TBD |
-| B5 | Backfill kernel — one-shot run over any existing narratives (post zero-data start, normally empty) computing confidence + setting `attributedTo='deterministic'` + bumping to schemaVersion 2 | pending | |
+| B5 | Backfill kernel — one-shot run over any existing narratives (post zero-data start, normally empty) computing confidence + setting `attributedTo='deterministic'` + bumping to schemaVersion 2 | in-review | PR #TBD (module `backfillNarrativeProvenance.ts`) |
 | B6 | Confidence-ladder helper (`computeConfidence(supporting, contradicting, prior)`) consuming THRESHOLDS | in-review | PR #TBD |
 | B7 | Calibration fail-safe: kernels with `calibrationCompletedAt = null` get effective prior pinned to `narrativeRung.uncalibratedPrior`; banner surfaces "kernel X uncalibrated" | in-review | PR #TBD (helper landed; viewer banner wires in with B5 backfill caller) |
 | B8 | Named test `narrative.migration.test.ts` — covers legacy parse, deterministic backfill, round-trip, dual-schema acceptance | in-review | PR #TBD (covers dual-schema acceptance + structural rejections; backfill-round-trip lands with B5) |

--- a/packages/exporter/src/db/backfillNarrativeProvenance.test.ts
+++ b/packages/exporter/src/db/backfillNarrativeProvenance.test.ts
@@ -1,0 +1,193 @@
+// Tests for the Rev3-B B5 backfill kernel.
+// Uses the existing seeded fixture from A11 (4 v1 narratives + 1 v2)
+// so we exercise the realistic mixed case without re-building a
+// bespoke fixture here.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  computeConfidence,
+  THRESHOLDS,
+} from '@chat-arch/analysis';
+
+import { openDb } from './connection.js';
+import { MIGRATIONS, runMigrations } from './migrations/index.js';
+import { backfillNarrativeProvenance } from './backfillNarrativeProvenance.js';
+import { SEED_IDS, seedRev3Fixture } from './sdk/seedFixture.js';
+
+interface BackfillCheckRow {
+  readonly id: string;
+  readonly schema_version: number;
+  readonly intent: string | null;
+  readonly observation: string | null;
+  readonly inference: string | null;
+  readonly attributed_to: string | null;
+  readonly verified_at: string | null;
+  readonly confidence: number | null;
+  readonly supporting_count: number | null;
+  readonly contradicting_count: number | null;
+  readonly correlated_outcome_json: string | null;
+}
+
+describe('backfillNarrativeProvenance (B5)', () => {
+  let tmpDir: string;
+  let db: Database;
+
+  beforeEach(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chat-arch-b5-test-'));
+    db = openDb(join(tmpDir, 'b5.db'));
+    runMigrations(db, MIGRATIONS);
+    await seedRev3Fixture(db);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('promotes all v1 narratives to v2 in one call (seedFixture has 4 v1 + 1 v2)', async () => {
+    const result = await backfillNarrativeProvenance(db);
+    expect(result.promoted).toBe(4);
+    expect(result.untouched).toBe(1);
+
+    const rows = db
+      .prepare<[], { schema_version: number; cnt: number }>(
+        `SELECT schema_version, COUNT(*) AS cnt FROM narratives GROUP BY schema_version ORDER BY schema_version`,
+      )
+      .all();
+    expect(rows).toEqual([{ schema_version: 2, cnt: 5 }]);
+  });
+
+  it('idempotent — second call promotes 0, untouched count includes the already-promoted rows', async () => {
+    const first = await backfillNarrativeProvenance(db);
+    expect(first.promoted).toBe(4);
+
+    const second = await backfillNarrativeProvenance(db);
+    expect(second.promoted).toBe(0);
+    expect(second.untouched).toBe(5);
+  });
+
+  it('populates provenance + attributedTo + confidence + counts on every promoted row', async () => {
+    await backfillNarrativeProvenance(db);
+    const rows = db
+      .prepare<[], BackfillCheckRow>(
+        `SELECT id, schema_version, intent, observation, inference,
+                attributed_to, verified_at, confidence,
+                supporting_count, contradicting_count, correlated_outcome_json
+         FROM narratives ORDER BY id`,
+      )
+      .all();
+
+    for (const row of rows) {
+      if (row.id === SEED_IDS.narratives.n3) {
+        // n3 was already v2 — backfill must NOT touch it. Verify the
+        // pre-existing nulls survived.
+        expect(row.schema_version).toBe(2);
+        expect(row.intent).toBeNull();
+        expect(row.attributed_to).toBeNull();
+        expect(row.confidence).toBeNull();
+        continue;
+      }
+      // Promoted rows.
+      expect(row.schema_version).toBe(2);
+      expect(row.intent).toBe('legacy-v1-backfill');
+      expect(row.observation).not.toBeNull();
+      expect(row.inference).not.toBeNull();
+      expect(row.attributed_to).toBe('deterministic');
+      expect(row.verified_at).toBeNull();
+      expect(row.contradicting_count).toBe(0);
+      expect(row.correlated_outcome_json).toBeNull();
+      expect(typeof row.confidence).toBe('number');
+      expect(row.confidence!).toBeGreaterThanOrEqual(0);
+      expect(row.confidence!).toBeLessThanOrEqual(1);
+      expect(typeof row.supporting_count).toBe('number');
+      expect(row.supporting_count!).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('supporting_count equals the count of narrative_evidence rows', async () => {
+    await backfillNarrativeProvenance(db);
+    // n1 had 2 evidence rows per seedFixture; n5 had 1; n2/n4 had 0.
+    const n1 = db
+      .prepare<[string], { supporting_count: number | null }>(
+        `SELECT supporting_count FROM narratives WHERE id = ?`,
+      )
+      .get(SEED_IDS.narratives.n1);
+    expect(n1?.supporting_count).toBe(2);
+
+    const n5 = db
+      .prepare<[string], { supporting_count: number | null }>(
+        `SELECT supporting_count FROM narratives WHERE id = ?`,
+      )
+      .get(SEED_IDS.narratives.n5);
+    expect(n5?.supporting_count).toBe(1);
+
+    const n2 = db
+      .prepare<[string], { supporting_count: number | null }>(
+        `SELECT supporting_count FROM narratives WHERE id = ?`,
+      )
+      .get(SEED_IDS.narratives.n2);
+    expect(n2?.supporting_count).toBe(0);
+
+    const n4 = db
+      .prepare<[string], { supporting_count: number | null }>(
+        `SELECT supporting_count FROM narratives WHERE id = ?`,
+      )
+      .get(SEED_IDS.narratives.n4);
+    expect(n4?.supporting_count).toBe(0);
+  });
+
+  it('confidence equals computeConfidence(supporting, 0, defaultPrior)', async () => {
+    await backfillNarrativeProvenance(db);
+    const rows = db
+      .prepare<[], { supporting_count: number; confidence: number }>(
+        `SELECT supporting_count, confidence FROM narratives
+         WHERE schema_version = 2 AND attributed_to = 'deterministic'`,
+      )
+      .all();
+    const prior = THRESHOLDS.narrativeRung.defaultPrior;
+    for (const row of rows) {
+      const expected = computeConfidence(row.supporting_count, 0, prior);
+      expect(row.confidence).toBeCloseTo(expected, 9);
+    }
+  });
+
+  it('returns {promoted: 0, untouched: 0} on an empty DB', async () => {
+    // Fresh DB without seedFixture call.
+    db.close();
+    const fresh = openDb(join(tmpDir, 'empty.db'));
+    try {
+      runMigrations(fresh, MIGRATIONS);
+      const r = await backfillNarrativeProvenance(fresh);
+      expect(r.promoted).toBe(0);
+      expect(r.untouched).toBe(0);
+    } finally {
+      fresh.close();
+    }
+  });
+
+  it('truncates synthesized observation/inference at 200 chars (PII / placeholder boundary)', async () => {
+    // Insert a v1 narrative with a long title and body.
+    const longTitle = 'T'.repeat(500);
+    const longBody = 'B'.repeat(500);
+    db.prepare(
+      `INSERT INTO narratives (id, project_id, sentiment, title, body, generated_at, action_type, schema_version)
+       VALUES ('n-long', ?, 'positive', ?, ?, '2025-01-01T00:00:00Z', 'encode-as-pattern', 1)`,
+    ).run(SEED_IDS.projects.p1, longTitle, longBody);
+
+    await backfillNarrativeProvenance(db);
+
+    const row = db
+      .prepare<[string], { observation: string; inference: string }>(
+        `SELECT observation, inference FROM narratives WHERE id = ?`,
+      )
+      .get('n-long');
+    expect(row?.observation.length).toBe(200);
+    expect(row?.inference.length).toBe(200);
+  });
+});

--- a/packages/exporter/src/db/backfillNarrativeProvenance.test.ts
+++ b/packages/exporter/src/db/backfillNarrativeProvenance.test.ts
@@ -171,7 +171,29 @@ describe('backfillNarrativeProvenance (B5)', () => {
     }
   });
 
-  it('truncates synthesized observation/inference at 200 chars (PII / placeholder boundary)', async () => {
+  it('substitutes sentinel when legacy title/body is empty (validateNarrative v2 non-empty contract)', async () => {
+    // Insert a v1 narrative with empty title + body (DDL allows
+    // empty strings; the v2 validator rejects them on provenance).
+    db.prepare(
+      `INSERT INTO narratives (id, project_id, sentiment, title, body, generated_at, action_type, schema_version)
+       VALUES ('n-empty', ?, 'positive', '', '', '2025-01-01T00:00:00Z', 'encode-as-pattern', 1)`,
+    ).run(SEED_IDS.projects.p1);
+
+    await backfillNarrativeProvenance(db);
+
+    const row = db
+      .prepare<[string], { observation: string; inference: string; schema_version: number }>(
+        `SELECT observation, inference, schema_version FROM narratives WHERE id = ?`,
+      )
+      .get('n-empty');
+    expect(row?.schema_version).toBe(2);
+    expect(row?.observation.length).toBeGreaterThan(0);
+    expect(row?.inference.length).toBeGreaterThan(0);
+    expect(row?.observation).toMatch(/legacy v1 backfill/);
+    expect(row?.inference).toMatch(/legacy v1 backfill/);
+  });
+
+  it('truncates synthesized observation/inference at 200 chars (placeholder length cap)', async () => {
     // Insert a v1 narrative with a long title and body.
     const longTitle = 'T'.repeat(500);
     const longBody = 'B'.repeat(500);

--- a/packages/exporter/src/db/backfillNarrativeProvenance.ts
+++ b/packages/exporter/src/db/backfillNarrativeProvenance.ts
@@ -14,7 +14,7 @@
  *     - `supportingCount` = `COUNT(*) FROM narrative_evidence
  *       WHERE narrative_id = ?` (every existing evidence row treated
  *       as supporting; legacy data has no contradiction tracking).
- *     - `contradictingCount` = 0 (no legacy contradiction info).
+ *     - `contradictingCount` = 0 — see "Deferred concerns" below.
  *     - `prior` = `THRESHOLDS.narrativeRung.defaultPrior` (legacy
  *       narratives that survived in the corpus are treated as
  *       informally calibrated; the conservative uncalibratedPrior
@@ -22,9 +22,9 @@
  *     - `confidence` = `computeConfidence(supporting, 0, prior)`.
  *     - `attributedTo` = `'deterministic'` per plan §B5.
  *     - `provenance` = synthesized placeholder ({ intent:
- *       'legacy-v1-backfill', observation: title[0..200], inference:
- *       body[0..200] }). Future kernel re-runs will overwrite with
- *       real provenance.
+ *       'legacy-v1-backfill', observation: title[0..200] or sentinel,
+ *       inference: body[0..200] or sentinel }). Future kernel re-runs
+ *       overwrite with real provenance.
  *     - `schema_version` = 2.
  *   - All writes inside a single `withWriteTransaction` for atomicity;
  *     a partial backfill never lands on disk.
@@ -35,6 +35,22 @@
  * Pure relative to the seed fixture used in tests: same input → same
  * output (no Date.now(), no PRNG, no I/O outside the passed Database
  * handle).
+ *
+ * No production caller yet: this PR ships the kernel but doesn't wire
+ * it into the analysis pipeline — `runAnalysis` is JSON-sidecar-only
+ * today and doesn't open the SQLite substrate. The wiring happens
+ * alongside the Phase Rev3-C entity-states ledger (where the SQLite
+ * read path lands) so the backfill runs once before any tier-based
+ * surface reads the v2 columns.
+ *
+ * Deferred concerns (intentionally out of scope for B5):
+ *   - **Dismissal-ledger contradictingCount.** Phase Rev3-C lands the
+ *     generalized `entity-states` ledger that tracks per-Narrative
+ *     dismissals. Until then no on-disk dismissal data exists to join,
+ *     so `contradictingCount = 0` is the only defensible default.
+ *     When Rev3-C ships, a follow-up backfill (or a new kernel) should
+ *     re-derive `contradictingCount` from the ledger and re-compute
+ *     confidence. Tracked: progress.md row B5 → re-open after C ships.
  */
 
 import type { Database } from 'better-sqlite3';
@@ -47,6 +63,14 @@ import { withWriteTransaction } from './transaction.js';
  *  placeholder. Truncate aggressively — these are placeholders only.
  *  See header doc for the rationale. */
 const PROVENANCE_PLACEHOLDER_MAX_LEN = 200;
+
+/** Sentinel substituted when a legacy v1 row has empty title or body.
+ *  The DDL allows `title TEXT NOT NULL` but doesn't enforce non-empty;
+ *  `validateNarrative` rejects schemaVersion=2 rows whose provenance
+ *  triple has an empty observation/inference. Substitute a sentinel
+ *  rather than skip the row — every v1 needs to reach v2 for the
+ *  schema-uniformity invariant downstream consumers rely on. */
+const EMPTY_FIELD_SENTINEL = '(empty — legacy v1 backfill)';
 
 export interface BackfillResult {
   /** Number of v1 rows promoted to v2. */
@@ -117,8 +141,17 @@ export async function backfillNarrativeProvenance(
       // control (evidence count is non-negative INTEGER from SQL;
       // prior is THRESHOLDS-pinned). Defensive guard regardless.
       const safeConfidence = Number.isFinite(confidence) ? confidence : 0;
-      const observation = row.title.slice(0, PROVENANCE_PLACEHOLDER_MAX_LEN);
-      const inference = row.body.slice(0, PROVENANCE_PLACEHOLDER_MAX_LEN);
+      // Substitute sentinel for empty title/body so the synthesized
+      // provenance triple satisfies the schemaVersion=2 non-empty
+      // contract in validateNarrative (PR #66 B4).
+      const observation =
+        row.title.length === 0
+          ? EMPTY_FIELD_SENTINEL
+          : row.title.slice(0, PROVENANCE_PLACEHOLDER_MAX_LEN);
+      const inference =
+        row.body.length === 0
+          ? EMPTY_FIELD_SENTINEL
+          : row.body.slice(0, PROVENANCE_PLACEHOLDER_MAX_LEN);
       update.run(
         'legacy-v1-backfill',
         observation,

--- a/packages/exporter/src/db/backfillNarrativeProvenance.ts
+++ b/packages/exporter/src/db/backfillNarrativeProvenance.ts
@@ -1,0 +1,134 @@
+/**
+ * Phase Rev3-B sub-task B5 — one-shot backfill kernel that promotes
+ * legacy schemaVersion=1 narratives to schemaVersion=2 with
+ * provenance + confidence fields populated.
+ *
+ * Plan reference: `_planning/chat-arch-v2-rev3-plan.md` §Phase Rev3-B
+ *   "Backfill kernel — one-shot run over any existing narratives
+ *    (post zero-data start, normally empty) computing confidence
+ *    + setting `attributedTo='deterministic'` + bumping to
+ *    schemaVersion 2."
+ *
+ * Backfill contract:
+ *   - For each v1 row (`schema_version = 1`):
+ *     - `supportingCount` = `COUNT(*) FROM narrative_evidence
+ *       WHERE narrative_id = ?` (every existing evidence row treated
+ *       as supporting; legacy data has no contradiction tracking).
+ *     - `contradictingCount` = 0 (no legacy contradiction info).
+ *     - `prior` = `THRESHOLDS.narrativeRung.defaultPrior` (legacy
+ *       narratives that survived in the corpus are treated as
+ *       informally calibrated; the conservative uncalibratedPrior
+ *       would over-suppress them).
+ *     - `confidence` = `computeConfidence(supporting, 0, prior)`.
+ *     - `attributedTo` = `'deterministic'` per plan §B5.
+ *     - `provenance` = synthesized placeholder ({ intent:
+ *       'legacy-v1-backfill', observation: title[0..200], inference:
+ *       body[0..200] }). Future kernel re-runs will overwrite with
+ *       real provenance.
+ *     - `schema_version` = 2.
+ *   - All writes inside a single `withWriteTransaction` for atomicity;
+ *     a partial backfill never lands on disk.
+ *
+ * Idempotent: a second call on the same DB does nothing (the
+ * `schema_version = 1` filter excludes already-backfilled rows).
+ *
+ * Pure relative to the seed fixture used in tests: same input → same
+ * output (no Date.now(), no PRNG, no I/O outside the passed Database
+ * handle).
+ */
+
+import type { Database } from 'better-sqlite3';
+
+import { computeConfidence, THRESHOLDS } from '@chat-arch/analysis';
+
+import { withWriteTransaction } from './transaction.js';
+
+/** Maximum length for the synthesized provenance.observation/inference
+ *  placeholder. Truncate aggressively — these are placeholders only.
+ *  See header doc for the rationale. */
+const PROVENANCE_PLACEHOLDER_MAX_LEN = 200;
+
+export interface BackfillResult {
+  /** Number of v1 rows promoted to v2. */
+  readonly promoted: number;
+  /** Number of v2 rows that were untouched. */
+  readonly untouched: number;
+}
+
+interface LegacyRow {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+interface EvidenceCountRow {
+  readonly cnt: number;
+}
+
+/**
+ * Run the backfill on every v1 narrative in `db`. Returns a count
+ * summary. Safe to call repeatedly — already-backfilled (v2) rows
+ * are excluded by the SELECT filter.
+ */
+export async function backfillNarrativeProvenance(
+  db: Database,
+): Promise<BackfillResult> {
+  const legacy = db
+    .prepare<[], LegacyRow>(
+      `SELECT id, title, body FROM narratives WHERE schema_version = 1`,
+    )
+    .all();
+
+  const v2Count = db
+    .prepare<[], { cnt: number }>(
+      `SELECT COUNT(*) AS cnt FROM narratives WHERE schema_version = 2`,
+    )
+    .get();
+  const untouched = v2Count?.cnt ?? 0;
+
+  if (legacy.length === 0) {
+    return { promoted: 0, untouched };
+  }
+
+  const prior = THRESHOLDS.narrativeRung.defaultPrior;
+
+  await withWriteTransaction(db, (tx) => {
+    const countEvidence = tx.prepare<[string], EvidenceCountRow>(
+      `SELECT COUNT(*) AS cnt FROM narrative_evidence WHERE narrative_id = ?`,
+    );
+    const update = tx.prepare(
+      `UPDATE narratives SET
+        intent = ?,
+        observation = ?,
+        inference = ?,
+        attributed_to = 'deterministic',
+        verified_at = NULL,
+        confidence = ?,
+        supporting_count = ?,
+        contradicting_count = 0,
+        correlated_outcome_json = NULL,
+        schema_version = 2
+       WHERE id = ? AND schema_version = 1`,
+    );
+    for (const row of legacy) {
+      const evidenceCount = countEvidence.get(row.id)?.cnt ?? 0;
+      const confidence = computeConfidence(evidenceCount, 0, prior);
+      // computeConfidence returns NaN only on invalid inputs we
+      // control (evidence count is non-negative INTEGER from SQL;
+      // prior is THRESHOLDS-pinned). Defensive guard regardless.
+      const safeConfidence = Number.isFinite(confidence) ? confidence : 0;
+      const observation = row.title.slice(0, PROVENANCE_PLACEHOLDER_MAX_LEN);
+      const inference = row.body.slice(0, PROVENANCE_PLACEHOLDER_MAX_LEN);
+      update.run(
+        'legacy-v1-backfill',
+        observation,
+        inference,
+        safeConfidence,
+        evidenceCount,
+        row.id,
+      );
+    }
+  });
+
+  return { promoted: legacy.length, untouched };
+}


### PR DESCRIPTION
## Summary

Third wave of Phase Rev3-B. Wires the B6/B7 helpers (PR #67) + B1-B4/B8 schema (PR #66) into a one-shot promotion kernel for legacy `schemaVersion=1` narrative rows.

## B5 — backfill kernel

[`packages/exporter/src/db/backfillNarrativeProvenance.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-b5-narrative-backfill/packages/exporter/src/db/backfillNarrativeProvenance.ts) exports `backfillNarrativeProvenance(db) → { promoted, untouched }`.

For each v1 row (`WHERE schema_version = 1`):
- `supporting_count` = `COUNT(*)` of `narrative_evidence` rows for the narrative.
- `contradicting_count` = 0 (legacy data has no contradiction tracking).
- `prior` = `THRESHOLDS.narrativeRung.defaultPrior` (2). Legacy narratives that survived in the corpus are treated as informally-calibrated; `uncalibratedPrior` (20) would over-suppress them.
- `confidence` = `computeConfidence(supporting_count, 0, prior)`.
- `attributed_to` = `'deterministic'` per plan §B5.
- `provenance` triple = synthesized placeholder:
  - `intent` = `'legacy-v1-backfill'`
  - `observation` = `title.slice(0, 200)`
  - `inference` = `body.slice(0, 200)`
- `schema_version` = 2.

All writes inside a single `withWriteTransaction` for atomicity. Idempotent — the `WHERE schema_version = 1` filter excludes already-backfilled rows on a re-run. Pure relative to inputs (no `Date.now()` / PRNG / external I/O).

## Test coverage (+7 tests against the PR #60 seed fixture)

The `seedFixture` has 4 v1 narratives (n1, n2, n4, n5) + 1 v2 (n3), giving the realistic mixed-state input the backfill must handle.

- **One-call promotion**: `promoted=4, untouched=1`; all rows end at `schema_version=2`.
- **Idempotency**: second call → `promoted=0, untouched=5`.
- **Per-row population**: every promoted row has provenance fields + `attributedTo='deterministic'` + `verifiedAt=NULL` + confidence in [0,1] + `contradicting_count=0` + `correlated_outcome_json=NULL`; the pre-existing v2 row (n3) is untouched (NULL provenance preserved).
- **`supporting_count` equals evidence-row count**: n1=2, n5=1, n2/n4=0 (per `seedFixture`).
- **Confidence equals `computeConfidence(supporting, 0, defaultPrior)`** to 9 decimal places.
- **Empty DB** → `{promoted: 0, untouched: 0}`.
- **500-char title/body input** → observation/inference truncated to exactly 200 chars (placeholder PII boundary).

## Plan anchor

- [§Phase Rev3-B](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

## Tracker delta

| Row | Was | Now |
|---|---|---|
| B5 (backfill kernel) | pending | **in-review** (module `backfillNarrativeProvenance.ts`) |

Only **B9 (PII default-blur UI)** remains in Phase Rev3-B.

## Gates

- [x] `pnpm install --frozen-lockfile` — green
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r test` — 1,618 tests pass (+7 new)
- [x] `pnpm build` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)