### PR TITLE
feat(rev3-e): applied-pattern watcher kernel (E4+E5)

### DIFF
--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -98,9 +98,9 @@ Plan anchor: [§Phase Rev3-E](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 |---|---|---|---|
 | E1 | Pattern entity schema gains `falsifierStatus: 'verified' \| 'skipped-by-user' \| 'unavailable'` | complete-and-merged | PR #79 (`Pattern.falsifierStatus` + `PatternFalsifierStatus` union + `PATTERN_FALSIFIER_STATUS_VALUES` exports in `packages/schema/src/pattern.ts`; optional for back-compat with pre-Rev3-E patterns) |
 | E2 | DB migration adding `falsifier_status` column to `patterns` table | complete-and-merged | PR #79 (migration 004 — `falsifier_status TEXT` with CHECK constraint over the three terminal states; NULL allowed for back-compat) |
-| E3 | Encode-as-pattern flow defaults to falsifier-gating; explicit override checkbox writes `skipped-by-user` | in-review | PR #TBD (`buildPatternFromNarrative` accepts `falsifierOverride`; `NarrativeCard` adds positive-only checkbox + status-message variant when override fires; default OFF so the safe path remains "let Rev3-F falsifier verify later") |
-| E4 | Next-sessions watcher: triggers `RECURRING_AFTER_APPLIED` or `WATCH_INCONCLUSIVE` on N=5 / 60d / project-inactivity 30d | pending | |
-| E5 | Wall-clock timeout emits low-priority `WATCH_INCONCLUSIVE` Narrative (not silence) | pending | |
+| E3 | Encode-as-pattern flow defaults to falsifier-gating; explicit override checkbox writes `skipped-by-user` | complete-and-merged | PR #80 (`buildPatternFromNarrative` accepts `falsifierOverride`; `NarrativeCard` adds positive-only checkbox + status-message variant when override fires; default OFF so the safe path remains "let Rev3-F falsifier verify later") |
+| E4 | Next-sessions watcher: triggers `RECURRING_AFTER_APPLIED` or `WATCH_INCONCLUSIVE` on N=5 / 60d / project-inactivity 30d | in-review | PR #TBD (`evaluateAppliedPatternWatcher` pure-decision kernel in `packages/analysis/src/applyWatcher.ts`; emits `{kind:'open'\|'holding'\|'recurring'\|'inconclusive'}` verdicts. Orchestration lands with Rev3-F curator) |
+| E5 | Wall-clock timeout emits low-priority `WATCH_INCONCLUSIVE` Narrative (not silence) | in-review | PR #TBD (same kernel returns `{kind:'inconclusive', reason:'wall-clock-timeout'\|'project-inactive'}`; curator formats the Narrative at low feed priority) |
 | E6 | Tests: applied pattern visibly closes its watcher within the window; bypass path produces auditable Pattern row | pending | Gate |
 
 **Gates:** an applied pattern visibly closes its watcher within the window; bypass path produces an auditable Pattern row.

--- a/packages/analysis/src/applyWatcher.test.ts
+++ b/packages/analysis/src/applyWatcher.test.ts
@@ -97,6 +97,27 @@ describe('evaluateAppliedPatternWatcher', () => {
       expect(result.kind).toBe('holding');
       if (result.kind === 'holding') {
         expect(result.sessionsObserved).toBe(N);
+        // Wilson 95% upper bound on failure rate given N=5 with 0
+        // observed failures ≈ 0.522. Pin the order-of-magnitude so
+        // consumers don't treat 5/5 as 50/50 evidence.
+        expect(result.failureRateUpperBound95).toBeGreaterThan(0.4);
+        expect(result.failureRateUpperBound95).toBeLessThan(0.6);
+      }
+    });
+
+    it('failureRateUpperBound95 tightens as sessionsObserved grows', () => {
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const widerN = N + 25;
+      const tight = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: widerN }, (_, i) => session(i + 1)),
+        projectNarratives: [],
+        now: now(widerN + 1),
+      });
+      expect(tight.kind).toBe('holding');
+      if (tight.kind === 'holding') {
+        // 30 trials with 0 failures → Wilson upper bound ≈ 0.115.
+        expect(tight.failureRateUpperBound95).toBeLessThan(0.2);
       }
     });
 
@@ -175,6 +196,23 @@ describe('evaluateAppliedPatternWatcher', () => {
         now: now(4),
       });
       expect(result.kind).toBe('open');
+    });
+
+    it('treats `neutral` and unknown sentiments as NON-recurring (allow-list)', () => {
+      // Stat-rigor iter-1 finding: the original `!== 'positive'`
+      // implementation admitted `'neutral'` (the default class for
+      // low-signal sessions) as recurrence — would close watchers on
+      // ambient noise. The allow-list `['negative', 'mixed']`
+      // pins the intent.
+      for (const noisy of ['neutral', 'unknown', 'negatve' /* typo */]) {
+        const result = evaluateAppliedPatternWatcher({
+          pattern: pattern(),
+          projectSessions: [session(1)],
+          projectNarratives: [narrative(2, noisy)],
+          now: now(3),
+        });
+        expect(result.kind).toBe('open');
+      }
     });
 
     it('ignores recurrences generated BEFORE encoding (pre-existing problem)', () => {

--- a/packages/analysis/src/applyWatcher.test.ts
+++ b/packages/analysis/src/applyWatcher.test.ts
@@ -1,0 +1,361 @@
+// Tests for the Phase Rev3-E E4+E5 applied-rule watcher kernel.
+//
+// Each closure path gets at least one positive case + one boundary
+// case. The kernel is pure (no DB, no clock — `now` is injected), so
+// every assertion is a deterministic value comparison.
+
+import { describe, expect, it } from 'vitest';
+
+import { THRESHOLDS } from './thresholds.js';
+import {
+  evaluateAppliedPatternWatcher,
+  type WatcherInput,
+  type WatcherNarrativeLike,
+  type WatcherPatternLike,
+  type WatcherSessionLike,
+} from './applyWatcher.js';
+
+const MS_PER_DAY = 86_400_000;
+
+function pattern(overrides: Partial<WatcherPatternLike> = {}): WatcherPatternLike {
+  return {
+    id: 'pattern_p1',
+    projectId: 'p1',
+    encodedAt: new Date('2026-04-01T00:00:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
+function session(
+  daysAfterEncoded: number,
+  overrides: Partial<WatcherSessionLike> = {},
+): WatcherSessionLike {
+  const t = Date.parse('2026-04-01T00:00:00Z') + daysAfterEncoded * MS_PER_DAY;
+  return {
+    id: `s_${daysAfterEncoded}`,
+    startedAt: t,
+    updatedAt: t,
+    projectId: 'p1',
+    ...overrides,
+  };
+}
+
+function narrative(
+  daysAfterEncoded: number,
+  sentiment: WatcherNarrativeLike['sentiment'],
+  overrides: Partial<WatcherNarrativeLike> = {},
+): WatcherNarrativeLike {
+  const t = Date.parse('2026-04-01T00:00:00Z') + daysAfterEncoded * MS_PER_DAY;
+  return {
+    id: `n_${daysAfterEncoded}_${sentiment}`,
+    projectId: 'p1',
+    generatedAt: new Date(t).toISOString(),
+    sentiment,
+    ...overrides,
+  };
+}
+
+function now(daysAfterEncoded: number): number {
+  return Date.parse('2026-04-01T00:00:00Z') + daysAfterEncoded * MS_PER_DAY;
+}
+
+describe('evaluateAppliedPatternWatcher', () => {
+  describe('open (no signal yet)', () => {
+    it('returns open when zero post-application sessions + zero narratives + within window', () => {
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [],
+        projectNarratives: [],
+        now: now(1),
+      });
+      expect(result.kind).toBe('open');
+    });
+
+    it('returns open with < N sessions and recent activity', () => {
+      const sessionCount = THRESHOLDS.appliedRuleWatcher.watcherSessionsN - 1;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: sessionCount }, (_, i) =>
+          session(i + 1),
+        ),
+        projectNarratives: [],
+        now: now(sessionCount + 1),
+      });
+      expect(result.kind).toBe('open');
+    });
+  });
+
+  describe('holding (N sessions, no recurrence)', () => {
+    it('returns holding when exactly N post-application sessions observed', () => {
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: N }, (_, i) => session(i + 1)),
+        projectNarratives: [],
+        now: now(N + 1),
+      });
+      expect(result.kind).toBe('holding');
+      if (result.kind === 'holding') {
+        expect(result.sessionsObserved).toBe(N);
+      }
+    });
+
+    it('returns holding with > N sessions (count never decreases on extra)', () => {
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const extra = N + 3;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: extra }, (_, i) => session(i + 1)),
+        projectNarratives: [
+          // A POSITIVE narrative doesn't count as recurrence.
+          narrative(2, 'positive'),
+        ],
+        now: now(extra + 1),
+      });
+      expect(result.kind).toBe('holding');
+    });
+
+    it('ignores pre-application sessions when counting', () => {
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [
+          session(-5),
+          session(-3),
+          session(-1),
+          ...Array.from({ length: N - 1 }, (_, i) => session(i + 1)),
+        ],
+        projectNarratives: [],
+        now: now(N),
+      });
+      // N-1 post-application sessions → still open.
+      expect(result.kind).toBe('open');
+    });
+  });
+
+  describe('recurring (negative/mixed narrative after encoding)', () => {
+    it('returns recurring on first negative narrative after encoding', () => {
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [session(1), session(2)],
+        projectNarratives: [narrative(2, 'negative')],
+        now: now(3),
+      });
+      expect(result.kind).toBe('recurring');
+      if (result.kind === 'recurring') {
+        expect(result.recurrenceNarrativeId).toBe('n_2_negative');
+      }
+    });
+
+    it('picks the EARLIEST recurrence when multiple exist', () => {
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [session(1), session(5), session(10)],
+        projectNarratives: [
+          narrative(10, 'negative'),
+          narrative(3, 'mixed'), // earliest
+          narrative(7, 'negative'),
+        ],
+        now: now(11),
+      });
+      expect(result.kind).toBe('recurring');
+      if (result.kind === 'recurring') {
+        expect(result.recurrenceNarrativeId).toBe('n_3_mixed');
+      }
+    });
+
+    it('ignores positive narratives + ignores recurrences from other projects', () => {
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [session(1)],
+        projectNarratives: [
+          narrative(2, 'positive'),
+          narrative(3, 'negative', { projectId: 'OTHER_PROJECT' }),
+        ],
+        now: now(4),
+      });
+      expect(result.kind).toBe('open');
+    });
+
+    it('ignores recurrences generated BEFORE encoding (pre-existing problem)', () => {
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [session(1)],
+        projectNarratives: [narrative(-3, 'negative')],
+        now: now(2),
+      });
+      expect(result.kind).toBe('open');
+    });
+
+    it('recurring beats holding (even if N sessions also passed)', () => {
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: N }, (_, i) => session(i + 1)),
+        projectNarratives: [narrative(2, 'negative')],
+        now: now(N + 1),
+      });
+      expect(result.kind).toBe('recurring');
+    });
+  });
+
+  describe('inconclusive — wall-clock timeout', () => {
+    it('returns inconclusive after watcherWallClockDays elapsed', () => {
+      const T = THRESHOLDS.appliedRuleWatcher.watcherWallClockDays;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [session(1)],
+        projectNarratives: [],
+        now: now(T),
+      });
+      expect(result.kind).toBe('inconclusive');
+      if (result.kind === 'inconclusive') {
+        expect(result.reason).toBe('wall-clock-timeout');
+      }
+    });
+
+    it('wall-clock timeout beats recurrence (you already missed the window)', () => {
+      const T = THRESHOLDS.appliedRuleWatcher.watcherWallClockDays;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [session(1)],
+        // A late recurrence happens at the boundary — the wall-clock
+        // closure fires first, recording the watch as inconclusive.
+        projectNarratives: [narrative(T - 1, 'negative')],
+        now: now(T + 1),
+      });
+      expect(result.kind).toBe('inconclusive');
+      if (result.kind === 'inconclusive') {
+        expect(result.reason).toBe('wall-clock-timeout');
+      }
+    });
+  });
+
+  describe('inconclusive — project-inactive', () => {
+    it('returns inconclusive when no activity for staleProjectDays before reaching N', () => {
+      const S = THRESHOLDS.appliedRuleWatcher.staleProjectDays;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        // Only 1 session, 31 days after encoding → daysSinceActivity
+        // crosses S=30 next.
+        projectSessions: [session(1)],
+        projectNarratives: [],
+        now: now(S + 5),
+      });
+      expect(result.kind).toBe('inconclusive');
+      if (result.kind === 'inconclusive') {
+        expect(result.reason).toBe('project-inactive');
+      }
+    });
+
+    it('does NOT invalidate via inactivity once N sessions have already passed', () => {
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const S = THRESHOLDS.appliedRuleWatcher.staleProjectDays;
+      // All N sessions land in the first few days, then quiet for S+
+      // days. The window closed naturally — holding beats inactive.
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: N }, (_, i) => session(i + 1)),
+        projectNarratives: [],
+        now: now(N + S + 5),
+      });
+      expect(result.kind).toBe('holding');
+    });
+  });
+
+  describe('defensive behavior', () => {
+    it('returns open on malformed pattern.encodedAt (never throws)', () => {
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern({ encodedAt: 'not-a-date' }),
+        projectSessions: [],
+        projectNarratives: [],
+        now: 1_700_000_000_000,
+      });
+      expect(result.kind).toBe('open');
+    });
+
+    it('skips narratives with malformed generatedAt', () => {
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: [session(1)],
+        projectNarratives: [
+          narrative(2, 'negative', { generatedAt: 'not-a-date' }),
+        ],
+        now: now(3),
+      });
+      // The malformed narrative is dropped → no recurrence found.
+      expect(result.kind).toBe('open');
+    });
+
+    it('ignores sessions from a different project (projectId mismatch)', () => {
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: N }, (_, i) =>
+          session(i + 1, { projectId: 'OTHER_PROJECT' }),
+        ),
+        projectNarratives: [],
+        now: now(N + 1),
+      });
+      // All sessions belong to OTHER_PROJECT → 0 in-project sessions.
+      // No activity → project-inactive after staleProjectDays.
+      const stale = THRESHOLDS.appliedRuleWatcher.staleProjectDays;
+      if (N + 1 >= stale) {
+        expect(result.kind).toBe('inconclusive');
+      } else {
+        expect(result.kind).toBe('open');
+      }
+    });
+
+    it('treats sessions with null/undefined projectId as in-scope', () => {
+      // SDK rows whose project_id is NULL still count — they're un-
+      // assigned but happened on the dev machine. The kernel doesn't
+      // assume strict project membership unless `projectId` is set.
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: N }, (_, i) =>
+          session(i + 1, { projectId: null }),
+        ),
+        projectNarratives: [],
+        now: now(N + 1),
+      });
+      expect(result.kind).toBe('holding');
+    });
+  });
+
+  describe('precedence (closure-path priority)', () => {
+    it('wall-clock > recurrence > project-inactive > holding > open', () => {
+      const T = THRESHOLDS.appliedRuleWatcher.watcherWallClockDays;
+      const N = THRESHOLDS.appliedRuleWatcher.watcherSessionsN;
+      // Construct a state that satisfies ALL closure conditions —
+      // verify wall-clock wins.
+      const result = evaluateAppliedPatternWatcher({
+        pattern: pattern(),
+        projectSessions: Array.from({ length: N }, (_, i) => session(i + 1)),
+        projectNarratives: [narrative(1, 'negative')],
+        now: now(T + 5),
+      });
+      expect(result.kind).toBe('inconclusive');
+      if (result.kind === 'inconclusive') {
+        expect(result.reason).toBe('wall-clock-timeout');
+      }
+    });
+  });
+});
+
+// Type-only test: verify WatcherInput accepts a SessionRow-shaped
+// object without coercion (structural typing pays off here).
+function _typeCheckWatcherInput(): void {
+  const input: WatcherInput = {
+    pattern: {
+      id: 'p',
+      projectId: 'x',
+      encodedAt: '2026-01-01T00:00:00Z',
+    },
+    projectSessions: [{ id: 's', startedAt: 0, updatedAt: 0 }],
+    projectNarratives: [],
+    now: Date.now(),
+  };
+  evaluateAppliedPatternWatcher(input);
+}

--- a/packages/analysis/src/applyWatcher.ts
+++ b/packages/analysis/src/applyWatcher.ts
@@ -28,8 +28,26 @@
 // deterministic + testable without a DB.
 
 import { THRESHOLDS } from './thresholds.js';
+import { wilsonCI } from './stats.js';
 
 const MS_PER_DAY = 86_400_000;
+
+/**
+ * Closed allow-list for sentiments that count as recurrence. Tighter
+ * than `!== 'positive'` — `'neutral'` is the default class for low-
+ * signal sessions in Rev3-B's sentiment kernel, so admitting it as
+ * recurrence would silently close watchers on ambient noise.
+ *
+ * Stat-rigor iter-1 finding on PR #81 (commit 743230d): the comment
+ * promised `negative || mixed` but the code used the broader
+ * complement of `positive`. Tightening to this allow-list pins the
+ * intent so a future sentiment-kernel change can't drift the rule.
+ *
+ * Topic-overlap filtering (does the recurrence actually relate to
+ * the pattern's domain?) is deferred to Rev3-F's falsifier as the
+ * plan §"Three closures" specifies.
+ */
+const RECURRENCE_SENTIMENTS: ReadonlySet<string> = new Set(['negative', 'mixed']);
 
 /**
  * The four terminal verdicts plus the holding-open "we don't know
@@ -44,8 +62,22 @@ export type WatcherVerdict =
   /**
    * N sessions observed in the project after the pattern was applied
    * with no recurrence. Confidence-up on the original Pattern.
+   *
+   * `failureRateUpperBound95` is the Wilson 95% upper bound on the
+   * recurrence rate given `sessionsObserved` trials with zero
+   * observed failures. At the default `watcherSessionsN = 5` the
+   * bound is ~0.52 (i.e., we can't rule out a 52% recurrence rate
+   * with 5/5 clean sessions). Surfaced so consumers don't treat
+   * "5/5 clean" as the same evidence as "50/50 clean" (Wilson is
+   * well-behaved at the p̂=0 boundary). Future tuning of
+   * `watcherSessionsN` tightens this naturally. Stat-rigor iter-1
+   * finding on PR #81.
    */
-  | { readonly kind: 'holding'; readonly sessionsObserved: number }
+  | {
+      readonly kind: 'holding';
+      readonly sessionsObserved: number;
+      readonly failureRateUpperBound95: number;
+    }
   /**
    * A narrative whose sentiment indicates the original problem
    * recurred fired in the project after the pattern was applied.
@@ -169,7 +201,7 @@ export function evaluateAppliedPatternWatcher(
   let earliestRecurrenceMs = Number.POSITIVE_INFINITY;
   for (const n of input.projectNarratives) {
     if (n.projectId !== input.pattern.projectId) continue;
-    if (n.sentiment === 'positive') continue;
+    if (!RECURRENCE_SENTIMENTS.has(n.sentiment)) continue;
     const ts = Date.parse(n.generatedAt);
     if (!Number.isFinite(ts)) continue;
     if (ts <= encodedAtMs) continue;
@@ -208,7 +240,15 @@ export function evaluateAppliedPatternWatcher(
     return { kind: 'inconclusive', reason: 'project-inactive' };
   }
   if (postSessions.length >= W.watcherSessionsN) {
-    return { kind: 'holding', sessionsObserved: postSessions.length };
+    // Wilson 95% upper bound on the failure rate given
+    // `sessionsObserved` trials with zero observed failures.
+    // At N=5 this is ~0.52; at N=20 ~0.16; at N=50 ~0.07.
+    const wilson = wilsonCI(0, postSessions.length);
+    return {
+      kind: 'holding',
+      sessionsObserved: postSessions.length,
+      failureRateUpperBound95: wilson.high,
+    };
   }
 
   // Otherwise, the watch is still active — not enough signal yet.

--- a/packages/analysis/src/applyWatcher.ts
+++ b/packages/analysis/src/applyWatcher.ts
@@ -1,0 +1,216 @@
+// Phase Rev3-E E4 + E5 — next-sessions watcher for Closure C
+// (applied-rule outcome).
+//
+// Plan reference: `_planning/chat-arch-v2-rev3-plan.md` §"Three
+// closures" (Closure C):
+//
+//   "After the optional CLAUDE.md append, the next-sessions watcher
+//    activates. Watcher closes by whichever fires first:
+//      (a) `THRESHOLDS.appliedRuleWatcher.watcherSessionsN` sessions
+//          observed in the target project (default 5),
+//      (b) `THRESHOLDS.appliedRuleWatcher.watcherWallClockDays`
+//          elapsed (default 60 days),
+//      (c) explicit user-side close.
+//    Wall-clock timeout emits a `WATCH_INCONCLUSIVE` Narrative at low
+//    feed priority — not silence. Project inactivity ≥
+//    `THRESHOLDS.appliedRuleWatcher.staleProjectDays` (default 30)
+//    before N is reached invalidates the watch entirely; a fresh
+//    watcher starts on project re-entry. Recurrence within the watch
+//    window → `RECURRING_AFTER_APPLIED` Narrative emitted.
+//    Non-recurrence → confidence-up on the original pattern."
+//
+// This module owns the *pure decision*: given a Pattern + the
+// project's subsequent sessions + the project's subsequent
+// narratives + a "now" clock, return a `WatcherVerdict` enum. The
+// orchestration (who emits findings, who confidence-bumps the
+// Pattern row) lands in Rev3-F when the curator runs the kernel
+// against live data. Keeping the decision-pure makes the kernel
+// deterministic + testable without a DB.
+
+import { THRESHOLDS } from './thresholds.js';
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * The four terminal verdicts plus the holding-open "we don't know
+ * yet" state. Encode as a tagged union so each outcome can carry
+ * its own evidence (which narrative triggered recurrence, how many
+ * sessions cleared the bar, etc.) without forcing callers to crack
+ * a stringly-typed enum + parallel evidence map.
+ */
+export type WatcherVerdict =
+  /** Watch is still active — not enough signal to close. */
+  | { readonly kind: 'open' }
+  /**
+   * N sessions observed in the project after the pattern was applied
+   * with no recurrence. Confidence-up on the original Pattern.
+   */
+  | { readonly kind: 'holding'; readonly sessionsObserved: number }
+  /**
+   * A narrative whose sentiment indicates the original problem
+   * recurred fired in the project after the pattern was applied.
+   * Emit `RECURRING_AFTER_APPLIED` carrying the offending narrative
+   * id so the UI can link from the Pattern to "this is what re-
+   * appeared after you applied the rule."
+   */
+  | {
+      readonly kind: 'recurring';
+      readonly recurrenceNarrativeId: string;
+      readonly recurrenceGeneratedAt: string;
+    }
+  /**
+   * Wall-clock timeout or project-inactivity invalidation. Emits a
+   * low-priority `WATCH_INCONCLUSIVE` Narrative — explicit "we
+   * couldn't decide" beats silence (the user shouldn't have to
+   * remember they applied a rule 60 days ago that no one ever
+   * re-evaluated).
+   */
+  | {
+      readonly kind: 'inconclusive';
+      readonly reason: 'wall-clock-timeout' | 'project-inactive';
+    };
+
+/**
+ * Minimal session shape the watcher needs. Wider shapes from the
+ * SDK / manifest are fine — TypeScript structural typing accepts any
+ * superset.
+ */
+export interface WatcherSessionLike {
+  readonly id: string;
+  /** ms since epoch (UnifiedSessionEntry convention). */
+  readonly startedAt: number;
+  /** ms since epoch — used to detect project inactivity. */
+  readonly updatedAt: number;
+  /**
+   * `projectId` is what we filter by; passed through so callers don't
+   * have to pre-filter (kernel ignores sessions that don't belong).
+   */
+  readonly projectId?: string | null;
+}
+
+/**
+ * Minimal narrative shape the watcher needs. The recurrence test is
+ * "non-positive sentiment generated in the same project after
+ * `pattern.encodedAt`." Until Rev3-F's falsifier wires a proper
+ * recurrence-detector to the curator pipeline, the sentiment check
+ * is the deterministic fallback — it's coarse but transparent.
+ */
+export interface WatcherNarrativeLike {
+  readonly id: string;
+  readonly projectId: string;
+  /** ISO-8601 string per existing narrative convention. */
+  readonly generatedAt: string;
+  readonly sentiment: 'positive' | 'negative' | 'mixed' | 'neutral' | string;
+}
+
+/**
+ * Minimal pattern shape — `encodedAt` is the watch-start clock,
+ * `projectId` is what we filter sessions+narratives by, `id` is
+ * carried through to findings for back-reference.
+ */
+export interface WatcherPatternLike {
+  readonly id: string;
+  readonly projectId: string;
+  /** ISO-8601 string (matches `Pattern.encodedAt`). */
+  readonly encodedAt: string;
+}
+
+export interface WatcherInput {
+  readonly pattern: WatcherPatternLike;
+  /**
+   * All sessions in the project (the kernel filters by `projectId`
+   * + `startedAt > encodedAt` itself). Pass the project's full list
+   * unfiltered — the kernel won't crash on foreign sessions.
+   */
+  readonly projectSessions: readonly WatcherSessionLike[];
+  /**
+   * All narratives in the project (kernel filters internally).
+   */
+  readonly projectNarratives: readonly WatcherNarrativeLike[];
+  /**
+   * ms since epoch. Test seam — production callers pass `Date.now()`.
+   */
+  readonly now: number;
+}
+
+/**
+ * Closure C decision kernel. Order of closure paths matters: wall-
+ * clock timeout takes precedence (you don't want a 61-day-old watch
+ * sitting "open" because it also lacks N sessions); recurrence
+ * comes next (a single recurring narrative is more informative than
+ * "no recurrence" even if N sessions also passed); project-inactive
+ * comes after recurrence (a project that died after a few sessions
+ * is inconclusive, not holding); holding fires last (N sessions
+ * with no recurrence + still-active project).
+ *
+ * Defensive contract: malformed `encodedAt` returns `{ kind: 'open' }`
+ * (never throws). Malformed narrative `generatedAt` skips that
+ * narrative for recurrence checks but doesn't crash the kernel.
+ */
+export function evaluateAppliedPatternWatcher(
+  input: WatcherInput,
+): WatcherVerdict {
+  const encodedAtMs = Date.parse(input.pattern.encodedAt);
+  if (!Number.isFinite(encodedAtMs)) {
+    return { kind: 'open' };
+  }
+  const W = THRESHOLDS.appliedRuleWatcher;
+
+  // ── Path 1: wall-clock timeout takes absolute precedence ────────
+  const ageDays = (input.now - encodedAtMs) / MS_PER_DAY;
+  if (ageDays >= W.watcherWallClockDays) {
+    return { kind: 'inconclusive', reason: 'wall-clock-timeout' };
+  }
+
+  // ── Path 2: recurrence beats holding ────────────────────────────
+  // Find the EARLIEST recurring narrative so the watcher closes on
+  // first recurrence (later recurrences don't change the verdict).
+  let earliestRecurrence: WatcherNarrativeLike | null = null;
+  let earliestRecurrenceMs = Number.POSITIVE_INFINITY;
+  for (const n of input.projectNarratives) {
+    if (n.projectId !== input.pattern.projectId) continue;
+    if (n.sentiment === 'positive') continue;
+    const ts = Date.parse(n.generatedAt);
+    if (!Number.isFinite(ts)) continue;
+    if (ts <= encodedAtMs) continue;
+    if (ts < earliestRecurrenceMs) {
+      earliestRecurrence = n;
+      earliestRecurrenceMs = ts;
+    }
+  }
+  if (earliestRecurrence !== null) {
+    return {
+      kind: 'recurring',
+      recurrenceNarrativeId: earliestRecurrence.id,
+      recurrenceGeneratedAt: earliestRecurrence.generatedAt,
+    };
+  }
+
+  // ── Path 3 + 4: count post-application sessions, check inactivity
+  const postSessions: WatcherSessionLike[] = [];
+  let lastActivityMs = encodedAtMs;
+  for (const s of input.projectSessions) {
+    if (s.projectId !== undefined && s.projectId !== null && s.projectId !== input.pattern.projectId) {
+      continue;
+    }
+    if (s.startedAt <= encodedAtMs) continue;
+    postSessions.push(s);
+    if (s.updatedAt > lastActivityMs) lastActivityMs = s.updatedAt;
+  }
+  const daysSinceActivity = (input.now - lastActivityMs) / MS_PER_DAY;
+  // Project-inactivity invalidates BEFORE N is reached. If we already
+  // have N sessions, "inactive since" doesn't apply — the holding
+  // verdict beats it because the window already closed naturally.
+  if (
+    postSessions.length < W.watcherSessionsN &&
+    daysSinceActivity >= W.staleProjectDays
+  ) {
+    return { kind: 'inconclusive', reason: 'project-inactive' };
+  }
+  if (postSessions.length >= W.watcherSessionsN) {
+    return { kind: 'holding', sessionsObserved: postSessions.length };
+  }
+
+  // Otherwise, the watch is still active — not enough signal yet.
+  return { kind: 'open' };
+}

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -384,3 +384,12 @@ export {
   type SkillCurveResult,
   type SkillCurveSeries,
 } from './skillCurve.js';
+
+export {
+  evaluateAppliedPatternWatcher,
+  type WatcherInput,
+  type WatcherNarrativeLike,
+  type WatcherPatternLike,
+  type WatcherSessionLike,
+  type WatcherVerdict,
+} from './applyWatcher.js';


### PR DESCRIPTION
## Summary

Phase Rev3-E E4 + E5. Pure-decision kernel for Closure C — \`evaluateAppliedPatternWatcher\` classifies whether an applied Pattern is still active, recurring, holding, or has timed out, given the project's subsequent sessions + narratives.

## Kernel

\`packages/analysis/src/applyWatcher.ts\` exports \`evaluateAppliedPatternWatcher({ pattern, projectSessions, projectNarratives, now })\` returning a \`WatcherVerdict\` tagged union:

- \`{ kind: 'open' }\` — watch still active.
- \`{ kind: 'holding', sessionsObserved }\` — N sessions in project with no recurrence.
- \`{ kind: 'recurring', recurrenceNarrativeId, recurrenceGeneratedAt }\` — non-positive narrative fired after encoding.
- \`{ kind: 'inconclusive', reason: 'wall-clock-timeout' | 'project-inactive' }\` — E5 closure paths.

### Closure-path precedence (load-bearing)

Wall-clock > recurrence > project-inactive > holding > open. Exercised in a dedicated precedence test.

### THRESHOLDS-resident

\`watcherSessionsN\` (5), \`watcherWallClockDays\` (60), \`staleProjectDays\` (30) — all landed in Rev3-A.A7.

### Defensive contract

- Malformed \`encodedAt\` → \`{kind:'open'}\` (no throw).
- Malformed \`generatedAt\` → narrative skipped silently.
- Sessions with NULL \`projectId\` treated as in-scope (matches SDK NULL semantics).
- Pre-encoding sessions / narratives filtered.

## Recurrence heuristic

Coarse but transparent: any non-positive (negative / mixed) narrative in the same project after \`pattern.encodedAt\` counts as recurrence. When Rev3-F's falsifier lands, the curator will swap this for a more precise signal. The kernel returns the EARLIEST recurrence so closure fires on first match.

## Orchestration deferred

The kernel is the pure decision. Who reads applied patterns from the SDK, calls the kernel, and emits findings — that orchestration lands when the curator skill ships in Phase Rev3-F. Keeping the decision-pure makes the kernel deterministic + testable without a DB.

## Plan anchor

[§Phase Rev3-E — Closure C wiring](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

## Tracker delta

| Row | Status |
|---|---|
| E4 (next-sessions watcher) | in-review |
| E5 (wall-clock + project-inactive timeouts) | in-review |

E6 (gate test) closes the phase.

## Gates

- [x] \`pnpm lint\` — clean
- [x] \`pnpm --filter @chat-arch/analysis test src/applyWatcher.test.ts\` — 19/19 pass
- [x] \`pnpm build\` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)