### PR TITLE
feat(rev3-c): add narrative ack kind (C3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ on-disk shape with this changelog.
 
 ### Added
 
+- **`narrative` ack kind (Phase Rev3-C C3).** Adds `'narrative'` to
+  `apps/standalone/src/pages/api/insights-ack.ts`'s `KNOWN_KINDS`
+  allow-list. Lets the existing binary-ack ledger record one-shot "I've
+  seen this Narrative" actions. The richer state machine for narratives
+  (PENDING / INSTALLED / DISMISSED + dismissalCount + growth-multiplier
+  re-promotion) continues to live in the entity-states ledger
+  (`/api/entity-states`, added in C1+C2). Two surfaces on purpose: the
+  ack endpoint stays as a thin idempotent ack, while entity-states
+  handles the multi-state lifecycle.
+
 - **Entity-states ledger (Phase Rev3-C C1+C2).** New endpoint
   `/api/entity-states` writes to `analysis/entity-states.json` (v2
   shape) keyed by composite `(entityKind, entityId)`. Generalizes the

--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -66,7 +66,7 @@ Plan anchor: [§Phase Rev3-C](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 |---|---|---|---|
 | C1 | Rename `knowledge-debt-state.ts` ledger to `entity-states.ts` (generalize over narrative + knowledge-debt items) | in-review | PR #TBD |
 | C2 | Migrate state shape — handle Narrative IDs + knowledge-debt IDs under one entry shape; preserve back-compat read | in-review | PR #TBD (server reads legacy `knowledge-debt-states.json` when v2 file absent; viewer client mirrors the fallback) |
-| C3 | Add `narrative` kind to `insights-ack.ts` KNOWN_KINDS allow-list for binary-ack case | pending | |
+| C3 | Add `narrative` kind to `insights-ack.ts` KNOWN_KINDS allow-list for binary-ack case | in-review | PR #TBD |
 | C4 | Wire the new entity-states ledger to read/write through the SQLite SDK (not a separate JSON file going forward) | pending | |
 | C5 | Tests: dismiss-then-evidence-grows-then-re-promote round-trip on a Narrative | pending | Gate |
 

--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -64,9 +64,9 @@ Plan anchor: [§Phase Rev3-C](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 
 | # | Sub-task | Status | PR / notes |
 |---|---|---|---|
-| C1 | Rename `knowledge-debt-state.ts` ledger to `entity-states.ts` (generalize over narrative + knowledge-debt items) | in-review | PR #TBD |
-| C2 | Migrate state shape — handle Narrative IDs + knowledge-debt IDs under one entry shape; preserve back-compat read | in-review | PR #TBD (server reads legacy `knowledge-debt-states.json` when v2 file absent; viewer client mirrors the fallback) |
-| C3 | Add `narrative` kind to `insights-ack.ts` KNOWN_KINDS allow-list for binary-ack case | in-review | PR #TBD |
+| C1 | Rename `knowledge-debt-state.ts` ledger to `entity-states.ts` (generalize over narrative + knowledge-debt items) | complete-and-merged | PR #70 |
+| C2 | Migrate state shape — handle Narrative IDs + knowledge-debt IDs under one entry shape; preserve back-compat read | complete-and-merged | PR #70 (server reads legacy `knowledge-debt-states.json` when v2 file absent; viewer client mirrors the fallback) |
+| C3 | Add `narrative` kind to `insights-ack.ts` KNOWN_KINDS allow-list for binary-ack case | in-review | PR #71 |
 | C4 | Wire the new entity-states ledger to read/write through the SQLite SDK (not a separate JSON file going forward) | pending | |
 | C5 | Tests: dismiss-then-evidence-grows-then-re-promote round-trip on a Narrative | pending | Gate |
 

--- a/apps/standalone/src/pages/api/insights-ack.ts
+++ b/apps/standalone/src/pages/api/insights-ack.ts
@@ -84,7 +84,18 @@ export interface InsightsAcksFile {
   entries: InsightsAckEntry[];
 }
 
-const KNOWN_KINDS = new Set(['its-contrast', 'knowledge-debt', 'reflexive', 'other']);
+const KNOWN_KINDS = new Set([
+  'its-contrast',
+  'knowledge-debt',
+  // Rev3-C C3 — `narrative` joins the ack allow-list for the binary
+  // ack case (one-shot "I've seen this Narrative"). The richer
+  // PENDING/INSTALLED/DISMISSED state machine for narratives lives
+  // in the entity-states ledger (`/api/entity-states`); this one is
+  // for the lightweight acknowledge action.
+  'narrative',
+  'reflexive',
+  'other',
+]);
 const MAX_ID_LEN = 256;
 
 export interface ValidatedAck {

--- a/apps/standalone/test/api/insights-ack.test.ts
+++ b/apps/standalone/test/api/insights-ack.test.ts
@@ -27,6 +27,22 @@ describe('validateAckBody', () => {
     expect('error' in r).toBe(true);
   });
 
+  it('accepts the `narrative` kind (Rev3-C C3 binary-ack case)', () => {
+    const r = validateAckBody({ id: 'narr-abc', kind: 'narrative' });
+    expect('error' in r).toBe(false);
+    if (!('error' in r)) {
+      expect(r.kind).toBe('narrative');
+      expect(r.id).toBe('narr-abc');
+    }
+  });
+
+  it('accepts all four established kinds (its-contrast, knowledge-debt, narrative, reflexive)', () => {
+    for (const kind of ['its-contrast', 'knowledge-debt', 'narrative', 'reflexive']) {
+      const r = validateAckBody({ id: 'x', kind });
+      expect('error' in r).toBe(false);
+    }
+  });
+
   it('rejects missing id', () => {
     const r = validateAckBody({ kind: 'its-contrast' });
     expect('error' in r).toBe(true);

--- a/apps/standalone/test/api/insights-ack.test.ts
+++ b/apps/standalone/test/api/insights-ack.test.ts
@@ -36,8 +36,8 @@ describe('validateAckBody', () => {
     }
   });
 
-  it('accepts all four established kinds (its-contrast, knowledge-debt, narrative, reflexive)', () => {
-    for (const kind of ['its-contrast', 'knowledge-debt', 'narrative', 'reflexive']) {
+  it('accepts all five established kinds (its-contrast, knowledge-debt, narrative, reflexive, other)', () => {
+    for (const kind of ['its-contrast', 'knowledge-debt', 'narrative', 'reflexive', 'other']) {
       const r = validateAckBody({ id: 'x', kind });
       expect('error' in r).toBe(false);
     }

--- a/packages/viewer/src/data/insightsAckClient.ts
+++ b/packages/viewer/src/data/insightsAckClient.ts
@@ -14,6 +14,7 @@ const REQUIRED_HEADER_VALUE = 'chat-arch-insights-ack';
 export type InsightsAckKind =
   | 'its-contrast'
   | 'knowledge-debt'
+  | 'narrative'
   | 'reflexive'
   | 'other';
 


### PR DESCRIPTION
## Summary

Phase Rev3-C C3. Adds `'narrative'` to the `KNOWN_KINDS` allow-list in `apps/standalone/src/pages/api/insights-ack.ts` so the binary-ack ledger accepts one-shot "I've seen this Narrative" actions.

## Two-surface separation

The richer state machine for narratives (PENDING / INSTALLED / DISMISSED + dismissalCount + growth-multiplier re-promotion) continues to live in the entity-states ledger (`/api/entity-states`, landed in C1+C2 / PR #70). Two surfaces on purpose:

- **insights-ack** — thin idempotent binary ack ("seen"). Same shape as ITS-contrast acks, knowledge-debt acks, reflexive acks. The viewer fires this for the "ACKNOWLEDGE" pill on narrative cards.
- **entity-states** — multi-state lifecycle. PENDING → INSTALLED / DISMISSED with a per-entity dismissal counter that drives Closure B's saturation rule (Phase D1).

A narrative can have BOTH an ack entry AND an entity-states entry — they answer different questions ("seen?" vs "what action did the user take?").

## Plan anchor

[§Phase Rev3-C — Closure A wiring (feedback ranking)](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

## Tracker delta

| Row | Status |
|---|---|
| C3 (insights-ack `narrative` kind) | in-review |

C4 (SQLite-SDK wiring through the renamed ledger) lands in the next PR; C5 (round-trip test gate) closes the phase.

## Gates

- [x] \`pnpm lint\` — clean
- [x] \`pnpm --filter @chat-arch/standalone test test/api/insights-ack.test.ts\` — 10/10 pass

## Test plan

- [x] Validate body accepts \`narrative\` kind
- [x] Matrix test covers all four established kinds (its-contrast, knowledge-debt, narrative, reflexive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)