### PR TITLE
feat(rev3-g): Welch's t-test + correlation tag visibility gate (G1+G2)

### DIFF
--- a/_planning/chat-arch-v2-rev3-progress.md
+++ b/_planning/chat-arch-v2-rev3-progress.md
@@ -134,8 +134,8 @@ Plan anchor: [§Phase Rev3-G](chat-arch-v2-rev3-plan.md#phased-delivery-post-§0
 
 | # | Sub-task | Status | PR / notes |
 |---|---|---|---|
-| G1 | Welch's t-test (or non-parametric permutation) implementation in `packages/analysis/src/` | pending | |
-| G2 | Outcome-correlation tag visibility gated on `\|Δ\|/SE` exceeding `curator.outcomeCorrelationSignificance` AND `evidence.length ≥ 5` | pending | |
+| G1 | Welch's t-test (or non-parametric permutation) implementation in `packages/analysis/src/` | in-review | PR #TBD (`welchsTTest` in `packages/analysis/src/welchsTTest.ts` — pure function returning `{t, delta, standardError, degreesOfFreedom, pValueTwoSided, valid}`; defensive on degenerate inputs; normal-CDF p-value approximation reuses existing `normalCdf` helper) |
+| G2 | Outcome-correlation tag visibility gated on `\|Δ\|/SE` exceeding `curator.outcomeCorrelationSignificance` AND `evidence.length ≥ 5` | in-review | PR #TBD (`evaluateCorrelationTagVisibility` in `packages/analysis/src/correlationTagGate.ts` — tagged-union verdict (`visible \| 'insufficient-evidence' \| 'below-significance' \| 'invalid-stat'`) so renderers can show distinct copy per non-shown reason) |
 | G3 | Extend `SourceAttribution.tsx` `AttributionKind` union with new rungs (`'tier1' \| 'tier2' \| 'tier3' \| 'falsifier-verified' \| 'llm-derived' \| 'deterministic-with-prior' \| 'correlation-significant'`) | pending | Single component; no parallel MethodHint |
 | G4 | Curator ranker uses correlation only as tie-breaker within a tier (does NOT promote across tiers) | pending | |
 | G5 | Falsifier runs permutation test resampling project sessions to confirm Δ unlikely under H0 | pending | |

--- a/packages/analysis/src/correlationTagGate.test.ts
+++ b/packages/analysis/src/correlationTagGate.test.ts
@@ -1,0 +1,117 @@
+// Tests for Phase Rev3-G G2 correlation tag visibility gate.
+
+import { describe, expect, it } from 'vitest';
+
+import { THRESHOLDS } from './thresholds.js';
+import {
+  evaluateCorrelationTagVisibility,
+} from './correlationTagGate.js';
+
+describe('evaluateCorrelationTagVisibility', () => {
+  it('shows the tag when both gates pass', () => {
+    const r = evaluateCorrelationTagVisibility({
+      stat: { t: 3.0, valid: true },
+      evidenceLength: 10,
+    });
+    expect(r.visible).toBe(true);
+    if (r.visible) {
+      expect(r.absoluteTStat).toBe(3.0);
+      expect(r.significanceThreshold).toBe(
+        THRESHOLDS.curator.outcomeCorrelationSignificance,
+      );
+    }
+  });
+
+  it('hides the tag with insufficient-evidence reason when evidence < min', () => {
+    const r = evaluateCorrelationTagVisibility({
+      stat: { t: 5.0, valid: true }, // would pass significance
+      evidenceLength: 2, // but evidence too small
+    });
+    expect(r.visible).toBe(false);
+    if (!r.visible) {
+      expect(r.reason).toBe('insufficient-evidence');
+      if (r.reason === 'insufficient-evidence') {
+        expect(r.evidenceLength).toBe(2);
+        expect(r.evidenceMinLength).toBe(
+          THRESHOLDS.curator.outcomeCorrelationEvidenceMinLength,
+        );
+      }
+    }
+  });
+
+  it('hides the tag with below-significance reason when |t| < threshold', () => {
+    const r = evaluateCorrelationTagVisibility({
+      stat: { t: 1.0, valid: true }, // |t| < 1.96
+      evidenceLength: 10, // evidence sufficient
+    });
+    expect(r.visible).toBe(false);
+    if (!r.visible) {
+      expect(r.reason).toBe('below-significance');
+    }
+  });
+
+  it('hides the tag with invalid-stat reason when test was degenerate', () => {
+    const r = evaluateCorrelationTagVisibility({
+      stat: { t: 0, valid: false },
+      evidenceLength: 10,
+    });
+    expect(r.visible).toBe(false);
+    if (!r.visible) {
+      expect(r.reason).toBe('invalid-stat');
+    }
+  });
+
+  it('check order: invalid > insufficient-evidence > below-significance', () => {
+    // Both gates would fail; invalid wins.
+    const invalid = evaluateCorrelationTagVisibility({
+      stat: { t: 1.0, valid: false },
+      evidenceLength: 2,
+    });
+    expect(invalid.visible).toBe(false);
+    if (!invalid.visible) expect(invalid.reason).toBe('invalid-stat');
+
+    // Valid stat, both evidence + significance fail → insufficient
+    // first.
+    const insufficient = evaluateCorrelationTagVisibility({
+      stat: { t: 1.0, valid: true },
+      evidenceLength: 2,
+    });
+    expect(insufficient.visible).toBe(false);
+    if (!insufficient.visible) expect(insufficient.reason).toBe('insufficient-evidence');
+  });
+
+  it('uses |t| not signed t (effect direction doesn\'t change visibility)', () => {
+    const positive = evaluateCorrelationTagVisibility({
+      stat: { t: 2.5, valid: true },
+      evidenceLength: 10,
+    });
+    const negative = evaluateCorrelationTagVisibility({
+      stat: { t: -2.5, valid: true },
+      evidenceLength: 10,
+    });
+    expect(positive.visible).toBe(true);
+    expect(negative.visible).toBe(true);
+  });
+
+  it('boundary: evidence exactly at min is sufficient (inclusive)', () => {
+    const r = evaluateCorrelationTagVisibility({
+      stat: { t: 3.0, valid: true },
+      evidenceLength: THRESHOLDS.curator.outcomeCorrelationEvidenceMinLength,
+    });
+    expect(r.visible).toBe(true);
+  });
+
+  it('boundary: |t| exactly at significance is below (strict-less-than fails the gate)', () => {
+    const r = evaluateCorrelationTagVisibility({
+      stat: {
+        t: THRESHOLDS.curator.outcomeCorrelationSignificance,
+        valid: true,
+      },
+      evidenceLength: 10,
+    });
+    // Implementation uses `< threshold` for the "below" check, so
+    // exactly-at-threshold counts as passing. Document the boundary
+    // here so any future change is caught.
+    expect(r.visible).toBe(true);
+  });
+});

--- a/packages/analysis/src/correlationTagGate.ts
+++ b/packages/analysis/src/correlationTagGate.ts
@@ -1,0 +1,105 @@
+// Phase Rev3-G G2 — outcome-correlation tag visibility gate.
+//
+// Plan reference: `_planning/chat-arch-v2-rev3-plan.md` §Phase
+// Rev3-G G2:
+//
+//   "Outcome-correlation tag visibility gated on `|Δ|/SE` exceeding
+//    `curator.outcomeCorrelationSignificance` AND
+//    `evidence.length ≥ outcomeCorrelationEvidenceMinLength`."
+//
+// This module owns the pure decision: given an Outcome-correlation
+// effect-size estimate (from a Welch's t-test or permutation test)
+// + the candidate's evidence count, return a tagged-union verdict
+// the renderer can switch on.
+
+import { THRESHOLDS } from './thresholds.js';
+
+/**
+ * The visibility decision for the correlation tag. Tagged union so
+ * the renderer can show distinct copy for each non-shown reason
+ * (small evidence set vs significance gate vs invalid stat).
+ */
+export type CorrelationTagVisibility =
+  | {
+      readonly visible: true;
+      readonly absoluteTStat: number;
+      readonly significanceThreshold: number;
+    }
+  | {
+      readonly visible: false;
+      readonly reason: 'insufficient-evidence';
+      readonly evidenceLength: number;
+      readonly evidenceMinLength: number;
+    }
+  | {
+      readonly visible: false;
+      readonly reason: 'below-significance';
+      readonly absoluteTStat: number;
+      readonly significanceThreshold: number;
+    }
+  | {
+      readonly visible: false;
+      readonly reason: 'invalid-stat';
+    };
+
+export interface CorrelationTagInput {
+  /**
+   * The Welch (or permutation) test result. `valid: false` means
+   * the test couldn't be computed (degenerate inputs) — gate
+   * returns `'invalid-stat'`.
+   */
+  readonly stat: {
+    readonly t: number;
+    readonly valid: boolean;
+  };
+  /**
+   * Number of evidence rows the candidate cites. Must clear
+   * `THRESHOLDS.curator.outcomeCorrelationEvidenceMinLength`
+   * (default 5).
+   */
+  readonly evidenceLength: number;
+}
+
+/**
+ * Apply the two-rail gate: evidence floor AND significance
+ * threshold. Both must pass for the tag to be visible.
+ *
+ * Order of checks matters for the reason code:
+ *   1. invalid-stat (test couldn't be computed)
+ *   2. insufficient-evidence (small sample)
+ *   3. below-significance (test ran, but effect too small)
+ *
+ * The renderer can use the discriminated reason to show different
+ * copy ("not enough evidence yet" vs "effect not significant" vs
+ * silence on invalid).
+ */
+export function evaluateCorrelationTagVisibility(
+  input: CorrelationTagInput,
+): CorrelationTagVisibility {
+  const significanceThreshold =
+    THRESHOLDS.curator.outcomeCorrelationSignificance;
+  const evidenceMinLength =
+    THRESHOLDS.curator.outcomeCorrelationEvidenceMinLength;
+
+  if (!input.stat.valid) {
+    return { visible: false, reason: 'invalid-stat' };
+  }
+  if (input.evidenceLength < evidenceMinLength) {
+    return {
+      visible: false,
+      reason: 'insufficient-evidence',
+      evidenceLength: input.evidenceLength,
+      evidenceMinLength,
+    };
+  }
+  const absoluteTStat = Math.abs(input.stat.t);
+  if (absoluteTStat < significanceThreshold) {
+    return {
+      visible: false,
+      reason: 'below-significance',
+      absoluteTStat,
+      significanceThreshold,
+    };
+  }
+  return { visible: true, absoluteTStat, significanceThreshold };
+}

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -415,3 +415,14 @@ export {
   type MetaAccuracyResult,
   type VerdictPair,
 } from './falsifierMetaAccuracy.js';
+
+export {
+  welchsTTest,
+  type WelchResult,
+} from './welchsTTest.js';
+
+export {
+  evaluateCorrelationTagVisibility,
+  type CorrelationTagInput,
+  type CorrelationTagVisibility,
+} from './correlationTagGate.js';

--- a/packages/analysis/src/welchsTTest.test.ts
+++ b/packages/analysis/src/welchsTTest.test.ts
@@ -71,6 +71,16 @@ describe('welchsTTest', () => {
       expect(() => welchsTTest([], [1, 2])).not.toThrow();
       expect(() => welchsTTest([NaN, 2], [3, 4])).not.toThrow();
     });
+
+    it('returns valid=false on NaN inputs (stat-rigor iter-1 NaN guard)', () => {
+      const a = welchsTTest([1, 2, NaN, 3], [4, 5, 6]);
+      expect(a.valid).toBe(false);
+      expect(a.t).toBe(0);
+      const b = welchsTTest([1, 2, 3], [4, Number.POSITIVE_INFINITY, 6]);
+      expect(b.valid).toBe(false);
+      const c = welchsTTest([1, 2, 3], [4, Number.NEGATIVE_INFINITY, 6]);
+      expect(c.valid).toBe(false);
+    });
   });
 
   describe('Welch–Satterthwaite df', () => {

--- a/packages/analysis/src/welchsTTest.test.ts
+++ b/packages/analysis/src/welchsTTest.test.ts
@@ -1,0 +1,97 @@
+// Tests for Phase Rev3-G G1 Welch's t-test.
+
+import { describe, expect, it } from 'vitest';
+
+import { welchsTTest } from './welchsTTest.js';
+
+describe('welchsTTest', () => {
+  describe('basic correctness', () => {
+    it('returns t=0 when samples have identical means + variances', () => {
+      const r = welchsTTest([1, 2, 3, 4, 5], [1, 2, 3, 4, 5]);
+      expect(r.valid).toBe(true);
+      expect(r.delta).toBe(0);
+      expect(r.t).toBe(0);
+      expect(r.pValueTwoSided).toBeCloseTo(1, 5);
+    });
+
+    it('detects a large mean difference (highly significant)', () => {
+      // sample1 mean=10, sample2 mean=1; |t| should be very large.
+      const s1 = [9.5, 10, 10.5, 9.8, 10.2];
+      const s2 = [0.5, 1, 1.5, 0.8, 1.2];
+      const r = welchsTTest(s1, s2);
+      expect(r.valid).toBe(true);
+      expect(r.delta).toBeCloseTo(9, 1);
+      expect(Math.abs(r.t)).toBeGreaterThan(20);
+      expect(r.pValueTwoSided).toBeLessThan(0.001);
+    });
+
+    it('detects a small but real mean difference (moderately significant)', () => {
+      // Differences in mean by ~0.5 with low variance, n=10 each.
+      const s1 = [1.0, 1.1, 0.9, 1.0, 1.0, 1.1, 0.9, 1.0, 1.1, 0.9];
+      const s2 = [1.5, 1.6, 1.4, 1.5, 1.5, 1.6, 1.4, 1.5, 1.6, 1.4];
+      const r = welchsTTest(s1, s2);
+      expect(r.valid).toBe(true);
+      expect(Math.abs(r.delta)).toBeCloseTo(0.5, 1);
+      // |t| should exceed 1.96 (5% sig) easily.
+      expect(Math.abs(r.t)).toBeGreaterThan(1.96);
+    });
+
+    it('does NOT detect a difference smaller than noise', () => {
+      // Overlapping samples with high variance, small means; |t| < 1.
+      const s1 = [1, 5, 0, 8, -2, 4, 3, 6, -1, 7];
+      const s2 = [2, 4, -1, 7, 1, 5, 2, 6, 0, 8];
+      const r = welchsTTest(s1, s2);
+      expect(r.valid).toBe(true);
+      expect(Math.abs(r.t)).toBeLessThan(1);
+    });
+  });
+
+  describe('defensive contract', () => {
+    it('returns valid=false when either sample has n<2', () => {
+      expect(welchsTTest([1], [1, 2, 3]).valid).toBe(false);
+      expect(welchsTTest([1, 2, 3], []).valid).toBe(false);
+      expect(welchsTTest([], []).valid).toBe(false);
+    });
+
+    it('returns valid=false when both variances zero AND means equal', () => {
+      const r = welchsTTest([5, 5, 5], [5, 5, 5]);
+      expect(r.valid).toBe(false);
+      expect(r.t).toBe(0);
+    });
+
+    it('returns clamped-Infinity t when both variances zero but means differ', () => {
+      const r = welchsTTest([5, 5, 5], [10, 10, 10]);
+      expect(r.valid).toBe(true);
+      expect(r.t).toBe(Number.MAX_SAFE_INTEGER);
+      expect(r.delta).toBe(-5);
+      expect(r.pValueTwoSided).toBe(0);
+    });
+
+    it('does NOT throw on degenerate inputs', () => {
+      expect(() => welchsTTest([], [1, 2])).not.toThrow();
+      expect(() => welchsTTest([NaN, 2], [3, 4])).not.toThrow();
+    });
+  });
+
+  describe('Welch–Satterthwaite df', () => {
+    it('approximately equals smaller-n - 1 when one sample dominates variance', () => {
+      // Sample 2 has much higher variance and small n → df should
+      // be close to n2 - 1.
+      const s1 = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]; // n=10, low var
+      const s2 = [0, 100, 200]; // n=3, high var
+      const r = welchsTTest(s1, s2);
+      expect(r.valid).toBe(true);
+      // df should be in the small-n regime (well below 18 = n1+n2-2).
+      expect(r.degreesOfFreedom).toBeLessThan(5);
+    });
+  });
+
+  describe('p-value direction', () => {
+    it('p-value is the same regardless of argument order (two-sided)', () => {
+      const r1 = welchsTTest([1, 2, 3, 4, 5], [6, 7, 8, 9, 10]);
+      const r2 = welchsTTest([6, 7, 8, 9, 10], [1, 2, 3, 4, 5]);
+      expect(r1.pValueTwoSided).toBeCloseTo(r2.pValueTwoSided, 10);
+      expect(r1.t).toBeCloseTo(-r2.t, 10);
+    });
+  });
+});

--- a/packages/analysis/src/welchsTTest.ts
+++ b/packages/analysis/src/welchsTTest.ts
@@ -28,8 +28,10 @@ import { normalCdf } from './stats.js';
  * Result of running Welch's t against two samples. `t` is the
  * raw t-statistic; `degreesOfFreedom` is the Welch–Satterthwaite
  * approximation; `pValueTwoSided` is the two-sided p-value
- * approximated via the normal CDF (acceptable for our `df ≥ 30`
- * use case — see degradation notes in the docstring).
+ * approximated via the normal CDF (acceptable for `df ≥ 30`; below
+ * that the normal under-reports tail mass — the gate uses |t| not
+ * p, so visibility is unaffected, but consumers rendering `p`
+ * directly should treat it as conservative at small df).
  */
 export interface WelchResult {
   readonly t: number;
@@ -38,10 +40,19 @@ export interface WelchResult {
   readonly degreesOfFreedom: number;
   readonly pValueTwoSided: number;
   /**
-   * `true` when both samples have at least 2 observations AND at
-   * least one of them has nonzero variance. False results carry
-   * `t: 0, pValue: 1` — the kernel does NOT throw on degenerate
-   * inputs, just reports "no signal."
+   * `true` when the test was computable. Three branches return
+   * `valid: false`:
+   *   - either sample n < 2
+   *   - any input is NaN / non-finite
+   *   - both variances zero AND means equal (degenerate)
+   * In all three the result carries `t: 0, pValueTwoSided: 1`.
+   *
+   * Two branches return `valid: true` with an extreme t:
+   *   - both variances zero, means differ → `t: MAX_SAFE_INTEGER,
+   *     pValueTwoSided: 0` (clamped Infinity so JSON survives).
+   *
+   * The kernel does NOT throw on degenerate inputs; it reports
+   * "no signal" via `valid: false`.
    */
   readonly valid: boolean;
 }
@@ -114,6 +125,35 @@ export function welchsTTest(
       pValueTwoSided: 1,
       valid: false,
     };
+  }
+  // NaN / non-finite guard (stat-rigor iter-1 finding on PR #89).
+  // Without this, a NaN propagates through variance → mean → t,
+  // and `NaN < significanceThreshold` is `false` in the gate, so
+  // the bad row would render as visible. Clamp to valid:false here
+  // so the gate's `invalid-stat` branch fires correctly.
+  for (const x of sample1) {
+    if (!Number.isFinite(x)) {
+      return {
+        t: 0,
+        delta: 0,
+        standardError: 0,
+        degreesOfFreedom: 0,
+        pValueTwoSided: 1,
+        valid: false,
+      };
+    }
+  }
+  for (const x of sample2) {
+    if (!Number.isFinite(x)) {
+      return {
+        t: 0,
+        delta: 0,
+        standardError: 0,
+        degreesOfFreedom: 0,
+        pValueTwoSided: 1,
+        valid: false,
+      };
+    }
   }
   const a = meanAndVariance(sample1);
   const b = meanAndVariance(sample2);

--- a/packages/analysis/src/welchsTTest.ts
+++ b/packages/analysis/src/welchsTTest.ts
@@ -1,0 +1,163 @@
+// Phase Rev3-G G1 — Welch's t-test for two-sample mean difference
+// with unequal variances.
+//
+// Plan reference: `_planning/chat-arch-v2-rev3-plan.md` §
+// "Outcome-correlation rendering":
+//
+//   "Welch's t-test (or non-parametric permutation) implementation
+//    in `packages/analysis/src/`. Outcome-correlation tag
+//    visibility gated on `|Δ|/SE` exceeding
+//    `curator.outcomeCorrelationSignificance` AND
+//    `evidence.length ≥ 5`."
+//
+// The kernel here computes the t-statistic, degrees of freedom
+// (Welch–Satterthwaite), and the two-sided p-value approximation.
+// `correlationTagGate.ts` (G2) wraps this and applies the
+// THRESHOLDS-resident visibility rule.
+//
+// Why Welch over Student's t: cited vs uncited samples in the
+// outcome-correlation use case very likely have unequal variances
+// (small cited sample with high effect size vs large uncited
+// sample with lower variance). Pooled-variance Student's t
+// over-rejects when variances diverge; Welch's correction is the
+// conservative default.
+
+import { normalCdf } from './stats.js';
+
+/**
+ * Result of running Welch's t against two samples. `t` is the
+ * raw t-statistic; `degreesOfFreedom` is the Welch–Satterthwaite
+ * approximation; `pValueTwoSided` is the two-sided p-value
+ * approximated via the normal CDF (acceptable for our `df ≥ 30`
+ * use case — see degradation notes in the docstring).
+ */
+export interface WelchResult {
+  readonly t: number;
+  readonly delta: number;
+  readonly standardError: number;
+  readonly degreesOfFreedom: number;
+  readonly pValueTwoSided: number;
+  /**
+   * `true` when both samples have at least 2 observations AND at
+   * least one of them has nonzero variance. False results carry
+   * `t: 0, pValue: 1` — the kernel does NOT throw on degenerate
+   * inputs, just reports "no signal."
+   */
+  readonly valid: boolean;
+}
+
+/**
+ * Compute sample mean + (Bessel-corrected) variance. Returns
+ * `{mean: 0, variance: 0}` for empty / single-element samples.
+ */
+function meanAndVariance(
+  sample: readonly number[],
+): { readonly mean: number; readonly variance: number } {
+  const n = sample.length;
+  if (n === 0) return { mean: 0, variance: 0 };
+  let sum = 0;
+  for (const x of sample) sum += x;
+  const mean = sum / n;
+  if (n < 2) return { mean, variance: 0 };
+  let sqDev = 0;
+  for (const x of sample) {
+    const d = x - mean;
+    sqDev += d * d;
+  }
+  return { mean, variance: sqDev / (n - 1) };
+}
+
+/**
+ * Two-sided p-value via the normal CDF approximation. For Welch's
+ * t with df ≥ 30 the normal is within ~0.005 of the exact
+ * t-distribution at α=0.05 — fine for the curator tag's
+ * significance gate (which uses z=1.96 by convention). For df < 30
+ * the approximation under-reports tail mass slightly; we accept the
+ * conservative bias.
+ *
+ * Uses the existing `erfApprox` helper from stats.ts.
+ */
+function normalCdfTwoSidedTail(z: number): number {
+  // p = 2 * (1 - Φ(|z|)). Reuses stats.normalCdf (Abramowitz &
+  // Stegun 7.1.26 — accurate to ~1.5e-7).
+  const absZ = Math.abs(z);
+  return 2 * (1 - normalCdf(absZ));
+}
+
+/**
+ * Welch's two-sample t-test. Returns the t-statistic, Δ (mean1 -
+ * mean2), standard error of the difference, Welch–Satterthwaite df,
+ * and the two-sided p-value approximation.
+ *
+ * Defensive contract:
+ *   - Either sample with n < 2 → `{valid: false, t: 0,
+ *     pValueTwoSided: 1}`.
+ *   - Both variances zero (constant samples) AND means equal →
+ *     `{valid: false, t: 0, pValueTwoSided: 1}`.
+ *   - Both variances zero but means differ → `{valid: true, t: Inf,
+ *     pValueTwoSided: 0}` clamped to `t: Number.MAX_SAFE_INTEGER`
+ *     so JSON serialization survives.
+ *
+ * No throws. Designed to slot into the outcome-correlation gate
+ * where corrupt or sparse data shouldn't crash the kernel.
+ */
+export function welchsTTest(
+  sample1: readonly number[],
+  sample2: readonly number[],
+): WelchResult {
+  if (sample1.length < 2 || sample2.length < 2) {
+    return {
+      t: 0,
+      delta: 0,
+      standardError: 0,
+      degreesOfFreedom: 0,
+      pValueTwoSided: 1,
+      valid: false,
+    };
+  }
+  const a = meanAndVariance(sample1);
+  const b = meanAndVariance(sample2);
+  const delta = a.mean - b.mean;
+  const n1 = sample1.length;
+  const n2 = sample2.length;
+  const seSquared = a.variance / n1 + b.variance / n2;
+  if (seSquared === 0) {
+    if (delta === 0) {
+      return {
+        t: 0,
+        delta: 0,
+        standardError: 0,
+        degreesOfFreedom: 0,
+        pValueTwoSided: 1,
+        valid: false,
+      };
+    }
+    // Zero-variance with non-zero delta — infinite t. Clamp so
+    // downstream JSON doesn't drop Infinity.
+    return {
+      t: Number.MAX_SAFE_INTEGER,
+      delta,
+      standardError: 0,
+      degreesOfFreedom: n1 + n2 - 2,
+      pValueTwoSided: 0,
+      valid: true,
+    };
+  }
+  const standardError = Math.sqrt(seSquared);
+  const t = delta / standardError;
+  // Welch–Satterthwaite degrees of freedom.
+  const dfNum = seSquared * seSquared;
+  const dfDen =
+    (a.variance * a.variance) / (n1 * n1 * (n1 - 1)) +
+    (b.variance * b.variance) / (n2 * n2 * (n2 - 1));
+  const degreesOfFreedom = dfDen > 0 ? dfNum / dfDen : 0;
+  const pValueTwoSided = normalCdfTwoSidedTail(t);
+  return {
+    t,
+    delta,
+    standardError,
+    degreesOfFreedom,
+    pValueTwoSided,
+    valid: true,
+  };
+}


### PR DESCRIPTION
## Summary

Phase Rev3-G G1 + G2. Two pure-decision kernels for outcome-correlation rendering.

## G1 — Welch's t-test

\`packages/analysis/src/welchsTTest.ts\`. \`welchsTTest(s1, s2)\` returns \`{t, delta, standardError, degreesOfFreedom, pValueTwoSided, valid}\` with Welch–Satterthwaite df + normal-CDF two-sided p-value (reuses existing \`stats.normalCdf\`).

**Why Welch over Student's t:** cited vs uncited samples in the outcome-correlation use case very likely have unequal variances. Pooled-variance Student's over-rejects when variances diverge; Welch is the conservative default.

Defensive: degenerate inputs return \`{valid: false}\` without throwing. JSON-clamped infinity for zero-variance / non-zero-delta case.

## G2 — correlation tag visibility gate

\`packages/analysis/src/correlationTagGate.ts\`. \`evaluateCorrelationTagVisibility({stat, evidenceLength})\` applies the plan §G2 two-rail gate:
- \`evidenceLength >= curator.outcomeCorrelationEvidenceMinLength\` (default 5)
- \`|t| >= curator.outcomeCorrelationSignificance\` (default 1.96)

Tagged-union verdict: \`visible | 'insufficient-evidence' | 'below-significance' | 'invalid-stat'\` — renderers can show distinct copy per non-shown reason.

Check priority: invalid > insufficient > below.

## Plan anchor

[§Phase Rev3-G — Outcome-correlation rendering + significance-gated ranker](https://github.com/BryceEWatson/chat-arch/blob/main/_planning/chat-arch-v2-rev3-plan.md#phased-delivery-post-§0-amendments)

## Tracker delta

| Row | Status |
|---|---|
| G1 (Welch's t-test) | in-review |
| G2 (correlation tag gate) | in-review |

Next: G3 (SourceAttribution AttributionKind union) + G4 (already done in F3 — cross-ref test) + G5 (permutation test) + G6 (gate test).

## Gates

- [x] \`pnpm lint\` — clean
- [x] \`pnpm --filter @chat-arch/analysis test src/welchsTTest.test.ts src/correlationTagGate.test.ts\` — 18/18 pass
- [x] \`pnpm build\` — all workspaces succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)