### PR TITLE
feat(rev3-d): per-narrative audit affordance (D3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,34 @@ on-disk shape with this changelog.
 
 ### Added
 
+- **Per-narrative audit affordance (Phase Rev3-D D3).** New
+  `NarrativeAudit` subcomponent in
+  `packages/viewer/src/components/modes/ProjectsMode.tsx` renders an
+  audit row inside every Narrative card showing:
+  - `N / cap` dismissal count from `entity_states.dismissal_count`.
+  - The effective re-promotion threshold ("re-emerges at ≥X
+    evidence (now: Y)") for DISMISSED entries, computed via the
+    D1-era `narrativeSaturation` helper.
+  - A `SHELVED` sentinel for cap-reached entries (D4 will add the
+    "show shelved" toggle to filter the cards from the active list).
+  - A DISMISS button that posts to `/api/entity-states` and bumps
+    the local-state counter optimistically (server-side counter is
+    canonical; the client mirrors per-transition).
+
+  Wired via a new `dataDirBaseUrl` prop on `ProjectsMode` →
+  `ProjectDetail`, defaulting to the standalone data root. The
+  detail surface loads the entity-states ledger once on mount and
+  passes each card its per-narrative audit slice.
+
+  Tests in `packages/viewer/src/components/modes/ProjectsMode.test.tsx`:
+  default counts when no ledger entry exists, DISMISSED rendering
+  with threshold display, SHELVED sentinel for at-cap, plus
+  click-DISMISS-then-assert-fetch + the standard a11y label shape.
+
+  Closure-B saturation is now visible in the UI — the user can see
+  exactly how close a narrative is to permanent shelving and what
+  evidence growth would re-emerge it. D4 + D5 complete the phase.
+
 - **Phase Rev3-C complete (C5 round-trip gate test).** New integration
   test `apps/standalone/test/integration/narrative-entity-state-round-trip.test.ts`
   exercises the full ledger pipeline on a narrative: validate POST body

--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -81,8 +81,8 @@ Plan anchor: [§Phase Rev3-D](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 | # | Sub-task | Status | PR / notes |
 |---|---|---|---|
 | D1 | Saturation rule (×2/×4/×8) implemented in entity-states ledger; cap K=3 (THRESHOLDS-resident) | complete-and-merged | PR #75 (`narrativeSaturation` helper in `packages/analysis/src/narrativeRung.ts`; consumes `THRESHOLDS.narrativeRung.dismissDecay` + `maxDismissals` + `actionBanner.knowledgeDebtRepromotionGrowthMultiplier`) |
-| D2 | Per-Narrative re-promotion-penalty prior += `narrativeRung.repromotionPenalty` on each dismissal | in-review | PR #76 (`narrativePriorPenalty` helper in `packages/analysis/src/narrativeRung.ts` — composes additively with `effectivePriorForKernel`) |
-| D3 | Audit-table view in the viewer surfacing dismissal count per item | pending | |
+| D2 | Per-Narrative re-promotion-penalty prior += `narrativeRung.repromotionPenalty` on each dismissal | complete-and-merged | PR #76 (`narrativePriorPenalty` helper in `packages/analysis/src/narrativeRung.ts` — composes additively with `effectivePriorForKernel`) |
+| D3 | Audit-table view in the viewer surfacing dismissal count per item | in-review | PR #TBD (`NarrativeAudit` row in `packages/viewer/src/components/modes/ProjectsMode.tsx` — surfaces dismissal count + re-promotion threshold; DISMISS button posts to `/api/entity-states`) |
 | D4 | Shelved-permanently affordance + explicit "show shelved" UI toggle | pending | |
 | D5 | Tests: cap-K behavior + family-wise α inflation documented in methodology disclosure | pending | Gate |
 

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -2974,6 +2974,7 @@ export function ChatArchViewer({
                         narratives={effectiveV2Entities.narratives ?? []}
                         sessions={activeManifest.sessions}
                         selectedProjectId={selectedProjectId}
+                        dataDirBaseUrl={dataRoot}
                         onSelectProject={(id) => {
                           setSelectedProjectId(id);
                           if (typeof window !== 'undefined') {

--- a/packages/viewer/src/components/modes/InsightsMode.tsx
+++ b/packages/viewer/src/components/modes/InsightsMode.tsx
@@ -196,6 +196,19 @@ export function InsightsMode({
         if (!r.ok) return;
         setClusterStates((prev) => {
           const next = new Map(prev);
+          // Prefer the server-returned canonical row when present (C4
+          // SDK is authoritative). Mirrors the same prefer-server
+          // pattern in ProjectsMode's `onNarrativeStateChange` —
+          // keeping the two surfaces consistent. Falls back to the
+          // payload echo only if the server omits `entry` (older
+          // server, partial deploy).
+          if (r.entry !== undefined) {
+            next.set(clusterId, {
+              state: r.entry.state,
+              sizeAtState: r.entry.sizeAtState,
+            });
+            return next;
+          }
           next.set(clusterId, { state, sizeAtState: currentSize });
           return next;
         });

--- a/packages/viewer/src/components/modes/ProjectsMode.test.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.test.tsx
@@ -300,4 +300,100 @@ describe('ProjectsMode narrative audit (Rev3-D D3)', () => {
     expect(screen.getByText(/re-emerges at/i)).toBeTruthy();
     expect(script.recordedPosts.length).toBe(1);
   });
+
+  it('prefers the server-returned dismissalCount over the local approximation', async () => {
+    // Reviewer finding (D3 iter-1): the C4 SDK is authoritative — its
+    // `upsertEntityState` runs the read-old + compute-counter + write
+    // sequence inside a single BEGIN IMMEDIATE, so its `dismissalCount`
+    // reflects any prior state we may not have known about (sibling
+    // tab dismissed first, legacy migrator seeded a count, etc.).
+    // This test pins that the client honors `r.entry.dismissalCount`
+    // when present rather than blindly applying the local
+    // PENDING→DISMISSED-bumps-by-one heuristic.
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    // Override the POST response to return an entry with
+    // dismissalCount=2 — the local heuristic would compute 1 (no
+    // prior entry → 0 + 1), so the assertion below proves the
+    // server's value wins.
+    const script: FetchScript = {
+      responses: new Map<string, unknown>([
+        [
+          '/api/entity-states',
+          { ok: true, available: true, entries: [] },
+        ],
+      ]),
+      recordedPosts: [],
+    };
+    vi.spyOn(globalThis, 'fetch').mockImplementation((async (
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+      if (method === 'POST') {
+        let body: unknown = init?.body;
+        if (typeof body === 'string') {
+          try {
+            body = JSON.parse(body);
+          } catch {
+            /* leave raw */
+          }
+        }
+        script.recordedPosts.push({ url, body });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            entry: {
+              entityKind: 'narrative',
+              entityId: 'n1',
+              state: 'DISMISSED',
+              updatedAt: 1000,
+              sizeAtState: 4,
+              dismissalCount: 2, // server's canonical count
+            },
+          }),
+          text: async () => '',
+        } as Response;
+      }
+      // GET: empty ledger.
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, available: true, entries: [] }),
+        text: async () => '',
+      } as Response;
+    }) as unknown as typeof fetch);
+
+    const proj = project('p1', ['n1']);
+    render(
+      <ProjectsMode
+        projects={[proj]}
+        topics={[]}
+        narratives={[narrative('n1', 4)]}
+        sessions={[session('p1-s0')]}
+        selectedProjectId="p1"
+        onSelectProject={() => {}}
+        onSelectSession={() => {}}
+        dataDirBaseUrl="/test-data"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /dismiss this narrative/i }),
+      ).toBeTruthy();
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /dismiss this narrative/i }),
+    );
+    await waitFor(() => {
+      // The server returned dismissalCount=2 — the UI must reflect THAT,
+      // not the local heuristic's 1.
+      expect(
+        screen.getByText(new RegExp(`2/${cap} dismissals`)),
+      ).toBeTruthy();
+    });
+  });
 });

--- a/packages/viewer/src/components/modes/ProjectsMode.test.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.test.tsx
@@ -1,0 +1,303 @@
+// Tests for the Phase Rev3-D D3 narrative audit affordance in
+// ProjectsMode's detail view. Verifies the dismiss button posts to
+// the entity-states endpoint, the audit row renders dismissal counts
+// using the production `narrativeSaturation` helper, and the shelved
+// regime hides the DISMISS button (D4 will add the corresponding
+// "show shelved" toggle that filters the card out entirely).
+//
+// The component-mode tests in this repo (InsightsMode.test.tsx,
+// DecisionsMode.test.tsx, etc.) all use React Testing Library +
+// vitest with global-fetch stubbing. We follow the same shape so the
+// audit affordance integrates with the existing test infrastructure.
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from '@testing-library/react';
+import type {
+  UnifiedSessionEntry,
+  Project,
+  Narrative,
+} from '@chat-arch/schema';
+import { THRESHOLDS } from '@chat-arch/analysis';
+import { ProjectsMode } from './ProjectsMode.js';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function project(id: string, narrativeIds: readonly string[]): Project {
+  return {
+    id,
+    displayName: `Project ${id}`,
+    discoveredAt: '2026-01-01T00:00:00Z',
+    lastActivityAt: '2026-01-02T00:00:00Z',
+    sentiment: 'positive',
+    source: 'cli-cwd',
+    sessionIds: [],
+    topicIds: [],
+    narrativeIds,
+    digestPath: null,
+  };
+}
+
+function narrative(
+  id: string,
+  evidenceCount: number,
+  overrides: Partial<Narrative> = {},
+): Narrative {
+  return {
+    id,
+    projectId: 'p1',
+    sentiment: 'positive',
+    actionType: 'encode-as-pattern',
+    title: `Title for ${id}`,
+    body: `Body for ${id}`,
+    generatedAt: '2026-01-02T00:00:00Z',
+    evidence: Array.from({ length: evidenceCount }, (_, i) => ({
+      sessionId: `${id}-s${i}`,
+      sessionSource: 'cli-direct',
+      excerpt: `excerpt ${i}`,
+    })),
+    schemaVersion: 1,
+    ...overrides,
+  };
+}
+
+function session(id: string): UnifiedSessionEntry {
+  return {
+    id,
+    title: `Session ${id}`,
+    rawSessionId: id,
+    source: 'cli-direct',
+    startedAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_000_000,
+    durationMs: 0,
+    workflow: { kind: 'unknown' },
+    messageCount: 1,
+    sentiment: 'neutral',
+    titleSource: 'first-prompt',
+  };
+}
+
+interface FetchScript {
+  // Map of (URL-suffix substring) → response body.
+  readonly responses: ReadonlyMap<string, unknown>;
+  readonly recordedPosts: { url: string; body: unknown }[];
+}
+
+function installFetchStub(script: FetchScript): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: unknown, init?: { method?: string; body?: unknown }) => {
+      const url = typeof input === 'string' ? input : String(input);
+      const method = init?.method ?? 'GET';
+      if (method === 'POST') {
+        let body: unknown = init?.body;
+        if (typeof body === 'string') {
+          try {
+            body = JSON.parse(body);
+          } catch {
+            // leave raw
+          }
+        }
+        script.recordedPosts.push({ url, body });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ ok: true }),
+          text: async () => '',
+        } as Response;
+      }
+      for (const [suffix, payload] of script.responses) {
+        if (url.includes(suffix)) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => payload,
+            text: async () => JSON.stringify(payload),
+          } as Response;
+        }
+      }
+      return {
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+        text: async () => '',
+      } as Response;
+    }),
+  );
+}
+
+function renderDetail(
+  options: {
+    narratives: readonly Narrative[];
+    entityStates?: readonly {
+      entityKind: string;
+      entityId: string;
+      state: string;
+      updatedAt: number;
+      sizeAtState: number;
+      dismissalCount?: number;
+    }[];
+  } & { fetchScript?: FetchScript },
+): FetchScript {
+  const script: FetchScript = options.fetchScript ?? {
+    responses: new Map<string, unknown>([
+      [
+        '/api/entity-states',
+        {
+          ok: true,
+          available: true,
+          entries: options.entityStates ?? [],
+        },
+      ],
+    ]),
+    recordedPosts: [],
+  };
+  installFetchStub(script);
+
+  const proj = project(
+    'p1',
+    options.narratives.map((n) => n.id),
+  );
+  render(
+    <ProjectsMode
+      projects={[proj]}
+      topics={[]}
+      narratives={options.narratives}
+      sessions={[session('p1-s0')]}
+      selectedProjectId="p1"
+      onSelectProject={() => {}}
+      onSelectSession={() => {}}
+      dataDirBaseUrl="/test-data"
+    />,
+  );
+  return script;
+}
+
+describe('ProjectsMode narrative audit (Rev3-D D3)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the audit row with default counts when no ledger entry exists', async () => {
+    renderDetail({ narratives: [narrative('n1', 3)] });
+    // Default state: 0/cap dismissals + no re-emerges-at line + a
+    // DISMISS button visible.
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    await waitFor(() => {
+      expect(
+        screen.getByText(new RegExp(`0/${cap} dismissals`)),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByText(/re-emerges at/i)).toBeNull();
+    expect(screen.getByRole('button', { name: /dismiss this narrative/i })).toBeTruthy();
+  });
+
+  it('shows the re-promotion threshold when state is DISMISSED', async () => {
+    renderDetail({
+      narratives: [narrative('n1', 5)],
+      entityStates: [
+        {
+          entityKind: 'narrative',
+          entityId: 'n1',
+          state: 'DISMISSED',
+          updatedAt: 1_700_000_000_000,
+          sizeAtState: 3,
+          dismissalCount: 1,
+        },
+      ],
+    });
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    // After 1 dismissal: base × decay (default 2 × 2 = 4).
+    // sizeAtState=3 → re-emerges at ≥ 3 × 4 = 12 evidence.
+    await waitFor(() => {
+      expect(
+        screen.getByText(new RegExp(`1/${cap} dismissals`)),
+      ).toBeTruthy();
+    });
+    expect(screen.getByText(/re-emerges at ≥12 evidence/i)).toBeTruthy();
+    // While DISMISSED, the DISMISS button doesn't render — re-promotion
+    // happens via evidence growth, not a re-click.
+    expect(
+      screen.queryByRole('button', { name: /dismiss this narrative/i }),
+    ).toBeNull();
+  });
+
+  it('hides the DISMISS button and shows SHELVED in the shelved regime', async () => {
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    renderDetail({
+      narratives: [narrative('n1', 2)],
+      entityStates: [
+        {
+          entityKind: 'narrative',
+          entityId: 'n1',
+          state: 'DISMISSED',
+          updatedAt: 1_700_000_000_000,
+          sizeAtState: 2,
+          // At-cap dismissals → narrativeSaturation returns shelved.
+          dismissalCount: cap,
+        },
+      ],
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/SHELVED/)).toBeTruthy();
+    });
+    expect(
+      screen.queryByRole('button', { name: /dismiss this narrative/i }),
+    ).toBeNull();
+  });
+
+  it('POSTs DISMISSED + current evidence count when DISMISS is clicked', async () => {
+    const script = renderDetail({ narratives: [narrative('n1', 4)] });
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /dismiss this narrative/i }),
+      ).toBeTruthy();
+    });
+    const button = screen.getByRole('button', {
+      name: /dismiss this narrative/i,
+    });
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(script.recordedPosts.length).toBeGreaterThan(0);
+    });
+    const post = script.recordedPosts[0]!;
+    expect(post.url).toContain('/api/entity-states');
+    expect(post.body).toMatchObject({
+      entityKind: 'narrative',
+      entityId: 'n1',
+      state: 'DISMISSED',
+      sizeAtState: 4,
+    });
+  });
+
+  it('bumps the local dismissalCount optimistically on a successful dismiss', async () => {
+    const script = renderDetail({ narratives: [narrative('n1', 4)] });
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /dismiss this narrative/i }),
+      ).toBeTruthy();
+    });
+    const button = screen.getByRole('button', {
+      name: /dismiss this narrative/i,
+    });
+    fireEvent.click(button);
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    await waitFor(() => {
+      // After the optimistic local update we should see 1/cap.
+      expect(
+        screen.getByText(new RegExp(`1/${cap} dismissals`)),
+      ).toBeTruthy();
+    });
+    // And the re-emerges-at line appears (state is now DISMISSED locally).
+    expect(screen.getByText(/re-emerges at/i)).toBeTruthy();
+    expect(script.recordedPosts.length).toBe(1);
+  });
+});

--- a/packages/viewer/src/components/modes/ProjectsMode.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.tsx
@@ -335,10 +335,22 @@ function ProjectDetail({
         if (!r.ok) return;
         setNarrativeStates((prev) => {
           const next = new Map(prev);
-          // Server returns the canonical row including the bumped
-          // dismissalCount; if the response shape lands first, prefer it.
-          // Otherwise approximate locally: bump only on the
-          // PENDING/INSTALLED → DISMISSED transition.
+          // Prefer the server-returned canonical row when present
+          // (C4 SDK is authoritative — its `upsertEntityState` runs
+          // the read-old + compute-counter + write sequence inside a
+          // single BEGIN IMMEDIATE, so its `dismissalCount` reflects
+          // any prior state we may not have known about, e.g. a sibling
+          // tab dismissed first or the legacy migrator seeded a count).
+          // Fall back to local approximation only if the response
+          // didn't carry `entry` (older server, partial deploy).
+          if (r.entry !== undefined) {
+            next.set(narrativeId, {
+              state: r.entry.state,
+              sizeAtState: r.entry.sizeAtState,
+              dismissalCount: r.entry.dismissalCount ?? 0,
+            });
+            return next;
+          }
           const prior = prev.get(narrativeId);
           const wasDismissed = prior?.state === 'DISMISSED';
           const becomeDismissed = state === 'DISMISSED';
@@ -669,13 +681,11 @@ function NarrativeAudit({
   return (
     <div
       className="lcars-narrative-card__audit"
-      // Screen readers should hear "audit" framing before the counts
-      // so the numbers have context (otherwise "1 of 4" is unclear).
-      aria-label={
-        saturation.shelved
-          ? `audit — shelved after ${saturation.dismissalsConsumed} dismissals (cap ${saturation.cap})`
-          : `audit — ${saturation.dismissalsConsumed} of ${saturation.cap} dismissals`
-      }
+      // Wrapper omits aria-label so the screen reader doesn't announce
+      // dismissal counts three times (wrapper → visible counts text →
+      // button label). The "AUDIT" sentinel chip gives spoken context
+      // via plain text instead.
+      role="group"
     >
       <span className="lcars-narrative-card__audit-label">AUDIT</span>
       <span className="lcars-narrative-card__audit-counts">

--- a/packages/viewer/src/components/modes/ProjectsMode.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.tsx
@@ -7,6 +7,7 @@ import type {
   ProjectSentiment,
 } from '@chat-arch/schema';
 import { isUnassignedProject } from '@chat-arch/schema';
+import { narrativeSaturation } from '@chat-arch/analysis';
 import { BlurredPii } from '../BlurredPii.js';
 import { EmptyState } from '../EmptyState.js';
 import { onActivate } from '../../util/a11y.js';
@@ -20,6 +21,11 @@ import {
   probeNarrativeActionsAvailable,
   savePrompt,
 } from '../../data/narrativeActions.js';
+import {
+  loadEntityStates,
+  setEntityState,
+  type EntityStateValue,
+} from '../../data/entityStatesClient.js';
 // `buildClaudeMdMarkdown` is exported by narrativeActions and consumed
 // by the encode-pattern endpoint when a `claudeMdMarkdown` payload is
 // supplied — Phase 7 ships the endpoint + helper, while the UI flow
@@ -51,6 +57,12 @@ export interface ProjectsModeProps {
   selectedProjectId: string | null;
   onSelectProject: (id: string | null) => void;
   onSelectSession: (id: string) => void;
+  /**
+   * Rev3-D D3 — base URL for the entity-states ledger. Defaults to the
+   * standalone data root; tests override. The detail surface uses this
+   * to load per-narrative dismissal state for the audit affordance.
+   */
+  dataDirBaseUrl?: string;
 }
 
 const SENTIMENT_LABEL: Record<ProjectSentiment, string> = {
@@ -89,6 +101,7 @@ export function ProjectsMode({
   selectedProjectId,
   onSelectProject,
   onSelectSession,
+  dataDirBaseUrl = 'chat-arch-data',
 }: ProjectsModeProps) {
   const now = useMemo(() => Date.now(), []);
 
@@ -141,6 +154,7 @@ export function ProjectsMode({
         onBack={() => onSelectProject(null)}
         onSelectSession={onSelectSession}
         now={now}
+        dataDirBaseUrl={dataDirBaseUrl}
       />
     );
   }
@@ -246,6 +260,22 @@ interface ProjectDetailProps {
   onBack: () => void;
   onSelectSession: (id: string) => void;
   now: number;
+  dataDirBaseUrl: string;
+}
+
+/**
+ * Per-narrative state surfaced via the audit affordance (Rev3-D D3).
+ * `dismissalCount` defaults to 0 for any narrative the user hasn't
+ * dismissed; `state` defaults to PENDING. Snapshotted `sizeAtState`
+ * is the evidence count at the moment of dismissal — the live
+ * `narrative.evidence.length` is compared against
+ * `sizeAtState × narrativeSaturation(dismissalCount).multiplier` to
+ * decide whether re-promotion is unlocked.
+ */
+interface NarrativeAuditState {
+  readonly state: EntityStateValue;
+  readonly sizeAtState: number;
+  readonly dismissalCount: number;
 }
 
 function ProjectDetail({
@@ -256,6 +286,7 @@ function ProjectDetail({
   onBack,
   onSelectSession,
   now,
+  dataDirBaseUrl,
 }: ProjectDetailProps) {
   const projectSessions = useMemo(() => {
     const list: UnifiedSessionEntry[] = [];
@@ -266,6 +297,64 @@ function ProjectDetail({
     list.sort((a, b) => b.updatedAt - a.updatedAt);
     return list;
   }, [project.sessionIds, sessionById]);
+
+  // Rev3-D D3 — load per-narrative entity-states for the audit
+  // affordance. PENDING is the implicit default for any narrative not
+  // in the ledger. Mirrors the InsightsMode knowledge-debt pattern
+  // (PR #70, generalized to narratives in C1+C2).
+  const [narrativeStates, setNarrativeStates] = useState<
+    ReadonlyMap<string, NarrativeAuditState>
+  >(new Map());
+  useEffect(() => {
+    let cancelled = false;
+    void loadEntityStates(dataDirBaseUrl).then((file) => {
+      if (cancelled || file === null) return;
+      const m = new Map<string, NarrativeAuditState>();
+      for (const e of file.entries) {
+        if (e.entityKind !== 'narrative') continue;
+        m.set(e.entityId, {
+          state: e.state,
+          sizeAtState: e.sizeAtState,
+          dismissalCount: e.dismissalCount ?? 0,
+        });
+      }
+      setNarrativeStates(m);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [dataDirBaseUrl]);
+
+  const onNarrativeStateChange = (
+    narrativeId: string,
+    state: EntityStateValue,
+    currentSize: number,
+  ): void => {
+    void setEntityState('narrative', narrativeId, state, currentSize).then(
+      (r) => {
+        if (!r.ok) return;
+        setNarrativeStates((prev) => {
+          const next = new Map(prev);
+          // Server returns the canonical row including the bumped
+          // dismissalCount; if the response shape lands first, prefer it.
+          // Otherwise approximate locally: bump only on the
+          // PENDING/INSTALLED → DISMISSED transition.
+          const prior = prev.get(narrativeId);
+          const wasDismissed = prior?.state === 'DISMISSED';
+          const becomeDismissed = state === 'DISMISSED';
+          const dismissalCount =
+            (prior?.dismissalCount ?? 0) +
+            (becomeDismissed && !wasDismissed ? 1 : 0);
+          next.set(narrativeId, {
+            state,
+            sizeAtState: currentSize,
+            dismissalCount,
+          });
+          return next;
+        });
+      },
+    );
+  };
 
   return (
     <div className="lcars-project-detail" id={`project-${project.id}`}>
@@ -321,7 +410,12 @@ function ProjectDetail({
           <ul className="lcars-project-detail__narrative-list" role="list">
             {narratives.map((n) => (
               <li key={n.id} role="listitem">
-                <NarrativeCard narrative={n} sessionById={sessionById} />
+                <NarrativeCard
+                  narrative={n}
+                  sessionById={sessionById}
+                  auditState={narrativeStates.get(n.id) ?? null}
+                  onStateChange={onNarrativeStateChange}
+                />
               </li>
             ))}
           </ul>
@@ -350,9 +444,27 @@ function ProjectDetail({
 interface NarrativeCardProps {
   narrative: Narrative;
   sessionById: ReadonlyMap<string, UnifiedSessionEntry>;
+  /**
+   * Rev3-D D3 — current dismissal-ledger entry for this narrative.
+   * `null` = the user has not dismissed it yet (effective state is
+   * PENDING). The component renders the audit affordance regardless
+   * so the user can see "Not dismissed (0/cap)" + a DISMISS button
+   * even before the first dismissal.
+   */
+  auditState: NarrativeAuditState | null;
+  onStateChange: (
+    narrativeId: string,
+    state: EntityStateValue,
+    currentSize: number,
+  ) => void;
 }
 
-function NarrativeCard({ narrative, sessionById }: NarrativeCardProps) {
+function NarrativeCard({
+  narrative,
+  sessionById,
+  auditState,
+  onStateChange,
+}: NarrativeCardProps) {
   const isPositive = narrative.sentiment === 'positive';
   const accent = isPositive ? 'positive' : 'negative';
 
@@ -478,6 +590,11 @@ function NarrativeCard({ narrative, sessionById }: NarrativeCardProps) {
             {actionMessage}
           </p>
         )}
+        <NarrativeAudit
+          narrative={narrative}
+          auditState={auditState}
+          onStateChange={onStateChange}
+        />
         <button
           type="button"
           className="lcars-narrative-card__action"
@@ -505,5 +622,90 @@ function NarrativeCard({ narrative, sessionById }: NarrativeCardProps) {
         </button>
       </footer>
     </article>
+  );
+}
+
+interface NarrativeAuditProps {
+  narrative: Narrative;
+  auditState: NarrativeAuditState | null;
+  onStateChange: (
+    narrativeId: string,
+    state: EntityStateValue,
+    currentSize: number,
+  ) => void;
+}
+
+/**
+ * Rev3-D D3 — per-narrative audit row. Surfaces the Closure-B
+ * dismissal counter + the effective re-promotion bar so the user can
+ * see (a) how many times they've shelved this narrative, (b) what
+ * evidence-count it would have to grow to before re-emerging, and
+ * (c) a DISMISS button for the next dismissal.
+ *
+ * The displayed re-promotion bar is derived from `narrativeSaturation`
+ * (Rev3-D D1) — never inline `pow(decay, count)` here. The shelved
+ * regime (dismissalCount ≥ maxDismissals) shows the cap reached + no
+ * DISMISS button; D4 will add the "show shelved" toggle that filters
+ * the card from the list entirely.
+ */
+function NarrativeAudit({
+  narrative,
+  auditState,
+  onStateChange,
+}: NarrativeAuditProps) {
+  const dismissalCount = auditState?.dismissalCount ?? 0;
+  const saturation = narrativeSaturation(dismissalCount);
+  const currentSize = narrative.evidence.length;
+  const state: EntityStateValue = auditState?.state ?? 'PENDING';
+  const sizeAtState = auditState?.sizeAtState ?? 0;
+  const repromotionThreshold = saturation.multiplier !== null && sizeAtState > 0
+    ? sizeAtState * saturation.multiplier
+    : null;
+
+  const handleDismiss = (): void => {
+    onStateChange(narrative.id, 'DISMISSED', currentSize);
+  };
+
+  return (
+    <div
+      className="lcars-narrative-card__audit"
+      // Screen readers should hear "audit" framing before the counts
+      // so the numbers have context (otherwise "1 of 4" is unclear).
+      aria-label={
+        saturation.shelved
+          ? `audit — shelved after ${saturation.dismissalsConsumed} dismissals (cap ${saturation.cap})`
+          : `audit — ${saturation.dismissalsConsumed} of ${saturation.cap} dismissals`
+      }
+    >
+      <span className="lcars-narrative-card__audit-label">AUDIT</span>
+      <span className="lcars-narrative-card__audit-counts">
+        {saturation.dismissalsConsumed}/{saturation.cap} dismissals
+      </span>
+      {state === 'DISMISSED' && repromotionThreshold !== null && (
+        <span className="lcars-narrative-card__audit-threshold">
+          re-emerges at ≥{Math.ceil(repromotionThreshold)} evidence
+          {' '}(now: {currentSize})
+        </span>
+      )}
+      {saturation.shelved && (
+        <span
+          className="lcars-narrative-card__audit-shelved"
+          role="note"
+          aria-label="shelved permanently"
+        >
+          SHELVED
+        </span>
+      )}
+      {!saturation.shelved && state !== 'DISMISSED' && (
+        <button
+          type="button"
+          className="lcars-narrative-card__audit-dismiss"
+          aria-label={`dismiss this narrative (dismissal ${saturation.dismissalsConsumed + 1} of ${saturation.cap})`}
+          onClick={handleDismiss}
+        >
+          DISMISS
+        </button>
+      )}
+    </div>
   );
 }

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -3940,6 +3940,61 @@
   color: var(--lcars-violet);
 }
 
+/* Rev3-D D3 — per-narrative audit affordance. Surfaces the
+ * Closure-B dismissal counter, the effective re-promotion bar
+ * (computed via narrativeSaturation), the SHELVED sentinel (D1
+ * cap reached), and the DISMISS button. Visually quieter than the
+ * primary action row above so it doesn't compete for attention. */
+.lcars-narrative-card__audit {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-right: auto;
+  font-family: var(--lcars-font-chrome);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  opacity: 0.75;
+}
+.lcars-narrative-card__audit-label {
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  color: var(--lcars-ice);
+  opacity: 0.7;
+}
+.lcars-narrative-card__audit-counts {
+  font-variant-numeric: tabular-nums;
+}
+.lcars-narrative-card__audit-threshold {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.85;
+}
+.lcars-narrative-card__audit-shelved {
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  color: var(--lcars-peach);
+  padding: 1px 6px;
+  border: 1px solid currentColor;
+  border-radius: 6px;
+}
+.lcars-narrative-card__audit-dismiss {
+  font-family: var(--lcars-font-chrome);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  padding: 2px 8px;
+  border-radius: 6px;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: var(--lcars-peach);
+  cursor: pointer;
+}
+.lcars-narrative-card__audit-dismiss:hover,
+.lcars-narrative-card__audit-dismiss:focus-visible {
+  background: rgba(255, 153, 102, 0.12);
+  outline: none;
+}
+
 /* ---------------------------------------------------------------- *
  * v2 Phase 8 — TOPICS surface (spec §5.2). Mirrors the PROJECTS    *
  * surface scaffolding with a topic-flavored ice accent.             *

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -3901,7 +3901,12 @@
 }
 .lcars-narrative-card__footer {
   display: flex;
-  justify-content: flex-end;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+}
+.lcars-narrative-card__footer > .lcars-narrative-card__action {
+  align-self: flex-end;
 }
 .lcars-narrative-card__action {
   font-family: var(--lcars-font-chrome);
@@ -3950,11 +3955,14 @@
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
-  margin-right: auto;
   font-family: var(--lcars-font-chrome);
   font-size: 10px;
   letter-spacing: 0.08em;
-  opacity: 0.75;
+  /* The audit row sits inside a column-flex footer; opacity 0.85 (was
+   * 0.75) preserves visual hierarchy below the primary action while
+   * staying within WCAG AA contrast for the `--lcars-ice` text colour
+   * over the LCARS dark surface. */
+  opacity: 0.85;
 }
 .lcars-narrative-card__audit-label {
   font-weight: 700;


### PR DESCRIPTION
## Summary

Phase Rev3-D sub-task D3. First viewer-side surface to consume the D1 (`narrativeSaturation`) + D2 (`narrativePriorPenalty`) kernels merged in PRs #75 and #76. Surfaces the Closure-B dismissal counter + effective re-promotion bar on every NarrativeCard in ProjectsMode's detail view; renders a DISMISS button that posts to the existing \`/api/entity-states\` endpoint.

## What ships

- **Detail-surface integration** — \`ProjectsMode.ProjectDetail\` loads per-narrative entries from the entity-states ledger and passes them to each NarrativeCard. Mirrors the knowledge-debt audit pattern in InsightsMode (Rev3-C C1+C2).
- **\`NarrativeAudit\`** inline component — the per-card audit row. Three states:
  1. Active (PENDING) — \`N/cap dismissals\` + DISMISS button.
  2. Currently DISMISSED — \`N/cap dismissals\` + re-promotion threshold (e.g. \"re-emerges at ≥12 evidence (now: 5)\").
  3. Shelved (\`dismissalCount ≥ maxDismissals\`) — SHELVED sentinel, no DISMISS button. D4 will add the \"show shelved\" toggle.
- **Optimistic local state** — after a successful POST, the local \`dismissalCount\` bumps immediately so the card reflects the new audit state without waiting for a re-fetch.
- **CSS** — new \`.lcars-narrative-card__audit*\` classes, visually quieter than the primary action row.

## Wiring

- \`ChatArchViewer\` passes \`dataDirBaseUrl={dataRoot}\` to ProjectsMode.
- ProjectsMode gains a \`dataDirBaseUrl?: string\` prop (default \"chat-arch-data\", same as InsightsMode).

## Tests

5-test suite at \`packages/viewer/src/components/modes/ProjectsMode.test.tsx\`:

- Default audit counts (0/cap) + DISMISS button when no ledger entry exists
- Re-promotion threshold displayed when state is DISMISSED
- SHELVED sentinel + no DISMISS in shelved regime
- DISMISS click POSTs DISMISSED + current evidence count to \`/api/entity-states\`
- Optimistic dismissalCount bump on successful POST

## Visual testing note

Component was developed alongside CSS classes the user matched in \`styles.css\`. Type-checking, unit tests, and the build all pass; the natural next step is visual review in a dev server before D4 builds on this surface.

## Local gates

- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 1683 passing, 4 skipped (+5 new ProjectsMode tests)
- [x] \`pnpm build\` — all workspaces succeed

## Phase-D unlock

D4 (show-shelved toggle) extends ProjectDetail with a filter affordance. D5 (gate test + methodology disclosure) closes the phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)