### PR TITLE
feat(feed-α): /api/curate + /api/falsify + surprises kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,27 +28,47 @@ recent work. No new kernel dependencies; no UI yet (Phase B lands the
 
 ### Added
 
-- **`analysis/surprises.json` sidecar.** Nine surprise kinds:
+- **`analysis/surprises.json` sidecar.** Nine surprise kinds defined
+  in the kernel API; **7 emit from the V1 builder pipeline**:
   `streak` / `trajectory-accelerating` / `config-helped` /
-  `pattern-closed` / `reflexive-positive` / `decision-paid-off`
-  (positive) and `trajectory-stalled` / `pattern-recurring` /
-  `debt-spinning` (concerns). Each row carries `{ id, kind, tone,
-  summary (≤120 chars), evidence, score (0-1), generatedAt }`. File
-  also exposes the threshold snapshot it used so the UI can disclaim.
+  `reflexive-positive` / `decision-paid-off` (positive) and
+  `trajectory-stalled` / `debt-spinning` (concerns). The remaining
+  two — `pattern-closed` and `pattern-recurring` — are defined and
+  unit-tested but **dormant in V1**: the applied-pattern watcher
+  ledger lives in the SQLite substrate and no
+  `@chat-arch/exporter/db` SDK accessor exposes the verdicts to a
+  Node consumer yet (see `TODO(applyWatcher-sdk):` marker in
+  `packages/exporter/src/analysis/surprisesBuilder.ts`). When the
+  accessor lands the builder swaps the empty list for the SDK call;
+  no kernel change is required.
+- Each row carries `{ id, kind, tone, summary (≤120 chars), evidence,
+  score (0-1), generatedAt }`. File also exposes the threshold
+  snapshot it used so the UI can disclaim.
 - `computeSurprises` kernel (pure, browser-safe, deterministic given
   identical inputs) + `surprisesBuilder` Node shell that wires the
   sidecar reads + writes. Fail-soft: any missing input sidecar
   degrades the corresponding kinds to zero rows rather than aborting
   the build.
+- All numeric knobs moved into `THRESHOLDS.surprises` (no inlined
+  defaults). New thresholds: `reflexiveEValueMin` (1.5) gates
+  `reflexive-positive` on E-value sensitivity in addition to CI
+  positivity; `decisionGoodFollowupsMin` raised 2 → 5 in concert with
+  a new Wilson-low > base-rate gate on `decision-paid-off`.
 - `EXPORTER_VERSION` bumped 1.3.0 → 1.4.0 to mark the new artifact.
 
 ### Notes
 
-- `pattern-closed` / `pattern-recurring` currently produce zero rows
-  in the builder — the applied-pattern watcher ledger lives in the
-  SQLite substrate and wiring the SDK call into the builder is a
-  follow-on. The kernel accepts watcher entries directly (used by
-  the test suite); only the I/O shell is stubbed.
+- `reflexive-positive` summary copy is **associational, not causal**
+  ("touching X is associated with +Npp" — not "lifted by Npp") to
+  match the matched-pair primitive's actual inferential strength.
+  The E-value floor + Wilson CI + practical-significance triple gate
+  is the new minimum bar for emission.
+- `decision-paid-off` is **same-project scoped**: followups outside
+  the decision-session's project no longer count toward the K-followups
+  floor or the Wilson lift gate. Decisions whose session has no
+  discovered `projectId` are silently skipped by this branch (the
+  decision still appears in `decisions.json`, just not as a paid-off
+  surprise).
 
 ## [1.3.0] — 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,42 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-05-24
+
+Feed-redesign Phase A plumbing — adds a new `analysis/surprises.json`
+sidecar produced by the pure `computeSurprises` kernel in
+`@chat-arch/analysis`. Snapshot-based: reads the existing Phase 1-3
+sidecars (composite-outcomes, project-trajectories, its-analysis,
+reflexive, decisions, knowledge-debt) and emits a ranked list of
+positive observations (`tone: 'positive'`) + concerns
+(`tone: 'concerning'`) the user might not have noticed about their
+recent work. No new kernel dependencies; no UI yet (Phase B lands the
+"happy surprises and stories" surface that consumes this sidecar).
+
+### Added
+
+- **`analysis/surprises.json` sidecar.** Nine surprise kinds:
+  `streak` / `trajectory-accelerating` / `config-helped` /
+  `pattern-closed` / `reflexive-positive` / `decision-paid-off`
+  (positive) and `trajectory-stalled` / `pattern-recurring` /
+  `debt-spinning` (concerns). Each row carries `{ id, kind, tone,
+  summary (≤120 chars), evidence, score (0-1), generatedAt }`. File
+  also exposes the threshold snapshot it used so the UI can disclaim.
+- `computeSurprises` kernel (pure, browser-safe, deterministic given
+  identical inputs) + `surprisesBuilder` Node shell that wires the
+  sidecar reads + writes. Fail-soft: any missing input sidecar
+  degrades the corresponding kinds to zero rows rather than aborting
+  the build.
+- `EXPORTER_VERSION` bumped 1.3.0 → 1.4.0 to mark the new artifact.
+
+### Notes
+
+- `pattern-closed` / `pattern-recurring` currently produce zero rows
+  in the builder — the applied-pattern watcher ledger lives in the
+  SQLite substrate and wiring the SDK call into the builder is a
+  follow-on. The kernel accepts watcher entries directly (used by
+  the test suite); only the I/O shell is stubbed.
+
 ## [1.3.0] — 2026-05-24
 
 Bumped from 1.2.0 to mark the Rev3 substrate landing. The on-disk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,25 @@ analysis/` (all gitignored — locally generated, may carry PII):
 - `skill-curves.json` — per-topic weekly ask-count series + Mann-
   Kendall trend test with BH-FDR. PII: topic + time series.
 
+### Feed-redesign Phase A sidecar (EXPORTER_VERSION 1.4.0)
+
+One additional sidecar under `apps/standalone/public/chat-arch-data/
+analysis/` (gitignored — locally generated, carries PII):
+
+- `surprises.json` — produced by the `computeSurprises` kernel +
+  `surprisesBuilder` shell. Snapshot kernel over the other Phase 1-3
+  sidecars; emits a ranked list of nine surprise kinds segmented by
+  `tone`: positive (streak / trajectory-accelerating / config-helped
+  / pattern-closed / reflexive-positive / decision-paid-off) and
+  concerning (trajectory-stalled / pattern-recurring / debt-spinning)
+  observations the user might not have noticed. Each row carries
+  `{ id, kind, tone, summary (≤120 chars), evidence, score (0-1),
+  generatedAt }`. The file also exposes the threshold snapshot it
+  used so the UI can disclaim. PII: session IDs + project IDs +
+  knowledge-debt canonical-question prose (for `debt-spinning` rows).
+  Read by the upcoming feed-redesign UI surface (Phase B, not yet
+  landed).
+
 ### Rev3-F curator + falsifier output (EXPORTER_VERSION 1.3.0)
 
 Two additional sidecars under `apps/standalone/public/chat-arch-data/
@@ -359,8 +378,8 @@ out of date and needs an update:
 4. **What sidecars under `analysis/` carry PII vs aggregate-only?**
    - PII-bearing (most files): composite-outcomes, knowledge-debt,
      reflexive, decisions, archetypes, project-trajectories,
-     skill-curves, curator-feed, falsifier-verdicts, correction-
-     candidates, corrections, correction-status-*.
+     skill-curves, surprises, curator-feed, falsifier-verdicts,
+     correction-candidates, corrections, correction-status-*.
    - Aggregate-numbers-only (lower-PII): its-analysis, surface-
      comparison. These are gitignored conservatively anyway.
 5. **What's the difference between hosted (`chat-arch.dev`) and
@@ -377,4 +396,6 @@ out of date and needs an update:
      appears in `analysis/meta.json` so operators can correlate a
      bundle with the CHANGELOG. Bumped 1.2.0 → 1.3.0 in Phase
      Rev3-I I5 for the Rev3 substrate cutover; see CHANGELOG.md
-     `[1.3.0]` for the full ledger of what landed.
+     `[1.3.0]` for the full ledger of what landed. Bumped 1.3.0
+     → 1.4.0 in the feed-redesign Phase A plumbing when
+     `analysis/surprises.json` landed; see CHANGELOG.md `[1.4.0]`.

--- a/apps/standalone/src/lib/curatorClaude.ts
+++ b/apps/standalone/src/lib/curatorClaude.ts
@@ -124,8 +124,12 @@ function isThrottled(stderr: string): boolean {
  * insufficient — security iter-1 finding on PR #84 noted that
  * `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BEARER_TOKEN`, `CLAUDE_API_KEY`,
  * and `ANTHROPIC_API_TOKEN` are all auto-detected by various
- * configurations. The default-deny gate must remove the full family
- * to prevent surprise billing.
+ * configurations. Security iter-2 finding on PR #97 extended the
+ * list to cover the Bedrock + Vertex billing routes: a user with
+ * `CLAUDE_CODE_USE_BEDROCK=1` + AWS creds in their shell would
+ * silently bill Bedrock from the curate/falsify subprocess despite
+ * the default-deny, so the route-flip flags + AWS/GCP credential
+ * vars also scrub.
  *
  * Exported so the test suite can pin the canonical list — any addition
  * here should be paired with a test in `curatorClaude.test.ts`.
@@ -136,6 +140,17 @@ export const AUTH_ENV_VARS: readonly string[] = [
   'ANTHROPIC_BEARER_TOKEN',
   'ANTHROPIC_API_TOKEN',
   'CLAUDE_API_KEY',
+  // Route-flip flags — set by users routing claude through Bedrock or
+  // Vertex AI instead of the Anthropic API. Scrubbing the flag itself
+  // is sufficient: with the flag absent, the CLI falls back to the
+  // (also-scrubbed) Anthropic env vars.
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  // Cloud-provider credential envs — if the route flag somehow
+  // survives (env-file injection, shell function, etc.), scrubbing
+  // these closes the billing path defense-in-depth.
+  'AWS_BEARER_TOKEN_BEDROCK',
+  'GOOGLE_APPLICATION_CREDENTIALS',
 ];
 
 /**

--- a/apps/standalone/src/pages/api/curate.ts
+++ b/apps/standalone/src/pages/api/curate.ts
@@ -22,7 +22,11 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { resolveClaudeBin } from '../../lib/resolveClaude.js';
-import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  AUTH_ENV_VARS,
+  computeAllowApiKeyFallback,
+  probeClaudeAvailable,
+} from '../../lib/curatorClaude.js';
 import {
   assertDataDirContained,
   handleDataDirGuardError,
@@ -65,6 +69,19 @@ const MAX_TAIL_BYTES = 8 * 1024;
 const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
 const DEFAULT_TOP_K = 10;
 const MAX_TOP_K = 50;
+/**
+ * Outer kill-timeout for the spawned `claude -p` child. Curator runs
+ * are 1-3 min on a healthy plan; 10 min is a generous ceiling that
+ * still releases `inFlight` if the subprocess hangs (network stall,
+ * deadlocked tool call, hung TTY).
+ *
+ * iter-1 finding: without this, a hung child would pin `inFlight`
+ * forever and the endpoint would permanently 409 until the dev
+ * server was restarted. SIGTERM-then-grace-then-SIGKILL is the
+ * standard escalation pattern.
+ */
+const SPAWN_KILL_TIMEOUT_MS = 10 * 60 * 1000;
+const SPAWN_KILL_GRACE_MS = 5_000;
 
 function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
   if (text.length <= max) return text;
@@ -104,7 +121,22 @@ interface CurateParams {
   dataDir: string;
   topK: number;
   noFalsifier: boolean;
+  /**
+   * Viewer-side opt-in flag (the raw value off the request body).
+   * Forwarded to the skill as a CLI flag so the skill's own pipeline
+   * knows whether the user opted in. The kernel-level decision about
+   * whether to scrub auth env vars BEFORE the spawn is the
+   * `allowApiKeyFallback` field below, which is the two-rail AND of
+   * viewer + server flags via `computeAllowApiKeyFallback`.
+   */
   apiKeyFallback: boolean;
+  /**
+   * Two-rail-resolved decision: viewer opt-in AND server env opt-in.
+   * Default-deny — when this is false we scrub the AUTH_ENV_VARS
+   * family from the spawn env so a server-side `ANTHROPIC_API_KEY`
+   * (or sibling auth var) cannot silently bill a claude -p call.
+   */
+  allowApiKeyFallback: boolean;
 }
 
 interface SpawnOutcome {
@@ -116,14 +148,33 @@ interface SpawnOutcome {
 
 /**
  * Spawn `claude -p /curate ...` and stream stdio over the NDJSON
- * response. Same machinery as mine-decisions; the skill is a scaffold
- * today (Rev3-F F1) so no fallback prompt — the F3+F4 PRs will exercise
- * the real pipeline against this endpoint.
+ * response. The streaming requirement (long-lived 1-3 min runs, UI
+ * needs per-line progress) prevents us from delegating to
+ * `runCuratorSubprocess` directly — that helper is fire-and-forget
+ * with a tagged-union result. We re-use its supporting machinery
+ * (`AUTH_ENV_VARS` scrub when the two-rail fallback is OFF, kill-
+ * timeout escalation) inline here instead.
+ *
+ * Security iter-1 findings addressed:
+ *
+ *   1. **API-key leak via inherited env.** Prior version passed
+ *      `env: process.env` verbatim — a server-side `ANTHROPIC_API_KEY`
+ *      (or any AUTH_ENV_VARS sibling) would silently bill the
+ *      subprocess. Now we scrub the full family when
+ *      `allowApiKeyFallback === false` (the default-deny two-rail
+ *      result from `computeAllowApiKeyFallback`).
+ *   2. **Unbounded hang pins `inFlight`.** No outer kill-timeout
+ *      meant a stuck child would permanently 409 the endpoint until
+ *      dev server restart. Now SIGTERM after
+ *      `SPAWN_KILL_TIMEOUT_MS`, SIGKILL after a `SPAWN_KILL_GRACE_MS`
+ *      grace window; the SpawnOutcome's `spawnError` is set so the
+ *      `finally` clears `inFlight`.
  */
 function runClaudeOnce(
   prompt: string,
   controller: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
+  allowApiKeyFallback: boolean,
 ): Promise<SpawnOutcome> {
   const send = (obj: unknown) => {
     try {
@@ -141,9 +192,19 @@ function runClaudeOnce(
     const allowedTools = 'Read Write Edit Bash Task Glob Grep';
     const bin = resolveClaudeBin();
     const args = ['--allowedTools', allowedTools, '-p', prompt];
+    // Default-deny env scrub. When the two-rail fallback resolves
+    // false, drop every AUTH_ENV_VARS entry so the subprocess can't
+    // inherit a surprise auth credential. Mirrors the scrub in
+    // `runCuratorSubprocess`.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (!allowApiKeyFallback) {
+      for (const name of AUTH_ENV_VARS) {
+        delete env[name];
+      }
+    }
     const child = spawn(bin.file, args, {
       cwd: repoRoot(),
-      env: process.env,
+      env,
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -153,6 +214,59 @@ function runClaudeOnce(
     const stdoutFull = { v: '' };
     const stderrFull = { v: '' };
     let spawnError: Error | null = null;
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+    let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimers = (): void => {
+      if (killTimer !== null) {
+        clearTimeout(killTimer);
+        killTimer = null;
+      }
+      if (graceTimer !== null) {
+        clearTimeout(graceTimer);
+        graceTimer = null;
+      }
+    };
+
+    const settleOnce = (outcome: SpawnOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      resolvePromise(outcome);
+    };
+
+    // Outer kill-timeout — SIGTERM first, SIGKILL after a grace
+    // window if the child doesn't exit promptly. The `close` handler
+    // below races with this; whichever fires first settles.
+    killTimer = setTimeout(() => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead — ignore
+      }
+      graceTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // already dead
+        }
+        // Synthesize a spawnError so the caller's `finally` clears
+        // inFlight; exitCode null signals "killed by us, not the
+        // child's own exit path".
+        settleOnce({
+          exitCode: null,
+          stdout: stdoutFull.v,
+          stderr:
+            stderrFull.v +
+            (stderrFull.v.length > 0 ? '\n' : '') +
+            `[curate] spawn exceeded ${SPAWN_KILL_TIMEOUT_MS}ms; SIGKILL'd.`,
+          spawnError: new Error(
+            `claude -p subprocess exceeded ${SPAWN_KILL_TIMEOUT_MS}ms kill-timeout`,
+          ),
+        });
+      }, SPAWN_KILL_GRACE_MS);
+    }, SPAWN_KILL_TIMEOUT_MS);
 
     const drain = (
       buf: string,
@@ -202,7 +316,7 @@ function runClaudeOnce(
         send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
         stderrFull.v += stderrBuf;
       }
-      resolvePromise({
+      settleOnce({
         exitCode: code,
         stdout: stdoutFull.v,
         stderr: stderrFull.v,
@@ -218,14 +332,25 @@ async function streamCurate(
   encoder: TextEncoder,
 ): Promise<void> {
   const started = Date.now();
-  const { requestId, dataDir, topK, noFalsifier, apiKeyFallback } = params;
+  const {
+    requestId,
+    dataDir,
+    topK,
+    noFalsifier,
+    apiKeyFallback,
+    allowApiKeyFallback,
+  } = params;
   const flags: string[] = [
     `--request-id=${requestId}`,
     `--data-dir=${dataDir}`,
     `--top-k=${topK}`,
   ];
   if (noFalsifier) flags.push('--no-falsifier');
-  if (apiKeyFallback) flags.push('--api-key-fallback');
+  // Surface the effective two-rail decision to the skill — the
+  // viewer-side opt-in alone is not enough to flip the flag. When
+  // either rail is OFF we don't pass `--api-key-fallback`; the env
+  // scrub in `runClaudeOnce` is the load-bearing enforcement.
+  if (allowApiKeyFallback) flags.push('--api-key-fallback');
   const prompt = `/curate ${flags.join(' ')}`;
 
   const send = (obj: unknown) => {
@@ -243,9 +368,16 @@ async function streamCurate(
     startedAt: started,
     topK,
     noFalsifier,
+    apiKeyFallback,
+    allowApiKeyFallback,
   });
 
-  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const outcome = await runClaudeOnce(
+    prompt,
+    controller,
+    encoder,
+    allowApiKeyFallback,
+  );
   const extraStderr = outcome.spawnError
     ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
     : '';
@@ -333,6 +465,10 @@ export const POST: APIRoute = async ({ request }) => {
   }
   const noFalsifier = body.noFalsifier === true;
   const apiKeyFallback = body.apiKeyFallback === true;
+  // Two-rail composition: viewer opt-in AND server env opt-in. This
+  // helper is the SINGLE source of truth for the decision — re-
+  // deriving the AND elsewhere is a defect (security iter-1).
+  const allowApiKeyFallback = computeAllowApiKeyFallback(body.apiKeyFallback);
 
   const params: CurateParams = {
     requestId: randomUUID(),
@@ -340,6 +476,7 @@ export const POST: APIRoute = async ({ request }) => {
     topK,
     noFalsifier,
     apiKeyFallback,
+    allowApiKeyFallback,
   };
 
   const encoder = new TextEncoder();

--- a/apps/standalone/src/pages/api/curate.ts
+++ b/apps/standalone/src/pages/api/curate.ts
@@ -1,0 +1,397 @@
+/**
+ * `/api/curate` — POST drives the `/curate` skill via `claude -p` so the
+ * PRACTICE surface's CuratorFeed has a producer the UI can trigger. The
+ * skill itself reads the SQLite substrate, ranks tier-2/tier-3 narratives
+ * + knowledge-debt + applied-pattern watcher items, and writes
+ * `analysis/curator-feed.json` (Rev3-F F1 scaffold; F3 + F4 land the
+ * ranker + falsifier wiring).
+ *
+ * Shape mirrors `/api/mine-decisions.ts` (the simpler of the two
+ * skill-spawn endpoints — no auto-window, no candidate-id sidecar). CSRF
+ * + in-flight + NDJSON streaming match `mine-corrections.ts` exactly.
+ *
+ * One real deviation from the mine-* siblings: we gate spawn behind
+ * `probeClaudeAvailable()`. The skills are slow (1-3 min) so paying a
+ * <200ms probe up front to short-circuit a missing-CLI session with a
+ * clean 503 beats letting the spawn fail opaquely two minutes in.
+ */
+
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { resolveClaudeBin } from '../../lib/resolveClaude.js';
+import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  assertDataDirContained,
+  handleDataDirGuardError,
+} from '../../lib/dataDirGuard.js';
+
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-curate';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Serializes concurrent curator runs. Two parallel passes would race to
+ * write `curator-feed.json`; concurrent callers get 409. `inFlightRequestId`
+ * lets the GET probe surface the active run's id so a page reload can
+ * attach to it instead of failing closed (same shape as mine-corrections).
+ */
+let inFlight: Promise<void> | null = null;
+let inFlightRequestId: string | null = null;
+
+const MAX_LINE_CHARS = 2_000;
+const MAX_TAIL_BYTES = 8 * 1024;
+const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
+const DEFAULT_TOP_K = 10;
+const MAX_TOP_K = 50;
+
+function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
+  if (text.length <= max) return text;
+  return '… (truncated) …\n' + text.slice(-max);
+}
+
+function clampLine(line: string): string {
+  if (line.length <= MAX_LINE_CHARS) return line;
+  return line.slice(0, MAX_LINE_CHARS - 12) + '… (truncated)';
+}
+
+/**
+ * Repo root from this file's location — same arithmetic as rescan /
+ * mine-corrections / mine-decisions:
+ *
+ *   apps/standalone/src/pages/api/curate.ts   (this file)
+ *   ..\..\..\..\..                            (five up = repo root)
+ */
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+interface CurateBody {
+  dataDir?: unknown;
+  /** Top-K items to surface in the feed. Clamped to [1, MAX_TOP_K]. */
+  topK?: unknown;
+  /** When true, skip Stage 2 falsifier pass — findings tagged `'skipped-by-user'`. */
+  noFalsifier?: unknown;
+  /** F6 viewer-side opt-in for API-key fallback. Forwarded verbatim to the skill;
+   *  the skill ANDs it with the server-side env flag. */
+  apiKeyFallback?: unknown;
+}
+
+interface CurateParams {
+  requestId: string;
+  dataDir: string;
+  topK: number;
+  noFalsifier: boolean;
+  apiKeyFallback: boolean;
+}
+
+interface SpawnOutcome {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  spawnError: Error | null;
+}
+
+/**
+ * Spawn `claude -p /curate ...` and stream stdio over the NDJSON
+ * response. Same machinery as mine-decisions; the skill is a scaffold
+ * today (Rev3-F F1) so no fallback prompt — the F3+F4 PRs will exercise
+ * the real pipeline against this endpoint.
+ */
+function runClaudeOnce(
+  prompt: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<SpawnOutcome> {
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // controller already closed
+    }
+  };
+  return new Promise<SpawnOutcome>((resolvePromise) => {
+    // Pre-authorize the tools the curator needs. Whitelist (not full
+    // bypass) keeps the spawn under per-tool scrutiny: only Read /
+    // Write / Edit / Bash / Task (sub-agent) / Glob / Grep are usable.
+    // Risk is bounded by this endpoint's CSRF gate + the skill's
+    // dataDir-scoped write surface (curator-feed.json + status file).
+    const allowedTools = 'Read Write Edit Bash Task Glob Grep';
+    const bin = resolveClaudeBin();
+    const args = ['--allowedTools', allowedTools, '-p', prompt];
+    const child = spawn(bin.file, args, {
+      cwd: repoRoot(),
+      env: process.env,
+      shell: bin.useShell,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    const stdoutFull = { v: '' };
+    const stderrFull = { v: '' };
+    let spawnError: Error | null = null;
+
+    const drain = (
+      buf: string,
+      chunk: string,
+      kind: 'stdout' | 'stderr',
+      full: { v: string },
+    ): string => {
+      full.v += chunk;
+      const combined = buf + chunk;
+      const parts = combined.split('\n');
+      const lastFragment = parts.pop() ?? '';
+      for (const raw of parts) {
+        const line = raw.trimEnd();
+        if (line.length === 0) continue;
+        send({ type: kind, line: clampLine(line) });
+        // Skill stages log `[N/4] stage-name:` markers per SKILL.md;
+        // surface them as phase events so the UI can render progress
+        // without parsing every stdout line.
+        const m = /\[(\d+)\/(\d+)\]\s+(\w[\w-]*)\s*:/.exec(line);
+        if (m) {
+          send({
+            type: 'phase',
+            phase: m[3],
+            ix: Number(m[1]),
+            total: Number(m[2]),
+          });
+        }
+      }
+      return lastFragment;
+    };
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutBuf = drain(stdoutBuf, chunk.toString('utf8'), 'stdout', stdoutFull);
+    });
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderrBuf = drain(stderrBuf, chunk.toString('utf8'), 'stderr', stderrFull);
+    });
+    child.on('error', (err) => {
+      spawnError = err;
+    });
+    child.on('close', (code) => {
+      if (stdoutBuf.trim().length > 0) {
+        send({ type: 'stdout', line: clampLine(stdoutBuf.trim()) });
+        stdoutFull.v += stdoutBuf;
+      }
+      if (stderrBuf.trim().length > 0) {
+        send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
+        stderrFull.v += stderrBuf;
+      }
+      resolvePromise({
+        exitCode: code,
+        stdout: stdoutFull.v,
+        stderr: stderrFull.v,
+        spawnError,
+      });
+    });
+  });
+}
+
+async function streamCurate(
+  params: CurateParams,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<void> {
+  const started = Date.now();
+  const { requestId, dataDir, topK, noFalsifier, apiKeyFallback } = params;
+  const flags: string[] = [
+    `--request-id=${requestId}`,
+    `--data-dir=${dataDir}`,
+    `--top-k=${topK}`,
+  ];
+  if (noFalsifier) flags.push('--no-falsifier');
+  if (apiKeyFallback) flags.push('--api-key-fallback');
+  const prompt = `/curate ${flags.join(' ')}`;
+
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // closed
+    }
+  };
+
+  send({
+    type: 'start',
+    command: `claude -p "${prompt}"`,
+    requestId,
+    startedAt: started,
+    topK,
+    noFalsifier,
+  });
+
+  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const extraStderr = outcome.spawnError
+    ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
+    : '';
+
+  send({
+    type: 'done',
+    ok: outcome.exitCode === 0 && outcome.spawnError === null,
+    exitCode: outcome.exitCode,
+    durationMs: Date.now() - started,
+    requestId,
+    stdoutTail: tailBytes(outcome.stdout),
+    stderrTail: tailBytes(outcome.stderr + extraStderr),
+    command: `claude -p "${prompt}"`,
+  });
+
+  try {
+    controller.close();
+  } catch {
+    // closed
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+  if (inFlight) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'A curator run is already in progress. Wait for it to finish (1-3 min).',
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  // Probe `claude --version` up front. Curator runs are 1-3 min; failing
+  // fast with a clean 503 beats a two-minute spawn that ends in a cryptic
+  // ENOENT. Per `feedback_claude_code_not_api` the answer to "claude
+  // missing" is NOT to silently fall back to the API key — that's the
+  // F6 opt-in path, gated by viewer + server flags inside the skill.
+  const probe = await probeClaudeAvailable();
+  if (!probe.available) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error:
+          'claude CLI not detected on this host. The curator runs as a `claude -p` subprocess (plan-billed); install Claude Code or set CLAUDE_BIN to a working binary, then retry.',
+        reason: probe.reason ?? 'not-found',
+      }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  let body: CurateBody = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') body = parsed as CurateBody;
+    }
+  } catch {
+    body = {};
+  }
+
+  const candidate =
+    typeof body.dataDir === 'string' && body.dataDir.trim().length > 0
+      ? body.dataDir
+      : DEFAULT_DATA_DIR;
+  let dataDir: string;
+  try {
+    dataDir = assertDataDirContained(candidate, repoRoot()); // (S1)
+  } catch (e) {
+    const r = handleDataDirGuardError(e); // (XN2)
+    if (r) return r;
+    throw e;
+  }
+
+  let topK = DEFAULT_TOP_K;
+  if (typeof body.topK === 'number' && Number.isFinite(body.topK) && body.topK >= 1) {
+    topK = Math.min(Math.floor(body.topK), MAX_TOP_K);
+  }
+  const noFalsifier = body.noFalsifier === true;
+  const apiKeyFallback = body.apiKeyFallback === true;
+
+  const params: CurateParams = {
+    requestId: randomUUID(),
+    dataDir,
+    topK,
+    noFalsifier,
+    apiKeyFallback,
+  };
+
+  const encoder = new TextEncoder();
+  let done: (() => void) | null = null;
+  const completed = new Promise<void>((res) => {
+    done = res;
+  });
+  inFlight = completed.then(() => undefined);
+  inFlightRequestId = params.requestId;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        await streamCurate(params, controller, encoder);
+      } finally {
+        inFlight = null;
+        inFlightRequestId = null;
+        done?.();
+      }
+    },
+    cancel() {
+      // client disconnected; CLI keeps running and writes to disk
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+      'cache-control': 'no-store',
+      'x-accel-buffering': 'no',
+    },
+  });
+};
+
+/**
+ * Readiness probe. The viewer pings this on mount to decide whether to
+ * surface the CURATE button (`available`) and whether a run is already
+ * in flight (`busy`). Production static builds have no GET; the viewer
+ * treats fetch failure as `available: false`.
+ */
+export const GET: APIRoute = () => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      available: true,
+      busy: inFlight !== null,
+      busyRequestId: inFlightRequestId,
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    },
+  );
+};

--- a/apps/standalone/src/pages/api/curate.ts
+++ b/apps/standalone/src/pages/api/curate.ts
@@ -63,6 +63,10 @@ function csrfReject(reason: string): Response {
  */
 let inFlight: Promise<void> | null = null;
 let inFlightRequestId: string | null = null;
+// Iter-2 security finding: empty cancel() left an orphan child holding
+// the inFlight slot for up to 10 min (until the kill-timer fired). We
+// track the active child so cancel() can SIGTERM it promptly.
+let inFlightChildKill: (() => void) | null = null;
 
 const MAX_LINE_CHARS = 2_000;
 const MAX_TAIL_BYTES = 8 * 1024;
@@ -208,6 +212,15 @@ function runClaudeOnce(
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    // Register the kill hook so the outer ReadableStream.cancel() can
+    // SIGTERM this child if the client disconnects. Cleared in settleOnce.
+    inFlightChildKill = () => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead — ignore
+      }
+    };
 
     let stdoutBuf = '';
     let stderrBuf = '';
@@ -233,6 +246,7 @@ function runClaudeOnce(
       if (settled) return;
       settled = true;
       clearTimers();
+      inFlightChildKill = null;
       resolvePromise(outcome);
     };
 
@@ -498,7 +512,11 @@ export const POST: APIRoute = async ({ request }) => {
       }
     },
     cancel() {
-      // client disconnected; CLI keeps running and writes to disk
+      // Iter-2 security fix: client disconnect now SIGTERMs the child
+      // so the inFlight slot releases promptly. The skill's stage-end
+      // checkpoints mean partial work isn't lost; a full re-run from
+      // the user re-spawns cleanly.
+      inFlightChildKill?.();
     },
   });
 

--- a/apps/standalone/src/pages/api/falsify.ts
+++ b/apps/standalone/src/pages/api/falsify.ts
@@ -1,0 +1,416 @@
+/**
+ * `/api/falsify` — POST drives the `/falsify` skill via `claude -p`.
+ * The skill reads each candidate finding's `evidenceChain`, pulls the
+ * cited session turns from the SQLite substrate, and emits a per-turn
+ * `supports / neutral / contradicts` verdict aggregated against
+ * `THRESHOLDS.curator.falsifierMinSupportRatio`. Writes
+ * `analysis/falsifier-verdicts.json` (Rev3-F F2 scaffold; F4 lands the
+ * verifier kernel).
+ *
+ * Sibling to `/api/curate` — same CSRF / in-flight / NDJSON streaming
+ * shape; the only real difference is the skill args (input file vs
+ * single finding-id) and the in-flight error copy.
+ *
+ * Note: the curator's Stage 2 calls /falsify in-process from inside the
+ * `claude -p /curate` subprocess; this endpoint is the manual /
+ * meta-validation entry point (a user spot-checking a finding, or F8
+ * re-judging a held-out set).
+ */
+
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { resolveClaudeBin } from '../../lib/resolveClaude.js';
+import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  assertDataDirContained,
+  handleDataDirGuardError,
+} from '../../lib/dataDirGuard.js';
+
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-falsify';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let inFlight: Promise<void> | null = null;
+let inFlightRequestId: string | null = null;
+
+const MAX_LINE_CHARS = 2_000;
+const MAX_TAIL_BYTES = 8 * 1024;
+const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
+/** Loose ceiling on finding-id length — UUIDs / kernel-prefixed ids are well under this. */
+const MAX_FINDING_ID_CHARS = 256;
+
+function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
+  if (text.length <= max) return text;
+  return '… (truncated) …\n' + text.slice(-max);
+}
+
+function clampLine(line: string): string {
+  if (line.length <= MAX_LINE_CHARS) return line;
+  return line.slice(0, MAX_LINE_CHARS - 12) + '… (truncated)';
+}
+
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+interface FalsifyBody {
+  dataDir?: unknown;
+  /** Verify a single finding by id. Mutually exclusive with `input`. */
+  findingId?: unknown;
+  /** Path to a JSON file with `{ findings: [...] }`. Validated under dataDir. */
+  input?: unknown;
+  /** Optional output path. Defaults inside the skill to `${dataDir}/analysis/falsifier-verdicts.json`. */
+  output?: unknown;
+  /** F6 viewer-side opt-in for API-key fallback. Forwarded verbatim. */
+  apiKeyFallback?: unknown;
+}
+
+interface FalsifyParams {
+  requestId: string;
+  dataDir: string;
+  findingId: string | null;
+  inputPath: string | null;
+  outputPath: string | null;
+  apiKeyFallback: boolean;
+}
+
+interface SpawnOutcome {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  spawnError: Error | null;
+}
+
+function runClaudeOnce(
+  prompt: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<SpawnOutcome> {
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // controller already closed
+    }
+  };
+  return new Promise<SpawnOutcome>((resolvePromise) => {
+    // Falsifier needs the same tool surface as the curator — Read for
+    // session turns, Bash for kernel invocations, Write for verdict
+    // output, Task for the K=3 self-consistency sub-agents.
+    const allowedTools = 'Read Write Edit Bash Task Glob Grep';
+    const bin = resolveClaudeBin();
+    const args = ['--allowedTools', allowedTools, '-p', prompt];
+    const child = spawn(bin.file, args, {
+      cwd: repoRoot(),
+      env: process.env,
+      shell: bin.useShell,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    const stdoutFull = { v: '' };
+    const stderrFull = { v: '' };
+    let spawnError: Error | null = null;
+
+    const drain = (
+      buf: string,
+      chunk: string,
+      kind: 'stdout' | 'stderr',
+      full: { v: string },
+    ): string => {
+      full.v += chunk;
+      const combined = buf + chunk;
+      const parts = combined.split('\n');
+      const lastFragment = parts.pop() ?? '';
+      for (const raw of parts) {
+        const line = raw.trimEnd();
+        if (line.length === 0) continue;
+        send({ type: kind, line: clampLine(line) });
+        const m = /\[(\d+)\/(\d+)\]\s+(\w[\w-]*)\s*:/.exec(line);
+        if (m) {
+          send({
+            type: 'phase',
+            phase: m[3],
+            ix: Number(m[1]),
+            total: Number(m[2]),
+          });
+        }
+      }
+      return lastFragment;
+    };
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutBuf = drain(stdoutBuf, chunk.toString('utf8'), 'stdout', stdoutFull);
+    });
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderrBuf = drain(stderrBuf, chunk.toString('utf8'), 'stderr', stderrFull);
+    });
+    child.on('error', (err) => {
+      spawnError = err;
+    });
+    child.on('close', (code) => {
+      if (stdoutBuf.trim().length > 0) {
+        send({ type: 'stdout', line: clampLine(stdoutBuf.trim()) });
+        stdoutFull.v += stdoutBuf;
+      }
+      if (stderrBuf.trim().length > 0) {
+        send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
+        stderrFull.v += stderrBuf;
+      }
+      resolvePromise({
+        exitCode: code,
+        stdout: stdoutFull.v,
+        stderr: stderrFull.v,
+        spawnError,
+      });
+    });
+  });
+}
+
+async function streamFalsify(
+  params: FalsifyParams,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<void> {
+  const started = Date.now();
+  const { requestId, dataDir, findingId, inputPath, outputPath, apiKeyFallback } = params;
+  const flags: string[] = [
+    `--request-id=${requestId}`,
+    `--data-dir=${dataDir}`,
+  ];
+  if (findingId !== null) flags.push(`--finding-id=${findingId}`);
+  if (inputPath !== null) flags.push(`--input=${inputPath}`);
+  if (outputPath !== null) flags.push(`--output=${outputPath}`);
+  if (apiKeyFallback) flags.push('--api-key-fallback');
+  const prompt = `/falsify ${flags.join(' ')}`;
+
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // closed
+    }
+  };
+
+  send({
+    type: 'start',
+    command: `claude -p "${prompt}"`,
+    requestId,
+    startedAt: started,
+    findingId,
+    inputPath,
+  });
+
+  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const extraStderr = outcome.spawnError
+    ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
+    : '';
+
+  send({
+    type: 'done',
+    ok: outcome.exitCode === 0 && outcome.spawnError === null,
+    exitCode: outcome.exitCode,
+    durationMs: Date.now() - started,
+    requestId,
+    stdoutTail: tailBytes(outcome.stdout),
+    stderrTail: tailBytes(outcome.stderr + extraStderr),
+    command: `claude -p "${prompt}"`,
+  });
+
+  try {
+    controller.close();
+  } catch {
+    // closed
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+  if (inFlight) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'A falsifier run is already in progress. Wait for it to finish (1-3 min).',
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  // Same up-front probe as /api/curate. The two endpoints fail fast
+  // independently — operator can be missing claude on a host that still
+  // has a stale curator run in flight from a different binary version,
+  // so we don't share probe state.
+  const probe = await probeClaudeAvailable();
+  if (!probe.available) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error:
+          'claude CLI not detected on this host. The falsifier runs as a `claude -p` subprocess (plan-billed); install Claude Code or set CLAUDE_BIN to a working binary, then retry.',
+        reason: probe.reason ?? 'not-found',
+      }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  let body: FalsifyBody = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') body = parsed as FalsifyBody;
+    }
+  } catch {
+    body = {};
+  }
+
+  const candidate =
+    typeof body.dataDir === 'string' && body.dataDir.trim().length > 0
+      ? body.dataDir
+      : DEFAULT_DATA_DIR;
+  let dataDir: string;
+  try {
+    dataDir = assertDataDirContained(candidate, repoRoot()); // (S1)
+  } catch (e) {
+    const r = handleDataDirGuardError(e); // (XN2)
+    if (r) return r;
+    throw e;
+  }
+
+  // Mutually exclusive: --finding-id verifies one finding, --input
+  // batch-processes a generator's output file. Both unset is fine —
+  // the skill falls back to its default input path.
+  let findingId: string | null = null;
+  if (typeof body.findingId === 'string' && body.findingId.trim().length > 0) {
+    const v = body.findingId.trim();
+    if (v.length > MAX_FINDING_ID_CHARS) {
+      return new Response(
+        JSON.stringify({ ok: false, error: `findingId exceeds ${MAX_FINDING_ID_CHARS} chars` }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    findingId = v;
+  }
+
+  let inputPath: string | null = null;
+  if (typeof body.input === 'string' && body.input.trim().length > 0) {
+    try {
+      // Containment: the input file MUST live under the chat-arch-data
+      // safe root. Same guard the dataDir param uses; without it a local-
+      // origin caller could ask the skill to read an arbitrary repo file.
+      inputPath = assertDataDirContained(body.input, repoRoot());
+    } catch (e) {
+      const r = handleDataDirGuardError(e);
+      if (r) return r;
+      throw e;
+    }
+  }
+
+  let outputPath: string | null = null;
+  if (typeof body.output === 'string' && body.output.trim().length > 0) {
+    try {
+      outputPath = assertDataDirContained(body.output, repoRoot());
+    } catch (e) {
+      const r = handleDataDirGuardError(e);
+      if (r) return r;
+      throw e;
+    }
+  }
+
+  if (findingId !== null && inputPath !== null) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'findingId and input are mutually exclusive — pick one.',
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  const apiKeyFallback = body.apiKeyFallback === true;
+
+  const params: FalsifyParams = {
+    requestId: randomUUID(),
+    dataDir,
+    findingId,
+    inputPath,
+    outputPath,
+    apiKeyFallback,
+  };
+
+  const encoder = new TextEncoder();
+  let done: (() => void) | null = null;
+  const completed = new Promise<void>((res) => {
+    done = res;
+  });
+  inFlight = completed.then(() => undefined);
+  inFlightRequestId = params.requestId;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        await streamFalsify(params, controller, encoder);
+      } finally {
+        inFlight = null;
+        inFlightRequestId = null;
+        done?.();
+      }
+    },
+    cancel() {
+      // client disconnected; CLI keeps running and writes to disk
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+      'cache-control': 'no-store',
+      'x-accel-buffering': 'no',
+    },
+  });
+};
+
+export const GET: APIRoute = () => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      available: true,
+      busy: inFlight !== null,
+      busyRequestId: inFlightRequestId,
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    },
+  );
+};

--- a/apps/standalone/src/pages/api/falsify.ts
+++ b/apps/standalone/src/pages/api/falsify.ts
@@ -23,7 +23,11 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { resolveClaudeBin } from '../../lib/resolveClaude.js';
-import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  AUTH_ENV_VARS,
+  computeAllowApiKeyFallback,
+  probeClaudeAvailable,
+} from '../../lib/curatorClaude.js';
 import {
   assertDataDirContained,
   handleDataDirGuardError,
@@ -60,6 +64,21 @@ const MAX_TAIL_BYTES = 8 * 1024;
 const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
 /** Loose ceiling on finding-id length — UUIDs / kernel-prefixed ids are well under this. */
 const MAX_FINDING_ID_CHARS = 256;
+/**
+ * Allowed charset for `findingId` — alphanumerics + `_`, `.`, `:`, `-`.
+ * Covers UUIDs, kernel-prefixed ids (`kernel:uuid`), short hash slugs,
+ * and dotted-namespace ids. Excludes whitespace, shell metacharacters
+ * (`$`, `` ` ``, `;`, `|`, `&`, `<`, `>`, `(`, `)`, `\`), quotes, and
+ * Unicode that could compose ambiguous flag tokens.
+ *
+ * Defense in depth: combined with the Windows `useShell: true`
+ * fallback in `resolveClaude`, an unvalidated findingId becomes a
+ * shell-injection sink. Iter-1 finding closes that gap.
+ */
+const FINDING_ID_CHARSET_RE = /^[A-Za-z0-9_.:-]{1,256}$/;
+/** See `curate.ts` — same kill-timeout / grace contract. */
+const SPAWN_KILL_TIMEOUT_MS = 10 * 60 * 1000;
+const SPAWN_KILL_GRACE_MS = 5_000;
 
 function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
   if (text.length <= max) return text;
@@ -94,7 +113,13 @@ interface FalsifyParams {
   findingId: string | null;
   inputPath: string | null;
   outputPath: string | null;
+  /** Viewer-side opt-in flag (raw body value). Surfaced to the skill. */
   apiKeyFallback: boolean;
+  /**
+   * Two-rail-resolved decision: viewer opt-in AND server env opt-in.
+   * Default-deny — drives the AUTH_ENV_VARS scrub in `runClaudeOnce`.
+   */
+  allowApiKeyFallback: boolean;
 }
 
 interface SpawnOutcome {
@@ -104,10 +129,17 @@ interface SpawnOutcome {
   spawnError: Error | null;
 }
 
+/**
+ * Spawn `claude -p /falsify ...` and stream stdio over NDJSON.
+ * Sibling to `curate.ts`'s `runClaudeOnce` — same security iter-1
+ * fixes apply (AUTH_ENV_VARS scrub when fallback is OFF, kill-timeout
+ * escalation so a hung child doesn't permanently 409 the endpoint).
+ */
 function runClaudeOnce(
   prompt: string,
   controller: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
+  allowApiKeyFallback: boolean,
 ): Promise<SpawnOutcome> {
   const send = (obj: unknown) => {
     try {
@@ -123,9 +155,16 @@ function runClaudeOnce(
     const allowedTools = 'Read Write Edit Bash Task Glob Grep';
     const bin = resolveClaudeBin();
     const args = ['--allowedTools', allowedTools, '-p', prompt];
+    // Default-deny env scrub — see curate.ts for the rationale.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (!allowApiKeyFallback) {
+      for (const name of AUTH_ENV_VARS) {
+        delete env[name];
+      }
+    }
     const child = spawn(bin.file, args, {
       cwd: repoRoot(),
-      env: process.env,
+      env,
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -135,6 +174,53 @@ function runClaudeOnce(
     const stdoutFull = { v: '' };
     const stderrFull = { v: '' };
     let spawnError: Error | null = null;
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+    let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimers = (): void => {
+      if (killTimer !== null) {
+        clearTimeout(killTimer);
+        killTimer = null;
+      }
+      if (graceTimer !== null) {
+        clearTimeout(graceTimer);
+        graceTimer = null;
+      }
+    };
+
+    const settleOnce = (outcome: SpawnOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      resolvePromise(outcome);
+    };
+
+    killTimer = setTimeout(() => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead
+      }
+      graceTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // already dead
+        }
+        settleOnce({
+          exitCode: null,
+          stdout: stdoutFull.v,
+          stderr:
+            stderrFull.v +
+            (stderrFull.v.length > 0 ? '\n' : '') +
+            `[falsify] spawn exceeded ${SPAWN_KILL_TIMEOUT_MS}ms; SIGKILL'd.`,
+          spawnError: new Error(
+            `claude -p subprocess exceeded ${SPAWN_KILL_TIMEOUT_MS}ms kill-timeout`,
+          ),
+        });
+      }, SPAWN_KILL_GRACE_MS);
+    }, SPAWN_KILL_TIMEOUT_MS);
 
     const drain = (
       buf: string,
@@ -181,7 +267,7 @@ function runClaudeOnce(
         send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
         stderrFull.v += stderrBuf;
       }
-      resolvePromise({
+      settleOnce({
         exitCode: code,
         stdout: stdoutFull.v,
         stderr: stderrFull.v,
@@ -197,7 +283,15 @@ async function streamFalsify(
   encoder: TextEncoder,
 ): Promise<void> {
   const started = Date.now();
-  const { requestId, dataDir, findingId, inputPath, outputPath, apiKeyFallback } = params;
+  const {
+    requestId,
+    dataDir,
+    findingId,
+    inputPath,
+    outputPath,
+    apiKeyFallback,
+    allowApiKeyFallback,
+  } = params;
   const flags: string[] = [
     `--request-id=${requestId}`,
     `--data-dir=${dataDir}`,
@@ -205,7 +299,10 @@ async function streamFalsify(
   if (findingId !== null) flags.push(`--finding-id=${findingId}`);
   if (inputPath !== null) flags.push(`--input=${inputPath}`);
   if (outputPath !== null) flags.push(`--output=${outputPath}`);
-  if (apiKeyFallback) flags.push('--api-key-fallback');
+  // Only forward the two-rail-resolved decision; viewer opt-in alone
+  // is not enough. The env-scrub in runClaudeOnce is the load-bearing
+  // enforcement.
+  if (allowApiKeyFallback) flags.push('--api-key-fallback');
   const prompt = `/falsify ${flags.join(' ')}`;
 
   const send = (obj: unknown) => {
@@ -223,9 +320,16 @@ async function streamFalsify(
     startedAt: started,
     findingId,
     inputPath,
+    apiKeyFallback,
+    allowApiKeyFallback,
   });
 
-  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const outcome = await runClaudeOnce(
+    prompt,
+    controller,
+    encoder,
+    allowApiKeyFallback,
+  );
   const extraStderr = outcome.spawnError
     ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
     : '';
@@ -318,6 +422,17 @@ export const POST: APIRoute = async ({ request }) => {
         { status: 400, headers: { 'content-type': 'application/json' } },
       );
     }
+    // Charset validation — defense-in-depth against shell-injection
+    // via the Windows `useShell: true` fallback. Whitelist is
+    // alphanumerics + `_`, `.`, `:`, `-` (covers all kernel-emitted
+    // finding-id shapes — UUIDs, prefixed slugs, dotted namespaces);
+    // rejects whitespace + shell metacharacters + quotes + Unicode.
+    if (!FINDING_ID_CHARSET_RE.test(v)) {
+      return new Response(
+        JSON.stringify({ ok: false, error: 'Invalid findingId format' }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      );
+    }
     findingId = v;
   }
 
@@ -357,6 +472,10 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   const apiKeyFallback = body.apiKeyFallback === true;
+  // Two-rail composition — see curate.ts. The viewer flag alone
+  // never enables the fallback; the server-side env opt-in must
+  // also be set. Default-deny.
+  const allowApiKeyFallback = computeAllowApiKeyFallback(body.apiKeyFallback);
 
   const params: FalsifyParams = {
     requestId: randomUUID(),
@@ -365,6 +484,7 @@ export const POST: APIRoute = async ({ request }) => {
     inputPath,
     outputPath,
     apiKeyFallback,
+    allowApiKeyFallback,
   };
 
   const encoder = new TextEncoder();

--- a/apps/standalone/src/pages/api/falsify.ts
+++ b/apps/standalone/src/pages/api/falsify.ts
@@ -58,6 +58,10 @@ function csrfReject(reason: string): Response {
 
 let inFlight: Promise<void> | null = null;
 let inFlightRequestId: string | null = null;
+// Iter-2 security finding (mirror of curate.ts): empty cancel() left
+// an orphan child holding the inFlight slot for up to 10 min until the
+// kill-timer fired. Track the active child so cancel() can SIGTERM it.
+let inFlightChildKill: (() => void) | null = null;
 
 const MAX_LINE_CHARS = 2_000;
 const MAX_TAIL_BYTES = 8 * 1024;
@@ -168,6 +172,13 @@ function runClaudeOnce(
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    inFlightChildKill = () => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead — ignore
+      }
+    };
 
     let stdoutBuf = '';
     let stderrBuf = '';
@@ -193,6 +204,7 @@ function runClaudeOnce(
       if (settled) return;
       settled = true;
       clearTimers();
+      inFlightChildKill = null;
       resolvePromise(outcome);
     };
 
@@ -506,7 +518,9 @@ export const POST: APIRoute = async ({ request }) => {
       }
     },
     cancel() {
-      // client disconnected; CLI keeps running and writes to disk
+      // Iter-2 security fix: client disconnect SIGTERMs the child so
+      // the inFlight slot releases promptly. Mirrors curate.ts.
+      inFlightChildKill?.();
     },
   });
 

--- a/apps/standalone/src/pages/playbook.astro
+++ b/apps/standalone/src/pages/playbook.astro
@@ -149,8 +149,8 @@ function fmtSid(sid: string): string {
               })),
             })
               .split('<').join('\\u003c')
-              .split(' ').join('\\u2028')
-              .split(' ').join('\\u2029')
+              .split('\u2028').join('\\u2028')
+              .split('\u2029').join('\\u2029')
           }
         />
 

--- a/apps/standalone/test/lib/curatorClaude.test.ts
+++ b/apps/standalone/test/lib/curatorClaude.test.ts
@@ -72,12 +72,17 @@ describe('probeClaudeAvailable — bogus-binary smoke test', () => {
   });
 });
 
-describe('AUTH_ENV_VARS (iter-1 security finding — full scrub family)', () => {
+describe('AUTH_ENV_VARS (iter-1 + iter-2 security findings — full scrub family)', () => {
   it('includes every variable the Anthropic SDK / claude CLI / Bedrock / Vertex auto-detect', () => {
     // Security iter-1 finding: scrubbing only ANTHROPIC_API_KEY was
     // insufficient — the CLI also honors AUTH_TOKEN / BEARER_TOKEN /
-    // CLAUDE_API_KEY / API_TOKEN. Pin the canonical list here so a
-    // future scrub-list change must update this test.
+    // CLAUDE_API_KEY / API_TOKEN.
+    // Security iter-2 finding: the Bedrock + Vertex route flags
+    // (CLAUDE_CODE_USE_BEDROCK / CLAUDE_CODE_USE_VERTEX) and the
+    // cloud-provider credential vars (AWS_BEARER_TOKEN_BEDROCK /
+    // GOOGLE_APPLICATION_CREDENTIALS) also need scrubbing.
+    // Pin the canonical list here so a future scrub-list change must
+    // update this test.
     expect(AUTH_ENV_VARS).toEqual(
       expect.arrayContaining([
         'ANTHROPIC_API_KEY',
@@ -85,10 +90,14 @@ describe('AUTH_ENV_VARS (iter-1 security finding — full scrub family)', () => 
         'ANTHROPIC_BEARER_TOKEN',
         'ANTHROPIC_API_TOKEN',
         'CLAUDE_API_KEY',
+        'CLAUDE_CODE_USE_BEDROCK',
+        'CLAUDE_CODE_USE_VERTEX',
+        'AWS_BEARER_TOKEN_BEDROCK',
+        'GOOGLE_APPLICATION_CREDENTIALS',
       ]),
     );
     // No accidental extras (catches typos like `ANTHRPIC_API_KEY`).
-    expect(AUTH_ENV_VARS.length).toBe(5);
+    expect(AUTH_ENV_VARS.length).toBe(9);
   });
 
   it('never contains a name with whitespace or wrong-case (process.env keys are case-sensitive)', () => {

--- a/packages/analysis/src/computeSurprises.test.ts
+++ b/packages/analysis/src/computeSurprises.test.ts
@@ -54,8 +54,14 @@ function compositeRow(
   sessionId: string,
   updatedAt: number,
   binary: 'good' | 'bad' | 'unknown' = 'good',
+  projectId?: string,
 ): SurpriseCompositeRow {
-  return { sessionId, updatedAt, composite: comp(sessionId, binary) };
+  return {
+    sessionId,
+    updatedAt,
+    composite: comp(sessionId, binary),
+    ...(projectId !== undefined ? { projectId } : {}),
+  };
 }
 
 function trajectoryRow(
@@ -182,6 +188,7 @@ function decision(
   sessionId: string,
   binaryClass: 'good' | 'bad' | 'neutral',
   compositeScore = binaryClass === 'good' ? 0.8 : 0.3,
+  projectId?: string,
 ): SurpriseDecisionRow {
   return {
     decisionId,
@@ -189,6 +196,7 @@ function decision(
     compositeScore,
     binaryClass,
     label: `decision-${decisionId}`,
+    ...(projectId !== undefined ? { projectId } : {}),
   };
 }
 
@@ -223,6 +231,11 @@ describe('computeSurprises — empty input', () => {
   it('always exposes the thresholds it used', () => {
     const out = computeSurprises(emptyInput(), { streakMin: 7 });
     expect(out.thresholds.streakMin).toBe(7);
+  });
+
+  it('snapshot includes reflexiveEValueMin (post-iter-1 sensitivity gate)', () => {
+    const out = computeSurprises(emptyInput(), { reflexiveEValueMin: 2.0 });
+    expect(out.thresholds.reflexiveEValueMin).toBe(2.0);
   });
 });
 
@@ -430,56 +443,186 @@ describe('reflexive-positive', () => {
     );
     expect(kindsOf(out.surprises)).toContain('reflexive-positive');
   });
+
+  it('does NOT emit when eValueStatus is not "computed" (CI straddles null)', () => {
+    // Even with strong meanDelta + positive CI, an inability to
+    // compute the E-value kills emission.
+    const r = reflexive(0.2, 0.05, 0.35);
+    const out = computeSurprises(
+      emptyInput({
+        reflexive: { ...r, eValueStatus: 'ci-straddles-null', eValueCIBound: null },
+      }),
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when eValueCIBound is below the reflexiveEValueMin floor', () => {
+    const r = reflexive(0.2, 0.05, 0.35);
+    const out = computeSurprises(
+      emptyInput({
+        reflexive: { ...r, eValueStatus: 'computed', eValueCIBound: 1.49 },
+      }),
+      { reflexiveEValueMin: 1.5 },
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('summary uses associational language ("is associated with"), not causal ("lifted")', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.2, 0.05, 0.35) }),
+    );
+    const reflexivePos = out.surprises.find((s) => s.kind === 'reflexive-positive');
+    expect(reflexivePos).toBeDefined();
+    expect(reflexivePos?.summary).toMatch(/associated with/);
+    expect(reflexivePos?.summary).not.toMatch(/lifted/);
+    // E-value surfaces in the summary so the user sees the sensitivity bound.
+    expect(reflexivePos?.summary).toMatch(/E-value/);
+  });
 });
 
 // ─── decision-paid-off ─────────────────────────────────────────────
 
 describe('decision-paid-off', () => {
-  it('emits when a good-binary decision is followed by ≥ K good sessions', () => {
+  // Helper: build a "noisy corpus" of mostly-bad in OTHER projects so
+  // the base good-share stays well below the followup rate.
+  //
+  // The Wilson-low > base-rate gate is tight: 5/5 same-project good
+  // followups gives Wilson low ≈ 0.566 (α=0.05). The corpus base rate
+  // must clear ≤ ≈ 0.5 for the gate to pass at this followup count.
+  // 2 good + 10 bad in 'noise' → 12 noise sessions, base rate including
+  // the 1 decision-good + 5 followup-good = 8/18 ≈ 0.444.
+  function noiseCorpus(): SurpriseCompositeRow[] {
+    const out: SurpriseCompositeRow[] = [];
+    for (let i = 0; i < 2; i += 1) {
+      out.push(compositeRow(`n-good-${i}`, 100 + i, 'good', 'noise'));
+    }
+    for (let i = 0; i < 10; i += 1) {
+      out.push(compositeRow(`n-bad-${i}`, 120 + i, 'bad', 'noise'));
+    }
+    return out;
+  }
+
+  it('emits when a good-binary decision is followed by ≥ K same-project good sessions', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'good'),
-      compositeRow('s-after1', 11, 'good'),
-      compositeRow('s-after2', 12, 'good'),
-      compositeRow('s-after3', 13, 'good'),
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     const paidOff = out.surprises.find((s) => s.kind === 'decision-paid-off');
     expect(paidOff).toBeDefined();
     expect(paidOff?.evidence.decisionId).toBe('d1');
+    // Summary surfaces the lift metrics (K/N + Wilson-low + base-rate).
+    expect(paidOff?.summary).toMatch(/same-project followups: 5\/5 good/);
+    expect(paidOff?.summary).toMatch(/Wilson low/);
+    expect(paidOff?.summary).toMatch(/base rate/);
   });
 
   it('does NOT emit when binaryClass is not "good"', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'bad'),
-      compositeRow('s-after1', 11, 'good'),
-      compositeRow('s-after2', 12, 'good'),
+      compositeRow('s-dec', 10, 'bad', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'bad')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'bad', 0.3, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
   });
 
-  it('does NOT emit when followups < threshold', () => {
+  it('does NOT emit when same-project followups < threshold', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'good'),
-      compositeRow('s-after1', 11, 'good'),
-      // only 1 followup; default threshold is 2
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      // only 1 same-project followup; threshold is 5
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
   });
 
-  it('boundary: exactly threshold followups emits', () => {
+  it('boundary: exactly threshold followups in-project emits', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'good'),
-      compositeRow('s-after1', 11, 'good'),
-      compositeRow('s-after2', 12, 'good'),
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     expect(kindsOf(out.surprises)).toContain('decision-paid-off');
+  });
+
+  it('does NOT count cross-project followups toward the threshold', () => {
+    // 5 good sessions follow the decision-session but in a DIFFERENT
+    // project — the prior cross-corpus version would have emitted.
+    const composites: SurpriseCompositeRow[] = [
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-x1', 11, 'good', 'p-other'),
+      compositeRow('s-x2', 12, 'good', 'p-other'),
+      compositeRow('s-x3', 13, 'good', 'p-other'),
+      compositeRow('s-x4', 14, 'good', 'p-other'),
+      compositeRow('s-x5', 15, 'good', 'p-other'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('does NOT emit when decision has no projectId (cannot scope followups)', () => {
+    const composites: SurpriseCompositeRow[] = [
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
+    ];
+    // Decision row deliberately missing projectId.
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8 /* no projectId */),
+    ];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('does NOT emit when Wilson low does not exceed base good-share', () => {
+    // Corpus is all-good (base rate 1.0). 5/5 good followups → Wilson
+    // low ≈ 0.566 — below 1.0. The lift gate kills the surprise even
+    // though the count floor is met.
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
   });
 });
 

--- a/packages/analysis/src/computeSurprises.test.ts
+++ b/packages/analysis/src/computeSurprises.test.ts
@@ -1,0 +1,652 @@
+/**
+ * Tests for `computeSurprises` — feed-redesign Phase A.
+ *
+ * Coverage shape per kind:
+ *   - happy path: kernel emits the expected row + score range
+ *   - negative path: kernel does NOT emit when inputs don't qualify
+ *   - boundary path: threshold-exact inputs behave correctly
+ *
+ * Plus a determinism test (same input → same output, ordering included)
+ * and a tone-segmentation sanity check.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CompositeOutcome } from '@chat-arch/schema';
+import {
+  computeSurprises,
+  type ComputeSurprisesInput,
+  type Surprise,
+  type SurpriseCompositeRow,
+  type SurpriseDecisionRow,
+  type SurpriseKind,
+  type SurpriseKnowledgeDebtRow,
+  type SurpriseTrajectoryRow,
+  type SurpriseWatcherEntry,
+} from './computeSurprises.js';
+import type { ItsResult } from './itsAnalysis.js';
+import type { ReflexiveResult } from './computeReflexive.js';
+
+// ─── Fixture helpers ───────────────────────────────────────────────
+
+const GENERATED_AT = 1_700_000_000_000;
+
+function comp(
+  sessionId: string,
+  binary: 'good' | 'bad' | 'unknown',
+  score = binary === 'good' ? 0.8 : 0.3,
+): CompositeOutcome {
+  return {
+    sessionId,
+    source: 'cowork',
+    testPass: null,
+    buildPass: null,
+    prLand: null,
+    noRework: null,
+    affirmation: null,
+    score,
+    linearLogit: 0,
+    binary,
+    weightsHash: 'cafebabecafebabe',
+  };
+}
+
+function compositeRow(
+  sessionId: string,
+  updatedAt: number,
+  binary: 'good' | 'bad' | 'unknown' = 'good',
+): SurpriseCompositeRow {
+  return { sessionId, updatedAt, composite: comp(sessionId, binary) };
+}
+
+function trajectoryRow(
+  projectId: string,
+  classification: SurpriseTrajectoryRow['classification'],
+  slope: number | null,
+  ci: { low: number; high: number } | null,
+): SurpriseTrajectoryRow {
+  return {
+    projectId,
+    projectName: projectId,
+    classification,
+    slope,
+    ci,
+    totalSessions: 20,
+    recentSessions: 5,
+    bootstrapStatus: 'ok',
+  };
+}
+
+function itsRow(
+  sha: string,
+  deltaGoodShare: number,
+  qValue: number,
+  subject = 'tweak claude.md',
+): ItsResult {
+  return {
+    sha,
+    ts: GENERATED_AT - 1_000_000,
+    path: 'CLAUDE.md',
+    subject,
+    windowDays: 10,
+    pre: {
+      n: 20,
+      meanScore: 0.5,
+      goodShare: 0.5,
+      goodShareCI: { low: 0.3, high: 0.7 },
+    },
+    post: {
+      n: 20,
+      meanScore: 0.5 + deltaGoodShare,
+      goodShare: 0.5 + deltaGoodShare,
+      goodShareCI: { low: 0.5 + deltaGoodShare - 0.1, high: 0.5 + deltaGoodShare + 0.1 },
+    },
+    deltaGoodShare,
+    deltaCI: { low: deltaGoodShare - 0.05, high: deltaGoodShare + 0.05 },
+    pValue: 0.01,
+    qValue,
+  };
+}
+
+function watcherHolding(
+  patternId: string,
+  sessionsObserved = 5,
+  failureRateUpperBound95 = 0.52,
+): SurpriseWatcherEntry {
+  return {
+    patternId,
+    projectId: 'p1',
+    verdict: {
+      kind: 'holding',
+      sessionsObserved,
+      failureRateUpperBound95,
+    },
+  };
+}
+
+function watcherRecurring(patternId: string, narrativeId: string): SurpriseWatcherEntry {
+  return {
+    patternId,
+    projectId: 'p1',
+    verdict: {
+      kind: 'recurring',
+      recurrenceNarrativeId: narrativeId,
+      recurrenceGeneratedAt: '2026-04-15T00:00:00Z',
+    },
+  };
+}
+
+function reflexive(
+  meanDelta: number,
+  ciLow: number,
+  ciHigh: number,
+  pairs: number = 5,
+): ReflexiveResult {
+  return {
+    pairs: Array.from({ length: pairs }, (_, i) => ({
+      treatedSessionId: `t-${i}`,
+      controlSessionId: `c-${i}`,
+      treatedGood: 1,
+      controlGood: 0,
+      distance: 0.1,
+    })),
+    pTreated: 0.5 + meanDelta / 2,
+    pControl: 0.5 - meanDelta / 2,
+    meanDelta,
+    ci: { low: ciLow, high: ciHigh },
+    eValueCIBound: 1.5,
+    eValueStatus: 'computed',
+    nTreated: pairs,
+    nControl: pairs * 2,
+    mcnemarP: 0.04,
+    mcnemarMethod: 'exact',
+    discordantCount: pairs,
+  };
+}
+
+function debtCluster(
+  id: string,
+  size: number,
+  confidence: 'high' | 'low' = 'high',
+  canonicalQuestion = 'how do I do X',
+): SurpriseKnowledgeDebtRow {
+  return {
+    id,
+    canonicalQuestion,
+    sessionIds: Array.from({ length: size }, (_, i) => `${id}-s${i}`),
+    confidence,
+  };
+}
+
+function decision(
+  decisionId: string,
+  sessionId: string,
+  binaryClass: 'good' | 'bad' | 'neutral',
+  compositeScore = binaryClass === 'good' ? 0.8 : 0.3,
+): SurpriseDecisionRow {
+  return {
+    decisionId,
+    sessionId,
+    compositeScore,
+    binaryClass,
+    label: `decision-${decisionId}`,
+  };
+}
+
+function emptyInput(overrides: Partial<ComputeSurprisesInput> = {}): ComputeSurprisesInput {
+  return {
+    generatedAt: GENERATED_AT,
+    composites: [],
+    trajectories: [],
+    itsResults: [],
+    patternWatchers: [],
+    reflexive: null,
+    decisions: [],
+    knowledgeDebt: [],
+    ...overrides,
+  };
+}
+
+function kindsOf(surprises: readonly Surprise[]): SurpriseKind[] {
+  return surprises.map((s) => s.kind);
+}
+
+// ─── Empty / smoke ─────────────────────────────────────────────────
+
+describe('computeSurprises — empty input', () => {
+  it('returns an empty surprises array on empty inputs', () => {
+    const out = computeSurprises(emptyInput());
+    expect(out.version).toBe(1);
+    expect(out.generatedAt).toBe(GENERATED_AT);
+    expect(out.surprises).toEqual([]);
+  });
+
+  it('always exposes the thresholds it used', () => {
+    const out = computeSurprises(emptyInput(), { streakMin: 7 });
+    expect(out.thresholds.streakMin).toBe(7);
+  });
+});
+
+// ─── streak ────────────────────────────────────────────────────────
+
+describe('streak', () => {
+  it('emits when trailing run >= streakMin good sessions', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s0', 1, 'bad'),
+      compositeRow('s1', 2, 'good'),
+      compositeRow('s2', 3, 'good'),
+      compositeRow('s3', 4, 'good'),
+      compositeRow('s4', 5, 'good'),
+      compositeRow('s5', 6, 'good'),
+    ];
+    const out = computeSurprises(emptyInput({ composites }));
+    const streak = out.surprises.find((s) => s.kind === 'streak');
+    expect(streak).toBeDefined();
+    expect(streak?.evidence.sessionIds).toEqual(['s1', 's2', 's3', 's4', 's5']);
+    expect(streak?.tone).toBe('positive');
+  });
+
+  it('does NOT emit when trailing run is broken by a non-good session', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s0', 1, 'good'),
+      compositeRow('s1', 2, 'good'),
+      compositeRow('s2', 3, 'good'),
+      compositeRow('s3', 4, 'good'),
+      compositeRow('s4', 5, 'good'),
+      compositeRow('s5', 6, 'bad'),
+    ];
+    const out = computeSurprises(emptyInput({ composites }));
+    expect(kindsOf(out.surprises)).not.toContain('streak');
+  });
+
+  it('boundary: exactly streakMin sessions emits, one short does not', () => {
+    const five: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+      compositeRow('s4', 4, 'good'),
+      compositeRow('s5', 5, 'good'),
+    ];
+    const four: SurpriseCompositeRow[] = five.slice(1);
+    expect(
+      kindsOf(computeSurprises(emptyInput({ composites: five })).surprises),
+    ).toContain('streak');
+    expect(
+      kindsOf(computeSurprises(emptyInput({ composites: four })).surprises),
+    ).not.toContain('streak');
+  });
+
+  it('respects streakMin override', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+    ];
+    const out = computeSurprises(
+      emptyInput({ composites }),
+      { streakMin: 2 },
+    );
+    expect(kindsOf(out.surprises)).toContain('streak');
+  });
+});
+
+// ─── trajectory-accelerating ───────────────────────────────────────
+
+describe('trajectory-accelerating', () => {
+  it('emits one row per accelerating project', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'accelerating', 0.08, { low: 0.01, high: 0.15 }),
+      trajectoryRow('p2', 'accelerating', 0.04, { low: 0.005, high: 0.08 }),
+      trajectoryRow('p3', 'flat', 0, { low: -0.01, high: 0.01 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    const accel = out.surprises.filter((s) => s.kind === 'trajectory-accelerating');
+    expect(accel).toHaveLength(2);
+    expect(accel.map((s) => s.evidence.projectId).sort()).toEqual(['p1', 'p2']);
+  });
+
+  it('does NOT emit for non-accelerating projects', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'flat', 0, { low: -0.01, high: 0.01 }),
+      trajectoryRow('p2', 'stalling', -0.05, { low: -0.08, high: -0.01 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-accelerating');
+  });
+});
+
+// ─── config-helped ─────────────────────────────────────────────────
+
+describe('config-helped', () => {
+  it('emits when qValue ≤ threshold AND deltaGoodShare ≥ threshold', () => {
+    const itsResults: ItsResult[] = [itsRow('abc123def', 0.2, 0.05)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    const helped = out.surprises.find((s) => s.kind === 'config-helped');
+    expect(helped).toBeDefined();
+    expect(helped?.evidence.configSha).toBe('abc123def');
+  });
+
+  it('does NOT emit when qValue is above threshold', () => {
+    const itsResults: ItsResult[] = [itsRow('abc', 0.2, 0.5)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    expect(kindsOf(out.surprises)).not.toContain('config-helped');
+  });
+
+  it('does NOT emit when delta is below threshold', () => {
+    const itsResults: ItsResult[] = [itsRow('abc', 0.05, 0.01)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    expect(kindsOf(out.surprises)).not.toContain('config-helped');
+  });
+
+  it('boundary: delta exactly at threshold emits', () => {
+    const itsResults: ItsResult[] = [itsRow('abc', 0.15, 0.1)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    expect(kindsOf(out.surprises)).toContain('config-helped');
+  });
+});
+
+// ─── pattern-closed / pattern-recurring ────────────────────────────
+
+describe('pattern-closed', () => {
+  it('emits for each holding watcher verdict', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherHolding('pat1', 5, 0.52),
+      watcherHolding('pat2', 20, 0.16),
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    const closed = out.surprises.filter((s) => s.kind === 'pattern-closed');
+    expect(closed).toHaveLength(2);
+    // pat2 (more sessions cleared → tighter Wilson) should score higher.
+    const byId = new Map(closed.map((s) => [s.evidence.narrativeId, s.score] as const));
+    expect((byId.get('pat2') ?? 0)).toBeGreaterThan(byId.get('pat1') ?? 0);
+  });
+
+  it('does NOT emit for open / inconclusive verdicts', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      { patternId: 'a', projectId: 'p1', verdict: { kind: 'open' } },
+      {
+        patternId: 'b',
+        projectId: 'p1',
+        verdict: { kind: 'inconclusive', reason: 'wall-clock-timeout' },
+      },
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    expect(kindsOf(out.surprises)).not.toContain('pattern-closed');
+  });
+});
+
+describe('pattern-recurring', () => {
+  it('emits one concern per recurring verdict', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherRecurring('pat-x', 'narr-1'),
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    const rec = out.surprises.find((s) => s.kind === 'pattern-recurring');
+    expect(rec).toBeDefined();
+    expect(rec?.tone).toBe('concerning');
+    expect(rec?.evidence.narrativeId).toBe('narr-1');
+  });
+
+  it('does NOT emit for non-recurring verdicts', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherHolding('pat1'),
+      { patternId: 'b', projectId: 'p1', verdict: { kind: 'open' } },
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    expect(kindsOf(out.surprises)).not.toContain('pattern-recurring');
+  });
+});
+
+// ─── reflexive-positive ────────────────────────────────────────────
+
+describe('reflexive-positive', () => {
+  it('emits when meanDelta ≥ threshold AND CI strictly positive', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.2, 0.05, 0.35) }),
+    );
+    expect(kindsOf(out.surprises)).toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when reflexive is null', () => {
+    const out = computeSurprises(emptyInput({ reflexive: null }));
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when CI straddles zero (low ≤ 0)', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.2, -0.01, 0.4) }),
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when meanDelta is below threshold', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.05, 0.01, 0.09) }),
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('boundary: meanDelta exactly at threshold emits', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.1, 0.01, 0.19) }),
+    );
+    expect(kindsOf(out.surprises)).toContain('reflexive-positive');
+  });
+});
+
+// ─── decision-paid-off ─────────────────────────────────────────────
+
+describe('decision-paid-off', () => {
+  it('emits when a good-binary decision is followed by ≥ K good sessions', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good'),
+      compositeRow('s-after1', 11, 'good'),
+      compositeRow('s-after2', 12, 'good'),
+      compositeRow('s-after3', 13, 'good'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    const paidOff = out.surprises.find((s) => s.kind === 'decision-paid-off');
+    expect(paidOff).toBeDefined();
+    expect(paidOff?.evidence.decisionId).toBe('d1');
+  });
+
+  it('does NOT emit when binaryClass is not "good"', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'bad'),
+      compositeRow('s-after1', 11, 'good'),
+      compositeRow('s-after2', 12, 'good'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'bad')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('does NOT emit when followups < threshold', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good'),
+      compositeRow('s-after1', 11, 'good'),
+      // only 1 followup; default threshold is 2
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('boundary: exactly threshold followups emits', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good'),
+      compositeRow('s-after1', 11, 'good'),
+      compositeRow('s-after2', 12, 'good'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).toContain('decision-paid-off');
+  });
+});
+
+// ─── trajectory-stalled ────────────────────────────────────────────
+
+describe('trajectory-stalled', () => {
+  it('emits for stalling and stalled-finished projects', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p-stalling', 'stalling', -0.1, { low: -0.15, high: -0.05 }),
+      trajectoryRow(
+        'p-finished',
+        'stalled-finished',
+        -0.1,
+        { low: -0.15, high: -0.05 },
+      ),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    const stalled = out.surprises.filter((s) => s.kind === 'trajectory-stalled');
+    expect(stalled).toHaveLength(2);
+    // stalling > stalled-finished on score (active decline biased higher)
+    const byId = new Map(stalled.map((s) => [s.evidence.projectId, s.score] as const));
+    expect((byId.get('p-stalling') ?? 0)).toBeGreaterThan(
+      byId.get('p-finished') ?? 0,
+    );
+  });
+
+  it('does NOT emit for flat / accelerating projects', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p-flat', 'flat', 0, { low: -0.01, high: 0.01 }),
+      trajectoryRow('p-up', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-stalled');
+  });
+});
+
+// ─── debt-spinning ─────────────────────────────────────────────────
+
+describe('debt-spinning', () => {
+  it('emits top-K clusters that meet the minimum size', () => {
+    const knowledgeDebt: SurpriseKnowledgeDebtRow[] = [
+      debtCluster('c-big', 15),
+      debtCluster('c-med', 8),
+      debtCluster('c-small', 3),
+      debtCluster('c-tiny', 1), // below min size
+    ];
+    const out = computeSurprises(emptyInput({ knowledgeDebt }));
+    const debt = out.surprises.filter((s) => s.kind === 'debt-spinning');
+    // default topK=3, default minSize=3 → c-big, c-med, c-small
+    expect(debt.map((s) => s.id)).toEqual([
+      'debt-spinning:c-big',
+      'debt-spinning:c-med',
+      'debt-spinning:c-small',
+    ]);
+  });
+
+  it('does NOT emit clusters below the minimum size', () => {
+    const knowledgeDebt: SurpriseKnowledgeDebtRow[] = [debtCluster('c1', 2)];
+    const out = computeSurprises(emptyInput({ knowledgeDebt }));
+    expect(kindsOf(out.surprises)).not.toContain('debt-spinning');
+  });
+
+  it('low-confidence clusters get 0.7× score multiplier', () => {
+    const knowledgeDebt: SurpriseKnowledgeDebtRow[] = [
+      debtCluster('c-high', 10, 'high'),
+      debtCluster('c-low', 10, 'low'),
+    ];
+    const out = computeSurprises(emptyInput({ knowledgeDebt }));
+    const byId = new Map(
+      out.surprises
+        .filter((s) => s.kind === 'debt-spinning')
+        .map((s) => [s.id, s.score] as const),
+    );
+    const high = byId.get('debt-spinning:c-high') ?? 0;
+    const low = byId.get('debt-spinning:c-low') ?? 0;
+    expect(low).toBeCloseTo(high * 0.7, 5);
+  });
+});
+
+// ─── Cross-cutting: determinism, ranking, summary length ───────────
+
+describe('cross-cutting properties', () => {
+  it('summary clips at 120 chars', () => {
+    const longName = 'p-'.padEnd(200, 'x');
+    const trajectories: SurpriseTrajectoryRow[] = [
+      {
+        ...trajectoryRow(longName, 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+        projectName: longName,
+      },
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    for (const s of out.surprises) {
+      expect(s.summary.length).toBeLessThanOrEqual(120);
+    }
+  });
+
+  it('output is sorted by score descending, then id ascending', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p-low', 'accelerating', 0.02, { low: 0.001, high: 0.04 }),
+      trajectoryRow('p-high', 'accelerating', 0.3, { low: 0.1, high: 0.5 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    const accel = out.surprises.filter((s) => s.kind === 'trajectory-accelerating');
+    // p-high should come first
+    expect(accel[0]?.evidence.projectId).toBe('p-high');
+  });
+
+  it('tie-breaks on id when scores are equal', () => {
+    // Two patterns with the same Wilson upper bound (same N=5) → same score.
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherHolding('zzz', 5, 0.52),
+      watcherHolding('aaa', 5, 0.52),
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    const closed = out.surprises.filter((s) => s.kind === 'pattern-closed');
+    expect(closed.map((s) => s.evidence.narrativeId)).toEqual(['aaa', 'zzz']);
+  });
+
+  it('every surprise carries generatedAt matching the input', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+      compositeRow('s4', 4, 'good'),
+      compositeRow('s5', 5, 'good'),
+    ];
+    const out = computeSurprises({ ...emptyInput({ composites }), generatedAt: 12345 });
+    for (const s of out.surprises) {
+      expect(s.generatedAt).toBe(12345);
+    }
+  });
+
+  it('determinism: identical inputs produce identical outputs (ordering included)', () => {
+    const input = emptyInput({
+      composites: [
+        compositeRow('s1', 1, 'good'),
+        compositeRow('s2', 2, 'good'),
+        compositeRow('s3', 3, 'good'),
+        compositeRow('s4', 4, 'good'),
+        compositeRow('s5', 5, 'good'),
+      ],
+      trajectories: [
+        trajectoryRow('p1', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+        trajectoryRow('p2', 'stalling', -0.05, { low: -0.1, high: -0.01 }),
+      ],
+      itsResults: [itsRow('sha1', 0.2, 0.05)],
+      patternWatchers: [watcherHolding('pat1'), watcherRecurring('pat2', 'narr-x')],
+      reflexive: reflexive(0.2, 0.05, 0.35),
+      decisions: [decision('d1', 's1', 'good')],
+      knowledgeDebt: [debtCluster('c1', 10)],
+    });
+    const a = computeSurprises(input);
+    const b = computeSurprises(input);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('tone segmentation: positive vs concerning kinds map to the right tone', () => {
+    const input = emptyInput({
+      trajectories: [
+        trajectoryRow('p-up', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+        trajectoryRow('p-down', 'stalling', -0.05, { low: -0.1, high: -0.01 }),
+      ],
+    });
+    const out = computeSurprises(input);
+    for (const s of out.surprises) {
+      if (s.kind === 'trajectory-accelerating') expect(s.tone).toBe('positive');
+      if (s.kind === 'trajectory-stalled') expect(s.tone).toBe('concerning');
+    }
+  });
+});

--- a/packages/analysis/src/computeSurprises.ts
+++ b/packages/analysis/src/computeSurprises.ts
@@ -1,0 +1,629 @@
+/**
+ * Surprises kernel — feed-redesign Phase A (plumbing).
+ *
+ * Snapshot-based: takes already-computed kernel outputs (composite
+ * outcomes, project trajectories, ITS contrasts, applied-pattern
+ * watcher verdicts, reflexive result, decisions, knowledge-debt
+ * clusters) and emits a ranked list of "surprise" observations the
+ * user might not have noticed about their recent work with Claude.
+ *
+ * Positive observations (`tone: 'positive'`):
+ *   - streak                  — N consecutive composite-good sessions
+ *   - trajectory-accelerating — project slope CI strictly positive
+ *   - config-helped           — ITS contrast with significantly +delta
+ *   - pattern-closed          — applied-pattern watcher `holding`
+ *                               (cooldown cleared with no recurrence)
+ *   - reflexive-positive      — reflexive meanDelta > threshold AND
+ *                               CI strictly positive
+ *   - decision-paid-off       — decision joined to a good outcome AND
+ *                               followed by ≥ K additional good outcomes
+ *
+ * Concerns (`tone: 'concerning'`):
+ *   - trajectory-stalled      — project slope CI strictly negative
+ *                               (decline) — picks `stalling` first,
+ *                               then `stalled-finished`
+ *   - pattern-recurring       — applied-pattern watcher `recurring`
+ *   - debt-spinning           — top knowledge-debt clusters by size
+ *                               (V1: highest count flagged; week-over-
+ *                                week growth is a follow-on)
+ *
+ * Pure. Browser-safe (no `node:*` imports). Deterministic — the
+ * caller passes `generatedAt` (the kernel does NOT call `Date.now()`),
+ * and tie-breaks on stable ids so identical inputs produce identical
+ * outputs including ordering.
+ *
+ * Ranking: score in [0, 1]; output is sorted descending by score, with
+ * `id` as the tie-breaker. The score formula is documented per-kind
+ * inside `compute*` helpers below — pre-launch placeholders, calibrate
+ * once the UI surface accumulates engagement data.
+ */
+
+import type { CompositeOutcome } from '@chat-arch/schema';
+import { THRESHOLDS } from './thresholds.js';
+import type { ItsResult } from './itsAnalysis.js';
+import type { ReflexiveResult } from './computeReflexive.js';
+import type { WatcherVerdict } from './applyWatcher.js';
+
+// ─── Input row shapes ──────────────────────────────────────────────
+//
+// We accept narrow "Like" interfaces here so the kernel doesn't pull
+// in the full exporter-shell builder output types. Anything assignable
+// to these (the on-disk sidecar shapes from
+// projectTrajectoryBuilder / decisionsBuilder / detectKnowledgeDebt /
+// the applied-pattern watcher loop) is accepted.
+
+/** Composite-outcome row paired with the session's terminal timestamp. */
+export interface SurpriseCompositeRow {
+  readonly sessionId: string;
+  /** Unix ms — session terminal timestamp (manifest.updatedAt). */
+  readonly updatedAt: number;
+  readonly composite: CompositeOutcome;
+}
+
+/** Project-trajectory row — mirrors the on-disk sidecar entry. */
+export interface SurpriseTrajectoryRow {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly classification: 'stalling' | 'stalled-finished' | 'accelerating' | 'flat';
+  readonly slope: number | null;
+  readonly ci: { readonly low: number; readonly high: number } | null;
+  readonly totalSessions: number;
+  readonly recentSessions: number;
+  readonly bootstrapStatus: 'ok' | 'series-too-short';
+}
+
+/** Per-pattern watcher verdict pairing — emitted by the curator loop. */
+export interface SurpriseWatcherEntry {
+  readonly patternId: string;
+  readonly projectId: string;
+  readonly verdict: WatcherVerdict;
+}
+
+/**
+ * Knowledge-debt cluster row — mirrors `KnowledgeDebtCluster` plus a
+ * passthrough `confidence` so we can de-rank low-confidence clusters.
+ */
+export interface SurpriseKnowledgeDebtRow {
+  readonly id: string;
+  readonly canonicalQuestion: string;
+  readonly sessionIds: readonly string[];
+  readonly confidence: 'high' | 'low';
+}
+
+/**
+ * Decision row — narrow projection of `Decision` carrying just what
+ * the kernel needs (session, outcome score, binary class, optional
+ * id for evidence).
+ */
+export interface SurpriseDecisionRow {
+  readonly decisionId: string;
+  readonly sessionId: string;
+  readonly compositeScore: number;
+  readonly binaryClass: 'good' | 'bad' | 'neutral';
+  /** Short label rendered into the summary; falls back to "a decision". */
+  readonly label?: string;
+}
+
+// ─── Output schema ─────────────────────────────────────────────────
+
+export type SurpriseKind =
+  | 'streak'
+  | 'trajectory-accelerating'
+  | 'config-helped'
+  | 'pattern-closed'
+  | 'reflexive-positive'
+  | 'decision-paid-off'
+  | 'trajectory-stalled'
+  | 'pattern-recurring'
+  | 'debt-spinning';
+
+export type SurpriseTone = 'positive' | 'concerning';
+
+export interface SurpriseEvidence {
+  readonly sessionIds?: readonly string[];
+  readonly projectId?: string;
+  readonly narrativeId?: string;
+  readonly configSha?: string;
+  readonly decisionId?: string;
+}
+
+export interface Surprise {
+  /** Stable id derived from kind + evidence (deterministic ordering). */
+  readonly id: string;
+  readonly kind: SurpriseKind;
+  readonly tone: SurpriseTone;
+  /** ≤ 120 chars. */
+  readonly summary: string;
+  readonly evidence: SurpriseEvidence;
+  /** 0..1 — higher means more surface-worthy. */
+  readonly score: number;
+  /** Mirrors the file-level `generatedAt`; carried per-row for downstream
+   *  filters that ingest individual surprises. */
+  readonly generatedAt: number;
+}
+
+/** Subset of THRESHOLDS we expose with the file so the UI can disclaim. */
+export interface SurpriseThresholdsSnapshot {
+  readonly streakMin: number;
+  readonly itsQValueMax: number;
+  readonly itsDeltaMin: number;
+  readonly reflexiveDeltaMin: number;
+  readonly decisionGoodFollowupsMin: number;
+  readonly debtSpinningTopK: number;
+  readonly debtSpinningMinClusterSize: number;
+}
+
+export interface SurprisesOutput {
+  readonly version: 1;
+  readonly generatedAt: number;
+  readonly surprises: readonly Surprise[];
+  readonly thresholds: SurpriseThresholdsSnapshot;
+}
+
+export interface ComputeSurprisesInput {
+  /** Unix ms — must be passed in (kernel does NOT call Date.now()). */
+  readonly generatedAt: number;
+  /** Composite-outcome rows for every scored session. */
+  readonly composites: readonly SurpriseCompositeRow[];
+  /** Per-project trajectory rows (one per project). */
+  readonly trajectories: readonly SurpriseTrajectoryRow[];
+  /** ITS contrast rows (one per config commit analyzed). */
+  readonly itsResults: readonly ItsResult[];
+  /**
+   * Applied-pattern watcher verdicts — one per (pattern, project) the
+   * curator loop tracked. The kernel surfaces `holding` as `pattern-
+   * closed` and `recurring` as `pattern-recurring`; other verdicts
+   * (`open`, `inconclusive`) are ignored.
+   */
+  readonly patternWatchers: readonly SurpriseWatcherEntry[];
+  /** Reflexive result — single row (the whole-corpus contrast). */
+  readonly reflexive: ReflexiveResult | null;
+  /** Decision rows (post outcome-join). */
+  readonly decisions: readonly SurpriseDecisionRow[];
+  /** Knowledge-debt clusters. */
+  readonly knowledgeDebt: readonly SurpriseKnowledgeDebtRow[];
+}
+
+export interface ComputeSurprisesOptions {
+  /** Override the minimum streak length. Default 5. */
+  readonly streakMin?: number;
+  /**
+   * ITS BH-FDR qValue ceiling — a contrast counts as "config-helped"
+   * when `qValue ≤ itsQValueMax` AND `deltaGoodShare ≥ itsDeltaMin`.
+   * Pre-launch placeholder; calibrate after first ~50 contrasts.
+   */
+  readonly itsQValueMax?: number;
+  readonly itsDeltaMin?: number;
+  /**
+   * Reflexive minimum mean-delta (good-share delta) to surface. Also
+   * requires the CI to be strictly positive (low > 0). Pre-launch
+   * placeholder.
+   */
+  readonly reflexiveDeltaMin?: number;
+  /**
+   * `decision-paid-off`: minimum number of additional good composite
+   * outcomes that must follow the decision's session (same project
+   * preferred but not required in V1; the kernel scopes by
+   * compositeRow.updatedAt > decision-session.updatedAt). Default 2.
+   */
+  readonly decisionGoodFollowupsMin?: number;
+  /** Top-K knowledge-debt clusters surfaced as `debt-spinning`. Default 3. */
+  readonly debtSpinningTopK?: number;
+  /** Minimum cluster size for `debt-spinning`. Default 3. */
+  readonly debtSpinningMinClusterSize?: number;
+}
+
+const DEFAULTS = {
+  streakMin: 5,
+  itsQValueMax: 0.1,
+  itsDeltaMin: 0.15,
+  reflexiveDeltaMin: 0.1,
+  decisionGoodFollowupsMin: 2,
+  debtSpinningTopK: 3,
+  debtSpinningMinClusterSize: 3,
+} as const;
+
+// ─── Kernel entry point ────────────────────────────────────────────
+
+export function computeSurprises(
+  input: ComputeSurprisesInput,
+  options: ComputeSurprisesOptions = {},
+): SurprisesOutput {
+  const opts = {
+    streakMin: options.streakMin ?? DEFAULTS.streakMin,
+    itsQValueMax: options.itsQValueMax ?? DEFAULTS.itsQValueMax,
+    itsDeltaMin: options.itsDeltaMin ?? DEFAULTS.itsDeltaMin,
+    reflexiveDeltaMin: options.reflexiveDeltaMin ?? DEFAULTS.reflexiveDeltaMin,
+    decisionGoodFollowupsMin:
+      options.decisionGoodFollowupsMin ?? DEFAULTS.decisionGoodFollowupsMin,
+    debtSpinningTopK: options.debtSpinningTopK ?? DEFAULTS.debtSpinningTopK,
+    debtSpinningMinClusterSize:
+      options.debtSpinningMinClusterSize ?? DEFAULTS.debtSpinningMinClusterSize,
+  };
+
+  const surprises: Surprise[] = [];
+
+  pushAll(surprises, computeStreak(input, opts));
+  pushAll(surprises, computeTrajectoryAccelerating(input));
+  pushAll(surprises, computeConfigHelped(input, opts));
+  pushAll(surprises, computePatternClosed(input));
+  pushAll(surprises, computeReflexivePositive(input, opts));
+  pushAll(surprises, computeDecisionPaidOff(input, opts));
+  pushAll(surprises, computeTrajectoryStalled(input));
+  pushAll(surprises, computePatternRecurring(input));
+  pushAll(surprises, computeDebtSpinning(input, opts));
+
+  // Stamp generatedAt on every row + stable-sort. Tie-break on id so
+  // equal-score rows still come out in a deterministic order.
+  const stamped = surprises.map((s) => ({ ...s, generatedAt: input.generatedAt }));
+  stamped.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+
+  return {
+    version: 1,
+    generatedAt: input.generatedAt,
+    surprises: stamped,
+    thresholds: {
+      streakMin: opts.streakMin,
+      itsQValueMax: opts.itsQValueMax,
+      itsDeltaMin: opts.itsDeltaMin,
+      reflexiveDeltaMin: opts.reflexiveDeltaMin,
+      decisionGoodFollowupsMin: opts.decisionGoodFollowupsMin,
+      debtSpinningTopK: opts.debtSpinningTopK,
+      debtSpinningMinClusterSize: opts.debtSpinningMinClusterSize,
+    },
+  };
+}
+
+// ─── Per-kind compute helpers ──────────────────────────────────────
+
+/**
+ * `streak`: find the LONGEST suffix run of composite-good sessions
+ * (ordered by `updatedAt`). Emits one surprise when the run length
+ * meets or exceeds `streakMin`. Boundary case: the run is computed as
+ * the trailing run only — we want to surface "currently on a hot
+ * streak", not "you once had 10 in a row last year".
+ *
+ * Score: saturating in run length. `min(1, runLength / (streakMin * 2))`
+ * — at exactly the threshold, score = 0.5; double the threshold caps
+ * the score at 1.
+ */
+function computeStreak(
+  input: ComputeSurprisesInput,
+  opts: { streakMin: number },
+): Surprise[] {
+  const sorted = input.composites
+    .slice()
+    .sort((a, b) => a.updatedAt - b.updatedAt || a.sessionId.localeCompare(b.sessionId));
+
+  const runIds: string[] = [];
+  for (let i = sorted.length - 1; i >= 0; i -= 1) {
+    const row = sorted[i] as SurpriseCompositeRow;
+    if (row.composite.binary === 'good') {
+      runIds.unshift(row.sessionId);
+    } else {
+      break;
+    }
+  }
+  if (runIds.length < opts.streakMin) return [];
+
+  const score = Math.min(1, runIds.length / (opts.streakMin * 2));
+  return [
+    {
+      id: `streak:${runIds[runIds.length - 1] as string}`,
+      kind: 'streak',
+      tone: 'positive',
+      summary: clip(
+        `${runIds.length} sessions in a row landed as composite-good.`,
+      ),
+      evidence: { sessionIds: runIds },
+      score,
+      generatedAt: 0,
+    },
+  ];
+}
+
+/**
+ * `trajectory-accelerating`: project rows with `classification ===
+ * 'accelerating'` (the trajectory builder already imposes CI strictly
+ * positive). One surprise per project. Score scales with slope.
+ *
+ * Score: `min(1, slope * 5)` — a slope of 0.2 per session caps the
+ * score at 1; smaller slopes scale down. Pre-launch placeholder.
+ */
+function computeTrajectoryAccelerating(
+  input: ComputeSurprisesInput,
+): Surprise[] {
+  const out: Surprise[] = [];
+  for (const t of input.trajectories) {
+    if (t.classification !== 'accelerating') continue;
+    const slope = t.slope ?? 0;
+    const score = Math.max(0, Math.min(1, slope * 5));
+    out.push({
+      id: `trajectory-accelerating:${t.projectId}`,
+      kind: 'trajectory-accelerating',
+      tone: 'positive',
+      summary: clip(
+        `${t.projectName} is on an accelerating slope (${slope.toFixed(2)}/session).`,
+      ),
+      evidence: { projectId: t.projectId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `config-helped`: ITS contrasts with `qValue ≤ itsQValueMax` AND
+ * `deltaGoodShare ≥ itsDeltaMin`. One surprise per qualifying commit.
+ *
+ * Score: `min(1, deltaGoodShare * 2)` — a 50pp delta caps at 1. We
+ * don't fold q-value into the score (it's a gating mechanism only;
+ * folding both would double-count statistical significance).
+ */
+function computeConfigHelped(
+  input: ComputeSurprisesInput,
+  opts: { itsQValueMax: number; itsDeltaMin: number },
+): Surprise[] {
+  const out: Surprise[] = [];
+  for (const r of input.itsResults) {
+    if (!Number.isFinite(r.qValue) || r.qValue > opts.itsQValueMax) continue;
+    if (!Number.isFinite(r.deltaGoodShare) || r.deltaGoodShare < opts.itsDeltaMin) continue;
+    const score = Math.max(0, Math.min(1, r.deltaGoodShare * 2));
+    out.push({
+      id: `config-helped:${r.sha}`,
+      kind: 'config-helped',
+      tone: 'positive',
+      summary: clip(
+        `Config change ${shortSha(r.sha)} (${r.subject}) lifted good-share by ` +
+          `${(r.deltaGoodShare * 100).toFixed(0)}pp.`,
+      ),
+      evidence: { configSha: r.sha },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `pattern-closed`: applied-pattern watcher returned `holding`. The
+ * watcher kernel already enforces "N sessions cleared + no recurrence
+ * + project still active" so we just need to surface those rows.
+ *
+ * Score: `1 - failureRateUpperBound95` — at N=5 the Wilson UB is
+ * ~0.52 so score ~0.48; at N=20 it tightens to ~0.84. More sessions
+ * cleared → tighter confidence → higher surprise score.
+ */
+function computePatternClosed(input: ComputeSurprisesInput): Surprise[] {
+  const out: Surprise[] = [];
+  for (const w of input.patternWatchers) {
+    if (w.verdict.kind !== 'holding') continue;
+    const score = Math.max(0, Math.min(1, 1 - w.verdict.failureRateUpperBound95));
+    out.push({
+      id: `pattern-closed:${w.patternId}`,
+      kind: 'pattern-closed',
+      tone: 'positive',
+      summary: clip(
+        `Pattern ${w.patternId} held — ${w.verdict.sessionsObserved} clean ` +
+          `sessions, no recurrence.`,
+      ),
+      evidence: { projectId: w.projectId, narrativeId: w.patternId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `reflexive-positive`: meanDelta ≥ reflexiveDeltaMin AND CI strictly
+ * positive (low > 0). One surprise at most (reflexive is whole-corpus).
+ *
+ * Score: `min(1, meanDelta * 2)` — same convention as config-helped.
+ */
+function computeReflexivePositive(
+  input: ComputeSurprisesInput,
+  opts: { reflexiveDeltaMin: number },
+): Surprise[] {
+  const r = input.reflexive;
+  if (r === null) return [];
+  if (!Number.isFinite(r.meanDelta) || r.meanDelta < opts.reflexiveDeltaMin) return [];
+  if (r.ci.low <= 0) return [];
+  const score = Math.max(0, Math.min(1, r.meanDelta * 2));
+  return [
+    {
+      id: 'reflexive-positive:whole-corpus',
+      kind: 'reflexive-positive',
+      tone: 'positive',
+      summary: clip(
+        `Touching chat-arch lifted good-share by ${(r.meanDelta * 100).toFixed(0)}pp ` +
+          `(CI low ${(r.ci.low * 100).toFixed(0)}pp).`,
+      ),
+      evidence: {
+        sessionIds: r.pairs.map((p) => p.treatedSessionId),
+      },
+      score,
+      generatedAt: 0,
+    },
+  ];
+}
+
+/**
+ * `decision-paid-off`: a decision whose outcome was `good` AND was
+ * followed by at least `decisionGoodFollowupsMin` additional good
+ * composite outcomes (across the whole corpus — V1 doesn't restrict
+ * to same-project; that's a follow-on once decisions carry a project
+ * pointer in the join).
+ *
+ * Score: saturating in follow-up count. `min(1, (followups + 1) / 10)`
+ * — a decision with 9 good followups caps the score at 1.
+ */
+function computeDecisionPaidOff(
+  input: ComputeSurprisesInput,
+  opts: { decisionGoodFollowupsMin: number },
+): Surprise[] {
+  if (input.decisions.length === 0) return [];
+
+  // Build a sorted (updatedAt, sessionId) lookup once for the followup
+  // count. O(N log N) once, then O(log N) per decision.
+  const sessionByUpdatedAt = input.composites
+    .slice()
+    .sort((a, b) => a.updatedAt - b.updatedAt || a.sessionId.localeCompare(b.sessionId));
+
+  const out: Surprise[] = [];
+  for (const d of input.decisions) {
+    if (d.binaryClass !== 'good') continue;
+    // Anchor on this decision's session in the sorted list.
+    const anchor = sessionByUpdatedAt.findIndex((s) => s.sessionId === d.sessionId);
+    if (anchor === -1) continue;
+    let followups = 0;
+    for (let i = anchor + 1; i < sessionByUpdatedAt.length; i += 1) {
+      const row = sessionByUpdatedAt[i] as SurpriseCompositeRow;
+      if (row.composite.binary === 'good') followups += 1;
+    }
+    if (followups < opts.decisionGoodFollowupsMin) continue;
+    const score = Math.max(0, Math.min(1, (followups + 1) / 10));
+    const label = d.label ?? 'a decision';
+    out.push({
+      id: `decision-paid-off:${d.decisionId}`,
+      kind: 'decision-paid-off',
+      tone: 'positive',
+      summary: clip(
+        `${label} paid off — ${followups} good sessions followed.`,
+      ),
+      evidence: { decisionId: d.decisionId, sessionIds: [d.sessionId] },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `trajectory-stalled`: project classified `stalling` or
+ * `stalled-finished`. Score weights `stalling` higher because it's an
+ * active decline (the user can still intervene); `stalled-finished` is
+ * a quieter retrospective signal.
+ */
+function computeTrajectoryStalled(
+  input: ComputeSurprisesInput,
+): Surprise[] {
+  const out: Surprise[] = [];
+  for (const t of input.trajectories) {
+    if (t.classification !== 'stalling' && t.classification !== 'stalled-finished') {
+      continue;
+    }
+    const slope = t.slope ?? 0;
+    const baseScore = Math.max(0, Math.min(1, Math.abs(slope) * 5));
+    // Bias active stalling above finished — same severity gets +0.2.
+    const score = Math.min(1, baseScore + (t.classification === 'stalling' ? 0.2 : 0));
+    const summary =
+      t.classification === 'stalling'
+        ? `${t.projectName} is actively stalling (slope ${slope.toFixed(2)}/session).`
+        : `${t.projectName} stalled out — slope ${slope.toFixed(2)}/session, no recent activity.`;
+    out.push({
+      id: `trajectory-stalled:${t.projectId}`,
+      kind: 'trajectory-stalled',
+      tone: 'concerning',
+      summary: clip(summary),
+      evidence: { projectId: t.projectId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `pattern-recurring`: watcher returned `recurring`. Score fixed at
+ * 0.9 — this is a strong signal regardless of how many sessions
+ * passed first; the user told the assistant "follow this rule" and
+ * the rule failed.
+ */
+function computePatternRecurring(input: ComputeSurprisesInput): Surprise[] {
+  const out: Surprise[] = [];
+  for (const w of input.patternWatchers) {
+    if (w.verdict.kind !== 'recurring') continue;
+    out.push({
+      id: `pattern-recurring:${w.patternId}`,
+      kind: 'pattern-recurring',
+      tone: 'concerning',
+      summary: clip(
+        `Pattern ${w.patternId} recurred — narrative ${w.verdict.recurrenceNarrativeId} ` +
+          `re-fired after application.`,
+      ),
+      evidence: {
+        projectId: w.projectId,
+        narrativeId: w.verdict.recurrenceNarrativeId,
+      },
+      score: 0.9,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `debt-spinning`: V1 surfaces the top-K knowledge-debt clusters by
+ * sessionIds.length whose size meets `debtSpinningMinClusterSize`.
+ * Week-over-week growth is a follow-on — V1 just flags "this
+ * question keeps coming back".
+ *
+ * Score: saturating in size. `min(1, size / 20)` — a 20-member
+ * cluster caps the score at 1. Low-confidence clusters get a 0.7×
+ * multiplier (they were resolved via TF-IDF, not embeddings).
+ */
+function computeDebtSpinning(
+  input: ComputeSurprisesInput,
+  opts: { debtSpinningTopK: number; debtSpinningMinClusterSize: number },
+): Surprise[] {
+  const eligible = input.knowledgeDebt
+    .filter((c) => c.sessionIds.length >= opts.debtSpinningMinClusterSize)
+    .slice()
+    .sort(
+      (a, b) =>
+        b.sessionIds.length - a.sessionIds.length || a.id.localeCompare(b.id),
+    );
+  const topK = eligible.slice(0, opts.debtSpinningTopK);
+
+  return topK.map<Surprise>((c) => {
+    const size = c.sessionIds.length;
+    const base = Math.min(1, size / 20);
+    const score = c.confidence === 'low' ? base * 0.7 : base;
+    return {
+      id: `debt-spinning:${c.id}`,
+      kind: 'debt-spinning',
+      tone: 'concerning',
+      summary: clip(
+        `"${c.canonicalQuestion}" — ${size} sessions keep asking this.`,
+      ),
+      evidence: { sessionIds: c.sessionIds },
+      score,
+      generatedAt: 0,
+    };
+  });
+}
+
+// ─── helpers ───────────────────────────────────────────────────────
+
+function pushAll<T>(target: T[], items: readonly T[]): void {
+  for (const item of items) target.push(item);
+}
+
+/** Truncate to 120 chars — schema contract for `summary`. */
+function clip(s: string): string {
+  const max = 120;
+  if (s.length <= max) return s;
+  // Reserve 1 char for the ellipsis. `…` is one codepoint.
+  return `${s.slice(0, max - 1)}…`;
+}
+
+function shortSha(sha: string): string {
+  return sha.length > 7 ? sha.slice(0, 7) : sha;
+}
+
+// Re-export the THRESHOLDS reference so this kernel stays discoverable
+// via the analysis package barrel. (Imported above so the bundler
+// tree-shakes appropriately.)
+export { THRESHOLDS };

--- a/packages/analysis/src/computeSurprises.ts
+++ b/packages/analysis/src/computeSurprises.ts
@@ -14,9 +14,13 @@
  *   - pattern-closed          — applied-pattern watcher `holding`
  *                               (cooldown cleared with no recurrence)
  *   - reflexive-positive      — reflexive meanDelta > threshold AND
- *                               CI strictly positive
+ *                               CI strictly positive AND E-value CI
+ *                               bound ≥ `reflexiveEValueMin` (associational,
+ *                               not causal — sensitivity-gated)
  *   - decision-paid-off       — decision joined to a good outcome AND
  *                               followed by ≥ K additional good outcomes
+ *                               IN THE SAME PROJECT AND Wilson-low good
+ *                               rate exceeds the corpus base rate
  *
  * Concerns (`tone: 'concerning'`):
  *   - trajectory-stalled      — project slope CI strictly negative
@@ -26,6 +30,16 @@
  *   - debt-spinning           — top knowledge-debt clusters by size
  *                               (V1: highest count flagged; week-over-
  *                                week growth is a follow-on)
+ *
+ * **V1 emission scope**: 7 of 9 kinds emit from the builder pipeline.
+ * `pattern-closed` and `pattern-recurring` accept watcher input in
+ * the kernel API (the test suite exercises them) but the
+ * `surprisesBuilder` Node shell passes an empty `patternWatchers`
+ * array — the applied-pattern watcher ledger lives in the SQLite
+ * substrate and no SDK accessor for it exists yet. The two pattern-*
+ * branches stay dormant until that accessor lands; see the
+ * `TODO(applyWatcher-sdk):` marker in
+ * `packages/exporter/src/analysis/surprisesBuilder.ts`.
  *
  * Pure. Browser-safe (no `node:*` imports). Deterministic — the
  * caller passes `generatedAt` (the kernel does NOT call `Date.now()`),
@@ -43,6 +57,7 @@ import { THRESHOLDS } from './thresholds.js';
 import type { ItsResult } from './itsAnalysis.js';
 import type { ReflexiveResult } from './computeReflexive.js';
 import type { WatcherVerdict } from './applyWatcher.js';
+import { wilsonCI } from './stats.js';
 
 // ─── Input row shapes ──────────────────────────────────────────────
 //
@@ -58,6 +73,13 @@ export interface SurpriseCompositeRow {
   /** Unix ms — session terminal timestamp (manifest.updatedAt). */
   readonly updatedAt: number;
   readonly composite: CompositeOutcome;
+  /**
+   * Project the session belongs to (manifest `projectId`). Optional —
+   * sessions without a discovered project are still scored and counted
+   * for streaks / base-rate computation, but they're skipped by the
+   * same-project gates (e.g. `decision-paid-off`).
+   */
+  readonly projectId?: string;
 }
 
 /** Project-trajectory row — mirrors the on-disk sidecar entry. */
@@ -102,6 +124,14 @@ export interface SurpriseDecisionRow {
   readonly binaryClass: 'good' | 'bad' | 'neutral';
   /** Short label rendered into the summary; falls back to "a decision". */
   readonly label?: string;
+  /**
+   * Project the decision-session belongs to. Required for the
+   * `decision-paid-off` same-project followup gate; rows without a
+   * projectId are skipped entirely by that branch (the decision can
+   * still appear as `unscoped` evidence but we won't claim it "paid
+   * off" without scoping).
+   */
+  readonly projectId?: string;
 }
 
 // ─── Output schema ─────────────────────────────────────────────────
@@ -148,6 +178,7 @@ export interface SurpriseThresholdsSnapshot {
   readonly itsQValueMax: number;
   readonly itsDeltaMin: number;
   readonly reflexiveDeltaMin: number;
+  readonly reflexiveEValueMin: number;
   readonly decisionGoodFollowupsMin: number;
   readonly debtSpinningTopK: number;
   readonly debtSpinningMinClusterSize: number;
@@ -185,43 +216,56 @@ export interface ComputeSurprisesInput {
 }
 
 export interface ComputeSurprisesOptions {
-  /** Override the minimum streak length. Default 5. */
+  /**
+   * Override the minimum streak length. Defaults to
+   * `THRESHOLDS.surprises.streakMin`. Tests use this to drive boundary
+   * cases without forking the threshold table.
+   */
   readonly streakMin?: number;
   /**
    * ITS BH-FDR qValue ceiling — a contrast counts as "config-helped"
    * when `qValue ≤ itsQValueMax` AND `deltaGoodShare ≥ itsDeltaMin`.
-   * Pre-launch placeholder; calibrate after first ~50 contrasts.
+   * Defaults to `THRESHOLDS.surprises.itsQValueMax` /
+   * `.itsDeltaMin`.
    */
   readonly itsQValueMax?: number;
   readonly itsDeltaMin?: number;
   /**
    * Reflexive minimum mean-delta (good-share delta) to surface. Also
-   * requires the CI to be strictly positive (low > 0). Pre-launch
-   * placeholder.
+   * requires the CI to be strictly positive (low > 0) AND
+   * `eValueCIBound ≥ reflexiveEValueMin`. Defaults to
+   * `THRESHOLDS.surprises.reflexiveDeltaMin` /
+   * `.reflexiveEValueMin`.
    */
   readonly reflexiveDeltaMin?: number;
   /**
+   * Reflexive E-value CI-bound floor. Defaults to
+   * `THRESHOLDS.surprises.reflexiveEValueMin`. Smaller values make
+   * the gate looser; the surprise is associational, not causal, so
+   * the E-value floor protects against surfacing a contrast a single
+   * weak unobserved confounder could explain away.
+   */
+  readonly reflexiveEValueMin?: number;
+  /**
    * `decision-paid-off`: minimum number of additional good composite
-   * outcomes that must follow the decision's session (same project
-   * preferred but not required in V1; the kernel scopes by
-   * compositeRow.updatedAt > decision-session.updatedAt). Default 2.
+   * outcomes IN THE SAME PROJECT that must follow the decision's
+   * session. Defaults to `THRESHOLDS.surprises.decisionGoodFollowupsMin`.
+   * The kernel also requires the followup good-rate's Wilson lower
+   * bound (α=0.05) to exceed the corpus base good-share — see
+   * `computeDecisionPaidOff` for the math.
    */
   readonly decisionGoodFollowupsMin?: number;
-  /** Top-K knowledge-debt clusters surfaced as `debt-spinning`. Default 3. */
+  /**
+   * Top-K knowledge-debt clusters surfaced as `debt-spinning`.
+   * Defaults to `THRESHOLDS.surprises.debtSpinningTopK`.
+   */
   readonly debtSpinningTopK?: number;
-  /** Minimum cluster size for `debt-spinning`. Default 3. */
+  /**
+   * Minimum cluster size for `debt-spinning`. Defaults to
+   * `THRESHOLDS.surprises.debtSpinningMinClusterSize`.
+   */
   readonly debtSpinningMinClusterSize?: number;
 }
-
-const DEFAULTS = {
-  streakMin: 5,
-  itsQValueMax: 0.1,
-  itsDeltaMin: 0.15,
-  reflexiveDeltaMin: 0.1,
-  decisionGoodFollowupsMin: 2,
-  debtSpinningTopK: 3,
-  debtSpinningMinClusterSize: 3,
-} as const;
 
 // ─── Kernel entry point ────────────────────────────────────────────
 
@@ -229,16 +273,22 @@ export function computeSurprises(
   input: ComputeSurprisesInput,
   options: ComputeSurprisesOptions = {},
 ): SurprisesOutput {
+  // All defaults route through THRESHOLDS.surprises so the no-hardcoded-
+  // numbers rule applies uniformly. Test overrides flow through `options`
+  // unchanged.
+  const defaults = THRESHOLDS.surprises;
   const opts = {
-    streakMin: options.streakMin ?? DEFAULTS.streakMin,
-    itsQValueMax: options.itsQValueMax ?? DEFAULTS.itsQValueMax,
-    itsDeltaMin: options.itsDeltaMin ?? DEFAULTS.itsDeltaMin,
-    reflexiveDeltaMin: options.reflexiveDeltaMin ?? DEFAULTS.reflexiveDeltaMin,
+    streakMin: options.streakMin ?? defaults.streakMin,
+    itsQValueMax: options.itsQValueMax ?? defaults.itsQValueMax,
+    itsDeltaMin: options.itsDeltaMin ?? defaults.itsDeltaMin,
+    reflexiveDeltaMin: options.reflexiveDeltaMin ?? defaults.reflexiveDeltaMin,
+    reflexiveEValueMin:
+      options.reflexiveEValueMin ?? defaults.reflexiveEValueMin,
     decisionGoodFollowupsMin:
-      options.decisionGoodFollowupsMin ?? DEFAULTS.decisionGoodFollowupsMin,
-    debtSpinningTopK: options.debtSpinningTopK ?? DEFAULTS.debtSpinningTopK,
+      options.decisionGoodFollowupsMin ?? defaults.decisionGoodFollowupsMin,
+    debtSpinningTopK: options.debtSpinningTopK ?? defaults.debtSpinningTopK,
     debtSpinningMinClusterSize:
-      options.debtSpinningMinClusterSize ?? DEFAULTS.debtSpinningMinClusterSize,
+      options.debtSpinningMinClusterSize ?? defaults.debtSpinningMinClusterSize,
   };
 
   const surprises: Surprise[] = [];
@@ -267,6 +317,7 @@ export function computeSurprises(
       itsQValueMax: opts.itsQValueMax,
       itsDeltaMin: opts.itsDeltaMin,
       reflexiveDeltaMin: opts.reflexiveDeltaMin,
+      reflexiveEValueMin: opts.reflexiveEValueMin,
       decisionGoodFollowupsMin: opts.decisionGoodFollowupsMin,
       debtSpinningTopK: opts.debtSpinningTopK,
       debtSpinningMinClusterSize: opts.debtSpinningMinClusterSize,
@@ -417,28 +468,60 @@ function computePatternClosed(input: ComputeSurprisesInput): Surprise[] {
 }
 
 /**
- * `reflexive-positive`: meanDelta ≥ reflexiveDeltaMin AND CI strictly
- * positive (low > 0). One surprise at most (reflexive is whole-corpus).
+ * `reflexive-positive`: three-gate associational surprise.
+ *
+ *   1. `meanDelta ≥ reflexiveDeltaMin` — practical significance.
+ *   2. `ci.low > 0` — Wilson CI strictly positive (not just a
+ *      directional point estimate; we want some inferential
+ *      confidence the contrast isn't noise).
+ *   3. `eValueStatus === 'computed' && eValueCIBound ≥
+ *      reflexiveEValueMin` — VanderWeele & Ding (2017) E-value on the
+ *      CI bound nearest the null. If the E-value is small, a
+ *      modestly-strong unobserved confounder could drag the
+ *      observation to RR=1. We refuse to surface contrasts that are
+ *      one weak confounder away from disappearing.
+ *
+ * Iter-1 adversarial finding: prior version emitted on (1)+(2) and
+ * called the contrast a "lift" — both the gating and the copy
+ * suggested a causal interpretation the matched-pair primitive
+ * doesn't support. Tightened to gate on E-value AND softened the
+ * verb to "is associated with" to match the methodology disclosure
+ * the viewer already shows.
+ *
+ * One surprise at most (reflexive is whole-corpus).
  *
  * Score: `min(1, meanDelta * 2)` — same convention as config-helped.
  */
 function computeReflexivePositive(
   input: ComputeSurprisesInput,
-  opts: { reflexiveDeltaMin: number },
+  opts: { reflexiveDeltaMin: number; reflexiveEValueMin: number },
 ): Surprise[] {
   const r = input.reflexive;
   if (r === null) return [];
   if (!Number.isFinite(r.meanDelta) || r.meanDelta < opts.reflexiveDeltaMin) return [];
   if (r.ci.low <= 0) return [];
+  // E-value sensitivity gate. `'ci-straddles-null'` / `'p-control-zero'`
+  // mean the kernel couldn't compute a meaningful E-value at all —
+  // those cases fail the gate by definition.
+  if (
+    r.eValueStatus !== 'computed' ||
+    r.eValueCIBound === null ||
+    !Number.isFinite(r.eValueCIBound) ||
+    r.eValueCIBound < opts.reflexiveEValueMin
+  ) {
+    return [];
+  }
   const score = Math.max(0, Math.min(1, r.meanDelta * 2));
   return [
     {
       id: 'reflexive-positive:whole-corpus',
       kind: 'reflexive-positive',
       tone: 'positive',
+      // Associational language (not "lifted") — the matched-pair
+      // primitive is descriptive, the E-value is sensitivity-bounded.
       summary: clip(
-        `Touching chat-arch lifted good-share by ${(r.meanDelta * 100).toFixed(0)}pp ` +
-          `(CI low ${(r.ci.low * 100).toFixed(0)}pp).`,
+        `Touching chat-arch is associated with +${(r.meanDelta * 100).toFixed(0)}pp ` +
+          `good-share (CI low ${(r.ci.low * 100).toFixed(0)}pp, E-value ${r.eValueCIBound.toFixed(2)}).`,
       ),
       evidence: {
         sessionIds: r.pairs.map((p) => p.treatedSessionId),
@@ -452,12 +535,35 @@ function computeReflexivePositive(
 /**
  * `decision-paid-off`: a decision whose outcome was `good` AND was
  * followed by at least `decisionGoodFollowupsMin` additional good
- * composite outcomes (across the whole corpus — V1 doesn't restrict
- * to same-project; that's a follow-on once decisions carry a project
- * pointer in the join).
+ * composite outcomes IN THE SAME PROJECT, AND whose followup good-
+ * rate's Wilson lower bound (α=0.05) exceeds the corpus-wide good
+ * base rate.
  *
- * Score: saturating in follow-up count. `min(1, (followups + 1) / 10)`
- * — a decision with 9 good followups caps the score at 1.
+ * Iter-1 adversarial findings:
+ *
+ *   - **Cross-project leak.** Prior version counted followups across
+ *     the WHOLE corpus, so any decision made early in a productive
+ *     week scored "paid off" by virtue of the user shipping in
+ *     unrelated projects. Now restricted to same-project followups
+ *     (rows where both decision-session and followup-session carry
+ *     the same `projectId`).
+ *   - **Threshold too loose.** Prior floor was 2 followups; Wilson
+ *     lower bound on 2/2 with Beta(1,1) prior is ≈0.16, well below
+ *     any plausible base rate. Raised to 5 (see
+ *     `THRESHOLDS.surprises.decisionGoodFollowupsMin`).
+ *   - **No lift test.** "K good followups happened" doesn't establish
+ *     the decision moved the curve — the user might just have a
+ *     consistent good week. Added a Wilson-low > base-rate gate so we
+ *     only emit when the followup good-rate is provably higher than
+ *     the user's typical share.
+ *
+ * Decisions whose `projectId` is unset are skipped (we cannot scope
+ * followups for them); composite rows whose `projectId` is unset are
+ * NOT counted as followups (same reason) but ARE counted in the
+ * corpus base-rate denominator (every scored session contributes to
+ * the user's overall good-share).
+ *
+ * Score: saturating in followup count. `min(1, (followups + 1) / 10)`.
  */
 function computeDecisionPaidOff(
   input: ComputeSurprisesInput,
@@ -465,8 +571,23 @@ function computeDecisionPaidOff(
 ): Surprise[] {
   if (input.decisions.length === 0) return [];
 
-  // Build a sorted (updatedAt, sessionId) lookup once for the followup
-  // count. O(N log N) once, then O(log N) per decision.
+  // Corpus-wide base rate of good outcomes. Denominator is every
+  // scored composite row (binary !== 'unknown' is the conservative
+  // line — 'unknown' rows had no measurable outcome).
+  let baseGood = 0;
+  let baseDenom = 0;
+  for (const row of input.composites) {
+    if (row.composite.binary === 'unknown') continue;
+    baseDenom += 1;
+    if (row.composite.binary === 'good') baseGood += 1;
+  }
+  // No scored composites at all → no base rate exists → cannot
+  // make the lift claim. Fall back to 0 so the Wilson gate trivially
+  // passes; the count floor still applies.
+  const baseRateGoodShare = baseDenom > 0 ? baseGood / baseDenom : 0;
+
+  // Build a sorted (updatedAt, sessionId) lookup once. O(N log N) once,
+  // then O(N) per decision (worst case scans the tail).
   const sessionByUpdatedAt = input.composites
     .slice()
     .sort((a, b) => a.updatedAt - b.updatedAt || a.sessionId.localeCompare(b.sessionId));
@@ -474,23 +595,40 @@ function computeDecisionPaidOff(
   const out: Surprise[] = [];
   for (const d of input.decisions) {
     if (d.binaryClass !== 'good') continue;
+    // Same-project scoping requires a projectId on the decision.
+    if (d.projectId === undefined) continue;
     // Anchor on this decision's session in the sorted list.
     const anchor = sessionByUpdatedAt.findIndex((s) => s.sessionId === d.sessionId);
     if (anchor === -1) continue;
-    let followups = 0;
+    let followupsGood = 0;
+    let followupsTotal = 0;
     for (let i = anchor + 1; i < sessionByUpdatedAt.length; i += 1) {
       const row = sessionByUpdatedAt[i] as SurpriseCompositeRow;
-      if (row.composite.binary === 'good') followups += 1;
+      // Same-project gate; skip cross-project ships entirely.
+      if (row.projectId === undefined || row.projectId !== d.projectId) continue;
+      if (row.composite.binary === 'unknown') continue;
+      followupsTotal += 1;
+      if (row.composite.binary === 'good') followupsGood += 1;
     }
-    if (followups < opts.decisionGoodFollowupsMin) continue;
-    const score = Math.max(0, Math.min(1, (followups + 1) / 10));
+    if (followupsGood < opts.decisionGoodFollowupsMin) continue;
+    // Wilson lower bound on the followup good-rate. Only emit when it
+    // strictly exceeds the corpus base rate — i.e. the decision is
+    // followed by a *higher* good-share than the user's typical week,
+    // with enough samples that the lower bound clears the bar.
+    const wilson = wilsonCI(followupsGood / followupsTotal, followupsTotal);
+    if (wilson.low <= baseRateGoodShare) continue;
+    const score = Math.max(0, Math.min(1, (followupsGood + 1) / 10));
     const label = d.label ?? 'a decision';
     out.push({
       id: `decision-paid-off:${d.decisionId}`,
       kind: 'decision-paid-off',
       tone: 'positive',
+      // Summary surfaces the lift: same-project K/N + Wilson-low + base
+      // rate. The user can see at a glance that we're not just counting
+      // good sessions in a row.
       summary: clip(
-        `${label} paid off — ${followups} good sessions followed.`,
+        `${label} paid off — same-project followups: ${followupsGood}/${followupsTotal} good ` +
+          `(Wilson low ${wilson.low.toFixed(2)}, base rate ${baseRateGoodShare.toFixed(2)}).`,
       ),
       evidence: { decisionId: d.decisionId, sessionIds: [d.sessionId] },
       score,

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -395,6 +395,23 @@ export {
 } from './applyWatcher.js';
 
 export {
+  computeSurprises,
+  type ComputeSurprisesInput,
+  type ComputeSurprisesOptions,
+  type Surprise,
+  type SurpriseCompositeRow,
+  type SurpriseDecisionRow,
+  type SurpriseEvidence,
+  type SurpriseKind,
+  type SurpriseKnowledgeDebtRow,
+  type SurpriseThresholdsSnapshot,
+  type SurpriseTone,
+  type SurpriseTrajectoryRow,
+  type SurpriseWatcherEntry,
+  type SurprisesOutput,
+} from './computeSurprises.js';
+
+export {
   rankCuratorCandidates,
   type CuratorCandidate,
   type CuratorCandidateKind,

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -361,6 +361,68 @@ export const THRESHOLDS = {
     falsifierMinSupportRatio: 0.6,
   },
   /**
+   * Feed-redesign Phase α — `computeSurprises` kernel knobs.
+   *
+   * Pre-launch placeholders, ALL of them — the surprises surface is
+   * brand-new (V1 = first land) and we have zero engagement data yet.
+   * Calibrate on the same 4-week empirical rolling window as
+   * `CHATARCH_THRASH_DETECT`: pull surprise emission rate per kind +
+   * user-side "useful / not useful" feedback once the FEED Phase β
+   * surface starts collecting it, then re-derive each value from the
+   * observed distribution. Bumping a threshold here should be paired
+   * with a fixture update + an entry under THRESHOLDS.surprises in the
+   * `CHANGELOG.md` calibration log.
+   *
+   * Knobs are mirrored as `SurpriseThresholdsSnapshot` on the
+   * `surprises.json` sidecar so the viewer can disclaim the values it
+   * was emitted under.
+   */
+  surprises: {
+    /** Minimum trailing-run length to emit a `streak` surprise. */
+    streakMin: 5,
+    /**
+     * ITS BH-FDR qValue ceiling — a contrast counts as
+     * `config-helped` when `qValue ≤ itsQValueMax` AND
+     * `deltaGoodShare ≥ itsDeltaMin`.
+     */
+    itsQValueMax: 0.1,
+    itsDeltaMin: 0.15,
+    /**
+     * Reflexive minimum mean-delta (good-share delta). Also requires
+     * the CI to be strictly positive AND the E-value CI bound to
+     * clear `reflexiveEValueMin` — descriptively significant +
+     * statistically significant + sensitivity-robust, three gates.
+     */
+    reflexiveDeltaMin: 0.1,
+    /**
+     * Reflexive E-value CI-bound floor. VanderWeele & Ding (2017)
+     * E-value on the Wilson CI bound nearest the null: how strong a
+     * confounder (RR scale, both arms) would have to be to drag the
+     * observed association to RR=1. 1.5 ≈ "a confounder twice the
+     * strength of any pre-treatment covariate already adjusted for
+     * would explain it away" — strong enough to surface, weak enough
+     * to be one of the looser gates. Pre-launch placeholder; raise to
+     * 2.0 after the first ~20 reflexive contrasts land if false-
+     * positive rate looks high.
+     */
+    reflexiveEValueMin: 1.5,
+    /**
+     * `decision-paid-off`: minimum number of additional good
+     * composite outcomes IN THE SAME PROJECT that must follow the
+     * decision's session. Raised from 2 → 5 after iter-1 adversarial:
+     * 2/2 followups gives Wilson lower bound ≈ 0.16 (Beta(1,1) prior),
+     * which is below any plausible base rate. 5 followups + Wilson-
+     * over-base-rate gate gives meaningful evidence the decision
+     * actually moved the curve rather than coinciding with a good
+     * week.
+     */
+    decisionGoodFollowupsMin: 5,
+    /** Top-K knowledge-debt clusters surfaced as `debt-spinning`. */
+    debtSpinningTopK: 3,
+    /** Minimum cluster size for `debt-spinning`. */
+    debtSpinningMinClusterSize: 3,
+  },
+  /**
    * Rev3 applied-rule outcome watcher (plan §"Three closures" —
    * Closure C). After a Pattern is `encode-as-pattern`'d and
    * (optionally) appended to CLAUDE.md, the next-sessions watcher

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -23,6 +23,9 @@
  *   - project-trajectories.json  (reads composite)
  *   - surface-comparison.json    (reads archetypes + composite)
  *   - skill-curves.json          (reads topics)
+ *   - surprises.json             (feed-redesign Phase A — reads
+ *                                 composite + trajectories + its +
+ *                                 reflexive + decisions + knowledge-debt)
  *
  * Phase 7 writers do NOT land here (they live in a separate skill/package
  * per Decision 1). Never writes tier-2 filenames.
@@ -60,6 +63,7 @@ import { buildArchetypesFile } from './archetypesBuilder.js';
 import { buildProjectTrajectoriesFile } from './projectTrajectoryBuilder.js';
 import { buildSurfaceComparisonFile } from './surfaceComparisonBuilder.js';
 import { buildSkillCurvesFile } from './skillCurvesBuilder.js';
+import { buildSurprisesFile } from './surprisesBuilder.js';
 
 export interface RunAnalysisOptions {
   /** Root output dir (same one `manifest.json` sits in). */
@@ -101,6 +105,7 @@ export interface RunAnalysisResult {
     projectTrajectories: string;
     surfaceComparison: string;
     skillCurves: string;
+    surprises: string;
   };
   counts: {
     duplicatesClusters: number;
@@ -124,6 +129,7 @@ export interface RunAnalysisResult {
     projectTrajectories: number;
     surfaceCells: number;
     skillCurves: number;
+    surprises: number;
   };
 }
 
@@ -151,8 +157,15 @@ export interface RunAnalysisResult {
  * because their per-file heuristic versions didn't change. The bump
  * is a coarse signal to operators that the bundle now reflects the
  * Rev3 substrate, not just outcome-substrate Phase 1-4.
+ *
+ * Bumped 1.3.0 → 1.4.0 in the feed-redesign Phase A plumbing:
+ * `analysis/surprises.json` lands as a new sidecar (per-kind ranked
+ * list of positive observations + concerns, snapshot-based — reads
+ * composite-outcomes + project-trajectories + its-analysis +
+ * reflexive + decisions + knowledge-debt). Pre-existing sidecars are
+ * unchanged.
  */
-export const EXPORTER_VERSION = '1.3.0';
+export const EXPORTER_VERSION = '1.4.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,
@@ -523,6 +536,23 @@ export async function runAnalysis(
   }
   const skillCurvesPath = path.join(analysisDir, 'skill-curves.json');
 
+  // surprises — feed-redesign Phase A. Snapshot kernel over the other
+  // Phase 1-3 sidecars; runs last so every input it consumes has had
+  // a chance to land on disk.
+  let surprisesCount = 0;
+  try {
+    const r = await buildSurprisesFile(manifest, {
+      outDir: options.outDir,
+      now,
+    });
+    surprisesCount = r.surpriseCount;
+  } catch (err) {
+    logger.warn(
+      `analysis: surprises soft-failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const surprisesPath = path.join(analysisDir, 'surprises.json');
+
   // ---- Meta ----
   const exporterRunId = options.exporterRunId ?? randomUUID();
   const gitSha = options.gitSha !== undefined ? options.gitSha : detectGitSha();
@@ -555,6 +585,7 @@ export async function runAnalysis(
           'project-trajectories.json',
           'surface-comparison.json',
           'skill-curves.json',
+          'surprises.json',
         ],
       },
     },
@@ -581,6 +612,7 @@ export async function runAnalysis(
       projectTrajectories: projectTrajectoriesCount,
       surfaceCells: surfaceCellsCount,
       skillCurves: skillCurvesCount,
+      surprises: surprisesCount,
     },
   };
   const metaPath = path.join(analysisDir, 'meta.json');
@@ -625,6 +657,7 @@ export async function runAnalysis(
       projectTrajectories: projectTrajectoriesPath,
       surfaceComparison: surfaceComparisonPath,
       skillCurves: skillCurvesPath,
+      surprises: surprisesPath,
     },
     counts: {
       duplicatesClusters: duplicatesFile.clusters.length,
@@ -646,6 +679,7 @@ export async function runAnalysis(
       projectTrajectories: projectTrajectoriesCount,
       surfaceCells: surfaceCellsCount,
       skillCurves: skillCurvesCount,
+      surprises: surprisesCount,
     },
   };
 }

--- a/packages/exporter/src/analysis/surprisesBuilder.ts
+++ b/packages/exporter/src/analysis/surprisesBuilder.ts
@@ -1,0 +1,235 @@
+/**
+ * Surprises builder — feed-redesign Phase A.
+ *
+ * Node-only I/O wrapper around the pure `computeSurprises` kernel.
+ *
+ * Reads:
+ *   - `analysis/composite-outcomes.json`   (foundation)
+ *   - `analysis/project-trajectories.json`
+ *   - `analysis/its-analysis.json`
+ *   - `analysis/reflexive.json`
+ *   - `analysis/decisions.json`
+ *   - `analysis/knowledge-debt.json`
+ *
+ * Writes:
+ *   - `analysis/surprises.json`
+ *
+ * Watcher entries are intentionally NOT read from disk in V1 — the
+ * applied-pattern watcher loop ledger lives in the SQLite substrate,
+ * not in a JSON sidecar, and wiring the DB query into the exporter is
+ * out-of-scope for the kernel landing PR. The builder passes an empty
+ * `patternWatchers` array; a follow-on adds the SDK call.
+ *
+ * Fail-soft: any missing input sidecar degrades the corresponding
+ * surprise kinds to "no rows" rather than aborting the build. The
+ * surprises sidecar is always written so the viewer can rely on its
+ * presence after a scan.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  CompositeOutcomesFile,
+  Decision,
+  DecisionsFile,
+  SessionManifest,
+} from '@chat-arch/schema';
+import {
+  computeSurprises,
+  type ComputeSurprisesInput,
+  type SurpriseCompositeRow,
+  type SurpriseDecisionRow,
+  type SurpriseKnowledgeDebtRow,
+  type SurpriseTrajectoryRow,
+  type SurpriseWatcherEntry,
+  type SurprisesOutput,
+} from '@chat-arch/analysis';
+import type { ItsResult } from '@chat-arch/analysis';
+import type { ReflexiveResult } from '@chat-arch/analysis';
+import { logger } from '../lib/logger.js';
+import { atomicWriteJsonSync } from '../lib/atomicWrite.js';
+
+export interface BuildSurprisesOptions {
+  outDir: string;
+  now: number;
+}
+
+export interface BuildSurprisesResult {
+  file: SurprisesOutput;
+  /** Sidecars that were readable; the others contributed empty inputs. */
+  inputsRead: {
+    composite: boolean;
+    trajectories: boolean;
+    its: boolean;
+    reflexive: boolean;
+    decisions: boolean;
+    knowledgeDebt: boolean;
+  };
+  surpriseCount: number;
+}
+
+async function readJsonOrNull<T>(p: string): Promise<T | null> {
+  try {
+    const raw = await readFile(p, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function buildSurprisesFile(
+  manifest: SessionManifest,
+  options: BuildSurprisesOptions,
+): Promise<BuildSurprisesResult> {
+  const t0 = Date.now();
+  const analysisDir = path.join(options.outDir, 'analysis');
+
+  // Map sessionId → updatedAt from the manifest. Composite rows on
+  // disk don't carry the terminal timestamp; we re-join here.
+  const updatedAtBySession = new Map<string, number>();
+  for (const entry of manifest.sessions) {
+    if (typeof entry.updatedAt === 'number') {
+      updatedAtBySession.set(entry.id, entry.updatedAt);
+    }
+  }
+
+  // ── composites ──
+  const compositeFile = await readJsonOrNull<CompositeOutcomesFile>(
+    path.join(analysisDir, 'composite-outcomes.json'),
+  );
+  const composites: SurpriseCompositeRow[] = [];
+  if (compositeFile !== null) {
+    for (const o of compositeFile.outcomes ?? []) {
+      const updatedAt = updatedAtBySession.get(o.sessionId) ?? 0;
+      composites.push({ sessionId: o.sessionId, updatedAt, composite: o });
+    }
+  }
+
+  // ── trajectories ──
+  interface ProjectTrajectoriesFileShape {
+    projects?: ReadonlyArray<{
+      projectId: string;
+      projectName: string;
+      classification: SurpriseTrajectoryRow['classification'];
+      slope: number | null;
+      ci: { low: number; high: number } | null;
+      totalSessions: number;
+      recentSessions: number;
+      bootstrapStatus: 'ok' | 'series-too-short';
+    }>;
+  }
+  const trajectoryFile = await readJsonOrNull<ProjectTrajectoriesFileShape>(
+    path.join(analysisDir, 'project-trajectories.json'),
+  );
+  const trajectories: SurpriseTrajectoryRow[] =
+    trajectoryFile?.projects?.map((p) => ({
+      projectId: p.projectId,
+      projectName: p.projectName,
+      classification: p.classification,
+      slope: p.slope,
+      ci: p.ci,
+      totalSessions: p.totalSessions,
+      recentSessions: p.recentSessions,
+      bootstrapStatus: p.bootstrapStatus,
+    })) ?? [];
+
+  // ── its ──
+  interface ItsFileShape {
+    results?: readonly ItsResult[];
+  }
+  const itsFile = await readJsonOrNull<ItsFileShape>(
+    path.join(analysisDir, 'its-analysis.json'),
+  );
+  const itsResults: readonly ItsResult[] = itsFile?.results ?? [];
+
+  // ── reflexive ──
+  interface ReflexiveFileShape {
+    result?: ReflexiveResult;
+  }
+  const reflexiveFile = await readJsonOrNull<ReflexiveFileShape>(
+    path.join(analysisDir, 'reflexive.json'),
+  );
+  const reflexive: ReflexiveResult | null = reflexiveFile?.result ?? null;
+
+  // ── decisions ──
+  const decisionsFile = await readJsonOrNull<DecisionsFile>(
+    path.join(analysisDir, 'decisions.json'),
+  );
+  const decisions: SurpriseDecisionRow[] = [];
+  if (decisionsFile !== null) {
+    for (const d of decisionsFile.decisions ?? []) {
+      const decision = d as Decision;
+      const ref = decision.outcomeRef;
+      if (ref === null || ref === undefined) continue;
+      decisions.push({
+        decisionId: decision.candidate.id,
+        sessionId: ref.sessionId,
+        compositeScore: ref.compositeScore,
+        binaryClass: ref.binaryClass,
+        ...(decision.classification?.distilledDecision !== undefined
+          ? { label: decision.classification.distilledDecision }
+          : {}),
+      });
+    }
+  }
+
+  // ── knowledge debt ──
+  interface KnowledgeDebtFileShape {
+    clusters?: ReadonlyArray<{
+      id: string;
+      canonicalQuestion: string;
+      sessionIds: readonly string[];
+      confidence: 'high' | 'low';
+    }>;
+  }
+  const debtFile = await readJsonOrNull<KnowledgeDebtFileShape>(
+    path.join(analysisDir, 'knowledge-debt.json'),
+  );
+  const knowledgeDebt: SurpriseKnowledgeDebtRow[] =
+    debtFile?.clusters?.map((c) => ({
+      id: c.id,
+      canonicalQuestion: c.canonicalQuestion,
+      sessionIds: c.sessionIds,
+      confidence: c.confidence,
+    })) ?? [];
+
+  // Pattern-watcher ledger lives in SQLite; wiring the SDK query is a
+  // follow-on. V1 passes an empty list so the kernel skips the two
+  // pattern-* kinds rather than synthesizing fake verdicts.
+  const patternWatchers: readonly SurpriseWatcherEntry[] = [];
+
+  const kernelInput: ComputeSurprisesInput = {
+    generatedAt: options.now,
+    composites,
+    trajectories,
+    itsResults,
+    patternWatchers,
+    reflexive,
+    decisions,
+    knowledgeDebt,
+  };
+  const file = computeSurprises(kernelInput);
+
+  const outPath = path.join(analysisDir, 'surprises.json');
+  atomicWriteJsonSync(outPath, file);
+
+  logger.info(
+    `analysis: surprises.json — ${file.surprises.length} surprises ` +
+      `(composites=${composites.length}, trajectories=${trajectories.length}, ` +
+      `its=${itsResults.length}, decisions=${decisions.length}, ` +
+      `knowledgeDebt=${knowledgeDebt.length}), ${Date.now() - t0}ms`,
+  );
+
+  return {
+    file,
+    inputsRead: {
+      composite: compositeFile !== null,
+      trajectories: trajectoryFile !== null,
+      its: itsFile !== null,
+      reflexive: reflexiveFile !== null,
+      decisions: decisionsFile !== null,
+      knowledgeDebt: debtFile !== null,
+    },
+    surpriseCount: file.surprises.length,
+  };
+}

--- a/packages/exporter/src/analysis/surprisesBuilder.ts
+++ b/packages/exporter/src/analysis/surprisesBuilder.ts
@@ -84,12 +84,18 @@ export async function buildSurprisesFile(
   const t0 = Date.now();
   const analysisDir = path.join(options.outDir, 'analysis');
 
-  // Map sessionId → updatedAt from the manifest. Composite rows on
-  // disk don't carry the terminal timestamp; we re-join here.
+  // Map sessionId → { updatedAt, projectId } from the manifest.
+  // Composite rows on disk don't carry the terminal timestamp or the
+  // discovered projectId; we re-join here so the kernel can apply the
+  // same-project gates (notably `decision-paid-off`).
   const updatedAtBySession = new Map<string, number>();
+  const projectIdBySession = new Map<string, string>();
   for (const entry of manifest.sessions) {
     if (typeof entry.updatedAt === 'number') {
       updatedAtBySession.set(entry.id, entry.updatedAt);
+    }
+    if (typeof entry.projectId === 'string' && entry.projectId.length > 0) {
+      projectIdBySession.set(entry.id, entry.projectId);
     }
   }
 
@@ -101,7 +107,13 @@ export async function buildSurprisesFile(
   if (compositeFile !== null) {
     for (const o of compositeFile.outcomes ?? []) {
       const updatedAt = updatedAtBySession.get(o.sessionId) ?? 0;
-      composites.push({ sessionId: o.sessionId, updatedAt, composite: o });
+      const projectId = projectIdBySession.get(o.sessionId);
+      composites.push({
+        sessionId: o.sessionId,
+        updatedAt,
+        composite: o,
+        ...(projectId !== undefined ? { projectId } : {}),
+      });
     }
   }
 
@@ -161,6 +173,12 @@ export async function buildSurprisesFile(
       const decision = d as Decision;
       const ref = decision.outcomeRef;
       if (ref === null || ref === undefined) continue;
+      // Same-project scoping for `decision-paid-off`: pull the
+      // decision-session's projectId from the manifest join above.
+      // Decisions whose session has no discovered projectId are still
+      // emitted to the kernel but won't qualify for the paid-off
+      // surprise (kernel-side gate).
+      const projectId = projectIdBySession.get(ref.sessionId);
       decisions.push({
         decisionId: decision.candidate.id,
         sessionId: ref.sessionId,
@@ -169,6 +187,7 @@ export async function buildSurprisesFile(
         ...(decision.classification?.distilledDecision !== undefined
           ? { label: decision.classification.distilledDecision }
           : {}),
+        ...(projectId !== undefined ? { projectId } : {}),
       });
     }
   }
@@ -193,9 +212,25 @@ export async function buildSurprisesFile(
       confidence: c.confidence,
     })) ?? [];
 
-  // Pattern-watcher ledger lives in SQLite; wiring the SDK query is a
-  // follow-on. V1 passes an empty list so the kernel skips the two
-  // pattern-* kinds rather than synthesizing fake verdicts.
+  // TODO(applyWatcher-sdk): wire the pattern-watcher ledger from the
+  // SQLite substrate once the read-side SDK accessor lands.
+  //
+  // The applied-pattern watcher loop (`evaluateAppliedPatternWatcher`
+  // in @chat-arch/analysis) emits per-(pattern, project) verdicts
+  // {kind: 'holding' | 'recurring' | 'open' | 'inconclusive'} that
+  // the kernel consumes for `pattern-closed` / `pattern-recurring`
+  // surprises. The verdicts persist in the SQLite substrate (Rev3-E
+  // pattern + applyWatcher tables) but no `@chat-arch/exporter/db`
+  // SDK accessor exposes them to a Node consumer yet.
+  //
+  // Until that accessor lands, this builder passes an empty list so
+  // the kernel skips both pattern-* kinds rather than synthesizing
+  // fake verdicts. V1 emission scope is therefore 7 of 9 kinds.
+  //
+  // When wiring lands, replace this assignment with the SDK call
+  // (likely `listWatcherVerdicts({ closedOnly: false })` returning a
+  // shape assignable to `SurpriseWatcherEntry[]`) and update CHANGELOG
+  // `[1.4.0]` accordingly.
   const patternWatchers: readonly SurpriseWatcherEntry[] = [];
 
   const kernelInput: ComputeSurprisesInput = {

--- a/packages/exporter/test/integration/analysis-pipeline.test.ts
+++ b/packages/exporter/test/integration/analysis-pipeline.test.ts
@@ -151,6 +151,7 @@ describe('Phase 6 analysis pipeline integration', () => {
         'project-trajectories.json',
         'surface-comparison.json',
         'skill-curves.json',
+        'surprises.json',
       ].sort(),
     );
     // Phase 6 does not populate the `local` tier.

--- a/packages/exporter/test/migration/v1.1.0-fixture.test.ts
+++ b/packages/exporter/test/migration/v1.1.0-fixture.test.ts
@@ -157,9 +157,10 @@ describe('migration v1.1.0 → 1.2.0', () => {
       tiers: { browser: { files: readonly string[] } };
       counts: Record<string, unknown>;
     }>(path.join(tmpDataDir, 'analysis', 'meta.json'));
-    expect(meta.exporterVersion).toBe('1.3.0');
+    expect(meta.exporterVersion).toBe('1.4.0');
 
-    // The Wave-5 sidecars must all be registered in the browser tier.
+    // The Wave-5 sidecars (+ feed-redesign Phase A surprises.json)
+    // must all be registered in the browser tier.
     const expectedNewSidecars = [
       'composite-outcomes.json',
       'config-history.json',
@@ -171,6 +172,7 @@ describe('migration v1.1.0 → 1.2.0', () => {
       'project-trajectories.json',
       'surface-comparison.json',
       'skill-curves.json',
+      'surprises.json',
     ];
     for (const f of expectedNewSidecars) {
       expect(


### PR DESCRIPTION
## Summary

Phase α of the FEED redesign (chat-arch UI first-principles rebuild). Invisible plumbing only — closes the producer→viewer loop for Rev3-F (curator + falsifier) and lands a new \`surprises.json\` sidecar for the future FEED home page.

- **\`/api/curate\` + \`/api/falsify\`** — mirror the \`mine-corrections.ts\` pattern; spawn the corresponding skill via \`claude -p\`, stream NDJSON. CSRF-gated; in-flight serialized; claude availability probed up-front (no silent API-key fallback per \`feedback_claude_code_not_api\`).
- **\`computeSurprises\` kernel** — snapshot-based ranked observations across 9 kinds (5 positive + 4 concerning). Pure / deterministic / 36 unit tests. Builder stubs pattern-watcher inputs until SQLite SDK wiring lands separately (CHANGELOG notes this).
- **EXPORTER_VERSION 1.3.0 → 1.4.0** + CHANGELOG entry + CLAUDE.md sidecar-table update (new \`surprises.json\` PII-bearing artifact).
- **Drive-by:** \`playbook.astro\` had literal U+2028/U+2029 characters in string literals that broke esbuild's dep scan. Replaced with escape sequences. (This was blocking \`pnpm dev\` startup.)

## Why this PR shape

Single-user behavioral feedback tool — the FEED redesign reframes chat-arch from a multi-tenant analytics dashboard (13 routes / 17 hash modes, half hidden) into a daily journal. Phase α ships the producers that the visible FEED (Phase β) will display, plus the playbook fix that was blocking the dev server.

Two more PRs follow:
- **Phase β** — TODAY → 5-section FEED (BRIEF / NEW / ACT / BROKEN / STORIES) + sidebar to 3 groups + drill-in wiring
- **Phase γ** — richer brief content + orphan-kernel cull (\`audit-claims\`, \`discovery-scores\`, \`duplicates.semantic\`)

## Test plan

- [x] \`pnpm lint\` — clean (informational threshold-budget note, pre-existing)
- [x] \`pnpm test\` — 2041 passed / 5 skipped (the 5 are pre-existing live-integration)
- [x] \`pnpm --filter @chat-arch/analysis test computeSurprises\` — 36/36
- [x] \`pnpm --filter @chat-arch/exporter build\` — clean
- [x] \`pnpm --filter @chat-arch/standalone build\` — clean
- [ ] Manual: hit \`POST /api/curate\` and \`/api/falsify\` from the running dev server to confirm streaming behavior (deferred — endpoints aren't wired into UI yet; happens in Phase β)
- [ ] Manual: run \`pnpm exporter run start all --no-cloud\` and confirm \`analysis/surprises.json\` is written (deferred — covered by the analysis-pipeline integration test in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)