### PR TITLE
feat(rev3-e): encode-as-pattern falsifier-skip override (E3)

### DIFF
--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -96,9 +96,9 @@ Plan anchor: [§Phase Rev3-E](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 
 | # | Sub-task | Status | PR / notes |
 |---|---|---|---|
-| E1 | Pattern entity schema gains `falsifierStatus: 'verified' \| 'skipped-by-user' \| 'unavailable'` | in-review | PR #TBD (`Pattern.falsifierStatus` + `PatternFalsifierStatus` union + `PATTERN_FALSIFIER_STATUS_VALUES` exports in `packages/schema/src/pattern.ts`; optional for back-compat with pre-Rev3-E patterns) |
-| E2 | DB migration adding `falsifier_status` column to `patterns` table | in-review | PR #TBD (migration 004 — `falsifier_status TEXT` with CHECK constraint over the three terminal states; NULL allowed for back-compat) |
-| E3 | Encode-as-pattern flow defaults to falsifier-gating; explicit override checkbox writes `skipped-by-user` | pending | |
+| E1 | Pattern entity schema gains `falsifierStatus: 'verified' \| 'skipped-by-user' \| 'unavailable'` | complete-and-merged | PR #79 (`Pattern.falsifierStatus` + `PatternFalsifierStatus` union + `PATTERN_FALSIFIER_STATUS_VALUES` exports in `packages/schema/src/pattern.ts`; optional for back-compat with pre-Rev3-E patterns) |
+| E2 | DB migration adding `falsifier_status` column to `patterns` table | complete-and-merged | PR #79 (migration 004 — `falsifier_status TEXT` with CHECK constraint over the three terminal states; NULL allowed for back-compat) |
+| E3 | Encode-as-pattern flow defaults to falsifier-gating; explicit override checkbox writes `skipped-by-user` | in-review | PR #TBD (`buildPatternFromNarrative` accepts `falsifierOverride`; `NarrativeCard` adds positive-only checkbox + status-message variant when override fires; default OFF so the safe path remains "let Rev3-F falsifier verify later") |
 | E4 | Next-sessions watcher: triggers `RECURRING_AFTER_APPLIED` or `WATCH_INCONCLUSIVE` on N=5 / 60d / project-inactivity 30d | pending | |
 | E5 | Wall-clock timeout emits low-priority `WATCH_INCONCLUSIVE` Narrative (not silence) | pending | |
 | E6 | Tests: applied pattern visibly closes its watcher within the window; bypass path produces auditable Pattern row | pending | Gate |

--- a/packages/viewer/src/components/modes/ProjectsMode.test.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.test.tsx
@@ -478,6 +478,71 @@ describe('ProjectsMode show-shelved toggle (Rev3-D D4)', () => {
   });
 });
 
+describe('ProjectsMode falsifier-override checkbox (Rev3-E E3)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function positive(id: string): Narrative {
+    return {
+      id,
+      projectId: 'p1',
+      sentiment: 'positive',
+      actionType: 'encode-as-pattern',
+      title: `Title for ${id}`,
+      body: `Body for ${id}`,
+      generatedAt: '2026-01-02T00:00:00Z',
+      evidence: [],
+      schemaVersion: 1,
+    };
+  }
+
+  function negative(id: string): Narrative {
+    return { ...positive(id), sentiment: 'negative', actionType: 'corrective-prompt' };
+  }
+
+  it('renders the override checkbox only for positive narratives (encode path)', async () => {
+    renderDetail({ narratives: [positive('n-pos'), negative('n-neg')] });
+    await waitFor(() => {
+      expect(screen.getByText(/Title for n-pos/)).toBeTruthy();
+    });
+    // Two narratives total, but only the positive one renders the
+    // skip-falsifier checkbox.
+    const checkboxes = screen.queryAllByLabelText(
+      /skip falsifier verification when encoding/i,
+    );
+    expect(checkboxes.length).toBe(1);
+  });
+
+  it('checkbox is unchecked by default (safe falsifier-gating default)', async () => {
+    renderDetail({ narratives: [positive('n1')] });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/skip falsifier verification when encoding/i),
+      ).toBeTruthy();
+    });
+    const checkbox = screen.getByLabelText(
+      /skip falsifier verification when encoding/i,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('flipping the checkbox toggles its state for the next encode click', async () => {
+    renderDetail({ narratives: [positive('n1')] });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/skip falsifier verification when encoding/i),
+      ).toBeTruthy();
+    });
+    const checkbox = screen.getByLabelText(
+      /skip falsifier verification when encoding/i,
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+  });
+});
+
 describe('ProjectsMode cap-K integration gate (Rev3-D D5)', () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/packages/viewer/src/components/modes/ProjectsMode.tsx
+++ b/packages/viewer/src/components/modes/ProjectsMode.tsx
@@ -553,6 +553,14 @@ function NarrativeCard({
   const [actionPhase, setActionPhase] = useState<'idle' | 'running' | 'ok' | 'error'>('idle');
   const [actionMessage, setActionMessage] = useState<string | null>(null);
 
+  // Rev3-E E3 — explicit falsifier-skip override for the
+  // encode-as-pattern flow. Default OFF — the safe path is to let the
+  // future Rev3-F falsifier verify the claim before the pattern surfaces
+  // as load-bearing. Checking the box records the bypass as
+  // `falsifierStatus: 'skipped-by-user'` in the persisted Pattern so
+  // the audit table can tell why this pattern lacks verification.
+  const [falsifierOverride, setFalsifierOverride] = useState(false);
+
   const isAvailable = available !== false; // null (unknown) optimistically allows
   const actionDisabled = actionPhase === 'running' || available === false;
 
@@ -560,11 +568,15 @@ function NarrativeCard({
     setActionPhase('running');
     setActionMessage(null);
     try {
-      const pattern = buildPatternFromNarrative(narrative, false);
+      const pattern = buildPatternFromNarrative(narrative, false, {
+        falsifierOverride,
+      });
       const result = await encodePattern(pattern);
       setActionPhase('ok');
       setActionMessage(
-        `Saved pattern (${result.patternsCount} total) to ${result.sidecarPath}.`,
+        falsifierOverride
+          ? `Saved pattern (${result.patternsCount} total) to ${result.sidecarPath} — falsifier skipped per override.`
+          : `Saved pattern (${result.patternsCount} total) to ${result.sidecarPath}.`,
       );
     } catch (err) {
       setActionPhase('error');
@@ -663,6 +675,23 @@ function NarrativeCard({
           auditState={auditState}
           onStateChange={onStateChange}
         />
+        {isPositive && (
+          // Rev3-E E3 — explicit override for the future falsifier
+          // check. Only renders for positive narratives (the
+          // encode-as-pattern path). The negative path goes to
+          // GENERATE CORRECTIVE PROMPT which doesn't produce a
+          // Pattern row, so the override doesn't apply.
+          <label className="lcars-narrative-card__falsifier-skip">
+            <input
+              type="checkbox"
+              checked={falsifierOverride}
+              onChange={(e) => setFalsifierOverride(e.target.checked)}
+              disabled={actionDisabled}
+              aria-label="skip falsifier verification when encoding"
+            />
+            <span>skip falsifier (record as skipped-by-user)</span>
+          </label>
+        )}
         <button
           type="button"
           className="lcars-narrative-card__action"

--- a/packages/viewer/src/data/narrativeActions.test.ts
+++ b/packages/viewer/src/data/narrativeActions.test.ts
@@ -1,0 +1,64 @@
+// Tests for narrativeActions builders (Rev3-E E3 surface). Focused
+// on `buildPatternFromNarrative`'s falsifierOverride wiring — the
+// HTTP-side `encodePattern` lives behind a fetch boundary and is
+// exercised by the integration tests in apps/standalone.
+
+import { describe, it, expect } from 'vitest';
+import type { Narrative } from '@chat-arch/schema';
+import { buildPatternFromNarrative } from './narrativeActions.js';
+
+function narrative(): Narrative {
+  return {
+    id: 'narr-1',
+    projectId: 'proj-1',
+    sentiment: 'positive',
+    actionType: 'encode-as-pattern',
+    title: 'Always run tests',
+    body: 'Run `pnpm test` before merging.',
+    generatedAt: '2026-01-02T00:00:00Z',
+    evidence: [],
+    schemaVersion: 1,
+  };
+}
+
+describe('buildPatternFromNarrative — Rev3-E E3 falsifierOverride', () => {
+  it('omits falsifierStatus by default (no override flag)', () => {
+    const p = buildPatternFromNarrative(narrative(), false);
+    expect(p.falsifierStatus).toBeUndefined();
+  });
+
+  it('omits falsifierStatus when falsifierOverride is false', () => {
+    const p = buildPatternFromNarrative(narrative(), false, {
+      falsifierOverride: false,
+    });
+    expect(p.falsifierStatus).toBeUndefined();
+  });
+
+  it('sets falsifierStatus="skipped-by-user" when falsifierOverride is true', () => {
+    const p = buildPatternFromNarrative(narrative(), true, {
+      falsifierOverride: true,
+    });
+    expect(p.falsifierStatus).toBe('skipped-by-user');
+  });
+
+  it('preserves appendedToClaudeMd independently of override flag', () => {
+    const a = buildPatternFromNarrative(narrative(), false, {
+      falsifierOverride: true,
+    });
+    const b = buildPatternFromNarrative(narrative(), true, {
+      falsifierOverride: true,
+    });
+    expect(a.appendedToClaudeMd).toBe(false);
+    expect(b.appendedToClaudeMd).toBe(true);
+    expect(a.falsifierStatus).toBe('skipped-by-user');
+    expect(b.falsifierStatus).toBe('skipped-by-user');
+  });
+
+  it('round-trips through JSON without losing the override signal', () => {
+    const p = buildPatternFromNarrative(narrative(), false, {
+      falsifierOverride: true,
+    });
+    const round = JSON.parse(JSON.stringify(p));
+    expect(round.falsifierStatus).toBe('skipped-by-user');
+  });
+});

--- a/packages/viewer/src/data/narrativeActions.ts
+++ b/packages/viewer/src/data/narrativeActions.ts
@@ -214,11 +214,29 @@ export async function encodePattern(
   };
 }
 
+/**
+ * Build a `Pattern` from a `Narrative` for the encode-as-pattern flow.
+ *
+ * Rev3-E E3 — the `falsifierOverride` option records the user's
+ * explicit decision to skip the future falsifier check. The flag maps
+ * to `falsifierStatus: 'skipped-by-user'` (the auditable bypass
+ * sentinel). When `false` / omitted, `falsifierStatus` is left
+ * undefined — the Rev3-F falsifier skill populates it on the next
+ * encode pass (target: `'verified'`; or `'unavailable'` if the
+ * `claude` CLI is missing / sandboxed).
+ *
+ * Default falsifier-gating per plan §Phase Rev3-E: the user does NOT
+ * opt in to a value here; the absence of `falsifierStatus` means
+ * "not yet falsified" rather than "explicitly skipped." That
+ * distinction is load-bearing for the D3 audit-style surfaces and
+ * the Rev3-F falsifier wiring.
+ */
 export function buildPatternFromNarrative(
   narrative: Narrative,
   appendedToClaudeMd: boolean,
+  options: { falsifierOverride?: boolean } = {},
 ): Pattern {
-  return {
+  const base: Pattern = {
     id: `pattern_${narrative.id}`,
     sourceNarrativeId: narrative.id,
     projectId: narrative.projectId,
@@ -227,6 +245,10 @@ export function buildPatternFromNarrative(
     encodedAt: new Date().toISOString(),
     appendedToClaudeMd,
   };
+  if (options.falsifierOverride === true) {
+    return { ...base, falsifierStatus: 'skipped-by-user' };
+  }
+  return base;
 }
 
 export function buildClaudeMdMarkdown(narrative: Narrative): string {

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -3945,6 +3945,30 @@
   color: var(--lcars-violet);
 }
 
+/* Rev3-E E3 — falsifier-skip override checkbox in the encode-as-
+ * pattern flow. Sits in the NarrativeCard footer above the primary
+ * action button (positive narratives only). Visually quieter than
+ * the action button so the safe default (unchecked) doesn't pull
+ * attention away from the encode CTA. */
+.lcars-narrative-card__falsifier-skip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-end;
+  font-family: var(--lcars-font-chrome);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  opacity: 0.78;
+  cursor: pointer;
+  user-select: none;
+}
+.lcars-narrative-card__falsifier-skip input {
+  cursor: pointer;
+}
+.lcars-narrative-card__falsifier-skip input:disabled {
+  cursor: not-allowed;
+}
+
 /* Rev3-D D4 — narratives section header + show-shelved toggle. The
  * header sits above the narrative list and holds the section title +
  * an optional shelved-count toggle on the right. Toggle is only


### PR DESCRIPTION
## Summary

Phase Rev3-E E3. Adds the explicit falsifier-skip override checkbox to the encode-as-pattern flow. When ticked, the persisted Pattern row carries \`falsifierStatus: 'skipped-by-user'\` — the auditable bypass sentinel introduced in E1+E2 (PR #79).

## Components

- **\`buildPatternFromNarrative\`** in \`packages/viewer/src/data/narrativeActions.ts\` accepts a new optional \`{ falsifierOverride?: boolean }\` param. Sets \`falsifierStatus: 'skipped-by-user'\` when true; otherwise omits the field (preserves "not yet falsified" semantics distinct from "explicitly skipped" — load-bearing for the Rev3-F falsifier to populate \`'verified'\` / \`'unavailable'\` later).
- **\`ProjectsMode.tsx\`** — new \`falsifierOverride\` state in \`NarrativeCard\`. Default OFF (safe path = let the future falsifier verify). Checkbox below the audit row offers "skip falsifier (record as skipped-by-user)". Success message annotates the bypass when it fires.

## Plan anchor

[§Phase Rev3-E — Closure C wiring](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

> "Encode-as-pattern flow defaults to falsifier-gating; explicit override checkbox writes \`skipped-by-user\`."

## Tracker delta

| Row | Status |
|---|---|
| E3 (encode-as-pattern + falsifier-skip override) | in-review |

Remaining for Rev3-E: E4 (next-sessions watcher), E5 (wall-clock timeout), E6 (gate test).

## Gates

- [x] \`pnpm lint\` — clean
- [x] \`pnpm --filter @chat-arch/viewer test src/data\` — 201/201 pass
- [x] \`pnpm build\` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)