### PR TITLE
feat(rev3-d): shelved-toggle + cap-K gate + methodology caveat (D4+D5) — closes Phase Rev3-D

### DIFF
--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -82,9 +82,9 @@ Plan anchor: [§Phase Rev3-D](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 |---|---|---|---|
 | D1 | Saturation rule (×2/×4/×8) implemented in entity-states ledger; cap K=3 (THRESHOLDS-resident) | complete-and-merged | PR #75 (`narrativeSaturation` helper in `packages/analysis/src/narrativeRung.ts`; consumes `THRESHOLDS.narrativeRung.dismissDecay` + `maxDismissals` + `actionBanner.knowledgeDebtRepromotionGrowthMultiplier`) |
 | D2 | Per-Narrative re-promotion-penalty prior += `narrativeRung.repromotionPenalty` on each dismissal | complete-and-merged | PR #76 (`narrativePriorPenalty` helper in `packages/analysis/src/narrativeRung.ts` — composes additively with `effectivePriorForKernel`) |
-| D3 | Audit-table view in the viewer surfacing dismissal count per item | in-review | PR #TBD (`NarrativeAudit` row in `packages/viewer/src/components/modes/ProjectsMode.tsx` — surfaces dismissal count + re-promotion threshold; DISMISS button posts to `/api/entity-states`) |
-| D4 | Shelved-permanently affordance + explicit "show shelved" UI toggle | pending | |
-| D5 | Tests: cap-K behavior + family-wise α inflation documented in methodology disclosure | pending | Gate |
+| D3 | Audit-table view in the viewer surfacing dismissal count per item | complete-and-merged | PR #77 (`NarrativeAudit` row in `packages/viewer/src/components/modes/ProjectsMode.tsx` — surfaces dismissal count + re-promotion threshold; DISMISS button posts to `/api/entity-states`; iter-1 fix column-flex footer + prefer-server-`entry` mirrored in InsightsMode) |
+| D4 | Shelved-permanently affordance + explicit "show shelved" UI toggle | in-review | PR #TBD (transient `showShelved` state + checkbox in `ProjectDetail`'s narratives header; partitions narratives via `narrativeSaturation`; safe default = OFF) |
+| D5 | Tests: cap-K behavior + family-wise α inflation documented in methodology disclosure | in-review | PR #TBD (gate test walks `dismissalCount` from cap−1 → cap and asserts shelved transition; `MethodologyDisclosure` gains family-wise correction caveat) |
 
 **Gates:** a previously-dismissed Narrative re-enters the feed only after evidence growth exceeds the multiplier; capped re-promotion attempts visible in the audit table.
 

--- a/packages/analysis/src/thresholds.test.ts
+++ b/packages/analysis/src/thresholds.test.ts
@@ -62,13 +62,9 @@ describe('THRESHOLDS.narrativeRung (Rev3 confidence ladder)', () => {
     expect(THRESHOLDS.narrativeRung.dismissDecay).toBeGreaterThan(1);
   });
 
-  it('maxDismissals + maxRepromotionAttempts are positive ints', () => {
-    const { maxDismissals, maxRepromotionAttempts, repromotionPenalty } =
-      THRESHOLDS.narrativeRung;
+  it('maxDismissals is a positive int + repromotionPenalty is non-negative', () => {
+    const { maxDismissals, repromotionPenalty } = THRESHOLDS.narrativeRung;
     expect(Number.isInteger(maxDismissals) && maxDismissals > 0).toBe(true);
-    expect(
-      Number.isInteger(maxRepromotionAttempts) && maxRepromotionAttempts > 0,
-    ).toBe(true);
     expect(repromotionPenalty).toBeGreaterThanOrEqual(0);
   });
 

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -238,9 +238,11 @@ export const THRESHOLDS = {
     /**
      * Closure B saturation: per-Narrative growth-multiplier multiplier
      * applied on each user dismissal. Default doubling per dismissal —
-     * a 2× multiplier becomes 4× after first dismissal, 8× after the
-     * second, 16× after the third. Closes the iter-1 unbounded-nag
-     * failure mode.
+     * with base × decay^dismissalCount, the multiplier sequence is
+     * ×2 (k=0 baseline), ×4 (after 1st dismissal), ×8 (after 2nd),
+     * shelve at k=3 = `maxDismissals` (matches plan §Phase Rev3-D
+     * "×2/×4/×8 cap K=3"). Closes the iter-1 unbounded-nag failure
+     * mode.
      *
      * Parallel mechanism — kept separate: knowledge-debt clusters use
      * `actionBanner.knowledgeDebtRepromotionGrowthMultiplier` (also
@@ -254,9 +256,12 @@ export const THRESHOLDS = {
     /**
      * Cap on user dismissals before a Narrative is shelved
      * permanently. After this many dismissals the item is visible
-     * only via an explicit "show shelved" affordance.
+     * only via an explicit "show shelved" affordance. K=3 per plan
+     * §Phase Rev3-D — matches the ×2/×4/×8 multiplier sequence
+     * documented above (after the K-th dismissal we'd see ×16, which
+     * the cap pre-empts by shelving instead).
      */
-    maxDismissals: 4,
+    maxDismissals: 3,
     /**
      * Closure B family-wise correction: per-Narrative prior increases
      * by this value on each dismissal. Each re-emergence is a re-test
@@ -264,11 +269,16 @@ export const THRESHOLDS = {
      * re-promotion attempts face a stiffer Bayesian threshold.
      */
     repromotionPenalty: 1,
-    /**
-     * Cap on re-promotion attempts. Document the resulting family-
-     * wise α inflation in the curator-surface methodology disclosure.
-     */
-    maxRepromotionAttempts: 3,
+    //
+    // Historical note (PR #78 review-loop): `maxRepromotionAttempts:
+    // 3` lived here as a planned-but-never-wired sibling of
+    // `maxDismissals`. It was never consumed by any kernel or UI
+    // surface — the audit row + cap-K gate test both consult
+    // `maxDismissals` because each dismissal IS a re-promotion
+    // rejection in the current model. Removed to keep the THRESHOLDS
+    // surface honest; re-add if/when a real distinction emerges
+    // (e.g. counting only post-promotion dismissals separately).
+    //
   },
   /**
    * Rev3 curator / falsifier metrics and gates. Used by the

--- a/packages/viewer/src/components/MethodologyDisclosure.tsx
+++ b/packages/viewer/src/components/MethodologyDisclosure.tsx
@@ -113,6 +113,25 @@ const CAVEATS: ReadonlyArray<{ title: string; body: ReactNode }> = [
       </>
     ),
   },
+  {
+    title: 'Family-wise correction on repeated dismissals',
+    body: (
+      <>
+        When a narrative is dismissed and later re-emerges, the
+        per-narrative prior is stiffened on each repeat (Closure-B
+        saturation). Each dismissal also compounds the growth-multiplier
+        bar evidence must clear before the narrative resurfaces. The
+        rule is the Bayesian sequential-evidence counterpart to a
+        frequentist FWER adjustment (Bonferroni / Holm) — not formally
+        equivalent (the latter adjusts a Type-I error rate; the former
+        shifts a posterior threshold) but motivated by the same intent:
+        a persistently re-emerging narrative should face a higher bar
+        each time. After cap-K dismissals the narrative is shelved
+        permanently and hidden unless the &ldquo;show shelved&rdquo;
+        toggle is on.
+      </>
+    ),
+  },
 ];
 
 export function MethodologyDisclosure() {

--- a/packages/viewer/src/components/modes/ProjectsMode.test.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.test.tsx
@@ -246,6 +246,14 @@ describe('ProjectsMode narrative audit (Rev3-D D3)', () => {
         },
       ],
     });
+    // D4 hides shelved cards by default — flip the toggle to assert
+    // the audit-row contents that show on reveal.
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/show 1 shelved narratives/i),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByLabelText(/show 1 shelved narratives/i));
     await waitFor(() => {
       expect(screen.getByText(/SHELVED/)).toBeTruthy();
     });
@@ -395,5 +403,170 @@ describe('ProjectsMode narrative audit (Rev3-D D3)', () => {
         screen.getByText(new RegExp(`2/${cap} dismissals`)),
       ).toBeTruthy();
     });
+  });
+});
+
+describe('ProjectsMode show-shelved toggle (Rev3-D D4)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('hides shelved narratives by default and surfaces a toggle showing the count', async () => {
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    renderDetail({
+      narratives: [narrative('n-active', 3), narrative('n-shelved', 3)],
+      entityStates: [
+        {
+          entityKind: 'narrative',
+          entityId: 'n-shelved',
+          state: 'DISMISSED',
+          updatedAt: 1_700_000_000_000,
+          sizeAtState: 3,
+          dismissalCount: cap,
+        },
+      ],
+    });
+    // Active narrative renders; shelved does NOT.
+    await waitFor(() => {
+      expect(screen.getByText(/Title for n-active/)).toBeTruthy();
+    });
+    expect(screen.queryByText(/Title for n-shelved/)).toBeNull();
+    // The toggle is present with the shelved count.
+    expect(
+      screen.getByLabelText(/show 1 shelved narratives/i),
+    ).toBeTruthy();
+  });
+
+  it('reveals shelved narratives when the toggle is flipped on', async () => {
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    renderDetail({
+      narratives: [narrative('n-shelved', 3)],
+      entityStates: [
+        {
+          entityKind: 'narrative',
+          entityId: 'n-shelved',
+          state: 'DISMISSED',
+          updatedAt: 1_700_000_000_000,
+          sizeAtState: 3,
+          dismissalCount: cap,
+        },
+      ],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/show 1 shelved narratives/i),
+      ).toBeTruthy();
+    });
+    // Before flip: empty-state message names the shelved scope.
+    expect(screen.getByText(/All 1 narrative is shelved/i)).toBeTruthy();
+    expect(screen.queryByText(/Title for n-shelved/)).toBeNull();
+    // Flip the toggle.
+    fireEvent.click(screen.getByLabelText(/show 1 shelved narratives/i));
+    await waitFor(() => {
+      expect(screen.getByText(/Title for n-shelved/)).toBeTruthy();
+    });
+    // The toggle's aria-label flips to "hide ..." now that it's checked.
+    expect(screen.getByLabelText(/hide 1 shelved narratives/i)).toBeTruthy();
+  });
+
+  it('omits the toggle entirely when no narratives are shelved', async () => {
+    renderDetail({ narratives: [narrative('n1', 3)] });
+    await waitFor(() => {
+      expect(screen.getByText(/Title for n1/)).toBeTruthy();
+    });
+    expect(screen.queryByLabelText(/shelved narratives/i)).toBeNull();
+  });
+});
+
+describe('ProjectsMode cap-K integration gate (Rev3-D D5)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Phase Rev3-D gate: a previously-dismissed Narrative re-enters the
+   * feed only after evidence growth exceeds the multiplier; capped
+   * re-promotion attempts visible in the audit table. This test
+   * drives the saturation kernel from end-state seeded ledger entries
+   * (mirroring what the user would observe after cap-K dismissals
+   * accumulated) and asserts the integrated viewer behavior:
+   *
+   *   - At dismissalCount=cap−1, the audit row shows the highest
+   *     pre-cap multiplier bar (×2^(cap-1) baseline ≈ ×8 with
+   *     defaults) and the card stays in the active pile.
+   *   - At dismissalCount=cap, the card hides from the active pile,
+   *     the show-shelved toggle reveals the SHELVED sentinel, and the
+   *     DISMISS button is no longer rendered (the cap is enforced).
+   *
+   * This walks the same gate the SDK-layer C5 round-trip test (PR #74)
+   * walks at the data layer — extending it through the entity-states
+   * SDK → endpoint → viewer composition.
+   */
+  it('walks dismissalCount from cap−1 to cap and asserts the shelved transition', async () => {
+    const cap = THRESHOLDS.narrativeRung.maxDismissals;
+    const base = THRESHOLDS.actionBanner.knowledgeDebtRepromotionGrowthMultiplier;
+    const decay = THRESHOLDS.narrativeRung.dismissDecay;
+
+    // Phase 1 — cap-1 dismissals: still re-promotable. Audit row
+    // shows the highest pre-cap multiplier bar.
+    cleanup();
+    renderDetail({
+      narratives: [narrative('n-cap-minus-1', 3)],
+      entityStates: [
+        {
+          entityKind: 'narrative',
+          entityId: 'n-cap-minus-1',
+          state: 'DISMISSED',
+          updatedAt: 1_700_000_000_000,
+          sizeAtState: 3,
+          dismissalCount: cap - 1,
+        },
+      ],
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText(new RegExp(`${cap - 1}/${cap} dismissals`)),
+      ).toBeTruthy();
+    });
+    // sizeAtState=3, multiplier = base × decay^(cap−1).
+    const preCapMultiplier = base * Math.pow(decay, cap - 1);
+    const preCapThreshold = Math.ceil(3 * preCapMultiplier);
+    expect(
+      screen.getByText(new RegExp(`re-emerges at ≥${preCapThreshold} evidence`)),
+    ).toBeTruthy();
+    // SHELVED sentinel must NOT appear.
+    expect(screen.queryByText(/SHELVED/)).toBeNull();
+
+    // Phase 2 — at the cap: shelved + hidden until the toggle reveals it.
+    cleanup();
+    renderDetail({
+      narratives: [narrative('n-at-cap', 3)],
+      entityStates: [
+        {
+          entityKind: 'narrative',
+          entityId: 'n-at-cap',
+          state: 'DISMISSED',
+          updatedAt: 1_700_000_000_000,
+          sizeAtState: 3,
+          dismissalCount: cap,
+        },
+      ],
+    });
+    // Default render: card hidden, toggle visible.
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/show 1 shelved narratives/i),
+      ).toBeTruthy();
+    });
+    expect(screen.queryByText(/Title for n-at-cap/)).toBeNull();
+
+    // Flip the toggle — SHELVED visible, DISMISS not rendered (cap enforced).
+    fireEvent.click(screen.getByLabelText(/show 1 shelved narratives/i));
+    await waitFor(() => {
+      expect(screen.getByText(/SHELVED/)).toBeTruthy();
+    });
+    expect(
+      screen.queryByRole('button', { name: /dismiss this narrative/i }),
+    ).toBeNull();
   });
 });

--- a/packages/viewer/src/components/modes/ProjectsMode.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.tsx
@@ -368,6 +368,31 @@ function ProjectDetail({
     );
   };
 
+  // Rev3-D D4 — show-shelved toggle state. Default OFF so high-
+  // friction narratives don't keep nag-rendering across reloads; the
+  // toggle is transient (no localStorage) so an explicit reveal is
+  // bounded to the current session.
+  const [showShelved, setShowShelved] = useState(false);
+
+  // Partition narratives into active (default rendering) vs shelved
+  // (hidden unless the toggle is on). Uses the saturation kernel as
+  // the single source of truth — never inline the cap comparison.
+  const { visibleNarratives, shelvedNarrativeIds } = useMemo(() => {
+    const shelvedIds = new Set<string>();
+    const visible: Narrative[] = [];
+    for (const n of narratives) {
+      const state = narrativeStates.get(n.id);
+      const sat = narrativeSaturation(state?.dismissalCount ?? 0);
+      if (sat.shelved) {
+        shelvedIds.add(n.id);
+        if (showShelved) visible.push(n);
+      } else {
+        visible.push(n);
+      }
+    }
+    return { visibleNarratives: visible, shelvedNarrativeIds: shelvedIds };
+  }, [narratives, narrativeStates, showShelved]);
+
   return (
     <div className="lcars-project-detail" id={`project-${project.id}`}>
       {/*
@@ -412,15 +437,46 @@ function ProjectDetail({
         className="lcars-project-detail__narratives"
         aria-label="discovered narratives"
       >
-        <h3 className="lcars-project-detail__section-title">NARRATIVES</h3>
-        {narratives.length === 0 ? (
+        <div className="lcars-project-detail__narratives-header">
+          <h3 className="lcars-project-detail__section-title">NARRATIVES</h3>
+          {/*
+            Rev3-D D4 — show-shelved toggle. Narratives whose
+            `dismissalCount >= maxDismissals` (see narrativeSaturation)
+            are hidden from the active pile by default; flipping the
+            toggle reveals them so the user can audit or re-promote.
+            Transient session-state (no localStorage) — the safe
+            default is "shelved hidden" so a high-friction narrative
+            doesn't keep reappearing across reloads.
+          */}
+          {shelvedNarrativeIds.size > 0 && (
+            <label
+              className="lcars-project-detail__shelved-toggle"
+              aria-label={
+                showShelved
+                  ? `hide ${shelvedNarrativeIds.size} shelved narratives`
+                  : `show ${shelvedNarrativeIds.size} shelved narratives`
+              }
+            >
+              <input
+                type="checkbox"
+                checked={showShelved}
+                onChange={(e) => setShowShelved(e.target.checked)}
+              />
+              <span>
+                show shelved ({shelvedNarrativeIds.size})
+              </span>
+            </label>
+          )}
+        </div>
+        {visibleNarratives.length === 0 ? (
           <p className="lcars-project-detail__empty-narratives">
-            No narratives for this project yet — narratives only emerge once a project has
-            multiple same-sentiment sessions.
+            {narratives.length === 0
+              ? 'No narratives for this project yet — narratives only emerge once a project has multiple same-sentiment sessions.'
+              : `All ${narratives.length} narrative${narratives.length === 1 ? ' is' : 's are'} shelved. Toggle "show shelved" to audit.`}
           </p>
         ) : (
           <ul className="lcars-project-detail__narrative-list" role="list">
-            {narratives.map((n) => (
+            {visibleNarratives.map((n) => (
               <li key={n.id} role="listitem">
                 <NarrativeCard
                   narrative={n}

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -3945,6 +3945,32 @@
   color: var(--lcars-violet);
 }
 
+/* Rev3-D D4 — narratives section header + show-shelved toggle. The
+ * header sits above the narrative list and holds the section title +
+ * an optional shelved-count toggle on the right. Toggle is only
+ * rendered when there's at least one shelved narrative (see
+ * `ProjectsMode.ProjectDetail` for the gating logic). */
+.lcars-project-detail__narratives-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+.lcars-project-detail__shelved-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--lcars-font-chrome);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  opacity: 0.85;
+  cursor: pointer;
+  user-select: none;
+}
+.lcars-project-detail__shelved-toggle input {
+  cursor: pointer;
+}
+
 /* Rev3-D D3 — per-narrative audit affordance. Surfaces the
  * Closure-B dismissal counter, the effective re-promotion bar
  * (computed via narrativeSaturation), the SHELVED sentinel (D1


### PR DESCRIPTION
## Summary

Closes Phase Rev3-D. Bundles D4 (show-shelved toggle) + D5 (cap-K gate test + methodology disclosure caveat). All four prior D-phase sub-tasks (D1 PR #75, D2 PR #76, D3 PR #77) merged this session — this PR closes the phase.

## D4 — show-shelved toggle

- Transient \`showShelved\` state in \`ProjectsMode.ProjectDetail\` (no localStorage; safe default = OFF). Cards whose \`narrativeSaturation(dismissalCount).shelved === true\` are hidden from the active pile by default.
- New narratives-section header with title on the left + shelved toggle on the right (only rendered when at least one shelved narrative exists).
- Empty-state copy gains an "All N narratives are shelved" variant for fully-shelved projects.

## D5 — cap-K integration gate

End-to-end test walking \`dismissalCount\` from cap−1 → cap and asserting the shelved transition:
- At cap−1: card stays in active pile; audit row shows the highest pre-cap multiplier bar (~×8 with defaults); no SHELVED sentinel.
- At cap: card hidden by default; toggle visible; flipping it reveals SHELVED + DISMISS button gone (cap enforced).

Extends the SDK-layer C5 round-trip test (PR #74) through the viewer composition.

## MethodologyDisclosure caveat

9th entry: "Family-wise correction on repeated dismissals." Explains Closure-B saturation in user-facing language with the Bayesian-sequential-vs-Bonferroni distinction surfaced during D2 review. Names the cap-K shelving + show-shelved toggle so a returning user knows where dismissed narratives go.

## Tracker delta

| Row | Status |
|---|---|
| D3 (audit-table view) | complete-and-merged (PR #77) |
| D4 (shelved affordance) | in-review (this PR) |
| D5 (cap-K gate + disclosure) | in-review (this PR) |

After this PR merges, **Phase Rev3-D is complete** and the loop continues to Rev3-E (Closure C wiring — Pattern.falsifierStatus + applied-rule outcome).

## Local gates

- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 1688 passing, 4 skipped (+5 new tests)
- [x] \`pnpm build\` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)