### PR TITLE
feat(rev3-d): narrativeSaturation kernel — Closure B saturation rule (D1)

### DIFF
--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -68,7 +68,7 @@ Plan anchor: [§Phase Rev3-C](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 | C2 | Migrate state shape — handle Narrative IDs + knowledge-debt IDs under one entry shape; preserve back-compat read | complete-and-merged | PR #70 (server reads legacy `knowledge-debt-states.json` when v2 file absent; viewer client mirrors the fallback) |
 | C3 | Add `narrative` kind to `insights-ack.ts` KNOWN_KINDS allow-list for binary-ack case | complete-and-merged | PR #71 |
 | C4 | Wire the new entity-states ledger to read/write through the SQLite SDK (not a separate JSON file going forward) | complete-and-merged | PR #73 (migration 003 + entityStates SDK module + standalone DB connection helper with legacy v1+v2 JSON fold + endpoint cutover + viewer client API-first read with JSON-sidecar fallback; iter-1 fix moved DB out of `public/` after security review) |
-| C5 | Tests: dismiss-then-evidence-grows-then-re-promote round-trip on a Narrative | in-review | PR #TBD (closes Phase Rev3-C) |
+| C5 | Tests: dismiss-then-evidence-grows-then-re-promote round-trip on a Narrative | complete-and-merged | PR #74 (closes Phase Rev3-C — SDK-layer round-trip + standalone-layer integration test) |
 
 **Gates:** a surfaced Narrative can be dismissed and re-promoted via the existing growth-multiplier mechanism.
 
@@ -80,7 +80,7 @@ Plan anchor: [§Phase Rev3-D](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 
 | # | Sub-task | Status | PR / notes |
 |---|---|---|---|
-| D1 | Saturation rule (×2/×4/×8) implemented in entity-states ledger; cap K=3 (THRESHOLDS-resident) | pending | |
+| D1 | Saturation rule (×2/×4/×8) implemented in entity-states ledger; cap K=3 (THRESHOLDS-resident) | in-review | PR #TBD (`narrativeSaturation` helper added to `packages/analysis/src/narrativeRung.ts`; consumes `THRESHOLDS.narrativeRung.dismissDecay` + `maxDismissals` + `actionBanner.knowledgeDebtRepromotionGrowthMultiplier`) |
 | D2 | Per-Narrative re-promotion-penalty prior += `narrativeRung.repromotionPenalty` on each dismissal | pending | |
 | D3 | Audit-table view in the viewer surfacing dismissal count per item | pending | |
 | D4 | Shelved-permanently affordance + explicit "show shelved" UI toggle | pending | |

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -296,8 +296,10 @@ export {
 export {
   computeConfidence,
   effectivePriorForKernel,
+  narrativeSaturation,
   narrativeTier,
   type EffectivePriorOptions,
+  type NarrativeSaturation,
 } from './narrativeRung.js';
 
 export {

--- a/packages/analysis/src/narrativeRung.test.ts
+++ b/packages/analysis/src/narrativeRung.test.ts
@@ -1,14 +1,16 @@
 // Tests for the Rev3-B B6 (computeConfidence) + B7 (effectivePrior
-// fail-safe) + narrativeTier joint-gate helper. The joint-gate
-// feasibility constants come from `THRESHOLDS.narrativeRung` (pinned
-// in PR #58); these tests freeze the contract so a future calibration
-// edit can't silently invalidate the documented feasibility proof.
+// fail-safe) + narrativeTier joint-gate helper + Rev3-D D1 saturation
+// rule. The joint-gate feasibility constants come from
+// `THRESHOLDS.narrativeRung` (pinned in PR #58); these tests freeze
+// the contract so a future calibration edit can't silently invalidate
+// the documented feasibility proof.
 
 import { describe, it, expect } from 'vitest';
 
 import {
   computeConfidence,
   effectivePriorForKernel,
+  narrativeSaturation,
   narrativeTier,
 } from './narrativeRung.js';
 import { THRESHOLDS } from './thresholds.js';
@@ -183,5 +185,81 @@ describe('narrativeTier (joint-gate dispatch)', () => {
     );
     const confidence = computeConfidence(supporting, contradicting, prior);
     expect(narrativeTier(confidence, supporting, contradicting)).toBe(3);
+  });
+});
+
+describe('narrativeSaturation (D1 — Closure B saturation rule)', () => {
+  const r = THRESHOLDS.narrativeRung;
+  const base = THRESHOLDS.actionBanner.knowledgeDebtRepromotionGrowthMultiplier;
+
+  it('dismissalCount=0 returns the base multiplier and is not shelved', () => {
+    const s = narrativeSaturation(0);
+    expect(s.multiplier).toBe(base);
+    expect(s.shelved).toBe(false);
+    expect(s.dismissalsConsumed).toBe(0);
+    expect(s.cap).toBe(r.maxDismissals);
+  });
+
+  it('each dismissal multiplies the bar by dismissDecay', () => {
+    // The doubling sequence the THRESHOLDS comment documents:
+    // 0 dismissals → base; 1 → base×decay; 2 → base×decay²; etc.
+    for (let k = 0; k < r.maxDismissals; k += 1) {
+      const expected = base * Math.pow(r.dismissDecay, k);
+      const s = narrativeSaturation(k);
+      expect(s.multiplier).toBeCloseTo(expected, 9);
+      expect(s.shelved).toBe(false);
+      expect(s.dismissalsConsumed).toBe(k);
+    }
+  });
+
+  it('reaching maxDismissals shelves the entity (multiplier=null)', () => {
+    const s = narrativeSaturation(r.maxDismissals);
+    expect(s.shelved).toBe(true);
+    expect(s.multiplier).toBeNull();
+    expect(s.dismissalsConsumed).toBe(r.maxDismissals);
+  });
+
+  it('dismissalCount above the cap clamps to maxDismissals + stays shelved', () => {
+    const s = narrativeSaturation(r.maxDismissals + 5);
+    expect(s.shelved).toBe(true);
+    expect(s.multiplier).toBeNull();
+    expect(s.dismissalsConsumed).toBe(r.maxDismissals);
+  });
+
+  it('floors fractional dismissalCount before comparison', () => {
+    // A ledger row corrupted by an off-spec writer that stored a
+    // fractional counter should not silently shelve early.
+    const fractionalJustUnderCap = r.maxDismissals - 0.1;
+    const s = narrativeSaturation(fractionalJustUnderCap);
+    expect(s.shelved).toBe(false);
+    expect(s.dismissalsConsumed).toBe(Math.floor(fractionalJustUnderCap));
+    expect(s.multiplier).toBeCloseTo(
+      base * Math.pow(r.dismissDecay, s.dismissalsConsumed),
+      9,
+    );
+  });
+
+  it('negative / non-finite dismissalCount collapses to baseline (defensive)', () => {
+    for (const bad of [-1, -100, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const s = narrativeSaturation(bad);
+      expect(s.multiplier).toBe(base);
+      expect(s.shelved).toBe(false);
+      expect(s.dismissalsConsumed).toBe(0);
+    }
+  });
+
+  it('THRESHOLDS contract — saturation values are tunable but the shape is locked', () => {
+    // dismissDecay must be > 1 (otherwise the bar never increases —
+    // confirms the same invariant the THRESHOLDS test asserts, but
+    // from the saturation kernel's perspective).
+    expect(r.dismissDecay).toBeGreaterThan(1);
+    // maxDismissals must be a positive integer (the saturation rule
+    // would silently always-shelve at 0).
+    expect(Number.isInteger(r.maxDismissals) && r.maxDismissals > 0).toBe(
+      true,
+    );
+    // The base growth multiplier must be > 1 (otherwise re-promotion
+    // would fire as soon as size hits the snapshot — no growth).
+    expect(base).toBeGreaterThan(1);
   });
 });

--- a/packages/analysis/src/narrativeRung.ts
+++ b/packages/analysis/src/narrativeRung.ts
@@ -1,7 +1,8 @@
 /**
- * Narrative confidence-ladder kernel (Phase Rev3-B sub-tasks B6 + B7).
+ * Narrative confidence-ladder + saturation kernel (Phase Rev3-B sub-
+ * tasks B6 + B7; Phase Rev3-D sub-task D1).
  *
- * Three pure helpers + their backing types:
+ * Four pure helpers + their backing types:
  *
  *   - `computeConfidence(supporting, contradicting, prior)` — B6.
  *     The Bayesian Beta-posterior-mean form pinned by
@@ -22,6 +23,14 @@
  *     gate per `THRESHOLDS.narrativeRung`. Returns the highest tier
  *     (0–3) whose floor AND supporting-count AND contradicting-cap
  *     gates are all satisfied. Tier 0 = "not surface-able."
+ *
+ *   - `narrativeSaturation(dismissalCount)` — D1. Maps the
+ *     `entity_states.dismissal_count` counter (Rev3-C C4) to the
+ *     effective re-promotion growth multiplier + shelved flag. Each
+ *     dismissal multiplies the base re-promotion bar by
+ *     `THRESHOLDS.narrativeRung.dismissDecay`; once dismissals reach
+ *     `maxDismissals` the entity is permanently shelved (visible only
+ *     via the Rev3-D D4 "show shelved" affordance).
  *
  * Pure, browser-safe. The viewer + curator-feed + Closure-B/C wirings
  * all consume these directly.
@@ -147,4 +156,95 @@ export function narrativeTier(
     return 1;
   }
   return 0;
+}
+
+/**
+ * D1 saturation result. The viewer and curator both consume this when
+ * deciding (a) whether a DISMISSED entity is still re-promotable and
+ * (b) what bar the current evidence size must clear to re-emerge.
+ */
+export interface NarrativeSaturation {
+  /**
+   * Effective re-promotion growth multiplier. The number the current
+   * evidence count must clear, relative to the size-at-last-dismissal
+   * snapshot persisted in `entity_states.size_at_state`. `null` when
+   * `shelved` is true — the bar is infinite by policy.
+   */
+  readonly multiplier: number | null;
+  /**
+   * `true` once the entity has been dismissed `maxDismissals` times.
+   * Shelved entities are visible only via the Rev3-D D4 "show shelved"
+   * affordance — they no longer re-emerge from growth alone.
+   */
+  readonly shelved: boolean;
+  /**
+   * Dismissals consumed so far, clamped to `[0, maxDismissals]`. Lets
+   * the audit table (D3) render "N/cap" without re-reading THRESHOLDS.
+   */
+  readonly dismissalsConsumed: number;
+  /**
+   * The cap pulled from THRESHOLDS. Same rationale as above — keeps
+   * callers free of a second THRESHOLDS import for display purposes.
+   */
+  readonly cap: number;
+}
+
+/**
+ * D1 saturation rule. Given the `dismissal_count` counter persisted by
+ * the SQLite SDK (Rev3-C C4), return the effective re-promotion
+ * growth multiplier the live evidence count must clear to bring the
+ * entity back from DISMISSED.
+ *
+ * Formula (all values from THRESHOLDS):
+ *
+ *     multiplier = baseGrowth × (dismissDecay ^ dismissalCount)
+ *
+ * where `baseGrowth =
+ * THRESHOLDS.actionBanner.knowledgeDebtRepromotionGrowthMultiplier`
+ * (the same constant the C5 round-trip test exercises for the
+ * `dismissalCount=0` baseline) and `dismissDecay =
+ * THRESHOLDS.narrativeRung.dismissDecay`. The doubling is documented
+ * in the THRESHOLDS comment block — each successive dismissal
+ * compounds the bar so a persistently-rejected narrative isn't a
+ * notifier nag.
+ *
+ * Edge cases:
+ *
+ *   - `dismissalCount` non-finite / negative → treated as 0
+ *     (fresh-state baseline; never throws so the viewer's render path
+ *     can't crash on a corrupt ledger row).
+ *   - `dismissalCount >= maxDismissals` → `shelved: true`, `multiplier:
+ *     null`. The viewer hides the entity from the active pile until
+ *     the D4 "show shelved" toggle is on.
+ *   - `dismissalCount` between (maxDismissals - 1, maxDismissals)
+ *     (fractional via persisted JSON) is `floor`'d before comparison,
+ *     so 2.9 dismissals counts as 2 (not yet shelved).
+ *
+ * The function is the single point of truth for re-promotion bar
+ * computation; UI callers MUST NOT inline `Math.pow(decay, count)`.
+ */
+export function narrativeSaturation(
+  dismissalCount: number,
+): NarrativeSaturation {
+  const r = THRESHOLDS.narrativeRung;
+  const base = THRESHOLDS.actionBanner.knowledgeDebtRepromotionGrowthMultiplier;
+  const safeCount =
+    !Number.isFinite(dismissalCount) || dismissalCount < 0
+      ? 0
+      : Math.floor(dismissalCount);
+  const consumed = Math.min(safeCount, r.maxDismissals);
+  if (consumed >= r.maxDismissals) {
+    return {
+      multiplier: null,
+      shelved: true,
+      dismissalsConsumed: consumed,
+      cap: r.maxDismissals,
+    };
+  }
+  return {
+    multiplier: base * Math.pow(r.dismissDecay, consumed),
+    shelved: false,
+    dismissalsConsumed: consumed,
+    cap: r.maxDismissals,
+  };
 }


### PR DESCRIPTION
## Summary

Phase Rev3-D sub-task D1. Adds `narrativeSaturation(dismissalCount)` to `packages/analysis/src/narrativeRung.ts` — the per-Narrative growth-multiplier escalation that closes the iter-1 unbounded re-promotion nag.

Pure helper that maps the `entity_states.dismissal_count` counter (persisted by the C4 SQLite SDK) to the effective re-promotion bar a live evidence count must clear to bring a DISMISSED entity back. Each dismissal compounds the bar by `THRESHOLDS.narrativeRung.dismissDecay`; reaching `maxDismissals` shelves the entity permanently (visible only via the D4 "show shelved" affordance still to ship).

Formula (all values from THRESHOLDS):

    multiplier = baseGrowth × (dismissDecay ^ dismissalCount)

With defaults (base=2, decay=2): ×2 / ×4 / ×8 / ×16 sequence for dismissals 0/1/2/3.

## Files

- `packages/analysis/src/narrativeRung.ts` — `narrativeSaturation` + `NarrativeSaturation` interface, plus doc-block update.
- `packages/analysis/src/narrativeRung.test.ts` — 7-test suite (baseline, escalation walk, shelving threshold, clamping, fractional-floor, defensive-input, THRESHOLDS-shape contract).
- `packages/analysis/src/index.ts` — re-export from the package barrel.
- `_planning/chat-arch-v2-rev3-progress.md` — flip C5 → complete-and-merged (PR #74), D1 → in-review.

## Plan / THRESHOLDS alignment note (for reviewer)

Plan §Phase Rev3-D says "Saturation rule (×2/×4/×8 cap K=3)". The current `THRESHOLDS.narrativeRung.maxDismissals` default is **4**, so the active sequence is ×2/×4/×8/×16 with shelving on the 4th dismissal. The kernel consumes THRESHOLDS faithfully — left for the user to decide whether to flip the default to 3 in a follow-up.

## Local gates

- [x] `pnpm lint` — clean (0 errors)
- [x] `pnpm test` — 1671 passing, 4 skipped (pre-existing integration-live)
- [x] `pnpm build` — all workspaces succeed

## Phase-D dependencies unlocked

D2 (re-promotion-penalty prior bump), D3 (audit table), D4 (shelved affordance), and D5 (gate test) all consume this kernel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)