### PR TITLE
feat(rev3-c): entity_states migration + SDK foundation (C4-A)

### DIFF
--- a/packages/exporter/src/db/migrations/001-initial-schema.test.ts
+++ b/packages/exporter/src/db/migrations/001-initial-schema.test.ts
@@ -319,6 +319,7 @@ describe('001-initial-schema migration', () => {
         expect(first.applied).toEqual([
           '001-initial-schema',
           '002-narrative-provenance',
+          '003-entity-states',
         ]);
       } finally {
         db.close();
@@ -332,6 +333,7 @@ describe('001-initial-schema migration', () => {
         expect(second.alreadyApplied).toEqual([
           '001-initial-schema',
           '002-narrative-provenance',
+          '003-entity-states',
         ]);
       } finally {
         db.close();

--- a/packages/exporter/src/db/migrations/002-narrative-provenance.test.ts
+++ b/packages/exporter/src/db/migrations/002-narrative-provenance.test.ts
@@ -41,6 +41,7 @@ describe('Rev3-B narrative-provenance migration (002)', () => {
     expect(applied).toEqual([
       '001-initial-schema',
       '002-narrative-provenance',
+      '003-entity-states',
     ]);
   });
 

--- a/packages/exporter/src/db/migrations/003-entity-states.test.ts
+++ b/packages/exporter/src/db/migrations/003-entity-states.test.ts
@@ -1,0 +1,122 @@
+// DB-side tests for Phase Rev3-C C4-foundation migration (003).
+// Walks a freshly-migrated DB through entity_states inserts +
+// asserts the CHECK constraints reject malformed inputs.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openDb } from '../connection.js';
+import { MIGRATIONS, runMigrations } from './index.js';
+
+describe('Rev3-C entity_states migration (003)', () => {
+  let tmpDir: string;
+  let db: Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chat-arch-rev3c-test-'));
+    db = openDb(join(tmpDir, 'rev3c.db'));
+    runMigrations(db, MIGRATIONS);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('all three migrations register in apply order', () => {
+    const applied = db
+      .prepare<unknown[], { id: string }>(
+        'SELECT id FROM schema_migrations ORDER BY id',
+      )
+      .all()
+      .map((r) => r.id);
+    expect(applied).toEqual([
+      '001-initial-schema',
+      '002-narrative-provenance',
+      '003-entity-states',
+    ]);
+  });
+
+  it('entity_states table accepts a valid PENDING insert', () => {
+    db.prepare(
+      `INSERT INTO entity_states
+         (entity_kind, entity_id, state, size_at_state, updated_at)
+       VALUES ('narrative', 'narr-1', 'PENDING', 5, 1000)`,
+    ).run();
+    const row = db
+      .prepare<[], Record<string, unknown>>(`SELECT * FROM entity_states`)
+      .get();
+    expect(row?.['entity_kind']).toBe('narrative');
+    expect(row?.['state']).toBe('PENDING');
+    expect(row?.['size_at_state']).toBe(5);
+    expect(row?.['dismissal_count']).toBe(0); // DEFAULT 0
+  });
+
+  it('CHECK rejects entity_kind outside the two-value union', () => {
+    expect(() =>
+      db.prepare(
+        `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, updated_at)
+         VALUES ('pattern', 'p-1', 'PENDING', 0, 1000)`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+
+  it('CHECK rejects state outside the three-value union', () => {
+    expect(() =>
+      db.prepare(
+        `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, updated_at)
+         VALUES ('narrative', 'narr-1', 'ACKNOWLEDGED', 0, 1000)`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+
+  it('CHECK rejects negative size_at_state', () => {
+    expect(() =>
+      db.prepare(
+        `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, updated_at)
+         VALUES ('narrative', 'narr-1', 'PENDING', -1, 1000)`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+
+  it('CHECK rejects negative dismissal_count', () => {
+    expect(() =>
+      db.prepare(
+        `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, dismissal_count, updated_at)
+         VALUES ('narrative', 'narr-1', 'DISMISSED', 0, -1, 1000)`,
+      ).run(),
+    ).toThrow(/CHECK constraint/);
+  });
+
+  it('PRIMARY KEY (entity_kind, entity_id) rejects duplicate inserts', () => {
+    db.prepare(
+      `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, updated_at)
+       VALUES ('narrative', 'narr-1', 'PENDING', 0, 1000)`,
+    ).run();
+    expect(() =>
+      db.prepare(
+        `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, updated_at)
+         VALUES ('narrative', 'narr-1', 'INSTALLED', 0, 2000)`,
+      ).run(),
+    ).toThrow(/UNIQUE constraint|PRIMARY KEY/);
+  });
+
+  it('same entity_id under two different kinds coexists (composite PK)', () => {
+    db.prepare(
+      `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, updated_at)
+       VALUES ('narrative', 'shared-id', 'PENDING', 0, 1000)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO entity_states (entity_kind, entity_id, state, size_at_state, updated_at)
+       VALUES ('knowledge-debt', 'shared-id', 'INSTALLED', 0, 2000)`,
+    ).run();
+    const count = db
+      .prepare<[], { cnt: number }>('SELECT COUNT(*) AS cnt FROM entity_states')
+      .get();
+    expect(count?.cnt).toBe(2);
+  });
+});

--- a/packages/exporter/src/db/migrations/003-entity-states.ts
+++ b/packages/exporter/src/db/migrations/003-entity-states.ts
@@ -1,0 +1,56 @@
+// Phase Rev3-C sub-task C4 (foundation) — entity_states table for
+// the generalized dismiss-state ledger.
+//
+// Plan reference: `_planning/chat-arch-v2-rev3-plan.md` §Phase Rev3-C:
+//   "Wire the new entity-states ledger to read/write through the
+//    SQLite SDK (not a separate JSON file going forward)."
+//
+// This migration adds the storage table. API-side wiring (replacing
+// the JSON file with SDK calls + one-time JSON-→-SQLite import) lands
+// in a follow-on PR; this one keeps scope to the schema.
+//
+// Shape mirrors `EntityStateEntry` in `apps/standalone/src/pages/api/
+// entity-states.ts`:
+//   - Composite PK `(entity_kind, entity_id)` — one entry per entity.
+//   - `entity_kind` CHECK restricted to the two known kinds.
+//   - `state` CHECK restricted to `PENDING` | `INSTALLED` | `DISMISSED`.
+//   - `size_at_state` INTEGER ≥ 0 — snapshot at state change for the
+//     growth-multiplier re-promotion rule.
+//   - `dismissal_count` INTEGER ≥ 0 DEFAULT 0 — Phase Rev3-D Closure
+//     B saturation counter.
+//   - `updated_at` INTEGER (ms since epoch).
+//
+// `entity_id` is TEXT with a max length check applied at the SDK
+// boundary (256 chars per the existing API validator); SQLite
+// doesn't enforce VARCHAR(n) so the DDL omits the length.
+
+import type { Database } from 'better-sqlite3';
+
+import type { Migration } from './types.js';
+
+const DDL = `
+  CREATE TABLE entity_states (
+    entity_kind TEXT NOT NULL
+      CHECK (entity_kind IN ('knowledge-debt', 'narrative')),
+    entity_id TEXT NOT NULL,
+    state TEXT NOT NULL
+      CHECK (state IN ('PENDING', 'INSTALLED', 'DISMISSED')),
+    size_at_state INTEGER NOT NULL
+      CHECK (size_at_state >= 0),
+    dismissal_count INTEGER NOT NULL DEFAULT 0
+      CHECK (dismissal_count >= 0),
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (entity_kind, entity_id)
+  );
+
+  CREATE INDEX idx_entity_states_kind ON entity_states (entity_kind);
+  CREATE INDEX idx_entity_states_state ON entity_states (state);
+`;
+
+export const entityStatesMigration: Migration = {
+  id: '003-entity-states',
+  name: 'Rev3-C entity_states table for the generalized dismiss-state ledger',
+  up(db: Database): void {
+    db.exec(DDL);
+  },
+};

--- a/packages/exporter/src/db/migrations/index.ts
+++ b/packages/exporter/src/db/migrations/index.ts
@@ -11,10 +11,12 @@
 import type { Migration } from './types.js';
 import { initialSchemaMigration } from './001-initial-schema.js';
 import { narrativeProvenanceMigration } from './002-narrative-provenance.js';
+import { entityStatesMigration } from './003-entity-states.js';
 
 export const MIGRATIONS: readonly Migration[] = [
   initialSchemaMigration,
   narrativeProvenanceMigration,
+  entityStatesMigration,
 ];
 
 export { runMigrations } from './runner.js';

--- a/packages/exporter/src/db/sdk/entityStates.test.ts
+++ b/packages/exporter/src/db/sdk/entityStates.test.ts
@@ -1,0 +1,238 @@
+// SDK round-trip tests for `entity_states` (Phase Rev3-C C4 foundation).
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Database } from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openDb } from '../connection.js';
+import { MIGRATIONS, runMigrations } from '../migrations/index.js';
+import {
+  deleteEntityState,
+  getEntityState,
+  listEntityStates,
+  upsertEntityState,
+} from './entityStates.js';
+
+describe('entity_states SDK round-trip', () => {
+  let tmpDir: string;
+  let db: Database;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chat-arch-es-sdk-test-'));
+    db = openDb(join(tmpDir, 'es.db'));
+    runMigrations(db, MIGRATIONS);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('upsert → get round-trips a new row with defaults', async () => {
+    const fresh = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'PENDING',
+      sizeAtState: 5,
+      updatedAt: 1000,
+    });
+    expect(fresh).toEqual({
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'PENDING',
+      sizeAtState: 5,
+      dismissalCount: 0,
+      updatedAt: 1000,
+    });
+    expect(getEntityState(db, 'narrative', 'narr-1')).toEqual(fresh);
+  });
+
+  it('upsert updates an existing row (composite PK)', async () => {
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'PENDING',
+      sizeAtState: 5,
+      updatedAt: 1000,
+    });
+    const after = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'INSTALLED',
+      sizeAtState: 6,
+      updatedAt: 2000,
+    });
+    expect(after.state).toBe('INSTALLED');
+    expect(after.sizeAtState).toBe(6);
+    expect(after.updatedAt).toBe(2000);
+    expect(after.dismissalCount).toBe(0); // no DISMISSED transition yet
+    expect(listEntityStates(db)).toHaveLength(1);
+  });
+
+  it('auto-increments dismissalCount on PENDING/INSTALLED → DISMISSED transition', async () => {
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'PENDING',
+      sizeAtState: 5,
+      updatedAt: 1000,
+    });
+    const dismissed = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'DISMISSED',
+      sizeAtState: 5,
+      updatedAt: 2000,
+    });
+    expect(dismissed.dismissalCount).toBe(1);
+  });
+
+  it('does NOT increment dismissalCount on DISMISSED → DISMISSED self-transition', async () => {
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'DISMISSED',
+      sizeAtState: 5,
+      updatedAt: 1000,
+    });
+    const stillDismissed = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'DISMISSED',
+      sizeAtState: 5,
+      updatedAt: 2000,
+    });
+    expect(stillDismissed.dismissalCount).toBe(1); // first write started at 1
+  });
+
+  it('Closure-B dismiss-then-revive-then-dismiss-again cycles counter', async () => {
+    // First dismiss
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'PENDING',
+      sizeAtState: 3,
+      updatedAt: 1000,
+    });
+    let r = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'DISMISSED',
+      sizeAtState: 3,
+      updatedAt: 2000,
+    });
+    expect(r.dismissalCount).toBe(1);
+
+    // Revive (evidence grew → re-promote)
+    r = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'PENDING',
+      sizeAtState: 6,
+      updatedAt: 3000,
+    });
+    expect(r.dismissalCount).toBe(1); // unchanged on non-DISMISSED transitions
+
+    // Dismiss again
+    r = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'DISMISSED',
+      sizeAtState: 6,
+      updatedAt: 4000,
+    });
+    expect(r.dismissalCount).toBe(2);
+  });
+
+  it('explicit dismissalCount override bypasses auto-increment (JSON-import path)', async () => {
+    const r = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'narr-1',
+      state: 'DISMISSED',
+      sizeAtState: 5,
+      updatedAt: 1000,
+      dismissalCount: 4, // import-time value
+    });
+    expect(r.dismissalCount).toBe(4);
+  });
+
+  it('listEntityStates filters by kind + state', async () => {
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'n1',
+      state: 'PENDING',
+      sizeAtState: 1,
+      updatedAt: 1000,
+    });
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'n2',
+      state: 'DISMISSED',
+      sizeAtState: 1,
+      updatedAt: 1000,
+    });
+    await upsertEntityState(db, {
+      entityKind: 'knowledge-debt',
+      entityId: 'kd1',
+      state: 'PENDING',
+      sizeAtState: 1,
+      updatedAt: 1000,
+    });
+
+    expect(listEntityStates(db)).toHaveLength(3);
+    expect(listEntityStates(db, { kind: 'narrative' })).toHaveLength(2);
+    expect(listEntityStates(db, { kind: 'knowledge-debt' })).toHaveLength(1);
+    expect(listEntityStates(db, { state: 'PENDING' })).toHaveLength(2);
+    expect(
+      listEntityStates(db, { kind: 'narrative', state: 'DISMISSED' }),
+    ).toHaveLength(1);
+  });
+
+  it('deleteEntityState removes the row and returns true; false on missing', async () => {
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'n1',
+      state: 'PENDING',
+      sizeAtState: 1,
+      updatedAt: 1000,
+    });
+    expect(await deleteEntityState(db, 'narrative', 'n1')).toBe(true);
+    expect(await deleteEntityState(db, 'narrative', 'n1')).toBe(false);
+    expect(getEntityState(db, 'narrative', 'n1')).toBeNull();
+  });
+
+  it('same entity_id under two kinds is independent (composite PK)', async () => {
+    await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'shared',
+      state: 'PENDING',
+      sizeAtState: 1,
+      updatedAt: 1000,
+    });
+    await upsertEntityState(db, {
+      entityKind: 'knowledge-debt',
+      entityId: 'shared',
+      state: 'INSTALLED',
+      sizeAtState: 1,
+      updatedAt: 2000,
+    });
+    const n = getEntityState(db, 'narrative', 'shared');
+    const k = getEntityState(db, 'knowledge-debt', 'shared');
+    expect(n?.state).toBe('PENDING');
+    expect(k?.state).toBe('INSTALLED');
+  });
+
+  it('first-write DISMISSED starts dismissalCount at 1 (not 0)', async () => {
+    const r = await upsertEntityState(db, {
+      entityKind: 'narrative',
+      entityId: 'n1',
+      state: 'DISMISSED',
+      sizeAtState: 5,
+      updatedAt: 1000,
+    });
+    expect(r.dismissalCount).toBe(1);
+  });
+});

--- a/packages/exporter/src/db/sdk/entityStates.ts
+++ b/packages/exporter/src/db/sdk/entityStates.ts
@@ -1,0 +1,181 @@
+// `entity_states` table SDK (Phase Rev3-C C4 foundation).
+//
+// Generalized dismiss-state ledger covering both knowledge-debt
+// clusters and Narratives. Schema lives in
+// `packages/exporter/src/db/migrations/003-entity-states.ts`.
+//
+// The matching legacy JSON shape is in
+// `apps/standalone/src/pages/api/entity-states.ts:EntityStateEntry`
+// (and its v1 predecessor `knowledge-debt-states.json`). When the API
+// rewires to use this SDK (follow-on PR), it'll do a one-shot import
+// of any existing JSON ledger entries before switching to SQLite as
+// the source of truth.
+
+import type { Database } from 'better-sqlite3';
+
+import { withWriteTransaction } from '../transaction.js';
+
+export type EntityStateKind = 'knowledge-debt' | 'narrative';
+export type EntityStateValue = 'PENDING' | 'INSTALLED' | 'DISMISSED';
+
+export interface EntityStateRow {
+  readonly entityKind: EntityStateKind;
+  readonly entityId: string;
+  readonly state: EntityStateValue;
+  readonly sizeAtState: number;
+  readonly dismissalCount: number;
+  /** Unix ms since epoch. */
+  readonly updatedAt: number;
+}
+
+interface RawEntityStateRow {
+  readonly entity_kind: string;
+  readonly entity_id: string;
+  readonly state: string;
+  readonly size_at_state: number;
+  readonly dismissal_count: number;
+  readonly updated_at: number;
+}
+
+function rowFromRaw(raw: RawEntityStateRow): EntityStateRow {
+  return {
+    entityKind: raw.entity_kind as EntityStateKind,
+    entityId: raw.entity_id,
+    state: raw.state as EntityStateValue,
+    sizeAtState: raw.size_at_state,
+    dismissalCount: raw.dismissal_count,
+    updatedAt: raw.updated_at,
+  };
+}
+
+const SELECT_COLUMNS =
+  'entity_kind, entity_id, state, size_at_state, dismissal_count, updated_at';
+
+export function getEntityState(
+  db: Database,
+  kind: EntityStateKind,
+  entityId: string,
+): EntityStateRow | null {
+  const raw = db
+    .prepare<[string, string], RawEntityStateRow>(
+      `SELECT ${SELECT_COLUMNS} FROM entity_states WHERE entity_kind = ? AND entity_id = ?`,
+    )
+    .get(kind, entityId);
+  return raw ? rowFromRaw(raw) : null;
+}
+
+export interface ListEntityStatesFilter {
+  readonly kind?: EntityStateKind;
+  readonly state?: EntityStateValue;
+}
+
+export function listEntityStates(
+  db: Database,
+  filter: ListEntityStatesFilter = {},
+): readonly EntityStateRow[] {
+  const where: string[] = [];
+  const args: unknown[] = [];
+  if (filter.kind !== undefined) {
+    where.push('entity_kind = ?');
+    args.push(filter.kind);
+  }
+  if (filter.state !== undefined) {
+    where.push('state = ?');
+    args.push(filter.state);
+  }
+  const whereClause = where.length === 0 ? '' : ` WHERE ${where.join(' AND ')}`;
+  const sql = `SELECT ${SELECT_COLUMNS} FROM entity_states${whereClause} ORDER BY entity_kind, entity_id`;
+  return db
+    .prepare<unknown[], RawEntityStateRow>(sql)
+    .all(...args)
+    .map(rowFromRaw);
+}
+
+export interface UpsertEntityStateInput {
+  readonly entityKind: EntityStateKind;
+  readonly entityId: string;
+  readonly state: EntityStateValue;
+  readonly sizeAtState: number;
+  readonly updatedAt: number;
+  /**
+   * Optional explicit override. When absent the upsert increments the
+   * existing row's `dismissal_count` by 1 if (and only if) the new
+   * state is `DISMISSED` AND the previous state was non-DISMISSED.
+   * Setting an explicit value bypasses the auto-increment (useful
+   * for the JSON-→-SQLite import path that preserves prior counts).
+   */
+  readonly dismissalCount?: number;
+}
+
+/**
+ * Insert or update an entity-state row. Returns the resulting row.
+ *
+ * Auto-increments `dismissal_count` on the PENDING/INSTALLED →
+ * DISMISSED transition (Closure B per `narrativeRung.dismissDecay`).
+ * Pass `dismissalCount` explicitly to override.
+ */
+export async function upsertEntityState(
+  db: Database,
+  input: UpsertEntityStateInput,
+): Promise<EntityStateRow> {
+  return withWriteTransaction(db, (tx) => {
+    let nextDismissalCount: number;
+    if (input.dismissalCount !== undefined) {
+      nextDismissalCount = input.dismissalCount;
+    } else {
+      const prev = tx
+        .prepare<[string, string], { state: string; dismissal_count: number }>(
+          `SELECT state, dismissal_count FROM entity_states WHERE entity_kind = ? AND entity_id = ?`,
+        )
+        .get(input.entityKind, input.entityId);
+      if (!prev) {
+        // First write — start at 0 (or 1 if the first state IS DISMISSED).
+        nextDismissalCount = input.state === 'DISMISSED' ? 1 : 0;
+      } else if (input.state === 'DISMISSED' && prev.state !== 'DISMISSED') {
+        nextDismissalCount = prev.dismissal_count + 1;
+      } else {
+        nextDismissalCount = prev.dismissal_count;
+      }
+    }
+    tx.prepare(
+      `INSERT INTO entity_states
+         (entity_kind, entity_id, state, size_at_state, dismissal_count, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(entity_kind, entity_id) DO UPDATE SET
+         state = excluded.state,
+         size_at_state = excluded.size_at_state,
+         dismissal_count = excluded.dismissal_count,
+         updated_at = excluded.updated_at`,
+    ).run(
+      input.entityKind,
+      input.entityId,
+      input.state,
+      input.sizeAtState,
+      nextDismissalCount,
+      input.updatedAt,
+    );
+    const fresh = getEntityState(tx, input.entityKind, input.entityId);
+    if (!fresh) {
+      // Shouldn't happen — we just upserted.
+      throw new Error(
+        `entity_states row vanished mid-transaction (${input.entityKind}, ${input.entityId})`,
+      );
+    }
+    return fresh;
+  });
+}
+
+export async function deleteEntityState(
+  db: Database,
+  kind: EntityStateKind,
+  entityId: string,
+): Promise<boolean> {
+  return withWriteTransaction(db, (tx) => {
+    const info = tx
+      .prepare(
+        'DELETE FROM entity_states WHERE entity_kind = ? AND entity_id = ?',
+      )
+      .run(kind, entityId);
+    return info.changes > 0;
+  });
+}

--- a/packages/exporter/src/db/sdk/index.ts
+++ b/packages/exporter/src/db/sdk/index.ts
@@ -6,6 +6,7 @@ export type * from './types.js';
 export { NotFoundError, UniqueViolationError, isUniqueViolation } from './errors.js';
 
 export * from './analyzers.js';
+export * from './entityStates.js';
 export * from './projects.js';
 export * from './topics.js';
 export * from './sessions.js';


### PR DESCRIPTION
## Summary

Foundation half of Phase Rev3-C C4. Lands the SQLite storage layer that the standalone `/api/entity-states` endpoint will switch to in a follow-on PR. Scope deliberately bounded to schema + SDK + tests so the API-rewiring change (which is the **first SQLite-in-standalone caller in the whole repo**) can be reviewed in isolation.

## Migration 003-entity-states

New `entity_states` table mirroring the existing JSON ledger shape:
- Composite PK `(entity_kind, entity_id)`.
- CHECK on `entity_kind` ∈ `{'knowledge-debt', 'narrative'}`.
- CHECK on `state` ∈ `{'PENDING', 'INSTALLED', 'DISMISSED'}`.
- CHECK on `size_at_state ≥ 0`.
- CHECK on `dismissal_count ≥ 0` (DEFAULT 0 — Closure B counter).
- `updated_at` INTEGER (ms since epoch).
- Indexes on `entity_kind` + `state` for the common filter patterns.

**7 DB-side tests** cover the four CHECK constraints, composite-PK collision rejection, and same-entity_id-under-two-kinds coexistence.

## SDK module [`packages/exporter/src/db/sdk/entityStates.ts`](https://github.com/BryceEWatson/chat-arch/blob/feature/rev3-c4a-entity-states-sdk/packages/exporter/src/db/sdk/entityStates.ts)

Exports:
- `getEntityState(db, kind, id)` → row | null
- `listEntityStates(db, {kind?, state?})` → readonly Row[]
- `upsertEntityState(db, input)` → row. Auto-increments `dismissalCount` on `PENDING/INSTALLED → DISMISSED` transition; explicit `dismissalCount` override bypasses the auto-increment for the JSON-import path.
- `deleteEntityState(db, kind, id)` → boolean

**11 SDK round-trip tests** cover: fresh upsert with defaults, upsert-update on composite PK, auto-increment on dismissal transition, self-DISMISSED no re-increment, full Closure-B dismiss → revive → re-dismiss cycle, explicit dismissalCount override, list-filter by kind + state, delete returns true/false, same-id-under-two-kinds independence, first-write DISMISSED starts counter at 1.

## Migration registry + idempotency tests updated

`MIGRATIONS` array in `index.ts` includes `entityStatesMigration` as the third entry. 001 + 002 idempotency tests updated to expect the new id in their applied lists.

## Scope NOT in this PR

- `/api/entity-states` API endpoint still writes JSON. Rewiring to use this SDK (+ one-shot import from legacy JSON files) is the **C4-B follow-on PR**.
- **C5** (round-trip dismiss → grow → re-promote gate test) needs the API wiring first, so lands with C4-B.

## Plan anchor

- [§Phase Rev3-C — Closure A wiring (feedback ranking)](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

## Gates

- [x] `pnpm install --frozen-lockfile` — green
- [x] `pnpm lint` — 0 errors
- [x] `pnpm -r test` — 1,664 tests pass (+18 new: 7 migration + 11 SDK)
- [x] `pnpm build` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)