### PR TITLE
feat(feed-γ): enrich daily brief + document intermediate sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,27 +28,47 @@ recent work. No new kernel dependencies; no UI yet (Phase B lands the
 
 ### Added
 
-- **`analysis/surprises.json` sidecar.** Nine surprise kinds:
+- **`analysis/surprises.json` sidecar.** Nine surprise kinds defined
+  in the kernel API; **7 emit from the V1 builder pipeline**:
   `streak` / `trajectory-accelerating` / `config-helped` /
-  `pattern-closed` / `reflexive-positive` / `decision-paid-off`
-  (positive) and `trajectory-stalled` / `pattern-recurring` /
-  `debt-spinning` (concerns). Each row carries `{ id, kind, tone,
-  summary (≤120 chars), evidence, score (0-1), generatedAt }`. File
-  also exposes the threshold snapshot it used so the UI can disclaim.
+  `reflexive-positive` / `decision-paid-off` (positive) and
+  `trajectory-stalled` / `debt-spinning` (concerns). The remaining
+  two — `pattern-closed` and `pattern-recurring` — are defined and
+  unit-tested but **dormant in V1**: the applied-pattern watcher
+  ledger lives in the SQLite substrate and no
+  `@chat-arch/exporter/db` SDK accessor exposes the verdicts to a
+  Node consumer yet (see `TODO(applyWatcher-sdk):` marker in
+  `packages/exporter/src/analysis/surprisesBuilder.ts`). When the
+  accessor lands the builder swaps the empty list for the SDK call;
+  no kernel change is required.
+- Each row carries `{ id, kind, tone, summary (≤120 chars), evidence,
+  score (0-1), generatedAt }`. File also exposes the threshold
+  snapshot it used so the UI can disclaim.
 - `computeSurprises` kernel (pure, browser-safe, deterministic given
   identical inputs) + `surprisesBuilder` Node shell that wires the
   sidecar reads + writes. Fail-soft: any missing input sidecar
   degrades the corresponding kinds to zero rows rather than aborting
   the build.
+- All numeric knobs moved into `THRESHOLDS.surprises` (no inlined
+  defaults). New thresholds: `reflexiveEValueMin` (1.5) gates
+  `reflexive-positive` on E-value sensitivity in addition to CI
+  positivity; `decisionGoodFollowupsMin` raised 2 → 5 in concert with
+  a new Wilson-low > base-rate gate on `decision-paid-off`.
 - `EXPORTER_VERSION` bumped 1.3.0 → 1.4.0 to mark the new artifact.
 
 ### Notes
 
-- `pattern-closed` / `pattern-recurring` currently produce zero rows
-  in the builder — the applied-pattern watcher ledger lives in the
-  SQLite substrate and wiring the SDK call into the builder is a
-  follow-on. The kernel accepts watcher entries directly (used by
-  the test suite); only the I/O shell is stubbed.
+- `reflexive-positive` summary copy is **associational, not causal**
+  ("touching X is associated with +Npp" — not "lifted by Npp") to
+  match the matched-pair primitive's actual inferential strength.
+  The E-value floor + Wilson CI + practical-significance triple gate
+  is the new minimum bar for emission.
+- `decision-paid-off` is **same-project scoped**: followups outside
+  the decision-session's project no longer count toward the K-followups
+  floor or the Wilson lift gate. Decisions whose session has no
+  discovered `projectId` are silently skipped by this branch (the
+  decision still appears in `decisions.json`, just not as a paid-off
+  surprise).
 
 ## [1.3.0] — 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,49 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-05-24
+
+Feed-redesign Phase γ polish — enriches the daily brief now that
+Phase β promoted it to the top of the TODAY page. Patch bump (no new
+on-disk artifact); the change is internal to the
+`buildDailyBrief` kernel output + the `regen-brief` API endpoint.
+
+### Changed
+
+- `dailyBrief.ts` grows four new sections rendered between the
+  existing "audit concerns" and "continuum health" blocks:
+  - **Shipped this week** — commit count + top 5 subject lines from
+    `git log --since="7 days ago" main`, computed by the
+    `regen-brief.ts` shell and passed in as a precomputed input.
+  - **Surprises today** — per-tone counts (positive / concerning)
+    from `analysis/surprises.json` plus the top 3 positive summaries
+    by score.
+  - **Project trajectories** — per-classification counts from
+    `analysis/project-trajectories.json` plus the top 3 most-active
+    projects by `totalSessions`.
+  - **Applied-pattern closures** — count of patterns currently held
+    in the watcher's `holding` state. SDK accessor not yet wired;
+    section skips cleanly (input is `null` in V1).
+- Each section is independently skippable — empty inputs render
+  nothing, matching the pre-existing convention.
+- `DailyBriefResult.counts` gains seven fields covering the new
+  sections (`shippedCommits`, `surprisesPositive`,
+  `surprisesConcerning`, `trajectoriesAccelerating`,
+  `trajectoriesFlat`, `trajectoriesStalling`,
+  `appliedPatternClosures`). Existing fields unchanged.
+
+### Notes
+
+- The brief stays markdown + deterministic + LLM-free. The kernel
+  remains a pure function; all I/O (sidecar reads + `git log`) lives
+  in the `regen-brief.ts` API endpoint.
+- `CLAUDE.md` "Outcome-substrate sidecars" section gains an
+  **Intermediate sidecars** note documenting which artifacts are
+  consumed internally by kernels / other sidecars rather than read
+  by a UI surface (audit-claims.json, discovery-scores.json,
+  duplicates.semantic.json, pr-land-cache.json). Pre-empts the
+  "why doesn't X have a surface?" question for future contributors.
+
 ## [1.4.0] — 2026-05-24
 
 Feed-redesign Phase A plumbing — adds a new `analysis/surprises.json`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,42 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-05-24
+
+Feed-redesign Phase A plumbing — adds a new `analysis/surprises.json`
+sidecar produced by the pure `computeSurprises` kernel in
+`@chat-arch/analysis`. Snapshot-based: reads the existing Phase 1-3
+sidecars (composite-outcomes, project-trajectories, its-analysis,
+reflexive, decisions, knowledge-debt) and emits a ranked list of
+positive observations (`tone: 'positive'`) + concerns
+(`tone: 'concerning'`) the user might not have noticed about their
+recent work. No new kernel dependencies; no UI yet (Phase B lands the
+"happy surprises and stories" surface that consumes this sidecar).
+
+### Added
+
+- **`analysis/surprises.json` sidecar.** Nine surprise kinds:
+  `streak` / `trajectory-accelerating` / `config-helped` /
+  `pattern-closed` / `reflexive-positive` / `decision-paid-off`
+  (positive) and `trajectory-stalled` / `pattern-recurring` /
+  `debt-spinning` (concerns). Each row carries `{ id, kind, tone,
+  summary (≤120 chars), evidence, score (0-1), generatedAt }`. File
+  also exposes the threshold snapshot it used so the UI can disclaim.
+- `computeSurprises` kernel (pure, browser-safe, deterministic given
+  identical inputs) + `surprisesBuilder` Node shell that wires the
+  sidecar reads + writes. Fail-soft: any missing input sidecar
+  degrades the corresponding kinds to zero rows rather than aborting
+  the build.
+- `EXPORTER_VERSION` bumped 1.3.0 → 1.4.0 to mark the new artifact.
+
+### Notes
+
+- `pattern-closed` / `pattern-recurring` currently produce zero rows
+  in the builder — the applied-pattern watcher ledger lives in the
+  SQLite substrate and wiring the SDK call into the builder is a
+  follow-on. The kernel accepts watcher entries directly (used by
+  the test suite); only the I/O shell is stubbed.
+
 ## [1.3.0] — 2026-05-24
 
 Bumped from 1.2.0 to mark the Rev3 substrate landing. The on-disk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,25 @@ analysis/` (all gitignored — locally generated, may carry PII):
 - `skill-curves.json` — per-topic weekly ask-count series + Mann-
   Kendall trend test with BH-FDR. PII: topic + time series.
 
+### Feed-redesign Phase A sidecar (EXPORTER_VERSION 1.4.0)
+
+One additional sidecar under `apps/standalone/public/chat-arch-data/
+analysis/` (gitignored — locally generated, carries PII):
+
+- `surprises.json` — produced by the `computeSurprises` kernel +
+  `surprisesBuilder` shell. Snapshot kernel over the other Phase 1-3
+  sidecars; emits a ranked list of nine surprise kinds segmented by
+  `tone`: positive (streak / trajectory-accelerating / config-helped
+  / pattern-closed / reflexive-positive / decision-paid-off) and
+  concerning (trajectory-stalled / pattern-recurring / debt-spinning)
+  observations the user might not have noticed. Each row carries
+  `{ id, kind, tone, summary (≤120 chars), evidence, score (0-1),
+  generatedAt }`. The file also exposes the threshold snapshot it
+  used so the UI can disclaim. PII: session IDs + project IDs +
+  knowledge-debt canonical-question prose (for `debt-spinning` rows).
+  Read by the upcoming feed-redesign UI surface (Phase B, not yet
+  landed).
+
 ### Rev3-F curator + falsifier output (EXPORTER_VERSION 1.3.0)
 
 Two additional sidecars under `apps/standalone/public/chat-arch-data/
@@ -359,8 +378,8 @@ out of date and needs an update:
 4. **What sidecars under `analysis/` carry PII vs aggregate-only?**
    - PII-bearing (most files): composite-outcomes, knowledge-debt,
      reflexive, decisions, archetypes, project-trajectories,
-     skill-curves, curator-feed, falsifier-verdicts, correction-
-     candidates, corrections, correction-status-*.
+     skill-curves, surprises, curator-feed, falsifier-verdicts,
+     correction-candidates, corrections, correction-status-*.
    - Aggregate-numbers-only (lower-PII): its-analysis, surface-
      comparison. These are gitignored conservatively anyway.
 5. **What's the difference between hosted (`chat-arch.dev`) and
@@ -377,4 +396,6 @@ out of date and needs an update:
      appears in `analysis/meta.json` so operators can correlate a
      bundle with the CHANGELOG. Bumped 1.2.0 → 1.3.0 in Phase
      Rev3-I I5 for the Rev3 substrate cutover; see CHANGELOG.md
-     `[1.3.0]` for the full ledger of what landed.
+     `[1.3.0]` for the full ledger of what landed. Bumped 1.3.0
+     → 1.4.0 in the feed-redesign Phase A plumbing when
+     `analysis/surprises.json` landed; see CHANGELOG.md `[1.4.0]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,3 +413,8 @@ out of date and needs an update:
      `[1.3.0]` for the full ledger of what landed. Bumped 1.3.0
      → 1.4.0 in the feed-redesign Phase A plumbing when
      `analysis/surprises.json` landed; see CHANGELOG.md `[1.4.0]`.
+     Bumped 1.4.0 → 1.4.1 in feed-redesign Phase γ when
+     `buildDailyBrief` gained shipped-this-week / surprises /
+     trajectories / applied-pattern-closures sections (no new on-
+     disk sidecar; brief markdown shape grew); see CHANGELOG.md
+     `[1.4.1]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,20 @@ analysis/` (all gitignored — locally generated, may carry PII):
 - `skill-curves.json` — per-topic weekly ask-count series + Mann-
   Kendall trend test with BH-FDR. PII: topic + time series.
 
+**Intermediate sidecars (no direct UI surface).** A few artifacts
+under `analysis/` exist as inputs to other kernels or downstream
+sidecars rather than as something a UI surface reads. If you're
+wondering why one of these doesn't show up in the viewer, that's
+the reason — not a missing feature, by design. Don't add a surface
+for them; the consuming sidecar is what gets rendered.
+
+| Sidecar | Consumer | Direct surface? |
+|---|---|---|
+| `audit-claims.json` | input to the audit verifier (which writes `audit-results.json`) | no — `/audit` + `/results` read `audit-results.json` |
+| `discovery-scores.json` | input to the curator ranker (which writes `curator-feed.json`) | no |
+| `duplicates.semantic.json` | input to other clustering kernels | no |
+| `pr-land-cache.json` | input to `composite-outcomes.json` (gated by `--enable-pr-join`) | no |
+
 ### Feed-redesign Phase A sidecar (EXPORTER_VERSION 1.4.0)
 
 One additional sidecar under `apps/standalone/public/chat-arch-data/

--- a/apps/standalone/src/components/AppSidebar.astro
+++ b/apps/standalone/src/components/AppSidebar.astro
@@ -1,11 +1,14 @@
 ---
 // App-wide vertical LEFT sidebar. Replaces the horizontal TodayNav
 // strip. TODAY sits in its own distinguished top section above the
-// four LCARS-style groups (WORKSHOP / TRACK / BROWSE / SYSTEM); the
-// DATA item is a panel trigger that links into the viewer's hash
-// router (#data → DataPanel modal in ChatArchViewer.tsx). CHAT and
-// CORRECTIONS share the same hash-routing pattern (/sessions#chat,
-// /sessions#corrections).
+// three LCARS-style groups (ARCHIVE / WORKSHOP / SYSTEM); the DATA
+// item is a panel trigger that links into the viewer's hash router
+// (#data → DataPanel modal in ChatArchViewer.tsx). CORRECTIONS shares
+// the same hash-routing pattern (/sessions#corrections). Surfaces
+// that previously had their own sidebar entries (CHAT, RESULTS,
+// AUDIT, DRAFTS) now live in the FEED's BROKEN / STORIES sections;
+// the full catalogue of kernel detail surfaces is reachable from
+// SYSTEM → ALL VIEWS (/views).
 //
 // Collapse: expanded by default desktop, auto-collapsed below 900px,
 // user-toggleable, persisted in localStorage. The pure state logic
@@ -34,37 +37,7 @@ const TODAY: NavItem = { href: '/', short: 'TDY', label: 'TODAY' };
 const DATA: NavItem = { href: '/sessions#data', short: 'DAT', label: 'DATA' };
 const groups: readonly NavGroup[] = [
   {
-    label: 'WORKSHOP',
-    items: [
-      { href: '/sessions#chat', short: 'CHT', label: 'CHAT' },
-      { href: '/sessions#corrections', short: 'COR', label: 'CORRECTIONS' },
-      // PLAYBOOK — positive counterpart to CORRECTIONS. Mines recurring
-      // user-turn phrasings ("first principles", "adversarial review")
-      // that precede F-layer pass-verdict claims. Sits next to
-      // CORRECTIONS in WORKSHOP because the two are paired surfaces:
-      // CORRECTIONS = pushback that produced a fix; PLAYBOOK = verbs
-      // that produced verified work.
-      { href: '/playbook', short: 'PLB', label: 'PLAYBOOK' },
-      { href: '/practice', short: 'PRC', label: 'PRACTICE' },
-      // RESULTS — cross-corpus outcomes view: claim-pass rate by
-      // project / claim type / session, plus loop-closure rollup.
-      // Lives in WORKSHOP (not TRACK) because it's a workshop verb —
-      // observe what's working across all your chats so you can act on
-      // it — rather than a passive monitoring surface.
-      { href: '/results', short: 'RES', label: 'RESULTS' },
-    ],
-  },
-  {
-    label: 'TRACK',
-    items: [
-      // TODAY lives ABOVE the groups now — removed from TRACK.
-      { href: '/audit', short: 'AUD', label: 'AUDIT' },
-      { href: '/health', short: 'HLT', label: 'HEALTH' },
-      { href: '/blog-drafts', short: 'DFT', label: 'DRAFTS' },
-    ],
-  },
-  {
-    label: 'BROWSE',
+    label: 'ARCHIVE',
     items: [
       { href: '/sessions', short: 'SES', label: 'SESSIONS' },
       { href: '/projects', short: 'PRJ', label: 'PROJECTS' },
@@ -72,8 +45,25 @@ const groups: readonly NavGroup[] = [
     ],
   },
   {
+    label: 'WORKSHOP',
+    items: [
+      // PLAYBOOK — positive counterpart to CORRECTIONS. Mines recurring
+      // user-turn phrasings ("first principles", "adversarial review")
+      // that precede F-layer pass-verdict claims.
+      { href: '/playbook', short: 'PLB', label: 'PLAYBOOK' },
+      { href: '/sessions#corrections', short: 'COR', label: 'CORRECTIONS' },
+      { href: '/practice', short: 'PRC', label: 'PRACTICE' },
+    ],
+  },
+  {
     label: 'SYSTEM',
     items: [
+      { href: '/health', short: 'HLT', label: 'HEALTH' },
+      { href: '/calibrate', short: 'CAL', label: 'CALIBRATE' },
+      // ALL VIEWS — flat catalogue of every kernel detail surface
+      // that still exists but isn't promoted in the FEED / TODAY.
+      // The escape hatch for "I know there's a surface for X."
+      { href: '/views', short: 'VWS', label: 'ALL VIEWS' },
       { href: '/design-system', short: 'DSY', label: 'DESIGN SYSTEM' },
       // DATA pushed in here so the SYSTEM group renders its own DATA
       // anchor with the panel-trigger styling — never active.

--- a/apps/standalone/src/components/AppSidebar.astro
+++ b/apps/standalone/src/components/AppSidebar.astro
@@ -10,6 +10,21 @@
 // the full catalogue of kernel detail surfaces is reachable from
 // SYSTEM → ALL VIEWS (/views).
 //
+// CHAT and RESULTS are INTENTIONALLY NOT in this sidebar — they are
+// discoverable via FEED-card secondary links:
+//   - STORIES section footer → "ask the corpus a question (CHAT)"
+//     (/sessions#chat)
+//   - BROKEN section footer  → "cross-corpus results" (/results)
+// Plus /views catalogue (SYSTEM → ALL VIEWS) for the comprehensive
+// list. Re-adding either to the sidebar would re-bloat the nav and
+// duplicate the FEED entry points — the Phase β review-loop iter-1
+// "nothing important lost" constraint is satisfied by the secondary
+// links, not by sidebar re-entry. Bryce's positioning principle
+// (feedback_positioning_by_features) backs the show-it-in-the-feed
+// choice: the link's CONTEXT (next to the section that motivates it)
+// communicates what CHAT / RESULTS are for, where a bare sidebar
+// label cannot.
+//
 // Collapse: expanded by default desktop, auto-collapsed below 900px,
 // user-toggleable, persisted in localStorage. The pure state logic
 // lives in ../scripts/appSidebarCollapse.ts so it can be unit-tested

--- a/apps/standalone/src/lib/curatorClaude.ts
+++ b/apps/standalone/src/lib/curatorClaude.ts
@@ -124,8 +124,12 @@ function isThrottled(stderr: string): boolean {
  * insufficient — security iter-1 finding on PR #84 noted that
  * `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BEARER_TOKEN`, `CLAUDE_API_KEY`,
  * and `ANTHROPIC_API_TOKEN` are all auto-detected by various
- * configurations. The default-deny gate must remove the full family
- * to prevent surprise billing.
+ * configurations. Security iter-2 finding on PR #97 extended the
+ * list to cover the Bedrock + Vertex billing routes: a user with
+ * `CLAUDE_CODE_USE_BEDROCK=1` + AWS creds in their shell would
+ * silently bill Bedrock from the curate/falsify subprocess despite
+ * the default-deny, so the route-flip flags + AWS/GCP credential
+ * vars also scrub.
  *
  * Exported so the test suite can pin the canonical list — any addition
  * here should be paired with a test in `curatorClaude.test.ts`.
@@ -136,6 +140,17 @@ export const AUTH_ENV_VARS: readonly string[] = [
   'ANTHROPIC_BEARER_TOKEN',
   'ANTHROPIC_API_TOKEN',
   'CLAUDE_API_KEY',
+  // Route-flip flags — set by users routing claude through Bedrock or
+  // Vertex AI instead of the Anthropic API. Scrubbing the flag itself
+  // is sufficient: with the flag absent, the CLI falls back to the
+  // (also-scrubbed) Anthropic env vars.
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  // Cloud-provider credential envs — if the route flag somehow
+  // survives (env-file injection, shell function, etc.), scrubbing
+  // these closes the billing path defense-in-depth.
+  'AWS_BEARER_TOKEN_BEDROCK',
+  'GOOGLE_APPLICATION_CREDENTIALS',
 ];
 
 /**

--- a/apps/standalone/src/lib/demoFixtures.ts
+++ b/apps/standalone/src/lib/demoFixtures.ts
@@ -24,7 +24,13 @@ import type {
   CorrectionPatternScope,
   ProposedUpgrade,
 } from '@chat-arch/schema';
-import type { TopAuditConcern, WorkshopStatus } from './readSidecars.ts';
+import type { SurprisesOutput } from '@chat-arch/analysis';
+import type {
+  CuratorFeedFileSsr,
+  RecentNarrative,
+  TopAuditConcern,
+  WorkshopStatus,
+} from './readSidecars.ts';
 
 /**
  * Sentinel prefix for all demo session IDs. Keeps demo SIDs visually
@@ -177,6 +183,249 @@ export function makeDemoBlogDraftSlugs(): readonly {
     {
       slug: 'when-the-pitch-doesnt-land-2026-05-08',
       isPrompt: true,
+    },
+  ];
+}
+
+/**
+ * Stable timestamp for the Phase β surprise / curator / narrative
+ * demos. Pinned so snapshot tests stay deterministic across runs.
+ */
+const DEMO_GENERATED_AT_MS = 1779665200000;
+
+/**
+ * Demo daily brief — drives the BRIEF section's empty state. The body
+ * mirrors the layout `regen-brief` produces (TODAY header bar, four
+ * bullet sections, attribution footer) so empty-state readers see the
+ * SHAPE they'll get once the brief skill runs. All session IDs use
+ * DEMO_SID_PREFIX (rendered as `[SID:demo01]` after slicing).
+ */
+export function makeDemoLatestBrief(): { date: string; markdown: string } {
+  const date = '2026-05-17';
+  const body =
+    `TODAY · ${date}\n` +
+    '━━━━━━━━━━━━━━━━━━\n' +
+    '► 3 audit concern(s)\n' +
+    `  • Session [SID:${demoSid('1').slice(0, 8)}] claimed "fixed the timeout" with no Edit/Write\n` +
+    `  • Session [SID:${demoSid('2').slice(0, 8)}] claimed "tests pass" with no command invocation\n` +
+    '► Shipped this week: 12 commit(s) to main\n' +
+    '  • feat(demo): example commit landing the loop\n' +
+    '  • fix(demo): repair an empty-state regression\n' +
+    '► Surprises today: 4 positive, 1 concerning\n' +
+    '  • [streak] 7 sessions in a row with all-green outcomes\n' +
+    '  • [decision-paid-off] adopting ripgrep dropped re-prompt rate\n' +
+    '► Continuum health: ok · 5 consecutive successful scans\n' +
+    '\n' +
+    '_chat-arch demo · auto-generated brief_\n';
+  return { date, markdown: body };
+}
+
+/**
+ * Demo surprises — drives the NEW + BROKEN section card grids. Mixes 3
+ * positive kinds (streak / trajectory-accelerating / decision-paid-off)
+ * + 2 concerning kinds (trajectory-stalled / debt-spinning) so both
+ * sections see populated cards. Every summary is ≤120 chars (matches
+ * the Surprise contract); evidence references DEMO_SID_PREFIX SIDs and
+ * `demo-project-N` ids so the show-don't-describe contract holds
+ * end-to-end (the SID-leak guard in empty-state-contracts.test.ts
+ * rejects any 8-hex SID not starting with `demo`).
+ *
+ * `generatedAt` is fixed to DEMO_GENERATED_AT_MS so snapshot tests
+ * stay deterministic — the kernel's defaults snapshot is structural
+ * only; the values here mirror THRESHOLDS.surprises defaults at the
+ * time of writing (kernel-derived; not load-bearing for the demo).
+ */
+export function makeDemoSurprises(): SurprisesOutput {
+  return {
+    version: 1,
+    generatedAt: DEMO_GENERATED_AT_MS,
+    surprises: [
+      {
+        id: 'sur_demo_streak_1',
+        kind: 'streak',
+        tone: 'positive',
+        summary: '7 sessions in a row with all-green outcomes — longest run this month.',
+        evidence: {
+          sessionIds: [demoSid('s1'), demoSid('s2'), demoSid('s3'), demoSid('s4')],
+        },
+        score: 0.92,
+        generatedAt: DEMO_GENERATED_AT_MS,
+      },
+      {
+        id: 'sur_demo_trajectory_acc_1',
+        kind: 'trajectory-accelerating',
+        tone: 'positive',
+        summary: 'demo-project-A composite score climbed +18% over the last 2 weeks.',
+        evidence: {
+          projectId: 'demo-project-A',
+          sessionIds: [demoSid('a1'), demoSid('a2')],
+        },
+        score: 0.78,
+        generatedAt: DEMO_GENERATED_AT_MS,
+      },
+      {
+        id: 'sur_demo_decision_paid_1',
+        kind: 'decision-paid-off',
+        tone: 'positive',
+        summary: 'Adopting ripgrep dropped average re-prompt rate by 23% on demo-project-B.',
+        evidence: {
+          decisionId: 'dec_demo_ripgrep',
+          projectId: 'demo-project-B',
+          sessionIds: [demoSid('d1')],
+        },
+        score: 0.71,
+        generatedAt: DEMO_GENERATED_AT_MS,
+      },
+      {
+        id: 'sur_demo_trajectory_stall_1',
+        kind: 'trajectory-stalled',
+        tone: 'concerning',
+        summary: 'demo-project-C composite score flat for 3 weeks despite 14 sessions invested.',
+        evidence: {
+          projectId: 'demo-project-C',
+          sessionIds: [demoSid('c1'), demoSid('c2')],
+        },
+        score: 0.66,
+        generatedAt: DEMO_GENERATED_AT_MS,
+      },
+      {
+        id: 'sur_demo_debt_spin_1',
+        kind: 'debt-spinning',
+        tone: 'concerning',
+        summary: '"how do I bind a port in Astro?" asked 9 times this month across 4 projects.',
+        evidence: {
+          sessionIds: [demoSid('k1'), demoSid('k2'), demoSid('k3')],
+        },
+        score: 0.58,
+        generatedAt: DEMO_GENERATED_AT_MS,
+      },
+    ],
+    thresholds: {
+      streakMin: 5,
+      itsQValueMax: 0.1,
+      itsDeltaMin: 0.15,
+      reflexiveDeltaMin: 0.1,
+      reflexiveEValueMin: 1.5,
+      decisionGoodFollowupsMin: 3,
+      debtSpinningTopK: 5,
+      debtSpinningMinClusterSize: 4,
+    },
+  };
+}
+
+/**
+ * Demo curator feed — drives the ACT section's CURATED FEED list when
+ * the /curate skill hasn't run yet. 5 items mix the three known kinds
+ * (`narrative` / `knowledge-debt` / `applied-pattern`) so the kind-
+ * coloured badges all render at least once. Verified status sprinkled
+ * so the green "verified" pill shows. Stable shape matches
+ * `CuratorFeedFileSsr` in readSidecars.ts.
+ */
+export function makeDemoCuratorFeed(): CuratorFeedFileSsr {
+  return {
+    schemaVersion: 1,
+    generatedAt: DEMO_GENERATED_AT_MS,
+    ranAt: '2026-05-17T10:00:00.000Z',
+    items: [
+      {
+        kind: 'narrative',
+        entityId: 'nar_demo_first_principles',
+        title: 'First-principles framing precedes pass-verdict outcomes',
+        rank: 1,
+        compositeScore: 0.89,
+        falsifierStatus: 'verified',
+        reasoning: 'tier-3 narrative with 4 supporting evidence rows.',
+      },
+      {
+        kind: 'knowledge-debt',
+        entityId: 'kd_demo_port_binding',
+        title: '"how do I bind a port in Astro?" — asked 9× across 4 projects',
+        rank: 2,
+        compositeScore: 0.81,
+        falsifierStatus: 'unavailable',
+        reasoning: 'cluster size 9 exceeds debtSpinningMinClusterSize floor.',
+      },
+      {
+        kind: 'applied-pattern',
+        entityId: 'pat_demo_ripgrep',
+        title: 'prefer ripgrep over grep for codebase search',
+        rank: 3,
+        compositeScore: 0.74,
+        tieBrokenByCorrelation: true,
+        falsifierStatus: 'verified',
+        reasoning: 'pattern is holding 11 weeks post-apply.',
+      },
+      {
+        kind: 'narrative',
+        entityId: 'nar_demo_adversarial_review',
+        title: 'Adversarial review precedes ship-readiness verdicts',
+        rank: 4,
+        compositeScore: 0.69,
+        falsifierStatus: 'unavailable',
+        reasoning: 'tier-2 narrative; awaiting verifier pass.',
+      },
+      {
+        kind: 'knowledge-debt',
+        entityId: 'kd_demo_cors_setup',
+        title: '"CORS preflight failing on /api/*" — asked 5× this month',
+        rank: 5,
+        compositeScore: 0.61,
+        falsifierStatus: 'skipped-by-user',
+        reasoning: 'cluster size below tie-breaker but recent surge.',
+      },
+    ],
+  };
+}
+
+/**
+ * Demo recent narratives — drives the STORIES section's narrative list
+ * when narratives.json is missing. 5 items across all three sentiment
+ * buckets (positive / negative / neutral) and three demo project ids
+ * so the sentiment-coloured pills + project links all render at least
+ * once. Generated-at strings use ISO format so the page's `.slice(0,10)`
+ * date crop produces a stable YYYY-MM-DD.
+ */
+export function makeDemoRecentNarratives(): RecentNarrative[] {
+  return [
+    {
+      id: 'nar_demo_first_principles',
+      title: 'First-principles framing precedes pass-verdict outcomes',
+      sentiment: 'positive',
+      projectId: 'demo-project-A',
+      sessionIds: [demoSid('n1'), demoSid('n2')],
+      generatedAt: '2026-05-15T14:30:00.000Z',
+    },
+    {
+      id: 'nar_demo_test_skip_drift',
+      title: 'Skipped tests accumulate then surface as silent regressions',
+      sentiment: 'negative',
+      projectId: 'demo-project-B',
+      sessionIds: [demoSid('n3')],
+      generatedAt: '2026-05-14T09:15:00.000Z',
+    },
+    {
+      id: 'nar_demo_adversarial_review',
+      title: 'Adversarial review precedes ship-readiness verdicts',
+      sentiment: 'positive',
+      projectId: 'demo-project-A',
+      sessionIds: [demoSid('n4'), demoSid('n5'), demoSid('n6')],
+      generatedAt: '2026-05-12T18:42:00.000Z',
+    },
+    {
+      id: 'nar_demo_session_handoff',
+      title: 'Session handoffs lose context about prior tool-call rationale',
+      sentiment: 'neutral',
+      projectId: 'demo-project-C',
+      sessionIds: [demoSid('n7')],
+      generatedAt: '2026-05-11T11:00:00.000Z',
+    },
+    {
+      id: 'nar_demo_loop_closure',
+      title: 'Applied patterns close the loop within 2 weeks 80% of the time',
+      sentiment: 'positive',
+      projectId: 'demo-project-B',
+      sessionIds: [demoSid('n8'), demoSid('n9')],
+      generatedAt: '2026-05-09T16:20:00.000Z',
     },
   ];
 }

--- a/apps/standalone/src/lib/readSidecars.ts
+++ b/apps/standalone/src/lib/readSidecars.ts
@@ -20,9 +20,11 @@ import type {
   ContinuumHealth,
   CorrectionPattern,
   CorrectionsFile,
+  Narrative,
   PlaybookCandidatesFile,
   UpgradeOutcomesFile,
 } from '@chat-arch/schema';
+import type { Surprise, SurprisesOutput } from '@chat-arch/analysis';
 
 function dataDir(): string {
   return path.join(process.cwd(), 'public', 'chat-arch-data');
@@ -328,4 +330,150 @@ export async function listBlogDraftSlugs(): Promise<
     }
   }
   return Array.from(seen.values()).sort((a, b) => b.slug.localeCompare(a.slug));
+}
+
+/**
+ * Read the surprises sidecar produced by the Phase α surprises kernel
+ * (`packages/analysis/src/computeSurprises.ts`). Returns null when the
+ * file is missing OR fails minimal shape validation. The TODAY page's
+ * NEW + BROKEN sections both filter the same array — NEW takes
+ * `tone: 'positive'`, BROKEN takes `tone: 'concerning'`.
+ */
+export async function readSurprises(): Promise<SurprisesOutput | null> {
+  const raw = await readJson<unknown>(path.join(analysisDir(), 'surprises.json'));
+  if (raw === null || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (r.version !== 1) return null;
+  if (typeof r.generatedAt !== 'number') return null;
+  if (!Array.isArray(r.surprises)) return null;
+  if (!r.thresholds || typeof r.thresholds !== 'object') return null;
+  // Trust the kernel's emitted shape for items; the kernel writes
+  // through atomicWriteJsonSync and is the only producer.
+  return raw as SurprisesOutput;
+}
+
+/**
+ * Filter surprises by tone and clamp to `limit`. Pure — the caller
+ * decides whether to render an empty state or the badges.
+ */
+export function pickSurprises(
+  file: SurprisesOutput | null,
+  tone: 'positive' | 'concerning',
+  limit: number,
+): readonly Surprise[] {
+  if (file === null) return [];
+  const matches = file.surprises.filter((s) => s.tone === tone);
+  // Kernel emits sorted-desc by score; honor that and just slice.
+  return matches.slice(0, limit);
+}
+
+/**
+ * Curator-feed sidecar reader — SSR-side equivalent of the viewer's
+ * `loadCuratorFeed`. The on-disk shape is pinned by the `/curate`
+ * skill SKILL.md Stage 3 and mirrored by
+ * `packages/viewer/src/data/curatorFeedClient.ts`. We re-declare the
+ * minimal types here so the standalone app doesn't have to import a
+ * non-exported viewer subpath.
+ */
+export type CuratorItemKind = 'narrative' | 'knowledge-debt' | 'applied-pattern';
+export type CuratorFalsifierStatus =
+  | 'verified'
+  | 'skipped-by-user'
+  | 'unavailable';
+
+export interface CuratorFeedItemSsr {
+  kind: CuratorItemKind;
+  entityId: string;
+  title: string;
+  rank: number;
+  compositeScore: number;
+  tieBrokenByCorrelation?: boolean;
+  falsifierStatus?: CuratorFalsifierStatus;
+  reasoning?: string;
+}
+
+export interface CuratorFeedFileSsr {
+  schemaVersion: 1;
+  generatedAt: number;
+  ranAt: string;
+  items: readonly CuratorFeedItemSsr[];
+}
+
+const CURATOR_KINDS: ReadonlySet<CuratorItemKind> = new Set([
+  'narrative',
+  'knowledge-debt',
+  'applied-pattern',
+]);
+
+function isCuratorItem(raw: unknown): raw is CuratorFeedItemSsr {
+  if (!raw || typeof raw !== 'object') return false;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.kind !== 'string' || !CURATOR_KINDS.has(o.kind as CuratorItemKind)) {
+    return false;
+  }
+  if (typeof o.entityId !== 'string' || o.entityId.length === 0) return false;
+  if (typeof o.title !== 'string') return false;
+  if (typeof o.rank !== 'number' || !Number.isFinite(o.rank)) return false;
+  if (typeof o.compositeScore !== 'number' || !Number.isFinite(o.compositeScore)) {
+    return false;
+  }
+  return true;
+}
+
+export async function readCuratorFeed(): Promise<CuratorFeedFileSsr | null> {
+  const raw = await readJson<unknown>(path.join(analysisDir(), 'curator-feed.json'));
+  if (raw === null || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (r.schemaVersion !== 1) return null;
+  if (!Array.isArray(r.items)) return null;
+  const items: CuratorFeedItemSsr[] = [];
+  for (const it of r.items) {
+    if (isCuratorItem(it)) items.push(it);
+  }
+  return {
+    schemaVersion: 1,
+    generatedAt: typeof r.generatedAt === 'number' ? r.generatedAt : Date.now(),
+    ranAt: typeof r.ranAt === 'string' ? r.ranAt : new Date().toISOString(),
+    items,
+  };
+}
+
+/**
+ * Recent narratives — surfaced by the STORIES section. The sidecar
+ * has `{ narratives: Narrative[] }`; we sort descending by
+ * `generatedAt` (ISO string) so the most-recent one floats to the
+ * top, then slice to `limit`.
+ *
+ * The narrative table carries PII (see CLAUDE.md "data on disk")
+ * — title + body excerpts. We surface only title + sentiment +
+ * projectId here; the body is left for click-through.
+ */
+export interface RecentNarrative {
+  id: string;
+  title: string;
+  sentiment: 'positive' | 'negative' | 'neutral';
+  projectId: string;
+  sessionIds: readonly string[];
+  generatedAt: string;
+}
+
+export async function readRecentNarratives(
+  limit: number = 5,
+): Promise<RecentNarrative[]> {
+  const file = await readJson<{ narratives?: readonly Narrative[] }>(
+    path.join(analysisDir(), 'narratives.json'),
+  );
+  const all = file?.narratives ?? [];
+  // Defensive sort + slice — the sidecar doesn't guarantee order.
+  const sorted = [...all].sort((a, b) =>
+    String(b.generatedAt).localeCompare(String(a.generatedAt)),
+  );
+  return sorted.slice(0, limit).map((n) => ({
+    id: n.id,
+    title: n.title,
+    sentiment: n.sentiment,
+    projectId: n.projectId,
+    sessionIds: n.sessionIds,
+    generatedAt: n.generatedAt,
+  }));
 }

--- a/apps/standalone/src/pages/api/curate.ts
+++ b/apps/standalone/src/pages/api/curate.ts
@@ -22,7 +22,11 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { resolveClaudeBin } from '../../lib/resolveClaude.js';
-import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  AUTH_ENV_VARS,
+  computeAllowApiKeyFallback,
+  probeClaudeAvailable,
+} from '../../lib/curatorClaude.js';
 import {
   assertDataDirContained,
   handleDataDirGuardError,
@@ -65,6 +69,19 @@ const MAX_TAIL_BYTES = 8 * 1024;
 const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
 const DEFAULT_TOP_K = 10;
 const MAX_TOP_K = 50;
+/**
+ * Outer kill-timeout for the spawned `claude -p` child. Curator runs
+ * are 1-3 min on a healthy plan; 10 min is a generous ceiling that
+ * still releases `inFlight` if the subprocess hangs (network stall,
+ * deadlocked tool call, hung TTY).
+ *
+ * iter-1 finding: without this, a hung child would pin `inFlight`
+ * forever and the endpoint would permanently 409 until the dev
+ * server was restarted. SIGTERM-then-grace-then-SIGKILL is the
+ * standard escalation pattern.
+ */
+const SPAWN_KILL_TIMEOUT_MS = 10 * 60 * 1000;
+const SPAWN_KILL_GRACE_MS = 5_000;
 
 function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
   if (text.length <= max) return text;
@@ -104,7 +121,22 @@ interface CurateParams {
   dataDir: string;
   topK: number;
   noFalsifier: boolean;
+  /**
+   * Viewer-side opt-in flag (the raw value off the request body).
+   * Forwarded to the skill as a CLI flag so the skill's own pipeline
+   * knows whether the user opted in. The kernel-level decision about
+   * whether to scrub auth env vars BEFORE the spawn is the
+   * `allowApiKeyFallback` field below, which is the two-rail AND of
+   * viewer + server flags via `computeAllowApiKeyFallback`.
+   */
   apiKeyFallback: boolean;
+  /**
+   * Two-rail-resolved decision: viewer opt-in AND server env opt-in.
+   * Default-deny — when this is false we scrub the AUTH_ENV_VARS
+   * family from the spawn env so a server-side `ANTHROPIC_API_KEY`
+   * (or sibling auth var) cannot silently bill a claude -p call.
+   */
+  allowApiKeyFallback: boolean;
 }
 
 interface SpawnOutcome {
@@ -116,14 +148,33 @@ interface SpawnOutcome {
 
 /**
  * Spawn `claude -p /curate ...` and stream stdio over the NDJSON
- * response. Same machinery as mine-decisions; the skill is a scaffold
- * today (Rev3-F F1) so no fallback prompt — the F3+F4 PRs will exercise
- * the real pipeline against this endpoint.
+ * response. The streaming requirement (long-lived 1-3 min runs, UI
+ * needs per-line progress) prevents us from delegating to
+ * `runCuratorSubprocess` directly — that helper is fire-and-forget
+ * with a tagged-union result. We re-use its supporting machinery
+ * (`AUTH_ENV_VARS` scrub when the two-rail fallback is OFF, kill-
+ * timeout escalation) inline here instead.
+ *
+ * Security iter-1 findings addressed:
+ *
+ *   1. **API-key leak via inherited env.** Prior version passed
+ *      `env: process.env` verbatim — a server-side `ANTHROPIC_API_KEY`
+ *      (or any AUTH_ENV_VARS sibling) would silently bill the
+ *      subprocess. Now we scrub the full family when
+ *      `allowApiKeyFallback === false` (the default-deny two-rail
+ *      result from `computeAllowApiKeyFallback`).
+ *   2. **Unbounded hang pins `inFlight`.** No outer kill-timeout
+ *      meant a stuck child would permanently 409 the endpoint until
+ *      dev server restart. Now SIGTERM after
+ *      `SPAWN_KILL_TIMEOUT_MS`, SIGKILL after a `SPAWN_KILL_GRACE_MS`
+ *      grace window; the SpawnOutcome's `spawnError` is set so the
+ *      `finally` clears `inFlight`.
  */
 function runClaudeOnce(
   prompt: string,
   controller: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
+  allowApiKeyFallback: boolean,
 ): Promise<SpawnOutcome> {
   const send = (obj: unknown) => {
     try {
@@ -141,9 +192,19 @@ function runClaudeOnce(
     const allowedTools = 'Read Write Edit Bash Task Glob Grep';
     const bin = resolveClaudeBin();
     const args = ['--allowedTools', allowedTools, '-p', prompt];
+    // Default-deny env scrub. When the two-rail fallback resolves
+    // false, drop every AUTH_ENV_VARS entry so the subprocess can't
+    // inherit a surprise auth credential. Mirrors the scrub in
+    // `runCuratorSubprocess`.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (!allowApiKeyFallback) {
+      for (const name of AUTH_ENV_VARS) {
+        delete env[name];
+      }
+    }
     const child = spawn(bin.file, args, {
       cwd: repoRoot(),
-      env: process.env,
+      env,
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -153,6 +214,59 @@ function runClaudeOnce(
     const stdoutFull = { v: '' };
     const stderrFull = { v: '' };
     let spawnError: Error | null = null;
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+    let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimers = (): void => {
+      if (killTimer !== null) {
+        clearTimeout(killTimer);
+        killTimer = null;
+      }
+      if (graceTimer !== null) {
+        clearTimeout(graceTimer);
+        graceTimer = null;
+      }
+    };
+
+    const settleOnce = (outcome: SpawnOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      resolvePromise(outcome);
+    };
+
+    // Outer kill-timeout — SIGTERM first, SIGKILL after a grace
+    // window if the child doesn't exit promptly. The `close` handler
+    // below races with this; whichever fires first settles.
+    killTimer = setTimeout(() => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead — ignore
+      }
+      graceTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // already dead
+        }
+        // Synthesize a spawnError so the caller's `finally` clears
+        // inFlight; exitCode null signals "killed by us, not the
+        // child's own exit path".
+        settleOnce({
+          exitCode: null,
+          stdout: stdoutFull.v,
+          stderr:
+            stderrFull.v +
+            (stderrFull.v.length > 0 ? '\n' : '') +
+            `[curate] spawn exceeded ${SPAWN_KILL_TIMEOUT_MS}ms; SIGKILL'd.`,
+          spawnError: new Error(
+            `claude -p subprocess exceeded ${SPAWN_KILL_TIMEOUT_MS}ms kill-timeout`,
+          ),
+        });
+      }, SPAWN_KILL_GRACE_MS);
+    }, SPAWN_KILL_TIMEOUT_MS);
 
     const drain = (
       buf: string,
@@ -202,7 +316,7 @@ function runClaudeOnce(
         send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
         stderrFull.v += stderrBuf;
       }
-      resolvePromise({
+      settleOnce({
         exitCode: code,
         stdout: stdoutFull.v,
         stderr: stderrFull.v,
@@ -218,14 +332,25 @@ async function streamCurate(
   encoder: TextEncoder,
 ): Promise<void> {
   const started = Date.now();
-  const { requestId, dataDir, topK, noFalsifier, apiKeyFallback } = params;
+  const {
+    requestId,
+    dataDir,
+    topK,
+    noFalsifier,
+    apiKeyFallback,
+    allowApiKeyFallback,
+  } = params;
   const flags: string[] = [
     `--request-id=${requestId}`,
     `--data-dir=${dataDir}`,
     `--top-k=${topK}`,
   ];
   if (noFalsifier) flags.push('--no-falsifier');
-  if (apiKeyFallback) flags.push('--api-key-fallback');
+  // Surface the effective two-rail decision to the skill — the
+  // viewer-side opt-in alone is not enough to flip the flag. When
+  // either rail is OFF we don't pass `--api-key-fallback`; the env
+  // scrub in `runClaudeOnce` is the load-bearing enforcement.
+  if (allowApiKeyFallback) flags.push('--api-key-fallback');
   const prompt = `/curate ${flags.join(' ')}`;
 
   const send = (obj: unknown) => {
@@ -243,9 +368,16 @@ async function streamCurate(
     startedAt: started,
     topK,
     noFalsifier,
+    apiKeyFallback,
+    allowApiKeyFallback,
   });
 
-  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const outcome = await runClaudeOnce(
+    prompt,
+    controller,
+    encoder,
+    allowApiKeyFallback,
+  );
   const extraStderr = outcome.spawnError
     ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
     : '';
@@ -333,6 +465,10 @@ export const POST: APIRoute = async ({ request }) => {
   }
   const noFalsifier = body.noFalsifier === true;
   const apiKeyFallback = body.apiKeyFallback === true;
+  // Two-rail composition: viewer opt-in AND server env opt-in. This
+  // helper is the SINGLE source of truth for the decision — re-
+  // deriving the AND elsewhere is a defect (security iter-1).
+  const allowApiKeyFallback = computeAllowApiKeyFallback(body.apiKeyFallback);
 
   const params: CurateParams = {
     requestId: randomUUID(),
@@ -340,6 +476,7 @@ export const POST: APIRoute = async ({ request }) => {
     topK,
     noFalsifier,
     apiKeyFallback,
+    allowApiKeyFallback,
   };
 
   const encoder = new TextEncoder();

--- a/apps/standalone/src/pages/api/curate.ts
+++ b/apps/standalone/src/pages/api/curate.ts
@@ -1,0 +1,397 @@
+/**
+ * `/api/curate` — POST drives the `/curate` skill via `claude -p` so the
+ * PRACTICE surface's CuratorFeed has a producer the UI can trigger. The
+ * skill itself reads the SQLite substrate, ranks tier-2/tier-3 narratives
+ * + knowledge-debt + applied-pattern watcher items, and writes
+ * `analysis/curator-feed.json` (Rev3-F F1 scaffold; F3 + F4 land the
+ * ranker + falsifier wiring).
+ *
+ * Shape mirrors `/api/mine-decisions.ts` (the simpler of the two
+ * skill-spawn endpoints — no auto-window, no candidate-id sidecar). CSRF
+ * + in-flight + NDJSON streaming match `mine-corrections.ts` exactly.
+ *
+ * One real deviation from the mine-* siblings: we gate spawn behind
+ * `probeClaudeAvailable()`. The skills are slow (1-3 min) so paying a
+ * <200ms probe up front to short-circuit a missing-CLI session with a
+ * clean 503 beats letting the spawn fail opaquely two minutes in.
+ */
+
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { resolveClaudeBin } from '../../lib/resolveClaude.js';
+import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  assertDataDirContained,
+  handleDataDirGuardError,
+} from '../../lib/dataDirGuard.js';
+
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-curate';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Serializes concurrent curator runs. Two parallel passes would race to
+ * write `curator-feed.json`; concurrent callers get 409. `inFlightRequestId`
+ * lets the GET probe surface the active run's id so a page reload can
+ * attach to it instead of failing closed (same shape as mine-corrections).
+ */
+let inFlight: Promise<void> | null = null;
+let inFlightRequestId: string | null = null;
+
+const MAX_LINE_CHARS = 2_000;
+const MAX_TAIL_BYTES = 8 * 1024;
+const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
+const DEFAULT_TOP_K = 10;
+const MAX_TOP_K = 50;
+
+function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
+  if (text.length <= max) return text;
+  return '… (truncated) …\n' + text.slice(-max);
+}
+
+function clampLine(line: string): string {
+  if (line.length <= MAX_LINE_CHARS) return line;
+  return line.slice(0, MAX_LINE_CHARS - 12) + '… (truncated)';
+}
+
+/**
+ * Repo root from this file's location — same arithmetic as rescan /
+ * mine-corrections / mine-decisions:
+ *
+ *   apps/standalone/src/pages/api/curate.ts   (this file)
+ *   ..\..\..\..\..                            (five up = repo root)
+ */
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+interface CurateBody {
+  dataDir?: unknown;
+  /** Top-K items to surface in the feed. Clamped to [1, MAX_TOP_K]. */
+  topK?: unknown;
+  /** When true, skip Stage 2 falsifier pass — findings tagged `'skipped-by-user'`. */
+  noFalsifier?: unknown;
+  /** F6 viewer-side opt-in for API-key fallback. Forwarded verbatim to the skill;
+   *  the skill ANDs it with the server-side env flag. */
+  apiKeyFallback?: unknown;
+}
+
+interface CurateParams {
+  requestId: string;
+  dataDir: string;
+  topK: number;
+  noFalsifier: boolean;
+  apiKeyFallback: boolean;
+}
+
+interface SpawnOutcome {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  spawnError: Error | null;
+}
+
+/**
+ * Spawn `claude -p /curate ...` and stream stdio over the NDJSON
+ * response. Same machinery as mine-decisions; the skill is a scaffold
+ * today (Rev3-F F1) so no fallback prompt — the F3+F4 PRs will exercise
+ * the real pipeline against this endpoint.
+ */
+function runClaudeOnce(
+  prompt: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<SpawnOutcome> {
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // controller already closed
+    }
+  };
+  return new Promise<SpawnOutcome>((resolvePromise) => {
+    // Pre-authorize the tools the curator needs. Whitelist (not full
+    // bypass) keeps the spawn under per-tool scrutiny: only Read /
+    // Write / Edit / Bash / Task (sub-agent) / Glob / Grep are usable.
+    // Risk is bounded by this endpoint's CSRF gate + the skill's
+    // dataDir-scoped write surface (curator-feed.json + status file).
+    const allowedTools = 'Read Write Edit Bash Task Glob Grep';
+    const bin = resolveClaudeBin();
+    const args = ['--allowedTools', allowedTools, '-p', prompt];
+    const child = spawn(bin.file, args, {
+      cwd: repoRoot(),
+      env: process.env,
+      shell: bin.useShell,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    const stdoutFull = { v: '' };
+    const stderrFull = { v: '' };
+    let spawnError: Error | null = null;
+
+    const drain = (
+      buf: string,
+      chunk: string,
+      kind: 'stdout' | 'stderr',
+      full: { v: string },
+    ): string => {
+      full.v += chunk;
+      const combined = buf + chunk;
+      const parts = combined.split('\n');
+      const lastFragment = parts.pop() ?? '';
+      for (const raw of parts) {
+        const line = raw.trimEnd();
+        if (line.length === 0) continue;
+        send({ type: kind, line: clampLine(line) });
+        // Skill stages log `[N/4] stage-name:` markers per SKILL.md;
+        // surface them as phase events so the UI can render progress
+        // without parsing every stdout line.
+        const m = /\[(\d+)\/(\d+)\]\s+(\w[\w-]*)\s*:/.exec(line);
+        if (m) {
+          send({
+            type: 'phase',
+            phase: m[3],
+            ix: Number(m[1]),
+            total: Number(m[2]),
+          });
+        }
+      }
+      return lastFragment;
+    };
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutBuf = drain(stdoutBuf, chunk.toString('utf8'), 'stdout', stdoutFull);
+    });
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderrBuf = drain(stderrBuf, chunk.toString('utf8'), 'stderr', stderrFull);
+    });
+    child.on('error', (err) => {
+      spawnError = err;
+    });
+    child.on('close', (code) => {
+      if (stdoutBuf.trim().length > 0) {
+        send({ type: 'stdout', line: clampLine(stdoutBuf.trim()) });
+        stdoutFull.v += stdoutBuf;
+      }
+      if (stderrBuf.trim().length > 0) {
+        send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
+        stderrFull.v += stderrBuf;
+      }
+      resolvePromise({
+        exitCode: code,
+        stdout: stdoutFull.v,
+        stderr: stderrFull.v,
+        spawnError,
+      });
+    });
+  });
+}
+
+async function streamCurate(
+  params: CurateParams,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<void> {
+  const started = Date.now();
+  const { requestId, dataDir, topK, noFalsifier, apiKeyFallback } = params;
+  const flags: string[] = [
+    `--request-id=${requestId}`,
+    `--data-dir=${dataDir}`,
+    `--top-k=${topK}`,
+  ];
+  if (noFalsifier) flags.push('--no-falsifier');
+  if (apiKeyFallback) flags.push('--api-key-fallback');
+  const prompt = `/curate ${flags.join(' ')}`;
+
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // closed
+    }
+  };
+
+  send({
+    type: 'start',
+    command: `claude -p "${prompt}"`,
+    requestId,
+    startedAt: started,
+    topK,
+    noFalsifier,
+  });
+
+  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const extraStderr = outcome.spawnError
+    ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
+    : '';
+
+  send({
+    type: 'done',
+    ok: outcome.exitCode === 0 && outcome.spawnError === null,
+    exitCode: outcome.exitCode,
+    durationMs: Date.now() - started,
+    requestId,
+    stdoutTail: tailBytes(outcome.stdout),
+    stderrTail: tailBytes(outcome.stderr + extraStderr),
+    command: `claude -p "${prompt}"`,
+  });
+
+  try {
+    controller.close();
+  } catch {
+    // closed
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+  if (inFlight) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'A curator run is already in progress. Wait for it to finish (1-3 min).',
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  // Probe `claude --version` up front. Curator runs are 1-3 min; failing
+  // fast with a clean 503 beats a two-minute spawn that ends in a cryptic
+  // ENOENT. Per `feedback_claude_code_not_api` the answer to "claude
+  // missing" is NOT to silently fall back to the API key — that's the
+  // F6 opt-in path, gated by viewer + server flags inside the skill.
+  const probe = await probeClaudeAvailable();
+  if (!probe.available) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error:
+          'claude CLI not detected on this host. The curator runs as a `claude -p` subprocess (plan-billed); install Claude Code or set CLAUDE_BIN to a working binary, then retry.',
+        reason: probe.reason ?? 'not-found',
+      }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  let body: CurateBody = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') body = parsed as CurateBody;
+    }
+  } catch {
+    body = {};
+  }
+
+  const candidate =
+    typeof body.dataDir === 'string' && body.dataDir.trim().length > 0
+      ? body.dataDir
+      : DEFAULT_DATA_DIR;
+  let dataDir: string;
+  try {
+    dataDir = assertDataDirContained(candidate, repoRoot()); // (S1)
+  } catch (e) {
+    const r = handleDataDirGuardError(e); // (XN2)
+    if (r) return r;
+    throw e;
+  }
+
+  let topK = DEFAULT_TOP_K;
+  if (typeof body.topK === 'number' && Number.isFinite(body.topK) && body.topK >= 1) {
+    topK = Math.min(Math.floor(body.topK), MAX_TOP_K);
+  }
+  const noFalsifier = body.noFalsifier === true;
+  const apiKeyFallback = body.apiKeyFallback === true;
+
+  const params: CurateParams = {
+    requestId: randomUUID(),
+    dataDir,
+    topK,
+    noFalsifier,
+    apiKeyFallback,
+  };
+
+  const encoder = new TextEncoder();
+  let done: (() => void) | null = null;
+  const completed = new Promise<void>((res) => {
+    done = res;
+  });
+  inFlight = completed.then(() => undefined);
+  inFlightRequestId = params.requestId;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        await streamCurate(params, controller, encoder);
+      } finally {
+        inFlight = null;
+        inFlightRequestId = null;
+        done?.();
+      }
+    },
+    cancel() {
+      // client disconnected; CLI keeps running and writes to disk
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+      'cache-control': 'no-store',
+      'x-accel-buffering': 'no',
+    },
+  });
+};
+
+/**
+ * Readiness probe. The viewer pings this on mount to decide whether to
+ * surface the CURATE button (`available`) and whether a run is already
+ * in flight (`busy`). Production static builds have no GET; the viewer
+ * treats fetch failure as `available: false`.
+ */
+export const GET: APIRoute = () => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      available: true,
+      busy: inFlight !== null,
+      busyRequestId: inFlightRequestId,
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    },
+  );
+};

--- a/apps/standalone/src/pages/api/curate.ts
+++ b/apps/standalone/src/pages/api/curate.ts
@@ -63,6 +63,10 @@ function csrfReject(reason: string): Response {
  */
 let inFlight: Promise<void> | null = null;
 let inFlightRequestId: string | null = null;
+// Iter-2 security finding: empty cancel() left an orphan child holding
+// the inFlight slot for up to 10 min (until the kill-timer fired). We
+// track the active child so cancel() can SIGTERM it promptly.
+let inFlightChildKill: (() => void) | null = null;
 
 const MAX_LINE_CHARS = 2_000;
 const MAX_TAIL_BYTES = 8 * 1024;
@@ -208,6 +212,15 @@ function runClaudeOnce(
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    // Register the kill hook so the outer ReadableStream.cancel() can
+    // SIGTERM this child if the client disconnects. Cleared in settleOnce.
+    inFlightChildKill = () => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead — ignore
+      }
+    };
 
     let stdoutBuf = '';
     let stderrBuf = '';
@@ -233,6 +246,7 @@ function runClaudeOnce(
       if (settled) return;
       settled = true;
       clearTimers();
+      inFlightChildKill = null;
       resolvePromise(outcome);
     };
 
@@ -498,7 +512,11 @@ export const POST: APIRoute = async ({ request }) => {
       }
     },
     cancel() {
-      // client disconnected; CLI keeps running and writes to disk
+      // Iter-2 security fix: client disconnect now SIGTERMs the child
+      // so the inFlight slot releases promptly. The skill's stage-end
+      // checkpoints mean partial work isn't lost; a full re-run from
+      // the user re-spawns cleanly.
+      inFlightChildKill?.();
     },
   });
 

--- a/apps/standalone/src/pages/api/falsify.ts
+++ b/apps/standalone/src/pages/api/falsify.ts
@@ -1,0 +1,416 @@
+/**
+ * `/api/falsify` — POST drives the `/falsify` skill via `claude -p`.
+ * The skill reads each candidate finding's `evidenceChain`, pulls the
+ * cited session turns from the SQLite substrate, and emits a per-turn
+ * `supports / neutral / contradicts` verdict aggregated against
+ * `THRESHOLDS.curator.falsifierMinSupportRatio`. Writes
+ * `analysis/falsifier-verdicts.json` (Rev3-F F2 scaffold; F4 lands the
+ * verifier kernel).
+ *
+ * Sibling to `/api/curate` — same CSRF / in-flight / NDJSON streaming
+ * shape; the only real difference is the skill args (input file vs
+ * single finding-id) and the in-flight error copy.
+ *
+ * Note: the curator's Stage 2 calls /falsify in-process from inside the
+ * `claude -p /curate` subprocess; this endpoint is the manual /
+ * meta-validation entry point (a user spot-checking a finding, or F8
+ * re-judging a held-out set).
+ */
+
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { resolveClaudeBin } from '../../lib/resolveClaude.js';
+import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  assertDataDirContained,
+  handleDataDirGuardError,
+} from '../../lib/dataDirGuard.js';
+
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-falsify';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let inFlight: Promise<void> | null = null;
+let inFlightRequestId: string | null = null;
+
+const MAX_LINE_CHARS = 2_000;
+const MAX_TAIL_BYTES = 8 * 1024;
+const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
+/** Loose ceiling on finding-id length — UUIDs / kernel-prefixed ids are well under this. */
+const MAX_FINDING_ID_CHARS = 256;
+
+function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
+  if (text.length <= max) return text;
+  return '… (truncated) …\n' + text.slice(-max);
+}
+
+function clampLine(line: string): string {
+  if (line.length <= MAX_LINE_CHARS) return line;
+  return line.slice(0, MAX_LINE_CHARS - 12) + '… (truncated)';
+}
+
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+interface FalsifyBody {
+  dataDir?: unknown;
+  /** Verify a single finding by id. Mutually exclusive with `input`. */
+  findingId?: unknown;
+  /** Path to a JSON file with `{ findings: [...] }`. Validated under dataDir. */
+  input?: unknown;
+  /** Optional output path. Defaults inside the skill to `${dataDir}/analysis/falsifier-verdicts.json`. */
+  output?: unknown;
+  /** F6 viewer-side opt-in for API-key fallback. Forwarded verbatim. */
+  apiKeyFallback?: unknown;
+}
+
+interface FalsifyParams {
+  requestId: string;
+  dataDir: string;
+  findingId: string | null;
+  inputPath: string | null;
+  outputPath: string | null;
+  apiKeyFallback: boolean;
+}
+
+interface SpawnOutcome {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  spawnError: Error | null;
+}
+
+function runClaudeOnce(
+  prompt: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<SpawnOutcome> {
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // controller already closed
+    }
+  };
+  return new Promise<SpawnOutcome>((resolvePromise) => {
+    // Falsifier needs the same tool surface as the curator — Read for
+    // session turns, Bash for kernel invocations, Write for verdict
+    // output, Task for the K=3 self-consistency sub-agents.
+    const allowedTools = 'Read Write Edit Bash Task Glob Grep';
+    const bin = resolveClaudeBin();
+    const args = ['--allowedTools', allowedTools, '-p', prompt];
+    const child = spawn(bin.file, args, {
+      cwd: repoRoot(),
+      env: process.env,
+      shell: bin.useShell,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    const stdoutFull = { v: '' };
+    const stderrFull = { v: '' };
+    let spawnError: Error | null = null;
+
+    const drain = (
+      buf: string,
+      chunk: string,
+      kind: 'stdout' | 'stderr',
+      full: { v: string },
+    ): string => {
+      full.v += chunk;
+      const combined = buf + chunk;
+      const parts = combined.split('\n');
+      const lastFragment = parts.pop() ?? '';
+      for (const raw of parts) {
+        const line = raw.trimEnd();
+        if (line.length === 0) continue;
+        send({ type: kind, line: clampLine(line) });
+        const m = /\[(\d+)\/(\d+)\]\s+(\w[\w-]*)\s*:/.exec(line);
+        if (m) {
+          send({
+            type: 'phase',
+            phase: m[3],
+            ix: Number(m[1]),
+            total: Number(m[2]),
+          });
+        }
+      }
+      return lastFragment;
+    };
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutBuf = drain(stdoutBuf, chunk.toString('utf8'), 'stdout', stdoutFull);
+    });
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderrBuf = drain(stderrBuf, chunk.toString('utf8'), 'stderr', stderrFull);
+    });
+    child.on('error', (err) => {
+      spawnError = err;
+    });
+    child.on('close', (code) => {
+      if (stdoutBuf.trim().length > 0) {
+        send({ type: 'stdout', line: clampLine(stdoutBuf.trim()) });
+        stdoutFull.v += stdoutBuf;
+      }
+      if (stderrBuf.trim().length > 0) {
+        send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
+        stderrFull.v += stderrBuf;
+      }
+      resolvePromise({
+        exitCode: code,
+        stdout: stdoutFull.v,
+        stderr: stderrFull.v,
+        spawnError,
+      });
+    });
+  });
+}
+
+async function streamFalsify(
+  params: FalsifyParams,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<void> {
+  const started = Date.now();
+  const { requestId, dataDir, findingId, inputPath, outputPath, apiKeyFallback } = params;
+  const flags: string[] = [
+    `--request-id=${requestId}`,
+    `--data-dir=${dataDir}`,
+  ];
+  if (findingId !== null) flags.push(`--finding-id=${findingId}`);
+  if (inputPath !== null) flags.push(`--input=${inputPath}`);
+  if (outputPath !== null) flags.push(`--output=${outputPath}`);
+  if (apiKeyFallback) flags.push('--api-key-fallback');
+  const prompt = `/falsify ${flags.join(' ')}`;
+
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // closed
+    }
+  };
+
+  send({
+    type: 'start',
+    command: `claude -p "${prompt}"`,
+    requestId,
+    startedAt: started,
+    findingId,
+    inputPath,
+  });
+
+  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const extraStderr = outcome.spawnError
+    ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
+    : '';
+
+  send({
+    type: 'done',
+    ok: outcome.exitCode === 0 && outcome.spawnError === null,
+    exitCode: outcome.exitCode,
+    durationMs: Date.now() - started,
+    requestId,
+    stdoutTail: tailBytes(outcome.stdout),
+    stderrTail: tailBytes(outcome.stderr + extraStderr),
+    command: `claude -p "${prompt}"`,
+  });
+
+  try {
+    controller.close();
+  } catch {
+    // closed
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+  if (inFlight) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'A falsifier run is already in progress. Wait for it to finish (1-3 min).',
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  // Same up-front probe as /api/curate. The two endpoints fail fast
+  // independently — operator can be missing claude on a host that still
+  // has a stale curator run in flight from a different binary version,
+  // so we don't share probe state.
+  const probe = await probeClaudeAvailable();
+  if (!probe.available) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error:
+          'claude CLI not detected on this host. The falsifier runs as a `claude -p` subprocess (plan-billed); install Claude Code or set CLAUDE_BIN to a working binary, then retry.',
+        reason: probe.reason ?? 'not-found',
+      }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  let body: FalsifyBody = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') body = parsed as FalsifyBody;
+    }
+  } catch {
+    body = {};
+  }
+
+  const candidate =
+    typeof body.dataDir === 'string' && body.dataDir.trim().length > 0
+      ? body.dataDir
+      : DEFAULT_DATA_DIR;
+  let dataDir: string;
+  try {
+    dataDir = assertDataDirContained(candidate, repoRoot()); // (S1)
+  } catch (e) {
+    const r = handleDataDirGuardError(e); // (XN2)
+    if (r) return r;
+    throw e;
+  }
+
+  // Mutually exclusive: --finding-id verifies one finding, --input
+  // batch-processes a generator's output file. Both unset is fine —
+  // the skill falls back to its default input path.
+  let findingId: string | null = null;
+  if (typeof body.findingId === 'string' && body.findingId.trim().length > 0) {
+    const v = body.findingId.trim();
+    if (v.length > MAX_FINDING_ID_CHARS) {
+      return new Response(
+        JSON.stringify({ ok: false, error: `findingId exceeds ${MAX_FINDING_ID_CHARS} chars` }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    findingId = v;
+  }
+
+  let inputPath: string | null = null;
+  if (typeof body.input === 'string' && body.input.trim().length > 0) {
+    try {
+      // Containment: the input file MUST live under the chat-arch-data
+      // safe root. Same guard the dataDir param uses; without it a local-
+      // origin caller could ask the skill to read an arbitrary repo file.
+      inputPath = assertDataDirContained(body.input, repoRoot());
+    } catch (e) {
+      const r = handleDataDirGuardError(e);
+      if (r) return r;
+      throw e;
+    }
+  }
+
+  let outputPath: string | null = null;
+  if (typeof body.output === 'string' && body.output.trim().length > 0) {
+    try {
+      outputPath = assertDataDirContained(body.output, repoRoot());
+    } catch (e) {
+      const r = handleDataDirGuardError(e);
+      if (r) return r;
+      throw e;
+    }
+  }
+
+  if (findingId !== null && inputPath !== null) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'findingId and input are mutually exclusive — pick one.',
+      }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  const apiKeyFallback = body.apiKeyFallback === true;
+
+  const params: FalsifyParams = {
+    requestId: randomUUID(),
+    dataDir,
+    findingId,
+    inputPath,
+    outputPath,
+    apiKeyFallback,
+  };
+
+  const encoder = new TextEncoder();
+  let done: (() => void) | null = null;
+  const completed = new Promise<void>((res) => {
+    done = res;
+  });
+  inFlight = completed.then(() => undefined);
+  inFlightRequestId = params.requestId;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        await streamFalsify(params, controller, encoder);
+      } finally {
+        inFlight = null;
+        inFlightRequestId = null;
+        done?.();
+      }
+    },
+    cancel() {
+      // client disconnected; CLI keeps running and writes to disk
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+      'cache-control': 'no-store',
+      'x-accel-buffering': 'no',
+    },
+  });
+};
+
+export const GET: APIRoute = () => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      available: true,
+      busy: inFlight !== null,
+      busyRequestId: inFlightRequestId,
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    },
+  );
+};

--- a/apps/standalone/src/pages/api/falsify.ts
+++ b/apps/standalone/src/pages/api/falsify.ts
@@ -23,7 +23,11 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { resolveClaudeBin } from '../../lib/resolveClaude.js';
-import { probeClaudeAvailable } from '../../lib/curatorClaude.js';
+import {
+  AUTH_ENV_VARS,
+  computeAllowApiKeyFallback,
+  probeClaudeAvailable,
+} from '../../lib/curatorClaude.js';
 import {
   assertDataDirContained,
   handleDataDirGuardError,
@@ -60,6 +64,21 @@ const MAX_TAIL_BYTES = 8 * 1024;
 const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
 /** Loose ceiling on finding-id length — UUIDs / kernel-prefixed ids are well under this. */
 const MAX_FINDING_ID_CHARS = 256;
+/**
+ * Allowed charset for `findingId` — alphanumerics + `_`, `.`, `:`, `-`.
+ * Covers UUIDs, kernel-prefixed ids (`kernel:uuid`), short hash slugs,
+ * and dotted-namespace ids. Excludes whitespace, shell metacharacters
+ * (`$`, `` ` ``, `;`, `|`, `&`, `<`, `>`, `(`, `)`, `\`), quotes, and
+ * Unicode that could compose ambiguous flag tokens.
+ *
+ * Defense in depth: combined with the Windows `useShell: true`
+ * fallback in `resolveClaude`, an unvalidated findingId becomes a
+ * shell-injection sink. Iter-1 finding closes that gap.
+ */
+const FINDING_ID_CHARSET_RE = /^[A-Za-z0-9_.:-]{1,256}$/;
+/** See `curate.ts` — same kill-timeout / grace contract. */
+const SPAWN_KILL_TIMEOUT_MS = 10 * 60 * 1000;
+const SPAWN_KILL_GRACE_MS = 5_000;
 
 function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
   if (text.length <= max) return text;
@@ -94,7 +113,13 @@ interface FalsifyParams {
   findingId: string | null;
   inputPath: string | null;
   outputPath: string | null;
+  /** Viewer-side opt-in flag (raw body value). Surfaced to the skill. */
   apiKeyFallback: boolean;
+  /**
+   * Two-rail-resolved decision: viewer opt-in AND server env opt-in.
+   * Default-deny — drives the AUTH_ENV_VARS scrub in `runClaudeOnce`.
+   */
+  allowApiKeyFallback: boolean;
 }
 
 interface SpawnOutcome {
@@ -104,10 +129,17 @@ interface SpawnOutcome {
   spawnError: Error | null;
 }
 
+/**
+ * Spawn `claude -p /falsify ...` and stream stdio over NDJSON.
+ * Sibling to `curate.ts`'s `runClaudeOnce` — same security iter-1
+ * fixes apply (AUTH_ENV_VARS scrub when fallback is OFF, kill-timeout
+ * escalation so a hung child doesn't permanently 409 the endpoint).
+ */
 function runClaudeOnce(
   prompt: string,
   controller: ReadableStreamDefaultController<Uint8Array>,
   encoder: TextEncoder,
+  allowApiKeyFallback: boolean,
 ): Promise<SpawnOutcome> {
   const send = (obj: unknown) => {
     try {
@@ -123,9 +155,16 @@ function runClaudeOnce(
     const allowedTools = 'Read Write Edit Bash Task Glob Grep';
     const bin = resolveClaudeBin();
     const args = ['--allowedTools', allowedTools, '-p', prompt];
+    // Default-deny env scrub — see curate.ts for the rationale.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (!allowApiKeyFallback) {
+      for (const name of AUTH_ENV_VARS) {
+        delete env[name];
+      }
+    }
     const child = spawn(bin.file, args, {
       cwd: repoRoot(),
-      env: process.env,
+      env,
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -135,6 +174,53 @@ function runClaudeOnce(
     const stdoutFull = { v: '' };
     const stderrFull = { v: '' };
     let spawnError: Error | null = null;
+    let settled = false;
+    let killTimer: ReturnType<typeof setTimeout> | null = null;
+    let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const clearTimers = (): void => {
+      if (killTimer !== null) {
+        clearTimeout(killTimer);
+        killTimer = null;
+      }
+      if (graceTimer !== null) {
+        clearTimeout(graceTimer);
+        graceTimer = null;
+      }
+    };
+
+    const settleOnce = (outcome: SpawnOutcome): void => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      resolvePromise(outcome);
+    };
+
+    killTimer = setTimeout(() => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead
+      }
+      graceTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // already dead
+        }
+        settleOnce({
+          exitCode: null,
+          stdout: stdoutFull.v,
+          stderr:
+            stderrFull.v +
+            (stderrFull.v.length > 0 ? '\n' : '') +
+            `[falsify] spawn exceeded ${SPAWN_KILL_TIMEOUT_MS}ms; SIGKILL'd.`,
+          spawnError: new Error(
+            `claude -p subprocess exceeded ${SPAWN_KILL_TIMEOUT_MS}ms kill-timeout`,
+          ),
+        });
+      }, SPAWN_KILL_GRACE_MS);
+    }, SPAWN_KILL_TIMEOUT_MS);
 
     const drain = (
       buf: string,
@@ -181,7 +267,7 @@ function runClaudeOnce(
         send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
         stderrFull.v += stderrBuf;
       }
-      resolvePromise({
+      settleOnce({
         exitCode: code,
         stdout: stdoutFull.v,
         stderr: stderrFull.v,
@@ -197,7 +283,15 @@ async function streamFalsify(
   encoder: TextEncoder,
 ): Promise<void> {
   const started = Date.now();
-  const { requestId, dataDir, findingId, inputPath, outputPath, apiKeyFallback } = params;
+  const {
+    requestId,
+    dataDir,
+    findingId,
+    inputPath,
+    outputPath,
+    apiKeyFallback,
+    allowApiKeyFallback,
+  } = params;
   const flags: string[] = [
     `--request-id=${requestId}`,
     `--data-dir=${dataDir}`,
@@ -205,7 +299,10 @@ async function streamFalsify(
   if (findingId !== null) flags.push(`--finding-id=${findingId}`);
   if (inputPath !== null) flags.push(`--input=${inputPath}`);
   if (outputPath !== null) flags.push(`--output=${outputPath}`);
-  if (apiKeyFallback) flags.push('--api-key-fallback');
+  // Only forward the two-rail-resolved decision; viewer opt-in alone
+  // is not enough. The env-scrub in runClaudeOnce is the load-bearing
+  // enforcement.
+  if (allowApiKeyFallback) flags.push('--api-key-fallback');
   const prompt = `/falsify ${flags.join(' ')}`;
 
   const send = (obj: unknown) => {
@@ -223,9 +320,16 @@ async function streamFalsify(
     startedAt: started,
     findingId,
     inputPath,
+    apiKeyFallback,
+    allowApiKeyFallback,
   });
 
-  const outcome = await runClaudeOnce(prompt, controller, encoder);
+  const outcome = await runClaudeOnce(
+    prompt,
+    controller,
+    encoder,
+    allowApiKeyFallback,
+  );
   const extraStderr = outcome.spawnError
     ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
     : '';
@@ -318,6 +422,17 @@ export const POST: APIRoute = async ({ request }) => {
         { status: 400, headers: { 'content-type': 'application/json' } },
       );
     }
+    // Charset validation — defense-in-depth against shell-injection
+    // via the Windows `useShell: true` fallback. Whitelist is
+    // alphanumerics + `_`, `.`, `:`, `-` (covers all kernel-emitted
+    // finding-id shapes — UUIDs, prefixed slugs, dotted namespaces);
+    // rejects whitespace + shell metacharacters + quotes + Unicode.
+    if (!FINDING_ID_CHARSET_RE.test(v)) {
+      return new Response(
+        JSON.stringify({ ok: false, error: 'Invalid findingId format' }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      );
+    }
     findingId = v;
   }
 
@@ -357,6 +472,10 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   const apiKeyFallback = body.apiKeyFallback === true;
+  // Two-rail composition — see curate.ts. The viewer flag alone
+  // never enables the fallback; the server-side env opt-in must
+  // also be set. Default-deny.
+  const allowApiKeyFallback = computeAllowApiKeyFallback(body.apiKeyFallback);
 
   const params: FalsifyParams = {
     requestId: randomUUID(),
@@ -365,6 +484,7 @@ export const POST: APIRoute = async ({ request }) => {
     inputPath,
     outputPath,
     apiKeyFallback,
+    allowApiKeyFallback,
   };
 
   const encoder = new TextEncoder();

--- a/apps/standalone/src/pages/api/falsify.ts
+++ b/apps/standalone/src/pages/api/falsify.ts
@@ -58,6 +58,10 @@ function csrfReject(reason: string): Response {
 
 let inFlight: Promise<void> | null = null;
 let inFlightRequestId: string | null = null;
+// Iter-2 security finding (mirror of curate.ts): empty cancel() left
+// an orphan child holding the inFlight slot for up to 10 min until the
+// kill-timer fired. Track the active child so cancel() can SIGTERM it.
+let inFlightChildKill: (() => void) | null = null;
 
 const MAX_LINE_CHARS = 2_000;
 const MAX_TAIL_BYTES = 8 * 1024;
@@ -168,6 +172,13 @@ function runClaudeOnce(
       shell: bin.useShell,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    inFlightChildKill = () => {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // already dead — ignore
+      }
+    };
 
     let stdoutBuf = '';
     let stderrBuf = '';
@@ -193,6 +204,7 @@ function runClaudeOnce(
       if (settled) return;
       settled = true;
       clearTimers();
+      inFlightChildKill = null;
       resolvePromise(outcome);
     };
 
@@ -506,7 +518,9 @@ export const POST: APIRoute = async ({ request }) => {
       }
     },
     cancel() {
-      // client disconnected; CLI keeps running and writes to disk
+      // Iter-2 security fix: client disconnect SIGTERMs the child so
+      // the inFlight slot releases promptly. Mirrors curate.ts.
+      inFlightChildKill?.();
     },
   });
 

--- a/apps/standalone/src/pages/api/regen-brief.ts
+++ b/apps/standalone/src/pages/api/regen-brief.ts
@@ -190,6 +190,10 @@ export const POST: APIRoute = async ({ request }) => {
   // no SDK accessor for it ships under `@chat-arch/exporter/db/sdk`
   // yet. We pass `null` so the kernel skips the section instead of
   // pretending zero-is-known; wiring lands when the SDK accessor does.
+  // TODO(applyWatcher-sdk): once `listWatcherVerdicts(db)` (or similar)
+  // exists in @chat-arch/exporter/db/sdk, change this to
+  // `listWatcherVerdicts(db).filter(v => v.verdict === 'no-recurrence').length`.
+  // Companion TODO at packages/analysis/src/dailyBrief.ts line ~360.
   const appliedPatternClosures: number | null = null;
   // Blog-drafts index isn't currently written as a single file — we
   // pass [] for now. The Today page reads blog drafts separately.

--- a/apps/standalone/src/pages/api/regen-brief.ts
+++ b/apps/standalone/src/pages/api/regen-brief.ts
@@ -9,10 +9,16 @@
  * a local hostname AND `X-Requested-With: chat-arch-regen-brief`.
  */
 import type { APIRoute } from 'astro';
+import { execFile } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
-import { buildDailyBrief } from '@chat-arch/analysis';
+import { promisify } from 'node:util';
+import {
+  buildDailyBrief,
+  type BriefTrajectoryRow,
+  type SurprisesOutput,
+} from '@chat-arch/analysis';
 import type {
   AuditResultsFile,
   AuditSummary,
@@ -21,6 +27,24 @@ import type {
   CorrectionsFile,
   UpgradeOutcomesFile,
 } from '@chat-arch/schema';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Project-trajectories sidecar shape. We only need the four fields the
+ * brief renders, so we narrow the on-disk type here instead of pulling
+ * the full `ProjectTrajectoriesFile` from the exporter package (which
+ * would create a cross-app dependency we don't otherwise have).
+ */
+interface ProjectTrajectoriesFileShape {
+  projects?: ReadonlyArray<{
+    projectId: string;
+    projectName: string;
+    classification: BriefTrajectoryRow['classification'];
+    slope: number | null;
+    totalSessions: number;
+  }>;
+}
 
 export const prerender = false;
 
@@ -61,6 +85,55 @@ async function readJsonOrNull<T>(absPath: string): Promise<T | null> {
   }
 }
 
+/**
+ * Locate the repo root by walking up from this file. We mirror the same
+ * 5-level climb that `dataDirAbs()` uses; resolving once and re-using
+ * keeps the two paths consistent.
+ */
+function repoRootAbs(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+/**
+ * Run `git log --since="7 days ago" ... main` against the repo root.
+ * Returns `null` on any failure (not a git repo, no `main` branch,
+ * `git` not on PATH, etc.) so the kernel skips the section cleanly.
+ *
+ * We pass each `git log` flag as a separate argv entry to `execFile`
+ * so no shell quoting is involved. Bounded `maxBuffer` (256KB) caps
+ * the output for very busy weeks; we'd still get the count line even
+ * if the subject lines were truncated.
+ */
+async function shippedThisWeekFromGit(
+  repoRoot: string,
+): Promise<{ commitCount: number; recentSubjects: string[] } | null> {
+  try {
+    const [countResult, subjectsResult] = await Promise.all([
+      execFileAsync(
+        'git',
+        ['log', '--since=7 days ago', '--pretty=format:%H', 'main'],
+        { cwd: repoRoot, maxBuffer: 256 * 1024 },
+      ),
+      execFileAsync(
+        'git',
+        ['log', '--since=7 days ago', '--pretty=format:%s', 'main'],
+        { cwd: repoRoot, maxBuffer: 256 * 1024 },
+      ),
+    ]);
+    const commitCount = countResult.stdout
+      .split('\n')
+      .filter((l) => l.trim().length > 0).length;
+    const recentSubjects = subjectsResult.stdout
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .slice(0, 5);
+    return { commitCount, recentSubjects };
+  } catch {
+    return null;
+  }
+}
+
 export const POST: APIRoute = async ({ request }) => {
   if (!isLocalOrigin(request.headers.get('origin'))) {
     return reject(403, 'Forbidden: non-local origin');
@@ -89,6 +162,35 @@ export const POST: APIRoute = async ({ request }) => {
   const upgradeOutcomes = await readJsonOrNull<UpgradeOutcomesFile>(
     join(analysisDir, 'upgrade-outcomes.json'),
   );
+  // Phase γ §2 — `analysis/surprises.json` (produced by the surprises
+  // builder). Fail-soft: missing/unparseable ⇒ kernel skips the
+  // section.
+  const surprises = await readJsonOrNull<SurprisesOutput>(
+    join(analysisDir, 'surprises.json'),
+  );
+  // Phase γ §3 — `analysis/project-trajectories.json` (produced by the
+  // project-trajectory builder). Narrowed inline so we don't pull the
+  // exporter type across.
+  const trajectoriesFile = await readJsonOrNull<ProjectTrajectoriesFileShape>(
+    join(analysisDir, 'project-trajectories.json'),
+  );
+  const projectTrajectories: BriefTrajectoryRow[] =
+    trajectoriesFile?.projects?.map((p) => ({
+      projectId: p.projectId,
+      projectName: p.projectName,
+      classification: p.classification,
+      slope: p.slope,
+      totalSessions: p.totalSessions,
+    })) ?? [];
+  // Phase γ §1 — `git log` for the shipped-this-week counter. Pure
+  // I/O in the shell; the kernel just formats the numbers.
+  const shippedThisWeek = await shippedThisWeekFromGit(repoRootAbs());
+  // Phase γ §4 — applied-pattern closures. The watcher verdict ledger
+  // lives in the SQLite substrate (see CLAUDE.md "Data on disk"), but
+  // no SDK accessor for it ships under `@chat-arch/exporter/db/sdk`
+  // yet. We pass `null` so the kernel skips the section instead of
+  // pretending zero-is-known; wiring lands when the SDK accessor does.
+  const appliedPatternClosures: number | null = null;
   // Blog-drafts index isn't currently written as a single file — we
   // pass [] for now. The Today page reads blog drafts separately.
   void (null as unknown as BlogDraftsIndexFile);
@@ -105,6 +207,10 @@ export const POST: APIRoute = async ({ request }) => {
     auditResults: auditResults?.results ?? [],
     auditSummary,
     continuumHealth,
+    shippedThisWeek,
+    surprises,
+    projectTrajectories,
+    appliedPatternClosures,
   });
 
   const outPath = join(briefsDir, `${date}.md`);

--- a/apps/standalone/src/pages/api/rescan.ts
+++ b/apps/standalone/src/pages/api/rescan.ts
@@ -28,7 +28,7 @@ export const prerender = false;
  * The viewer's `useRescan()` hook sends both. Anything that doesn't
  * (curl one-liner, hostile <form>, DNS-rebinding probe) gets 403.
  */
-const REQUIRED_HEADER = 'chat-arch-rescan';
+export const REQUIRED_HEADER = 'chat-arch-rescan';
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
 function isLocalOrigin(origin: string | null): boolean {

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -1,17 +1,31 @@
 ---
-// v2 §FD.1 — TODAY page. Reframed against research/refocus-plan.md
-// north star: "Find the rules Claude keeps breaking. Patch your
-// CLAUDE.md / skills. Prove the loop closed." The hero panel is the
-// workshop-loop status (corrections to apply, applies made, loop
-// closure rate). Audit concerns + brief content are demoted below.
+// Phase β — TODAY as a 5-section FEED. The page is the single home
+// surface for a daily-journal behavioral feedback tool. It answers
+// "what should I keep doing / stop doing / what just changed / what's
+// broken" plus "happy surprises and stories that track the work."
+//
+// Sections (in DOM order, rendered top → bottom):
+//   1. BRIEF    — latest daily brief, full markdown body
+//   2. NEW      — happy surprises (positive-tone surprise rows)
+//   3. ACT      — curator feed (top-K) + corrections to APPLY
+//   4. BROKEN   — concerning surprises + audit concerns + continuum health
+//   5. STORIES  — recent narratives + blog-draft slugs
+//
+// The header (TODAY title, RESCAN/MINE/REGEN/FULL SCAN buttons,
+// progress UI) sits above section 1. A new FULL SCAN button
+// orchestrates the four producers sequentially via fullScan.ts.
 export const prerender = false;
 
 import BaseLayout from '../layouts/BaseLayout.astro';
 import {
   listBlogDraftSlugs,
+  pickSurprises,
   readContinuumHealth,
   readCorrectionCandidatesSummary,
+  readCuratorFeed,
   readLatestBrief,
+  readRecentNarratives,
+  readSurprises,
   readTopAuditConcerns,
   readWorkshopStatus,
 } from '../lib/readSidecars.ts';
@@ -30,41 +44,83 @@ const health = await readContinuumHealth();
 const candidatesSummary = await readCorrectionCandidatesSummary();
 const candidateCount = candidatesSummary?.candidateCount ?? 0;
 
-// 3-state detection for the WORKSHOP LOOP hero:
-//   (1) workshopMined — corrections.json has patterns OR applied-improvements
-//       has entries. Real workshop status renders normally.
-//   (2) workshopJustScanned — the exporter has populated
-//       `correction-candidates.json` (candidateCount > 0) but mining
-//       hasn't run yet, so workshop counts are all 0. This is the
-//       "scan done, mine next" state — render a real-data card with
-//       a clear CTA to MINE CORRECTIONS, NOT the demo grid (the demo
-//       reads as "your scan didn't work" when the real story is
-//       "your scan worked, now run mining").
-//   (3) workshopUnscanned — neither candidates nor patterns exist
-//       (fresh install / hosted demo / brand-new clone). Demo grid
-//       fires with full DEMO badge + aria-label.
-// Memory: feedback_positioning_by_features — show the loop in motion,
-// don't describe it. The (2) state previously fell through to (3),
-// which was actively confusing once we'd verified the scan ran.
+const surprisesFile = await readSurprises();
+const surprisesNew = pickSurprises(surprisesFile, 'positive', 5);
+const surprisesBroken = pickSurprises(surprisesFile, 'concerning', 5);
+
+const curatorFeed = await readCuratorFeed();
+const recentNarratives = await readRecentNarratives(5);
+
+// Workshop sub-detection (preserved from prior page — drives the ACT
+// section's "corrections to APPLY" line + the "mine next" CTA wiring).
 const workshopHasPatterns =
   workshop.unappliedPatternCount > 0 ||
   workshop.appliedPatternCount > 0 ||
   workshop.recurringAfterApplyCount > 0;
 const workshopJustScanned = !workshopHasPatterns && candidateCount > 0;
 const workshopUnscanned = !workshopHasPatterns && candidateCount === 0;
-// Demo grid only fires for the truly-unscanned case now.
 const workshopEmpty = workshopUnscanned;
 const draftsEmpty = drafts.length === 0;
 const concernsEmpty = concerns.length === 0;
 
-// View binding — when a surface is empty, swap in the demo. Same JSX
-// renders against either source; the demo path adds the badge + sr-only.
+// Demo fixtures fire for empty surfaces (memory: feedback_positioning
+// _by_features — show the loop in motion, don't describe it).
 const wsView = workshopEmpty ? makeDemoWorkshopStatus() : workshop;
 const draftsView = draftsEmpty ? makeDemoBlogDraftSlugs() : drafts;
 const concernsView = concernsEmpty ? makeDemoTopAuditConcerns() : concerns;
 
 const draftFinals = draftsView.filter((d) => !d.isPrompt).length;
 const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
+
+// Empty-state flags for the 5 sections (drives copy + button rendering).
+const briefEmpty = brief === null;
+const newEmpty = surprisesNew.length === 0;
+const curatorEmpty = curatorFeed === null || curatorFeed.items.length === 0;
+const brokenEmpty =
+  surprisesBroken.length === 0 &&
+  concerns.length === 0 &&
+  (health === null || health.warnings.length === 0);
+const storiesEmpty = recentNarratives.length === 0 && drafts.length === 0;
+
+// SectionBar label rendering helper — keeps every section's heading
+// consistent without hand-rolling the same markup five times.
+const SECTIONS = [
+  { key: 'BRIEF', sub: brief?.date ?? null },
+  { key: 'NEW', sub: `${surprisesNew.length} positive` },
+  {
+    key: 'ACT',
+    sub: `${workshop.unappliedPatternCount} to APPLY · ${
+      curatorFeed?.items.length ?? 0
+    } curated`,
+  },
+  {
+    key: 'BROKEN',
+    sub: `${surprisesBroken.length + concerns.length} concern${
+      surprisesBroken.length + concerns.length === 1 ? '' : 's'
+    }`,
+  },
+  {
+    key: 'STORIES',
+    sub: `${recentNarratives.length} narrative${
+      recentNarratives.length === 1 ? '' : 's'
+    } · ${draftFinals} draft${draftFinals === 1 ? '' : 's'}`,
+  },
+] as const;
+
+// SurpriseKind → human badge label. Each kind also gets a CSS class so
+// the badge color can subtly differentiate (config-helped reads as a
+// blue/teal beat against streak's gold, etc. — see CSS at bottom).
+const SURPRISE_KIND_LABEL: Record<string, string> = {
+  streak: 'streak',
+  'trajectory-accelerating': 'accelerating',
+  'config-helped': 'config helped',
+  'pattern-closed': 'pattern closed',
+  'reflexive-positive': 'reflexive',
+  'decision-paid-off': 'decision paid off',
+  'trajectory-stalled': 'stalled',
+  'pattern-recurring': 'pattern recurring',
+  'debt-spinning': 'debt spinning',
+};
 ---
 <BaseLayout title="Chat Archaeologist — Today" current="TODAY">
   <main class="today">
@@ -75,6 +131,9 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
         {brief !== null ? <span class="today__chip">brief at {brief.date}</span> : null}
       </p>
       <div class="today__actions">
+        <button id="action-full-scan" type="button" class="today__btn-primary">
+          FULL SCAN
+        </button>
         <button id="action-rescan" type="button">RESCAN</button>
         <button id="action-mine" type="button">MINE CORRECTIONS</button>
         <button id="action-brief" type="button">REGEN BRIEF</button>
@@ -95,99 +154,142 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       </div>
     </header>
 
-    {/* ======================= WORKSHOP LOOP ======================= */}
-    {/* Three states:
-          (a) workshopJustScanned — real data exists (candidates from
-              exporter) but mining hasn't classified them yet. Render
-              a real-data card pointing at MINE CORRECTIONS. NO demo
-              badge, NO fake metrics.
-          (b) workshopEmpty (unscanned) — fresh install / hosted demo.
-              Demo modifier + DEMO badge + aria-label + sr-only.
-          (c) mined — render real workshop status with normal chrome. */}
-    {workshopJustScanned ? (
-      <section
-        class="today__hero today__hero--scanned"
-        aria-label="Scan complete — mine corrections next to populate the workshop loop"
-      >
-        <h2>
-          WORKSHOP LOOP
-          <span class="today__hero-status">· SCAN COMPLETE · MINE NEXT</span>
-        </h2>
-        <p class="today__hero-lede">
-          The exporter found{' '}
-          <code>{candidateCount.toLocaleString()}</code> correction candidate{candidateCount === 1 ? '' : 's'}
-          {candidatesSummary && candidatesSummary.sessionsScanned > 0 ? (
-            <>
-              {' '}across <code>{candidatesSummary.sessionsScanned.toLocaleString()}</code> of{' '}
-              <code>{candidatesSummary.sessionsInManifest.toLocaleString()}</code> sessions
-            </>
-          ) : null}
-          . Click <strong>MINE CORRECTIONS</strong> to classify them into patterns — each pattern is a
-          CLAUDE.md / skill / agent fix you can review and APPLY.
-        </p>
-        <p class="today__hero-cta">
-          <button id="action-mine-cta" type="button" class="today__hero-cta-btn">
-            MINE CORRECTIONS →
-          </button>
-          <span class="today__hero-cta-hint">
-            Typically 1–3 minutes depending on candidate count.
-          </span>
-        </p>
-      </section>
-    ) : (
-      <section
-        class={`today__hero${workshopEmpty ? ' today__hero--demo' : ''}`}
-        aria-label={workshopEmpty
-          ? 'Example data — your real WORKSHOP LOOP populates after running /mine-corrections'
-          : undefined}
-      >
-        {workshopEmpty ? (
-          <span class="sr-only">Example data, not your data:</span>
+    {/* ─────────────────────── 1. BRIEF ─────────────────────── */}
+    <section class="today__section today__brief" aria-labelledby="sec-brief">
+      <div class="today__bar">
+        <span class="today__bar-key" id="sec-brief">{SECTIONS[0].key}</span>
+        {SECTIONS[0].sub ? (
+          <span class="today__bar-sub">{SECTIONS[0].sub}</span>
         ) : null}
-        <h2>
-          WORKSHOP LOOP
-          {workshopEmpty ? <span class="demo-badge">DEMO</span> : null}
-        </h2>
-        <div class="today__hero-grid">
-          <div class="today__metric today__metric--big">
-            <span class="today__metric-label">to APPLY</span>
-            <span class="today__metric-value">{wsView.unappliedPatternCount}</span>
-            <span class="today__metric-sub">new patterns waiting for review</span>
-          </div>
-          <div class="today__metric">
-            <span class="today__metric-label">applied total</span>
-            <span class="today__metric-value">{wsView.appliedPatternCount}</span>
-            <span class="today__metric-sub">CLAUDE.md / skill patches shipped</span>
-          </div>
-          <div class={`today__metric ${wsView.recurringAfterApplyCount > 0 ? 'today__metric--warn' : ''}`}>
-            <span class="today__metric-label">still recurring</span>
-            <span class="today__metric-value">{wsView.recurringAfterApplyCount}</span>
-            <span class="today__metric-sub">
-              {wsView.recurringAfterApplyCount > 0
-                ? 'rules patched but Claude still breaks them'
-                : 'no patched rule recurring'}
-            </span>
-          </div>
-          <div class="today__metric">
-            <span class="today__metric-label">loop closure</span>
-            <span class="today__metric-value">
-              {wsView.loopClosureRate === null
-                ? '—'
-                : `${(wsView.loopClosureRate * 100).toFixed(0)}%`}
-            </span>
-            <span class="today__metric-sub">
-              {wsView.loopClosureRate === null
-                ? 'no observed windows yet'
-                : 'patches that stuck (no recurrence in window)'}
-            </span>
-          </div>
+      </div>
+      {briefEmpty ? (
+        <div class="today__empty-block">
+          <p class="today__empty">
+            No daily brief on disk. The brief synthesizes recent scan
+            output — workshop status, audit deltas, surprises — into a
+            short morning-coffee summary.
+          </p>
+          <p>
+            <button id="action-brief-cta" type="button" class="today__cta-btn">
+              REGEN BRIEF →
+            </button>
+          </p>
         </div>
+      ) : (
+        <article class="today__brief-body">
+          {/* V1 markdown rendering: render the raw markdown inside a
+              <pre> with whitespace preservation. The repo has no
+              markdown lib in the dep tree (verified — no marked /
+              markdown-it / remark) and the user permitted this
+              fallback. Brief content is short (≤ a few KB) so this
+              reads cleanly. */}
+          <pre class="today__brief-md">{brief.markdown}</pre>
+        </article>
+      )}
+    </section>
 
-        {wsView.topUnapplied.length > 0 ? (
-          <div class="today__queue">
-            <h3>NEXT TO REVIEW · top {wsView.topUnapplied.length} by confidence</h3>
-            <ul>
-              {wsView.topUnapplied.map((p) => (
+    {/* ─────────────────────── 2. NEW ─────────────────────── */}
+    <section class="today__section today__new" aria-labelledby="sec-new">
+      <div class="today__bar">
+        <span class="today__bar-key" id="sec-new">{SECTIONS[1].key}</span>
+        <span class="today__bar-sub">{SECTIONS[1].sub}</span>
+      </div>
+      {newEmpty ? (
+        <p class="today__empty">
+          No surprises detected. Surprises arrive after a scan finds
+          positive thresholds-crossings.
+        </p>
+      ) : (
+        <ul class="today__cards">
+          {surprisesNew.map((s) => (
+            <li class={`today__card today__card--${s.kind}`}>
+              <div class="today__card-head">
+                <span class={`today__kind today__kind--${s.tone}`}>
+                  {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                </span>
+                <span class="today__card-score">
+                  score {(s.score * 100).toFixed(0)}
+                </span>
+              </div>
+              <p class="today__card-summary">{s.summary}</p>
+              {s.evidence.sessionIds && s.evidence.sessionIds.length > 0 ? (
+                <p class="today__card-evidence">
+                  <span class="today__card-evlabel">sessions:</span>
+                  {s.evidence.sessionIds.slice(0, 4).map((sid, ix) => (
+                    <>
+                      {ix > 0 ? ' · ' : ' '}
+                      <a href={`/sessions/${sid}`}>{sid.slice(0, 8)}</a>
+                    </>
+                  ))}
+                  {s.evidence.sessionIds.length > 4 ? (
+                    <span> · +{s.evidence.sessionIds.length - 4} more</span>
+                  ) : null}
+                </p>
+              ) : null}
+              {s.evidence.projectId ? (
+                <p class="today__card-evidence">
+                  <span class="today__card-evlabel">project:</span>{' '}
+                  <a href={`/projects/${s.evidence.projectId}`}>
+                    {s.evidence.projectId}
+                  </a>
+                </p>
+              ) : null}
+              {s.evidence.configSha ? (
+                <p class="today__card-evidence">
+                  <span class="today__card-evlabel">config:</span>{' '}
+                  <code>{s.evidence.configSha.slice(0, 7)}</code>
+                </p>
+              ) : null}
+              {s.evidence.decisionId ? (
+                <p class="today__card-evidence">
+                  <span class="today__card-evlabel">decision:</span>{' '}
+                  <code>{s.evidence.decisionId}</code>
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+
+    {/* ─────────────────────── 3. ACT ─────────────────────── */}
+    <section class="today__section today__act" aria-labelledby="sec-act">
+      <div class="today__bar">
+        <span class="today__bar-key" id="sec-act">{SECTIONS[2].key}</span>
+        <span class="today__bar-sub">{SECTIONS[2].sub}</span>
+      </div>
+
+      {/* Corrections to APPLY — preserve the workshop loop signal that
+          previously dominated the hero. Three states: real / just-
+          scanned / unscanned (demo). */}
+      {workshopJustScanned ? (
+        <div class="today__act-block today__act-block--scanned">
+          <p class="today__act-lede">
+            The exporter found{' '}
+            <code>{candidateCount.toLocaleString()}</code> correction candidate{candidateCount === 1 ? '' : 's'}
+            {candidatesSummary && candidatesSummary.sessionsScanned > 0 ? (
+              <>
+                {' '}across <code>{candidatesSummary.sessionsScanned.toLocaleString()}</code> of{' '}
+                <code>{candidatesSummary.sessionsInManifest.toLocaleString()}</code> sessions
+              </>
+            ) : null}
+            . Run <strong>MINE CORRECTIONS</strong> to classify them into
+            patterns you can APPLY.
+          </p>
+          <p>
+            <button id="action-mine-cta" type="button" class="today__cta-btn">
+              MINE CORRECTIONS →
+            </button>
+          </p>
+        </div>
+      ) : workshop.unappliedPatternCount > 0 ? (
+        <div class="today__act-block">
+          <p class="today__act-lede">
+            <code>{workshop.unappliedPatternCount}</code> pattern{workshop.unappliedPatternCount === 1 ? '' : 's'} waiting for review and APPLY.
+          </p>
+          {workshop.topUnapplied.length > 0 ? (
+            <ul class="today__act-list">
+              {workshop.topUnapplied.map((p) => (
                 <li>
                   <span class="today__confidence">
                     {(p.confidence * 100).toFixed(0)}%
@@ -196,93 +298,221 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
                   <span class="today__scope">
                     ({p.occurrenceCount}× · scope={p.scope.kind})
                   </span>
-                  <a href={`/sessions#corrections`}>review →</a>
+                  <a href="/sessions#corrections">review →</a>
                 </li>
               ))}
             </ul>
-          </div>
-        ) : null}
-
-        {wsView.recentApplies.length > 0 ? (
-          <div class="today__applies">
-            <h3>RECENT APPLIES</h3>
-            <ul>
-              {wsView.recentApplies.map((a) => (
-                <li>
-                  <code>{new Date(a.appliedAt).toISOString().slice(0, 10)}</code>
-                  · {a.ruleSummary}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-      </section>
-    )}
-
-    {/* ======================= DRAFTS READY ======================= */}
-    <section class="today__row">
-      <h2>BLOG DRAFTS</h2>
-      {draftsEmpty ? (
+          ) : null}
+        </div>
+      ) : workshopEmpty ? (
         <section
-          class="today__row-demo"
-          aria-label="Example data — your real BLOG DRAFTS populate after the candidate selector emits any"
+          class="today__act-block today__row-demo"
+          aria-label="Example data — your real ACT items populate after MINE CORRECTIONS runs"
         >
           <span class="sr-only">Example data, not your data:</span>
-          <p class="today__row-summary">
+          <p class="today__act-lede">
             <span class="demo-badge">DEMO</span>
-            <a href="/blog-drafts">
-              {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
-            </a>
+            <code>{wsView.unappliedPatternCount}</code> pattern{wsView.unappliedPatternCount === 1 ? '' : 's'} would be waiting for review here once the scan + mine cycle runs.
           </p>
         </section>
       ) : (
-        <p class="today__row-summary">
-          <a href="/blog-drafts">
-            {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
-          </a>
+        <p class="today__empty">
+          No corrections waiting. Every mined pattern is already APPLY'd.
         </p>
       )}
-    </section>
 
-    {/* ======================= AUDIT CONCERNS (demoted) ======================= */}
-    <section class="today__row">
-      <h2>AUDIT CONCERNS · top {concernsView.length}</h2>
-      {concernsEmpty ? (
-        <section
-          class="today__row-demo"
-          aria-label="Example data — your real AUDIT CONCERNS populate after the F-layer verifier runs"
-        >
-          <span class="sr-only">Example data, not your data:</span>
-          <span class="demo-badge">DEMO</span>
-          <ul class="today__concerns">
-            {concernsView.map((c) => (
-              <li>
-                <code class="today__concern-type">{c.claimType}</code>
-                <span class="today__concern-span">claimed "{c.span}"</span>
-                <span class="today__concern-reason">— {c.reason}</span>
-                <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
-              </li>
-            ))}
-          </ul>
-        </section>
+      {/* Curator feed — top-K ranked items the /curate skill emitted. */}
+      <h3 class="today__act-subhead">CURATED FEED · top {curatorFeed?.items.length ?? 0}</h3>
+      {curatorEmpty ? (
+        <div class="today__empty-block">
+          <p class="today__empty">
+            No curated items. Run <strong>CURATE</strong> after a scan
+            to rank narratives and knowledge-debt clusters worth
+            looking at now.
+          </p>
+          <p>
+            <button id="action-curate-cta" type="button" class="today__cta-btn">
+              CURATE →
+            </button>
+          </p>
+        </div>
       ) : (
-        <ul class="today__concerns">
-          {concernsView.map((c) => (
+        <ul class="today__curator-list">
+          {curatorFeed!.items.slice(0, 10).map((item) => (
             <li>
-              <code class="today__concern-type">{c.claimType}</code>
-              <span class="today__concern-span">claimed "{c.span}"</span>
-              <span class="today__concern-reason">— {c.reason}</span>
-              <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
+              <span class="today__curator-rank">#{item.rank}</span>
+              <span class={`today__curator-kind today__curator-kind--${item.kind}`}>
+                {item.kind}
+              </span>
+              <span class="today__curator-title">{item.title}</span>
+              <span class="today__curator-score">
+                {(item.compositeScore * 100).toFixed(0)}
+              </span>
+              {item.falsifierStatus === 'verified' ? (
+                <span class="today__curator-verified">verified</span>
+              ) : null}
             </li>
           ))}
         </ul>
       )}
-      <p class="today__row-summary">
-        <a href="/audit">full audit table →</a>
-      </p>
     </section>
 
-    {/* ======================= CORPUS HEALTH (footer-y) ======================= */}
+    {/* ─────────────────────── 4. BROKEN ─────────────────────── */}
+    <section class="today__section today__broken" aria-labelledby="sec-broken">
+      <div class="today__bar">
+        <span class="today__bar-key" id="sec-broken">{SECTIONS[3].key}</span>
+        <span class="today__bar-sub">{SECTIONS[3].sub}</span>
+      </div>
+
+      {brokenEmpty && concernsEmpty ? (
+        <p class="today__empty">Nothing broken right now.</p>
+      ) : (
+        <>
+          {surprisesBroken.length > 0 ? (
+            <ul class="today__cards">
+              {surprisesBroken.map((s) => (
+                <li class={`today__card today__card--alert today__card--${s.kind}`}>
+                  <div class="today__card-head">
+                    <span class={`today__kind today__kind--${s.tone}`}>
+                      {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                    </span>
+                    <span class="today__card-score">
+                      score {(s.score * 100).toFixed(0)}
+                    </span>
+                  </div>
+                  <p class="today__card-summary">{s.summary}</p>
+                  {s.evidence.projectId ? (
+                    <p class="today__card-evidence">
+                      <span class="today__card-evlabel">project:</span>{' '}
+                      <a href={`/projects/${s.evidence.projectId}`}>
+                        {s.evidence.projectId}
+                      </a>
+                    </p>
+                  ) : null}
+                  {s.evidence.narrativeId ? (
+                    <p class="today__card-evidence">
+                      <span class="today__card-evlabel">narrative:</span>{' '}
+                      <code>{s.evidence.narrativeId}</code>
+                    </p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          {/* AUDIT CONCERNS — preserved from prior page, demoted from a
+              standalone row into the BROKEN section. */}
+          <h3 class="today__broken-subhead">AUDIT CONCERNS · top {concernsView.length}</h3>
+          {concernsEmpty ? (
+            <section
+              class="today__row-demo"
+              aria-label="Example data — your real AUDIT CONCERNS populate after the F-layer verifier runs"
+            >
+              <span class="sr-only">Example data, not your data:</span>
+              <span class="demo-badge">DEMO</span>
+              <ul class="today__concerns">
+                {concernsView.map((c) => (
+                  <li>
+                    <code class="today__concern-type">{c.claimType}</code>
+                    <span class="today__concern-span">claimed "{c.span}"</span>
+                    <span class="today__concern-reason">— {c.reason}</span>
+                    <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : (
+            <ul class="today__concerns">
+              {concernsView.map((c) => (
+                <li>
+                  <code class="today__concern-type">{c.claimType}</code>
+                  <span class="today__concern-span">claimed "{c.span}"</span>
+                  <span class="today__concern-reason">— {c.reason}</span>
+                  <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <p class="today__row-summary">
+            <a href="/audit">full audit table →</a>
+          </p>
+
+          {/* CONTINUUM HEALTH warnings — show only when they exist. */}
+          {health !== null && health.warnings.length > 0 ? (
+            <div class="today__broken-health">
+              <h3 class="today__broken-subhead">CONTINUUM WARNINGS</h3>
+              <ul class="today__concerns">
+                {health.warnings.map((w) => (
+                  <li>
+                    <span class="today__warn">{String(w)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </>
+      )}
+    </section>
+
+    {/* ─────────────────────── 5. STORIES ─────────────────────── */}
+    <section class="today__section today__stories" aria-labelledby="sec-stories">
+      <div class="today__bar">
+        <span class="today__bar-key" id="sec-stories">{SECTIONS[4].key}</span>
+        <span class="today__bar-sub">{SECTIONS[4].sub}</span>
+      </div>
+
+      {storiesEmpty ? (
+        <p class="today__empty">
+          No stories yet. Stories arrive when a scan finds project-level
+          narrative arcs.
+        </p>
+      ) : (
+        <>
+          {recentNarratives.length > 0 ? (
+            <ul class="today__story-list">
+              {recentNarratives.map((n) => (
+                <li>
+                  <span class={`today__story-sentiment today__story-sentiment--${n.sentiment}`}>
+                    {n.sentiment}
+                  </span>
+                  <span class="today__story-title">{n.title}</span>
+                  <a class="today__story-project" href={`/projects/${n.projectId}`}>
+                    {n.projectId}
+                  </a>
+                  <span class="today__story-date">
+                    {n.generatedAt.slice(0, 10)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          <h3 class="today__stories-subhead">BLOG DRAFTS</h3>
+          {draftsEmpty ? (
+            <section
+              class="today__row-demo"
+              aria-label="Example data — your real BLOG DRAFTS populate after the candidate selector emits any"
+            >
+              <span class="sr-only">Example data, not your data:</span>
+              <p class="today__row-summary">
+                <span class="demo-badge">DEMO</span>
+                <a href="/blog-drafts">
+                  {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
+                </a>
+              </p>
+            </section>
+          ) : (
+            <p class="today__row-summary">
+              <a href="/blog-drafts">
+                {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
+              </a>
+            </p>
+          )}
+        </>
+      )}
+    </section>
+
+    {/* ─────────────────────── CORPUS HEALTH (footer-y) ─────────────────────── */}
     <section class="today__row today__row--footer">
       <h2>CORPUS HEALTH</h2>
       {health === null ? (
@@ -301,41 +531,39 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
         </p>
       )}
     </section>
-
-    {brief !== null ? (
-      <details class="today__raw">
-        <summary>raw daily brief markdown</summary>
-        <pre>{brief.markdown}</pre>
-      </details>
-    ) : null}
   </main>
 
-  <script is:inline>
-    // Wire the action buttons against the per-endpoint streams.
-    //
-    // /api/rescan and /api/mine-corrections both return NDJSON
-    // (start / stdout / stderr / phase / done). The mine-corrections
-    // skill additionally writes a status file at
-    //   /chat-arch-data/analysis/correction-status-${requestId}.json
-    // that we poll for stage-level progress (claude -p stdout doesn't
-    // expose internal stages). /api/regen-brief is a fast synchronous
-    // JSON endpoint so we just POST and reload on success.
-    const status = document.getElementById('action-status');
-    const progressEl = document.getElementById('action-progress');
-    const labelEl = document.getElementById('progress-label');
-    const elapsedEl = document.getElementById('progress-elapsed');
-    const phaseEl = document.getElementById('progress-phase');
-    const barEl = document.getElementById('progress-bar');
-    const barFillEl = document.getElementById('progress-bar-fill');
-    const logEl = document.getElementById('progress-log');
+  <script>
+    // Action-button wiring. The original RESCAN / MINE / REGEN paths
+    // stay verbatim (NDJSON streaming for rescan + mine, synchronous
+    // POST for regen-brief). FULL SCAN orchestrates all four
+    // producers sequentially via the fullScan.ts module.
+    import {
+      FULL_SCAN_STEPS,
+      formatStepLabel,
+      runFullScan,
+      type FullScanUi,
+    } from '../scripts/fullScan.ts';
+
+    const status = document.getElementById('action-status') as HTMLElement | null;
+    const progressEl = document.getElementById('action-progress') as HTMLElement | null;
+    const labelEl = document.getElementById('progress-label') as HTMLElement | null;
+    const elapsedEl = document.getElementById('progress-elapsed') as HTMLElement | null;
+    const phaseEl = document.getElementById('progress-phase') as HTMLElement | null;
+    const barEl = document.getElementById('progress-bar') as HTMLElement | null;
+    const barFillEl = document.getElementById('progress-bar-fill') as HTMLElement | null;
+    const logEl = document.getElementById('progress-log') as HTMLElement | null;
     const buttons = [
+      document.getElementById('action-full-scan'),
       document.getElementById('action-rescan'),
       document.getElementById('action-mine'),
       document.getElementById('action-brief'),
+      document.getElementById('action-brief-cta'),
       document.getElementById('action-mine-cta'),
-    ].filter(Boolean);
+      document.getElementById('action-curate-cta'),
+    ].filter((b): b is HTMLButtonElement => b !== null);
 
-    const STAGE_LABELS = {
+    const STAGE_LABELS: Record<string, string> = {
       starting: 'starting',
       classifying: 'classifying candidates',
       'ingesting-configs': 'ingesting config history',
@@ -343,32 +571,33 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       clustering: 'clustering corrections',
       proposing: 'proposing upgrades',
       'tagging-topics': 'tagging topics',
-      writing: 'writing corrections.json',
+      writing: 'writing output',
       complete: 'complete',
       error: 'error',
     };
 
-    let elapsedTimer = null;
-    let statusPollTimer = null;
+    let elapsedTimer: number | null = null;
+    let statusPollTimer: number | null = null;
 
-    function setStatus(text, isError) {
+    function setStatus(text: string, isError: boolean): void {
       if (!status) return;
       status.textContent = text;
       status.style.color = isError ? '#f08080' : '#88e088';
     }
 
-    function setButtonsDisabled(disabled) {
+    function setButtonsDisabled(disabled: boolean): void {
       for (const b of buttons) b.disabled = disabled;
     }
 
-    function formatElapsed(startedAt) {
+    function formatElapsed(startedAt: number): string {
       const sec = Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
       const m = Math.floor(sec / 60);
       const s = sec % 60;
       return `${m}:${s.toString().padStart(2, '0')} elapsed`;
     }
 
-    function showProgress(label) {
+    function showProgress(label: string): void {
+      if (!progressEl || !labelEl || !phaseEl || !barEl || !logEl || !elapsedEl) return;
       progressEl.hidden = false;
       labelEl.textContent = label;
       phaseEl.textContent = '';
@@ -379,8 +608,8 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       setStatus('', false);
     }
 
-    function hideProgress() {
-      progressEl.hidden = true;
+    function hideProgress(): void {
+      if (progressEl) progressEl.hidden = true;
       if (elapsedTimer !== null) {
         clearInterval(elapsedTimer);
         elapsedTimer = null;
@@ -391,16 +620,18 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       }
     }
 
-    function startElapsedTicker(startedAt) {
+    function startElapsedTicker(startedAt: number): void {
+      if (!elapsedEl) return;
       if (elapsedTimer !== null) clearInterval(elapsedTimer);
       elapsedEl.textContent = formatElapsed(startedAt);
-      elapsedTimer = setInterval(() => {
-        elapsedEl.textContent = formatElapsed(startedAt);
+      elapsedTimer = window.setInterval(() => {
+        if (elapsedEl) elapsedEl.textContent = formatElapsed(startedAt);
       }, 1000);
     }
 
-    function setPhase(phase, current, total) {
-      const friendly = STAGE_LABELS[phase] || phase;
+    function setPhase(phase: string, current?: number, total?: number): void {
+      if (!phaseEl || !barEl || !barFillEl) return;
+      const friendly = STAGE_LABELS[phase] ?? phase;
       let line = `· ${friendly}`;
       if (typeof current === 'number' && typeof total === 'number' && total > 0) {
         line += ` (${current}/${total})`;
@@ -410,32 +641,36 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       phaseEl.textContent = line;
     }
 
-    function appendLog(line) {
+    function appendLog(line: string): void {
+      if (!logEl) return;
       const trimmed = line.trim();
       if (trimmed.length === 0) return;
       logEl.hidden = false;
       // Keep last 6 lines only — this region is a heartbeat, not a transcript.
-      const next = (logEl.textContent + '\n' + trimmed)
+      const next = ((logEl.textContent ?? '') + '\n' + trimmed)
         .split('\n')
         .filter((l) => l.length > 0);
       logEl.textContent = next.slice(-6).join('\n');
     }
 
-    function reloadSoon() {
+    function reloadSoon(): void {
       // Brief delay so "complete" is visible before the page refreshes.
-      setTimeout(() => window.location.reload(), 800);
+      window.setTimeout(() => window.location.reload(), 800);
     }
 
-    async function pollMineStatus(requestId) {
+    async function pollMineStatus(requestId: string): Promise<void> {
       try {
         const res = await fetch(
           `/chat-arch-data/analysis/correction-status-${requestId}.json`,
           { cache: 'no-store' },
         );
         if (!res.ok) return;
-        const body = await res.json();
+        const body = (await res.json()) as {
+          status?: string;
+          progress?: { current?: number; total?: number; phase?: string };
+        };
         if (body && typeof body.status === 'string') {
-          const p = body.progress || {};
+          const p = body.progress ?? {};
           setPhase(body.status, p.current, p.total);
           if (typeof p.phase === 'string' && p.phase.length > 0) {
             appendLog(`[${body.status}] ${p.phase}`);
@@ -447,14 +682,26 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       }
     }
 
-    async function streamNdjson(url, header, label, opts) {
-      const { onStart, onPhase, onLine, onDone } = opts || {};
+    interface StreamOpts {
+      onStart?: (evt: Record<string, unknown>) => void;
+      onPhase?: (evt: Record<string, unknown>) => void;
+      onLine?: (evt: Record<string, unknown>) => void;
+      onDone?: (evt: Record<string, unknown>) => void;
+    }
+
+    async function streamNdjson(
+      url: string,
+      header: string,
+      label: string,
+      opts: StreamOpts,
+    ): Promise<void> {
+      const { onStart, onPhase, onLine, onDone } = opts;
       showProgress(label);
       setButtonsDisabled(true);
       const startedAt = Date.now();
       startElapsedTicker(startedAt);
 
-      let res;
+      let res: Response;
       try {
         res = await fetch(url, {
           method: 'POST',
@@ -464,7 +711,7 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       } catch (err) {
         hideProgress();
         setButtonsDisabled(false);
-        setStatus(`${label} failed: ${(err && err.message) || err}`, true);
+        setStatus(`${label} failed: ${(err as Error).message ?? String(err)}`, true);
         return;
       }
 
@@ -486,7 +733,7 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
       let buf = '';
-      let terminalOk = null;
+      let terminalOk: boolean | null = null;
       let terminalErr = '';
 
       try {
@@ -499,20 +746,26 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
           for (const raw of parts) {
             const line = raw.trim();
             if (line.length === 0) continue;
-            let evt;
-            try { evt = JSON.parse(line); } catch { continue; }
+            let evt: Record<string, unknown>;
+            try {
+              evt = JSON.parse(line) as Record<string, unknown>;
+            } catch {
+              continue;
+            }
             if (evt.type === 'start') {
               if (onStart) onStart(evt);
             } else if (evt.type === 'phase') {
               if (onPhase) onPhase(evt);
-              else setPhase(evt.phase, evt.ix, evt.total);
+              else setPhase(String(evt.phase), evt.ix as number, evt.total as number);
             } else if (evt.type === 'stdout' || evt.type === 'stderr') {
               if (onLine) onLine(evt);
-              else appendLog(evt.line);
+              else appendLog(String(evt.line ?? ''));
             } else if (evt.type === 'done') {
               terminalOk = evt.ok === true;
               if (!terminalOk) {
-                terminalErr = (evt.stderrTail || evt.stdoutTail || '').trim().slice(-400);
+                terminalErr = String(evt.stderrTail ?? evt.stdoutTail ?? '')
+                  .trim()
+                  .slice(-400);
               }
               if (onDone) onDone(evt);
             }
@@ -521,7 +774,7 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       } catch (err) {
         hideProgress();
         setButtonsDisabled(false);
-        setStatus(`${label} stream broke: ${(err && err.message) || err}`, true);
+        setStatus(`${label} stream broke: ${(err as Error).message ?? String(err)}`, true);
         return;
       }
 
@@ -537,7 +790,7 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       }
     }
 
-    async function runMine() {
+    async function runMine(): Promise<void> {
       await streamNdjson(
         '/api/mine-corrections',
         'chat-arch-mine-corrections',
@@ -547,12 +800,20 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
             // The headless claude -p stream is mostly silent; the
             // skill's status file is the real progress source.
             if (statusPollTimer !== null) clearInterval(statusPollTimer);
-            pollMineStatus(evt.requestId);
-            statusPollTimer = setInterval(() => pollMineStatus(evt.requestId), 1500);
-            if (evt.autoWindow && typeof evt.autoWindow.candidateCount === 'number') {
-              const w = evt.autoWindow;
+            const requestId = String(evt.requestId ?? '');
+            if (requestId.length > 0) {
+              void pollMineStatus(requestId);
+              statusPollTimer = window.setInterval(
+                () => void pollMineStatus(requestId),
+                1500,
+              );
+            }
+            const aw = evt.autoWindow as
+              | { mode?: string; candidateCount?: number; windowDays?: number }
+              | undefined;
+            if (aw && typeof aw.candidateCount === 'number') {
               appendLog(
-                `auto-window: ${w.mode} · ${w.candidateCount} candidate${w.candidateCount === 1 ? '' : 's'} · ~${w.windowDays} day${w.windowDays === 1 ? '' : 's'}`,
+                `auto-window: ${aw.mode} · ${aw.candidateCount} candidate${aw.candidateCount === 1 ? '' : 's'} · ~${aw.windowDays} day${aw.windowDays === 1 ? '' : 's'}`,
               );
             }
           },
@@ -560,11 +821,11 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       );
     }
 
-    async function runRescan() {
+    async function runRescan(): Promise<void> {
       await streamNdjson('/api/rescan', 'chat-arch-rescan', 'rescan', {});
     }
 
-    async function runRegenBrief() {
+    async function runRegenBrief(): Promise<void> {
       showProgress('regen brief');
       setButtonsDisabled(true);
       const startedAt = Date.now();
@@ -590,83 +851,127 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
       } catch (err) {
         hideProgress();
         setButtonsDisabled(false);
-        setStatus(`regen brief failed: ${(err && err.message) || err}`, true);
+        setStatus(`regen brief failed: ${(err as Error).message ?? String(err)}`, true);
       }
     }
 
+    async function runCurate(): Promise<void> {
+      await streamNdjson('/api/curate', 'chat-arch-curate', 'curate', {});
+    }
+
+    async function runFullScanFlow(): Promise<void> {
+      const total = FULL_SCAN_STEPS.length;
+      showProgress(`STEP 1 OF ${total}: ${FULL_SCAN_STEPS[0]!.label}`);
+      setButtonsDisabled(true);
+      const startedAt = Date.now();
+      startElapsedTicker(startedAt);
+
+      const ui: FullScanUi = {
+        onStepStart(stepIx, totalSteps, step) {
+          if (labelEl) labelEl.textContent = formatStepLabel(stepIx, totalSteps, step);
+          if (phaseEl) phaseEl.textContent = '';
+          // Reset per-step progress bar — each producer has its own
+          // (ix/total) range and we don't want stale fill carrying over.
+          if (barEl) barEl.hidden = true;
+          if (barFillEl) barFillEl.style.width = '0%';
+          appendLog(`▶ ${step.label}`);
+        },
+        onPhase(_step, phase, current, total) {
+          setPhase(phase, current, total);
+        },
+        onLine(_step, _kind, line) {
+          appendLog(line);
+        },
+        onStepDone(step, ok, errSummary) {
+          if (ok) {
+            appendLog(`✓ ${step.label}`);
+          } else {
+            appendLog(`✗ ${step.label}${errSummary ? ': ' + errSummary : ''}`);
+          }
+        },
+        onChainDone(success, lastError) {
+          if (success) {
+            setPhase('complete');
+            setStatus('FULL SCAN complete — refreshing…', false);
+            hideProgress();
+            reloadSoon();
+          } else {
+            hideProgress();
+            setButtonsDisabled(false);
+            setStatus(`FULL SCAN failed: ${lastError ?? 'unknown'}`, true);
+          }
+        },
+      };
+
+      await runFullScan(ui);
+    }
+
+    document.getElementById('action-full-scan')?.addEventListener('click', () => {
+      void runFullScanFlow();
+    });
     document.getElementById('action-rescan')?.addEventListener('click', () => { void runRescan(); });
     document.getElementById('action-mine')?.addEventListener('click', () => { void runMine(); });
-    // In-hero CTA on the scanned-but-not-mined state shares the handler.
+    // In-section CTAs share handlers with their header twins.
     document.getElementById('action-mine-cta')?.addEventListener('click', () => { void runMine(); });
+    document.getElementById('action-curate-cta')?.addEventListener('click', () => { void runCurate(); });
     document.getElementById('action-brief')?.addEventListener('click', () => { void runRegenBrief(); });
+    document.getElementById('action-brief-cta')?.addEventListener('click', () => { void runRegenBrief(); });
 
     // On page load, if a mining run is already in flight from a prior
     // tab/session, attach to its status file so the user sees live
-    // progress instead of a stale UI. We can't re-attach to the
-    // original POST's stream from a new connection, but the status
-    // file gives us everything that matters.
-    //
-    // XN3 refactor: named function with an explicit `deps` object
-    // (rather than the previous IIFE closing over module-scope state).
-    // Dependencies are surfaced in one place so a future Vite-bundled
-    // module extraction can lift this verbatim. The function is still
-    // invoked once at module-load time below.
-    async function attachIfBusy(deps) {
+    // progress instead of a stale UI.
+    async function attachIfBusy(): Promise<void> {
       try {
         const res = await fetch('/api/mine-corrections', { method: 'GET' });
         if (!res.ok) return;
-        const body = await res.json();
+        const body = (await res.json()) as {
+          busy?: boolean;
+          busyRequestId?: string;
+        };
         if (body && body.busy === true && typeof body.busyRequestId === 'string') {
-          deps.showProgress('mine corrections (resumed)');
-          deps.setButtonsDisabled(true);
-          deps.startElapsedTicker(Date.now());
+          showProgress('mine corrections (resumed)');
+          setButtonsDisabled(true);
+          startElapsedTicker(Date.now());
           const requestId = body.busyRequestId;
-          await deps.pollMineStatus(requestId);
-          deps.setStatusPollTimer(setInterval(async () => {
-            await deps.pollMineStatus(requestId);
-            // When the status file flips to complete/error, refresh.
+          await pollMineStatus(requestId);
+          statusPollTimer = window.setInterval(async () => {
+            await pollMineStatus(requestId);
             try {
-              const r = await fetch(`/chat-arch-data/analysis/correction-status-${requestId}.json`, { cache: 'no-store' });
+              const r = await fetch(
+                `/chat-arch-data/analysis/correction-status-${requestId}.json`,
+                { cache: 'no-store' },
+              );
               if (!r.ok) return;
-              const s = await r.json();
+              const s = (await r.json()) as { status?: string; error?: string };
               if (s && (s.status === 'complete' || s.status === 'error')) {
-                deps.clearStatusPollTimer();
+                if (statusPollTimer !== null) {
+                  clearInterval(statusPollTimer);
+                  statusPollTimer = null;
+                }
                 if (s.status === 'complete') {
-                  deps.setStatus('mine corrections complete — refreshing…', false);
-                  deps.hideProgress();
-                  deps.reloadSoon();
+                  setStatus('mine corrections complete — refreshing…', false);
+                  hideProgress();
+                  reloadSoon();
                 } else {
-                  deps.hideProgress();
-                  deps.setButtonsDisabled(false);
-                  deps.setStatus(`mine corrections failed${s.error ? ': ' + String(s.error).slice(0, 200) : ''}`, true);
+                  hideProgress();
+                  setButtonsDisabled(false);
+                  setStatus(
+                    `mine corrections failed${s.error ? ': ' + String(s.error).slice(0, 200) : ''}`,
+                    true,
+                  );
                 }
               }
             } catch {
               // Transient — keep polling.
             }
-          }, 1500));
+          }, 1500);
         }
       } catch {
         // No backend / network error — silently skip the attach.
       }
     }
 
-    void attachIfBusy({
-      showProgress,
-      setButtonsDisabled,
-      startElapsedTicker,
-      pollMineStatus,
-      setStatus,
-      hideProgress,
-      reloadSoon,
-      setStatusPollTimer: (handle) => { statusPollTimer = handle; },
-      clearStatusPollTimer: () => {
-        if (statusPollTimer !== null) {
-          clearInterval(statusPollTimer);
-          statusPollTimer = null;
-        }
-      },
-    });
+    void attachIfBusy();
   </script>
 </BaseLayout>
 
@@ -693,12 +998,26 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
     background: #FFCC9911; padding: 2px 8px; border-radius: 3px;
     font-family: 'JetBrains Mono', monospace; font-size: 11px;
   }
-  .today__actions { display: flex; gap: 12px; align-items: center; margin-bottom: 32px; }
+  .today__actions {
+    display: flex; gap: 12px; align-items: center; margin-bottom: 32px;
+    flex-wrap: wrap;
+  }
   .today__actions button {
     background: #FFCC99; color: #0a0a0a; border: none; padding: 8px 16px;
     font-family: 'Antonio', sans-serif; letter-spacing: 0.08em; font-size: 12px;
     cursor: pointer; border-radius: 2px;
   }
+  /* FULL SCAN — sunflower-gold primary, larger pad. Visual hierarchy
+     says "this is the everything button"; the other three remain
+     available as escape hatches. */
+  .today__btn-primary {
+    background: #FFCC33 !important;
+    color: #0a0a0a;
+    padding: 10px 22px !important;
+    font-size: 13px !important;
+    font-weight: 700;
+  }
+  .today__btn-primary:hover { background: #ffdb5c !important; }
   .today__actions button:hover { background: #ffd680; }
   .today__actions button:disabled {
     opacity: 0.5;
@@ -761,52 +1080,157 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
     overflow-y: auto;
   }
 
-  .today__hero {
-    border: 1px solid #FFCC9944;
-    background: linear-gradient(180deg, #0a0a0a, #050505);
-    padding: 24px;
-    border-radius: 4px;
-    margin-bottom: 32px;
+  /* ─── Section scaffolding ──────────────────────────────────────── */
+  .today__section { margin-bottom: 32px; }
+  /* LCARS mid-bar — the key + sub on a thin sunflower-gold bar.
+     Each section opens with one so the page reads as a stack of
+     feed cards rather than one continuous wall of text. */
+  .today__bar {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    padding: 4px 12px;
+    margin: 0 0 12px;
+    background: linear-gradient(90deg, rgba(255, 204, 153, 0.18) 0%, rgba(255, 204, 153, 0.03) 70%, rgba(255, 204, 153, 0) 100%);
+    border-left: 3px solid #FFCC99;
+    border-radius: 2px;
   }
-  /* Demo modifier on the WHOLE hero section — the peach left-rule +
-     subtle horizontal tint mirror the .today__hero-demo / .today__row-demo
-     treatment defined in BaseLayout, but layered ON TOP of the hero's
-     dark vertical gradient (two stacked backgrounds) so the section
-     keeps its dark fill instead of being replaced by a peach wash. */
-  .today__hero--demo {
-    padding-left: 12px;
-    border-left: 3px solid rgba(255, 153, 51, 0.55);
-    background:
-      linear-gradient(90deg, rgba(255, 153, 51, 0.06) 0%, rgba(255, 153, 51, 0) 60%),
-      linear-gradient(180deg, #0a0a0a, #050505);
+  .today__bar-key {
+    font-family: 'Antonio', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    font-size: 16px;
+    color: #FFCC99;
   }
-  /* Scanned-but-not-mined modifier. Different cue from --demo (which
-     warns "fake values"): a sunflower-gold left-rule + tint signals
-     "real data, action required" — the visual conveys "you're in the
-     loop, your next move is MINE." Mirrors the demo's two-gradient
-     layering so the hero keeps its dark fill. */
-  .today__hero--scanned {
-    padding-left: 12px;
-    border-left: 3px solid rgba(255, 204, 153, 0.6);
-    background:
-      linear-gradient(90deg, rgba(255, 204, 153, 0.05) 0%, rgba(255, 204, 153, 0) 60%),
-      linear-gradient(180deg, #0a0a0a, #050505);
-  }
-  .today__hero-status {
+  .today__bar-sub {
     font-family: 'JetBrains Mono', monospace;
     font-size: 11px;
-    color: #FFCC99cc;
+    color: #FFCC9999;
+  }
+
+  .today__empty { color: #FFCC99cc; font-size: 13px; line-height: 1.6; margin: 8px 0; }
+  .today__empty code { background: #FFCC9911; padding: 1px 6px; border-radius: 2px; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+  .today__empty-block { padding: 12px 0; }
+  .today__cta-btn {
+    background: #FFCC99;
+    color: #0a0a0a;
+    border: none;
+    padding: 8px 16px;
+    font-family: 'Antonio', sans-serif;
     letter-spacing: 0.08em;
-    margin-left: 8px;
-    font-weight: normal;
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    border-radius: 2px;
+    margin-top: 8px;
   }
-  .today__hero-lede {
-    font-size: 13px;
-    line-height: 1.6;
+  .today__cta-btn:hover { background: #ffd680; }
+
+  /* ─── 1. BRIEF ─────────────────────────────────────────────────── */
+  .today__brief-body { margin: 0; }
+  /* Markdown rendered as monospace pre — V1 fallback per task spec
+     (no markdown lib in dep tree). Inherits .today__progress-log's
+     dark surface for visual consistency with the other "raw text"
+     regions. */
+  .today__brief-md {
+    margin: 0;
+    padding: 16px 18px;
+    background: #0a0a0a;
+    border: 1px solid #FFCC9933;
+    border-left: 3px solid #FFCC99cc;
+    border-radius: 3px;
     color: #FFCC99cc;
-    margin: 0 0 16px;
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 12px;
+    line-height: 1.65;
+    white-space: pre-wrap;
+    overflow-x: auto;
+    max-height: 480px;
+    overflow-y: auto;
   }
-  .today__hero-lede code {
+
+  /* ─── 2. NEW / 4. BROKEN cards (shared) ────────────────────────── */
+  .today__cards {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 12px;
+  }
+  .today__card {
+    background: #0a0a0a;
+    border: 1px solid #FFCC9933;
+    border-left: 3px solid #FFCC99;
+    border-radius: 3px;
+    padding: 12px 14px;
+  }
+  .today__card--alert {
+    border-left-color: #ff9933;
+  }
+  .today__card-head {
+    display: flex; align-items: baseline; justify-content: space-between;
+    gap: 8px; margin-bottom: 6px;
+  }
+  .today__kind {
+    display: inline-block;
+    font-family: 'Antonio', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    padding: 2px 8px;
+    border-radius: 2px;
+    background: #FFCC99;
+    color: #0a0a0a;
+    font-weight: 700;
+  }
+  .today__kind--concerning {
+    background: #ff9933;
+  }
+  .today__card-score {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    color: #FFCC9999;
+  }
+  .today__card-summary {
+    margin: 4px 0 8px;
+    color: #FFCC99;
+    font-size: 13px;
+    line-height: 1.45;
+  }
+  .today__card-evidence {
+    margin: 2px 0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    color: #FFCC9999;
+  }
+  .today__card-evidence a {
+    color: #FFCC99;
+    text-decoration: none;
+    border-bottom: 1px dashed #FFCC9955;
+  }
+  .today__card-evidence code {
+    background: #FFCC9911;
+    padding: 1px 5px;
+    border-radius: 2px;
+  }
+  .today__card-evlabel {
+    color: #FFCC9966;
+    margin-right: 4px;
+  }
+
+  /* ─── 3. ACT ──────────────────────────────────────────────────── */
+  .today__act-block { margin-bottom: 16px; padding: 8px 0; }
+  .today__act-block--scanned {
+    padding-left: 12px;
+    border-left: 3px solid rgba(255, 204, 153, 0.55);
+  }
+  .today__act-lede {
+    margin: 0 0 8px;
+    color: #FFCC99cc;
+    font-size: 13px;
+    line-height: 1.55;
+  }
+  .today__act-lede code {
     background: #FFCC9911;
     padding: 1px 6px;
     border-radius: 2px;
@@ -814,83 +1238,125 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
     font-size: 12px;
     color: #FFCC99;
   }
-  .today__hero-lede strong {
-    color: #FFCC99;
-    font-weight: 700;
+  .today__act-list {
+    list-style: none; padding: 0; margin: 8px 0 0;
+    font-family: 'JetBrains Mono', monospace; font-size: 12px;
   }
-  .today__hero-cta {
-    display: flex;
-    align-items: center;
-    gap: 16px;
-    margin: 0;
-    flex-wrap: wrap;
+  .today__act-list li {
+    padding: 6px 0;
+    border-bottom: 1px solid #FFCC9922;
+    display: flex; align-items: baseline; gap: 10px;
   }
-  .today__hero-cta-btn {
-    background: #FFCC99;
-    color: #0a0a0a;
-    border: none;
-    padding: 10px 20px;
-    font-family: 'Antonio', sans-serif;
-    letter-spacing: 0.1em;
-    font-size: 13px;
-    font-weight: 700;
-    cursor: pointer;
-    border-radius: 2px;
-  }
-  .today__hero-cta-btn:hover {
-    background: #ffd680;
-  }
-  .today__hero-cta-hint {
-    font-size: 11px;
-    color: #FFCC9999;
-    font-style: italic;
-  }
-  .today__hero h2 {
-    font-family: 'Antonio', sans-serif; letter-spacing: 0.12em;
-    font-size: 14px; color: #FFCC99; margin: 0 0 16px;
-  }
-  .today__hero-grid {
-    display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 16px; margin-bottom: 24px;
-  }
-  .today__metric {
-    background: #0a0a0a; border: 1px solid #FFCC9933; padding: 16px;
-    border-radius: 3px; display: flex; flex-direction: column;
-  }
-  .today__metric--big { border-color: #FFCC9988; }
-  .today__metric--warn { border-color: #ffaa3388; }
-  .today__metric--warn .today__metric-value { color: #ffd680; }
-  .today__metric-label { font-size: 11px; color: #FFCC9999; letter-spacing: 0.08em; }
-  .today__metric-value {
-    font-family: 'Antonio', sans-serif; font-size: 36px; line-height: 1.1;
-    margin: 6px 0; color: #FFCC99;
-  }
-  .today__metric-sub { font-size: 11px; color: #FFCC9999; }
-
-  .today__empty { color: #FFCC99cc; font-size: 14px; line-height: 1.6; }
-  .today__empty code { background: #FFCC9911; padding: 1px 6px; border-radius: 2px; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
-  .today__empty-note { font-size: 12px; color: #FFCC9999; font-style: italic; margin-top: 12px; }
-
-  .today__queue, .today__applies { margin-top: 16px; }
-  .today__queue h3, .today__applies h3 {
-    font-family: 'Antonio', sans-serif; font-size: 12px; letter-spacing: 0.1em;
-    color: #FFCC9999; margin: 0 0 8px;
-  }
-  .today__queue ul, .today__applies ul {
-    list-style: none; padding: 0; margin: 0; font-family: 'JetBrains Mono', monospace; font-size: 12px;
-  }
-  .today__queue li {
-    padding: 6px 0; border-bottom: 1px solid #FFCC9922;
-    display: flex; align-items: baseline; gap: 12px;
-  }
-  .today__queue li:last-child { border-bottom: none; }
+  .today__act-list li:last-child { border-bottom: none; }
   .today__confidence { color: #FFCC99; font-weight: 600; min-width: 40px; }
   .today__rule { flex: 1; color: #FFCC99cc; }
   .today__scope { color: #FFCC9999; font-size: 11px; }
-  .today__queue a { color: #FFCC99; text-decoration: none; border-bottom: 1px dashed #FFCC9955; }
-  .today__applies li { padding: 4px 0; color: #FFCC99cc; }
-  .today__applies code { color: #FFCC9999; }
+  .today__act-list a { color: #FFCC99; text-decoration: none; border-bottom: 1px dashed #FFCC9955; }
 
+  .today__act-subhead, .today__broken-subhead, .today__stories-subhead {
+    font-family: 'Antonio', sans-serif;
+    font-size: 11px;
+    letter-spacing: 0.12em;
+    color: #FFCC9999;
+    margin: 18px 0 8px;
+  }
+
+  .today__curator-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+  }
+  .today__curator-list li {
+    padding: 6px 0;
+    border-bottom: 1px solid #FFCC9922;
+    display: flex; align-items: baseline; gap: 10px;
+  }
+  .today__curator-list li:last-child { border-bottom: none; }
+  .today__curator-rank {
+    color: #FFCC9966; min-width: 30px; font-size: 11px;
+  }
+  .today__curator-kind {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 2px;
+    background: #FFCC9922;
+    color: #FFCC99cc;
+    letter-spacing: 0.04em;
+    min-width: 60px;
+    text-align: center;
+  }
+  .today__curator-title {
+    flex: 1;
+    color: #FFCC99;
+  }
+  .today__curator-score {
+    color: #FFCC9999;
+    font-size: 11px;
+  }
+  .today__curator-verified {
+    color: #88e088;
+    font-size: 10px;
+    letter-spacing: 0.06em;
+  }
+
+  /* ─── 4. BROKEN extras ─────────────────────────────────────────── */
+  .today__concerns { list-style: none; padding: 0; margin: 0; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
+  .today__concerns li { padding: 4px 0; color: #FFCC99cc; display: flex; flex-wrap: wrap; gap: 6px; align-items: baseline; }
+  .today__concern-type { color: #ffd680; font-size: 11px; }
+  .today__concern-span { color: #FFCC99; }
+  .today__concern-reason { color: #FFCC9999; }
+  .today__concern-sid { color: #FFCC9966; font-size: 11px; }
+  .today__warn { color: #ff9933; }
+  .today__broken-health { margin-top: 16px; }
+
+  /* ─── 5. STORIES ──────────────────────────────────────────────── */
+  .today__story-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+  }
+  .today__story-list li {
+    padding: 6px 0;
+    border-bottom: 1px solid #FFCC9922;
+    display: flex; align-items: baseline; gap: 10px;
+  }
+  .today__story-list li:last-child { border-bottom: none; }
+  .today__story-sentiment {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 2px;
+    letter-spacing: 0.06em;
+    min-width: 60px;
+    text-align: center;
+  }
+  .today__story-sentiment--positive {
+    background: #FFCC99; color: #0a0a0a;
+  }
+  .today__story-sentiment--negative {
+    background: #ff9933; color: #0a0a0a;
+  }
+  .today__story-sentiment--neutral {
+    background: #FFCC9922; color: #FFCC9999;
+  }
+  .today__story-title {
+    flex: 1;
+    color: #FFCC99;
+  }
+  .today__story-project {
+    color: #FFCC99cc;
+    text-decoration: none;
+    border-bottom: 1px dashed #FFCC9955;
+  }
+  .today__story-date {
+    color: #FFCC9966;
+    font-size: 11px;
+  }
+
+  /* ─── footer corpus-health row (preserved) ─────────────────────── */
   .today__row { margin-bottom: 28px; }
   .today__row--footer { margin-top: 16px; padding-top: 16px; border-top: 1px dashed #FFCC9933; }
   .today__row h2 {
@@ -898,23 +1364,6 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
     color: #FFCC99; margin: 0 0 8px;
   }
   .today__row code { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: #FFCC99; }
-  .today__row-empty { color: #FFCC9999; font-size: 13px; }
   .today__row-summary { font-size: 13px; }
   .today__row-summary a { color: #FFCC99; text-decoration: none; border-bottom: 1px dashed #FFCC9955; }
-
-  .today__concerns { list-style: none; padding: 0; margin: 0; font-family: 'JetBrains Mono', monospace; font-size: 12px; }
-  .today__concerns li { padding: 4px 0; color: #FFCC99cc; display: flex; flex-wrap: wrap; gap: 6px; align-items: baseline; }
-  .today__concern-type { color: #ffd680; font-size: 11px; }
-  .today__concern-span { color: #FFCC99; }
-  .today__concern-reason { color: #FFCC9999; }
-  .today__concern-sid { color: #FFCC9966; font-size: 11px; }
-  .today__warn { color: #ffd680; }
-
-  .today__raw { margin-top: 32px; font-size: 12px; color: #FFCC9999; }
-  .today__raw summary { cursor: pointer; padding: 6px 0; font-family: 'Antonio', sans-serif; letter-spacing: 0.1em; }
-  .today__raw pre {
-    background: #0a0a0a; border: 1px solid #FFCC9922; padding: 12px 16px;
-    margin-top: 8px; border-radius: 3px; font-family: 'JetBrains Mono', monospace;
-    font-size: 12px; line-height: 1.6; overflow-x: auto; white-space: pre-wrap;
-  }
 </style>

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -31,6 +31,10 @@ import {
 } from '../lib/readSidecars.ts';
 import {
   makeDemoBlogDraftSlugs,
+  makeDemoCuratorFeed,
+  makeDemoLatestBrief,
+  makeDemoRecentNarratives,
+  makeDemoSurprises,
   makeDemoTopAuditConcerns,
   makeDemoWorkshopStatus,
 } from '../lib/demoFixtures.ts';
@@ -81,6 +85,27 @@ const brokenEmpty =
   concerns.length === 0 &&
   (health === null || health.warnings.length === 0);
 const storiesEmpty = recentNarratives.length === 0 && drafts.length === 0;
+const narrativesEmpty = recentNarratives.length === 0;
+
+// Phase β review-loop iter-1 fix: the four new FEED sections (BRIEF /
+// NEW / curated ACT / STORIES narratives) had no demo fixtures on the
+// hosted build. Without them, chat-arch.dev rendered four empty-state
+// copy blocks across the redesigned page — exactly the prose-fallback
+// the positioning principle (memory: feedback_positioning_by_features)
+// is meant to prevent. Each `…View` below swaps in a deterministic
+// fixture when the real sidecar is empty.
+const briefView = briefEmpty ? makeDemoLatestBrief() : brief;
+const demoSurprisesFile = newEmpty || brokenEmpty ? makeDemoSurprises() : null;
+const surprisesNewView = newEmpty
+  ? pickSurprises(demoSurprisesFile, 'positive', 5)
+  : surprisesNew;
+const surprisesBrokenView = brokenEmpty
+  ? pickSurprises(demoSurprisesFile, 'concerning', 5)
+  : surprisesBroken;
+const curatorView = curatorEmpty ? makeDemoCuratorFeed() : curatorFeed!;
+const narrativesView = narrativesEmpty
+  ? makeDemoRecentNarratives()
+  : recentNarratives;
 
 // SectionBar label rendering helper — keeps every section's heading
 // consistent without hand-rolling the same markup five times.
@@ -163,18 +188,22 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
         ) : null}
       </div>
       {briefEmpty ? (
-        <div class="today__empty-block">
-          <p class="today__empty">
-            No daily brief on disk. The brief synthesizes recent scan
-            output — workshop status, audit deltas, surprises — into a
-            short morning-coffee summary.
-          </p>
-          <p>
+        <section
+          class="today__row-demo"
+          aria-label="Example data — your real BRIEF populates after REGEN BRIEF runs"
+        >
+          <span class="sr-only">Example data, not your data:</span>
+          <p class="today__act-lede">
+            <span class="demo-badge">DEMO</span>
+            preview of the daily brief shape ·{' '}
             <button id="action-brief-cta" type="button" class="today__cta-btn">
               REGEN BRIEF →
             </button>
           </p>
-        </div>
+          <article class="today__brief-body">
+            <pre class="today__brief-md">{briefView!.markdown}</pre>
+          </article>
+        </section>
       ) : (
         <article class="today__brief-body">
           {/* V1 markdown rendering: render the raw markdown inside a
@@ -183,7 +212,7 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
               markdown-it / remark) and the user permitted this
               fallback. Brief content is short (≤ a few KB) so this
               reads cleanly. */}
-          <pre class="today__brief-md">{brief.markdown}</pre>
+          <pre class="today__brief-md">{briefView!.markdown}</pre>
         </article>
       )}
     </section>
@@ -195,13 +224,59 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
         <span class="today__bar-sub">{SECTIONS[1].sub}</span>
       </div>
       {newEmpty ? (
-        <p class="today__empty">
-          No surprises detected. Surprises arrive after a scan finds
-          positive thresholds-crossings.
-        </p>
+        <section
+          class="today__row-demo"
+          aria-label="Example data — your real NEW surprises populate after FULL SCAN runs"
+        >
+          <span class="sr-only">Example data, not your data:</span>
+          <p class="today__act-lede">
+            <span class="demo-badge">DEMO</span>
+            preview of positive surprises this kernel surfaces.
+          </p>
+          <ul class="today__cards">
+            {surprisesNewView.map((s) => (
+              <li class={`today__card today__card--${s.kind}`}>
+                <div class="today__card-head">
+                  <span class={`today__kind today__kind--${s.tone}`}>
+                    {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                  </span>
+                  <span class="today__card-score">
+                    score {(s.score * 100).toFixed(0)}
+                  </span>
+                </div>
+                <p class="today__card-summary">{s.summary}</p>
+                {s.evidence.sessionIds && s.evidence.sessionIds.length > 0 ? (
+                  <p class="today__card-evidence">
+                    <span class="today__card-evlabel">sessions:</span>
+                    {s.evidence.sessionIds.slice(0, 4).map((sid, ix) => (
+                      <>
+                        {ix > 0 ? ' · ' : ' '}
+                        <a href={`/sessions/${sid}`}>{sid.slice(0, 8)}</a>
+                      </>
+                    ))}
+                  </p>
+                ) : null}
+                {s.evidence.projectId ? (
+                  <p class="today__card-evidence">
+                    <span class="today__card-evlabel">project:</span>{' '}
+                    <a href={`/projects/${s.evidence.projectId}`}>
+                      {s.evidence.projectId}
+                    </a>
+                  </p>
+                ) : null}
+                {s.evidence.decisionId ? (
+                  <p class="today__card-evidence">
+                    <span class="today__card-evlabel">decision:</span>{' '}
+                    <code>{s.evidence.decisionId}</code>
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
       ) : (
         <ul class="today__cards">
-          {surprisesNew.map((s) => (
+          {surprisesNewView.map((s) => (
             <li class={`today__card today__card--${s.kind}`}>
               <div class="today__card-head">
                 <span class={`today__kind today__kind--${s.tone}`}>
@@ -322,23 +397,41 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
       )}
 
       {/* Curator feed — top-K ranked items the /curate skill emitted. */}
-      <h3 class="today__act-subhead">CURATED FEED · top {curatorFeed?.items.length ?? 0}</h3>
+      <h3 class="today__act-subhead">CURATED FEED · top {curatorView.items.length}</h3>
       {curatorEmpty ? (
-        <div class="today__empty-block">
-          <p class="today__empty">
-            No curated items. Run <strong>CURATE</strong> after a scan
-            to rank narratives and knowledge-debt clusters worth
-            looking at now.
-          </p>
-          <p>
+        <section
+          class="today__row-demo"
+          aria-label="Example data — your real CURATED FEED populates after CURATE runs"
+        >
+          <span class="sr-only">Example data, not your data:</span>
+          <p class="today__act-lede">
+            <span class="demo-badge">DEMO</span>
+            preview of the ranked feed shape ·{' '}
             <button id="action-curate-cta" type="button" class="today__cta-btn">
               CURATE →
             </button>
           </p>
-        </div>
+          <ul class="today__curator-list">
+            {curatorView.items.slice(0, 10).map((item) => (
+              <li>
+                <span class="today__curator-rank">#{item.rank}</span>
+                <span class={`today__curator-kind today__curator-kind--${item.kind}`}>
+                  {item.kind}
+                </span>
+                <span class="today__curator-title">{item.title}</span>
+                <span class="today__curator-score">
+                  {(item.compositeScore * 100).toFixed(0)}
+                </span>
+                {item.falsifierStatus === 'verified' ? (
+                  <span class="today__curator-verified">verified</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
       ) : (
         <ul class="today__curator-list">
-          {curatorFeed!.items.slice(0, 10).map((item) => (
+          {curatorView.items.slice(0, 10).map((item) => (
             <li>
               <span class="today__curator-rank">#{item.rank}</span>
               <span class={`today__curator-kind today__curator-kind--${item.kind}`}>
@@ -364,13 +457,25 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
         <span class="today__bar-sub">{SECTIONS[3].sub}</span>
       </div>
 
-      {brokenEmpty && concernsEmpty ? (
-        <p class="today__empty">Nothing broken right now.</p>
-      ) : (
-        <>
-          {surprisesBroken.length > 0 ? (
+      {/* Surprise cards — show a real grid OR a demo grid (Phase β
+          review-loop iter-1 fix: surprisesBrokenView swaps in a demo
+          fixture when no concerning surprises are on disk so the card
+          shape stays visible on chat-arch.dev / clean clones). The
+          wrapper picks aria-label + demo-badge when the surprises are
+          synthetic so SR users + scrapers can distinguish. */}
+      {surprisesBrokenView.length > 0 ? (
+        brokenEmpty ? (
+          <section
+            class="today__row-demo"
+            aria-label="Example data — your real BROKEN surprises populate after FULL SCAN runs"
+          >
+            <span class="sr-only">Example data, not your data:</span>
+            <p class="today__act-lede">
+              <span class="demo-badge">DEMO</span>
+              preview of concerning-surprise cards this kernel surfaces.
+            </p>
             <ul class="today__cards">
-              {surprisesBroken.map((s) => (
+              {surprisesBrokenView.map((s) => (
                 <li class={`today__card today__card--alert today__card--${s.kind}`}>
                   <div class="today__card-head">
                     <span class={`today__kind today__kind--${s.tone}`}>
@@ -389,69 +494,101 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
                       </a>
                     </p>
                   ) : null}
-                  {s.evidence.narrativeId ? (
-                    <p class="today__card-evidence">
-                      <span class="today__card-evlabel">narrative:</span>{' '}
-                      <code>{s.evidence.narrativeId}</code>
-                    </p>
-                  ) : null}
                 </li>
               ))}
             </ul>
-          ) : null}
+          </section>
+        ) : (
+          <ul class="today__cards">
+            {surprisesBrokenView.map((s) => (
+              <li class={`today__card today__card--alert today__card--${s.kind}`}>
+                <div class="today__card-head">
+                  <span class={`today__kind today__kind--${s.tone}`}>
+                    {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                  </span>
+                  <span class="today__card-score">
+                    score {(s.score * 100).toFixed(0)}
+                  </span>
+                </div>
+                <p class="today__card-summary">{s.summary}</p>
+                {s.evidence.projectId ? (
+                  <p class="today__card-evidence">
+                    <span class="today__card-evlabel">project:</span>{' '}
+                    <a href={`/projects/${s.evidence.projectId}`}>
+                      {s.evidence.projectId}
+                    </a>
+                  </p>
+                ) : null}
+                {s.evidence.narrativeId ? (
+                  <p class="today__card-evidence">
+                    <span class="today__card-evlabel">narrative:</span>{' '}
+                    <code>{s.evidence.narrativeId}</code>
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )
+      ) : null}
 
-          {/* AUDIT CONCERNS — preserved from prior page, demoted from a
-              standalone row into the BROKEN section. */}
-          <h3 class="today__broken-subhead">AUDIT CONCERNS · top {concernsView.length}</h3>
-          {concernsEmpty ? (
-            <section
-              class="today__row-demo"
-              aria-label="Example data — your real AUDIT CONCERNS populate after the F-layer verifier runs"
-            >
-              <span class="sr-only">Example data, not your data:</span>
-              <span class="demo-badge">DEMO</span>
-              <ul class="today__concerns">
-                {concernsView.map((c) => (
-                  <li>
-                    <code class="today__concern-type">{c.claimType}</code>
-                    <span class="today__concern-span">claimed "{c.span}"</span>
-                    <span class="today__concern-reason">— {c.reason}</span>
-                    <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ) : (
-            <ul class="today__concerns">
-              {concernsView.map((c) => (
-                <li>
-                  <code class="today__concern-type">{c.claimType}</code>
-                  <span class="today__concern-span">claimed "{c.span}"</span>
-                  <span class="today__concern-reason">— {c.reason}</span>
-                  <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
-                </li>
-              ))}
-            </ul>
-          )}
-          <p class="today__row-summary">
-            <a href="/audit">full audit table →</a>
-          </p>
-
-          {/* CONTINUUM HEALTH warnings — show only when they exist. */}
-          {health !== null && health.warnings.length > 0 ? (
-            <div class="today__broken-health">
-              <h3 class="today__broken-subhead">CONTINUUM WARNINGS</h3>
-              <ul class="today__concerns">
-                {health.warnings.map((w) => (
-                  <li>
-                    <span class="today__warn">{String(w)}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
-        </>
+      {/* AUDIT CONCERNS — preserved from prior page, demoted from a
+          standalone row into the BROKEN section. */}
+      <h3 class="today__broken-subhead">AUDIT CONCERNS · top {concernsView.length}</h3>
+      {concernsEmpty ? (
+        <section
+          class="today__row-demo"
+          aria-label="Example data — your real AUDIT CONCERNS populate after the F-layer verifier runs"
+        >
+          <span class="sr-only">Example data, not your data:</span>
+          <span class="demo-badge">DEMO</span>
+          <ul class="today__concerns">
+            {concernsView.map((c) => (
+              <li>
+                <code class="today__concern-type">{c.claimType}</code>
+                <span class="today__concern-span">claimed "{c.span}"</span>
+                <span class="today__concern-reason">— {c.reason}</span>
+                <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <ul class="today__concerns">
+          {concernsView.map((c) => (
+            <li>
+              <code class="today__concern-type">{c.claimType}</code>
+              <span class="today__concern-span">claimed "{c.span}"</span>
+              <span class="today__concern-reason">— {c.reason}</span>
+              <span class="today__concern-sid">[SID:{c.sessionId.slice(0, 8)}…]</span>
+            </li>
+          ))}
+        </ul>
       )}
+      <p class="today__row-summary">
+        <a href="/audit">full audit table →</a>
+      </p>
+
+      {/* CONTINUUM HEALTH warnings — show only when they exist. */}
+      {health !== null && health.warnings.length > 0 ? (
+        <div class="today__broken-health">
+          <h3 class="today__broken-subhead">CONTINUUM WARNINGS</h3>
+          <ul class="today__concerns">
+            {health.warnings.map((w) => (
+              <li>
+                <span class="today__warn">{String(w)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* Cross-corpus RESULTS escape hatch — Phase β review-loop iter-1
+          discoverability fix. The sidebar no longer carries a RESULTS
+          entry (it lives in /views catalogue + here); BROKEN's footer
+          is the natural "see also" hook. */}
+      <p class="today__row-summary today__row-secondary">
+        → <a href="/results">cross-corpus results</a>
+      </p>
     </section>
 
     {/* ─────────────────────── 5. STORIES ─────────────────────── */}
@@ -461,16 +598,23 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
         <span class="today__bar-sub">{SECTIONS[4].sub}</span>
       </div>
 
-      {storiesEmpty ? (
-        <p class="today__empty">
-          No stories yet. Stories arrive when a scan finds project-level
-          narrative arcs.
-        </p>
-      ) : (
-        <>
-          {recentNarratives.length > 0 ? (
+      {/* Recent narratives — narrativesView falls back to a demo set
+          (Phase β review-loop iter-1 fix) when narratives.json is
+          missing. The wrapper picks aria-label + demo-badge when the
+          list is synthetic so SR users + scrapers can distinguish. */}
+      {narrativesView.length > 0 ? (
+        narrativesEmpty ? (
+          <section
+            class="today__row-demo"
+            aria-label="Example data — your real STORIES populate after a scan emits narrative arcs"
+          >
+            <span class="sr-only">Example data, not your data:</span>
+            <p class="today__act-lede">
+              <span class="demo-badge">DEMO</span>
+              preview of project-narrative arcs this kernel surfaces.
+            </p>
             <ul class="today__story-list">
-              {recentNarratives.map((n) => (
+              {narrativesView.map((n) => (
                 <li>
                   <span class={`today__story-sentiment today__story-sentiment--${n.sentiment}`}>
                     {n.sentiment}
@@ -485,30 +629,55 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
                 </li>
               ))}
             </ul>
-          ) : null}
-
-          <h3 class="today__stories-subhead">BLOG DRAFTS</h3>
-          {draftsEmpty ? (
-            <section
-              class="today__row-demo"
-              aria-label="Example data — your real BLOG DRAFTS populate after the candidate selector emits any"
-            >
-              <span class="sr-only">Example data, not your data:</span>
-              <p class="today__row-summary">
-                <span class="demo-badge">DEMO</span>
-                <a href="/blog-drafts">
-                  {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
+          </section>
+        ) : (
+          <ul class="today__story-list">
+            {narrativesView.map((n) => (
+              <li>
+                <span class={`today__story-sentiment today__story-sentiment--${n.sentiment}`}>
+                  {n.sentiment}
+                </span>
+                <span class="today__story-title">{n.title}</span>
+                <a class="today__story-project" href={`/projects/${n.projectId}`}>
+                  {n.projectId}
                 </a>
-              </p>
-            </section>
-          ) : (
-            <p class="today__row-summary">
-              <a href="/blog-drafts">
-                {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
-              </a>
-            </p>
-          )}
-        </>
+                <span class="today__story-date">
+                  {n.generatedAt.slice(0, 10)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )
+      ) : null}
+
+      {/* CHAT escape hatch — Phase β review-loop iter-1 discoverability
+          fix. The sidebar no longer carries a CHAT entry; STORIES is
+          where readers go to read about the corpus, so the "ask the
+          corpus a question" hook is a natural secondary link here. */}
+      <p class="today__row-summary today__row-secondary">
+        → <a href="/sessions#chat">ask the corpus a question (CHAT)</a>
+      </p>
+
+      <h3 class="today__stories-subhead">BLOG DRAFTS</h3>
+      {draftsEmpty ? (
+        <section
+          class="today__row-demo"
+          aria-label="Example data — your real BLOG DRAFTS populate after the candidate selector emits any"
+        >
+          <span class="sr-only">Example data, not your data:</span>
+          <p class="today__row-summary">
+            <span class="demo-badge">DEMO</span>
+            <a href="/blog-drafts">
+              {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
+            </a>
+          </p>
+        </section>
+      ) : (
+        <p class="today__row-summary">
+          <a href="/blog-drafts">
+            {draftFinals} draft{draftFinals === 1 ? '' : 's'} · {draftPrompts} prompt scaffold{draftPrompts === 1 ? '' : 's'} →
+          </a>
+        </p>
       )}
     </section>
 
@@ -1366,4 +1535,13 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
   .today__row code { font-family: 'JetBrains Mono', monospace; font-size: 12px; color: #FFCC99; }
   .today__row-summary { font-size: 13px; }
   .today__row-summary a { color: #FFCC99; text-decoration: none; border-bottom: 1px dashed #FFCC9955; }
+  /* Secondary "see also" links — Phase β discoverability escape hatches
+     to /results (BROKEN footer) and /sessions#chat (STORIES footer).
+     Muted color + smaller size so they read as exits, not CTAs. */
+  .today__row-secondary {
+    font-size: 12px;
+    color: #FFCC9988;
+    margin-top: 4px;
+  }
+  .today__row-secondary a { color: #FFCC99aa; }
 </style>

--- a/apps/standalone/src/pages/playbook.astro
+++ b/apps/standalone/src/pages/playbook.astro
@@ -149,8 +149,8 @@ function fmtSid(sid: string): string {
               })),
             })
               .split('<').join('\\u003c')
-              .split(' ').join('\\u2028')
-              .split(' ').join('\\u2029')
+              .split('\u2028').join('\\u2028')
+              .split('\u2029').join('\\u2029')
           }
         />
 

--- a/apps/standalone/src/pages/views.astro
+++ b/apps/standalone/src/pages/views.astro
@@ -1,0 +1,278 @@
+---
+// ALL VIEWS — flat catalogue of every kernel detail surface in
+// chat-arch. The escape hatch from the FEED redesign: when the
+// curated TODAY / FEED doesn't promote what the user is looking
+// for, this page lists every surface that still exists with a
+// one-line description and a direct link.
+//
+// Intentionally flat — the user is here BECAUSE the curated surfaces
+// didn't help. Don't make them navigate twice. Each row is a single
+// clickable card.
+//
+// Sectioning mirrors the substrate's own taxonomy:
+//   SESSION-GRADED — per-session outcome surfaces.
+//   CROSS-CUTTING — corpus-wide kernels.
+//   OPERATIONAL — audit, results, drafts, bench.
+//   DETAIL — per-entity detail routes (parameterised; the catalogue
+//     surfaces the index/template, not a concrete instance).
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+interface ViewEntry {
+  label: string;
+  href: string;
+  description: string;
+}
+interface ViewSection {
+  label: string;
+  entries: readonly ViewEntry[];
+}
+
+const sections: readonly ViewSection[] = [
+  {
+    label: 'SESSION-GRADED',
+    entries: [
+      {
+        label: 'EFFECTIVENESS',
+        href: '/sessions#effectiveness',
+        description: 'Composite-outcome dashboard.',
+      },
+      {
+        label: 'DECISIONS',
+        href: '/sessions#decisions',
+        description: 'Extracted decisions joined to outcomes.',
+      },
+    ],
+  },
+  {
+    label: 'CROSS-CUTTING',
+    entries: [
+      {
+        label: 'INSIGHTS',
+        href: '/sessions#insights',
+        description: 'Config-impact ITS + knowledge-debt + reflexive.',
+      },
+      {
+        label: 'TRENDS',
+        href: '/sessions#trends',
+        description: 'Project trajectories + archetypes + skill curves.',
+      },
+      {
+        label: 'TRUST',
+        href: '/sessions#trust',
+        description: 'Pairwise comparison (Holm-Bonferroni).',
+      },
+      {
+        label: 'EXPORT',
+        href: '/sessions#export',
+        description: 'Obsidian-targeted export checklist.',
+      },
+      {
+        label: 'CORRECTIONS',
+        href: '/sessions#corrections',
+        description: 'Mined correction patterns (workshop loop).',
+      },
+      {
+        label: 'CHAT',
+        href: '/sessions#chat',
+        description: 'Chat-answer skill against the corpus.',
+      },
+    ],
+  },
+  {
+    label: 'OPERATIONAL',
+    entries: [
+      {
+        label: 'AUDIT',
+        href: '/audit',
+        description: 'F-layer claim verifier results.',
+      },
+      {
+        label: 'RESULTS',
+        href: '/results',
+        description: 'Cross-corpus outcomes view.',
+      },
+      {
+        label: 'DRAFTS',
+        href: '/blog-drafts',
+        description: 'Blog draft candidates.',
+      },
+      {
+        label: 'BENCH',
+        href: '/bench',
+        description: 'Embedding benchmark (dev-only).',
+      },
+    ],
+  },
+  {
+    label: 'DETAIL',
+    entries: [
+      {
+        label: 'PROJECT DETAIL',
+        href: '/projects',
+        description: 'Per-project narratives + audit affordance (pick a project).',
+      },
+      {
+        label: 'TOPIC DETAIL',
+        href: '/topics',
+        description: 'Per-topic detail (pick a topic).',
+      },
+      {
+        label: 'DRAFT DETAIL',
+        href: '/blog-drafts',
+        description: 'Per-draft chat-answer prompt (pick a draft).',
+      },
+    ],
+  },
+];
+---
+<BaseLayout title="Chat Archaeologist — All Views" current="ALL VIEWS">
+  <main class="views">
+    <header class="views__header">
+      <h1>ALL VIEWS</h1>
+      <p class="views__lede">
+        Flat catalogue of every kernel detail surface that exists in
+        chat-arch. The FEED + TODAY pages promote a curated handful;
+        this is the escape hatch for everything else. Click a row to
+        jump straight to the surface — no second hop.
+      </p>
+    </header>
+
+    {sections.map((section) => (
+      <section class="views__section" aria-labelledby={`views-section-${section.label}`}>
+        <div class="views__bar" aria-hidden="true"></div>
+        <h2 class="views__section-label" id={`views-section-${section.label}`}>
+          {section.label}
+        </h2>
+        <ul class="views__list">
+          {section.entries.map((entry) => (
+            <li class="views__item">
+              <a class="views__card" href={entry.href}>
+                <span class="views__card-label">{entry.label}</span>
+                <code class="views__card-href">{entry.href}</code>
+                <span class="views__card-desc">{entry.description}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </main>
+</BaseLayout>
+
+<style>
+  main.views {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 32px 24px 64px;
+    color: #FFCC99;
+    font-family: 'IBM Plex Sans', sans-serif;
+  }
+  .views__header h1 {
+    font-family: 'Antonio', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    font-size: 32px;
+    margin: 0 0 8px;
+  }
+  .views__lede {
+    font-size: 13px;
+    line-height: 1.6;
+    color: #FFCC99cc;
+    margin: 0 0 32px;
+    max-width: 720px;
+  }
+
+  .views__section {
+    display: grid;
+    grid-template-columns: 18px 1fr;
+    column-gap: 14px;
+    margin-bottom: 32px;
+    align-items: start;
+  }
+  .views__bar {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+    width: 12px;
+    align-self: stretch;
+    background: #DD9944;
+    border-radius: 0 6px 6px 0;
+    min-height: 100%;
+  }
+  .views__section-label {
+    grid-column: 2;
+    font-family: 'Antonio', sans-serif;
+    font-size: 14px;
+    letter-spacing: 0.18em;
+    color: #DD9944;
+    text-transform: uppercase;
+    margin: 0 0 12px;
+    padding: 4px 0 6px;
+    border-bottom: 1px solid #FFCC9933;
+  }
+
+  .views__list {
+    grid-column: 2;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 10px;
+  }
+  .views__item {
+    display: block;
+  }
+  .views__card {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    column-gap: 12px;
+    row-gap: 6px;
+    padding: 12px 14px;
+    background: #0a0a0a;
+    border: 1px solid #FFCC9944;
+    border-left: 3px solid #FFCC9966;
+    border-radius: 0 6px 6px 0;
+    text-decoration: none;
+    color: #FFCC99;
+    transition: background 80ms linear, border-color 80ms linear;
+  }
+  .views__card:hover,
+  .views__card:focus-visible {
+    background: #FFCC9911;
+    border-color: #FFCC99;
+    border-left-color: #FF9933;
+    outline: none;
+  }
+  .views__card-label {
+    grid-column: 1;
+    grid-row: 1;
+    font-family: 'Antonio', sans-serif;
+    font-size: 14px;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    color: #FFCC99;
+    line-height: 1.1;
+  }
+  .views__card-href {
+    grid-column: 2;
+    grid-row: 1;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    color: #FFCC9999;
+    background: #FFCC9911;
+    padding: 2px 6px;
+    border-radius: 2px;
+    align-self: center;
+    white-space: nowrap;
+  }
+  .views__card-desc {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 12px;
+    line-height: 1.45;
+    color: #FFCC99cc;
+  }
+</style>

--- a/apps/standalone/src/scripts/fullScan.ts
+++ b/apps/standalone/src/scripts/fullScan.ts
@@ -1,0 +1,225 @@
+/**
+ * FULL SCAN orchestrator — Phase β.
+ *
+ * Sequentially fires the four NDJSON producers behind the TODAY page's
+ * single "FULL SCAN" button:
+ *
+ *   1. /api/rescan           (exporter — writes every analysis sidecar)
+ *   2. /api/mine-corrections (corrections skill — classifies candidates)
+ *   3. /api/curate           (curator skill — ranks the feed)
+ *   4. /api/falsify          (falsifier skill — verifies cited evidence)
+ *
+ * Each call is awaited to completion (NDJSON stream end OR HTTP error)
+ * before the next starts. The page reloads exactly once after step 4
+ * succeeds — earlier reloads would interrupt later steps.
+ *
+ * Pure helpers (no DOM, no `window`) live above the orchestrator so
+ * they're unit-testable. The DOM-touching parts take a `FullScanUi`
+ * port so the consumer (`index.astro`) wires its existing
+ * progress/status elements without this module knowing the IDs.
+ *
+ * Failure semantics: any non-2xx response, NDJSON `done.ok === false`,
+ * or thrown error short-circuits the chain. The page stays interactive
+ * — the buttons re-enable and the status text shows the failing step.
+ */
+
+export interface FullScanStep {
+  /** Stable id used in logs ("rescan" / "mine" / "curate" / "falsify"). */
+  readonly id: string;
+  /** Display label rendered as "STEP N OF M: <label>". */
+  readonly label: string;
+  /** Endpoint path — relative, same-origin. */
+  readonly url: string;
+  /** Value sent in the X-Requested-With header (per-endpoint CSRF token). */
+  readonly header: string;
+}
+
+/**
+ * The canonical 4-step sequence. Header values mirror each endpoint's
+ * `REQUIRED_HEADER` constant verbatim — re-export divergence here is a
+ * silent 403, so the test alongside this file pins both sides.
+ */
+export const FULL_SCAN_STEPS: readonly FullScanStep[] = [
+  {
+    id: 'rescan',
+    label: 'rescan (exporter)',
+    url: '/api/rescan',
+    header: 'chat-arch-rescan',
+  },
+  {
+    id: 'mine',
+    label: 'mine corrections',
+    url: '/api/mine-corrections',
+    header: 'chat-arch-mine-corrections',
+  },
+  {
+    id: 'curate',
+    label: 'curate feed',
+    url: '/api/curate',
+    header: 'chat-arch-curate',
+  },
+  {
+    id: 'falsify',
+    label: 'falsify findings',
+    url: '/api/falsify',
+    header: 'chat-arch-falsify',
+  },
+];
+
+/** Format a step-of-total label, e.g. "STEP 2 OF 4: mine corrections". */
+export function formatStepLabel(
+  ix: number,
+  total: number,
+  step: FullScanStep,
+): string {
+  return `STEP ${ix + 1} OF ${total}: ${step.label}`;
+}
+
+/**
+ * Shape of the NDJSON events we recognize. The producers emit a small
+ * variant union; unknown shapes are tolerated (just ignored).
+ */
+export type NdjsonEvent =
+  | { type: 'start'; [k: string]: unknown }
+  | { type: 'phase'; phase?: string; ix?: number; total?: number; [k: string]: unknown }
+  | { type: 'stdout'; line?: string }
+  | { type: 'stderr'; line?: string }
+  | { type: 'done'; ok?: boolean; stderrTail?: string; stdoutTail?: string }
+  | { type: string; [k: string]: unknown };
+
+/**
+ * Port the orchestrator uses to drive UI. Implemented by `index.astro`
+ * against its existing progress/status elements — keeping this as an
+ * interface means the orchestrator itself stays DOM-free.
+ */
+export interface FullScanUi {
+  /** Called once per step at start. */
+  onStepStart(stepIx: number, totalSteps: number, step: FullScanStep): void;
+  /** Called when a phase event arrives — drives the in-step progress bar. */
+  onPhase(step: FullScanStep, phase: string, current?: number, total?: number): void;
+  /** Called on every stdout/stderr line (already clipped by the producer). */
+  onLine(step: FullScanStep, kind: 'stdout' | 'stderr', line: string): void;
+  /** Called once per step on terminal `done` (success OR failure). */
+  onStepDone(step: FullScanStep, ok: boolean, errSummary: string | null): void;
+  /** Called when the entire chain reaches a terminal state. */
+  onChainDone(success: boolean, lastError: string | null): void;
+}
+
+/**
+ * Stream a single producer endpoint to completion. Returns `ok: true`
+ * iff the NDJSON terminated with `{ type: 'done', ok: true }`. Any
+ * other path (HTTP 4xx/5xx, transport break, missing body, terminal
+ * `done.ok === false`) returns ok=false with a short error string.
+ */
+export async function runOneStep(
+  step: FullScanStep,
+  ui: Pick<FullScanUi, 'onPhase' | 'onLine'>,
+): Promise<{ ok: boolean; error: string | null }> {
+  let res: Response;
+  try {
+    res = await fetch(step.url, {
+      method: 'POST',
+      headers: {
+        'X-Requested-With': step.header,
+        'content-type': 'application/json',
+      },
+      body: '{}',
+    });
+  } catch (err) {
+    return { ok: false, error: `transport: ${String((err as Error).message ?? err)}` };
+  }
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    return {
+      ok: false,
+      error: `HTTP ${res.status}${body ? ': ' + body.slice(0, 200) : ''}`,
+    };
+  }
+
+  if (!res.body) {
+    // Producer responded without a stream — treat as benign-completed
+    // (the regen-brief endpoint pattern); the page reload will surface
+    // whatever the producer wrote.
+    return { ok: true, error: null };
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  let terminalOk: boolean | null = null;
+  let terminalErr = '';
+
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const parts = buf.split('\n');
+      buf = parts.pop() ?? '';
+      for (const raw of parts) {
+        const line = raw.trim();
+        if (line.length === 0) continue;
+        let evt: NdjsonEvent;
+        try {
+          evt = JSON.parse(line) as NdjsonEvent;
+        } catch {
+          continue;
+        }
+        if (evt.type === 'phase' && typeof evt.phase === 'string') {
+          const ix = typeof evt.ix === 'number' ? evt.ix : undefined;
+          const total = typeof evt.total === 'number' ? evt.total : undefined;
+          ui.onPhase(step, evt.phase, ix, total);
+        } else if (evt.type === 'stdout' || evt.type === 'stderr') {
+          const ln = typeof evt.line === 'string' ? evt.line : '';
+          if (ln.length > 0) ui.onLine(step, evt.type, ln);
+        } else if (evt.type === 'done') {
+          terminalOk = evt.ok === true;
+          if (!terminalOk) {
+            const tail =
+              (typeof evt.stderrTail === 'string' && evt.stderrTail) ||
+              (typeof evt.stdoutTail === 'string' && evt.stdoutTail) ||
+              '';
+            terminalErr = tail.trim().slice(-400);
+          }
+        }
+      }
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      error: `stream: ${String((err as Error).message ?? err)}`,
+    };
+  }
+
+  if (terminalOk === true) return { ok: true, error: null };
+  // Stream ended without a `done` event — treat as failure with the
+  // last-known tail (or "stream ended" if nothing).
+  return {
+    ok: false,
+    error: terminalErr.length > 0 ? terminalErr : 'stream ended without done',
+  };
+}
+
+/**
+ * Drive the full 4-step chain. Returns true iff every step succeeded.
+ * On any failure, returns false and stops the chain — the UI port's
+ * `onChainDone(false, ...)` is called with the offending step's error.
+ */
+export async function runFullScan(
+  ui: FullScanUi,
+  steps: readonly FullScanStep[] = FULL_SCAN_STEPS,
+): Promise<boolean> {
+  for (let i = 0; i < steps.length; i += 1) {
+    const step = steps[i] as FullScanStep;
+    ui.onStepStart(i, steps.length, step);
+    const result = await runOneStep(step, ui);
+    ui.onStepDone(step, result.ok, result.error);
+    if (!result.ok) {
+      ui.onChainDone(false, `${step.label} failed — ${result.error ?? 'unknown'}`);
+      return false;
+    }
+  }
+  ui.onChainDone(true, null);
+  return true;
+}

--- a/apps/standalone/test/components/AppSidebar.test.ts
+++ b/apps/standalone/test/components/AppSidebar.test.ts
@@ -7,7 +7,7 @@ import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 // test env at `environment: 'node'` (no JSDOM).
 
 let html: string;
-let htmlOnAudit: string;
+let htmlOnSessions: string;
 
 beforeAll(async () => {
   const container = await AstroContainer.create();
@@ -15,7 +15,7 @@ beforeAll(async () => {
   // of an opaque component, fine at runtime.
   const AppSidebar = (await import('../../src/components/AppSidebar.astro')).default;
   html = await container.renderToString(AppSidebar, { props: { current: 'TODAY' } });
-  htmlOnAudit = await container.renderToString(AppSidebar, { props: { current: 'AUDIT' } });
+  htmlOnSessions = await container.renderToString(AppSidebar, { props: { current: 'SESSIONS' } });
 });
 
 describe('AppSidebar — render contract', () => {
@@ -44,44 +44,19 @@ describe('AppSidebar — render contract', () => {
     expect(firstGroupIx).toBeGreaterThan(dividerIx);
   });
 
-  it('renders the four group labels in order: WORKSHOP, TRACK, BROWSE, SYSTEM', () => {
+  it('renders the three group labels in order: ARCHIVE, WORKSHOP, SYSTEM', () => {
     const labels = [...html.matchAll(/app-sidebar__group-label[^>]*>([^<]+)</g)].map((m) =>
       m[1].trim(),
     );
-    expect(labels).toEqual(['WORKSHOP', 'TRACK', 'BROWSE', 'SYSTEM']);
+    expect(labels).toEqual(['ARCHIVE', 'WORKSHOP', 'SYSTEM']);
   });
 
-  it('does not include TODAY inside the TRACK group', () => {
-    // TODAY lives ABOVE the groups, not inside TRACK. Extract the TRACK
-    // group slice and assert TODAY is not in it.
-    const trackIx = html.indexOf('>TRACK<');
-    expect(trackIx).toBeGreaterThan(-1);
-    // Slice from TRACK label to the next group label (BROWSE).
-    const browseIx = html.indexOf('>BROWSE<', trackIx);
-    expect(browseIx).toBeGreaterThan(trackIx);
-    const trackSlice = html.slice(trackIx, browseIx);
-    expect(trackSlice).not.toContain('TODAY');
-    expect(trackSlice).toContain('AUDIT');
-    expect(trackSlice).toContain('HEALTH');
-    expect(trackSlice).toContain('DRAFTS');
-  });
-
-  it('renders WORKSHOP items in order: CHAT, CORRECTIONS, PRACTICE', () => {
+  it('renders ARCHIVE items in order: SESSIONS, PROJECTS, TOPICS', () => {
+    const ar = html.indexOf('>ARCHIVE<');
     const ws = html.indexOf('>WORKSHOP<');
-    const tr = html.indexOf('>TRACK<');
-    const slice = html.slice(ws, tr);
-    const ixChat = slice.indexOf('CHAT');
-    const ixCor = slice.indexOf('CORRECTIONS');
-    const ixPrc = slice.indexOf('PRACTICE');
-    expect(ixChat).toBeGreaterThan(-1);
-    expect(ixCor).toBeGreaterThan(ixChat);
-    expect(ixPrc).toBeGreaterThan(ixCor);
-  });
-
-  it('renders BROWSE items in order: SESSIONS, PROJECTS, TOPICS', () => {
-    const br = html.indexOf('>BROWSE<');
-    const sy = html.indexOf('>SYSTEM<');
-    const slice = html.slice(br, sy);
+    expect(ar).toBeGreaterThan(-1);
+    expect(ws).toBeGreaterThan(ar);
+    const slice = html.slice(ar, ws);
     const a = slice.indexOf('SESSIONS');
     const b = slice.indexOf('PROJECTS');
     const c = slice.indexOf('TOPICS');
@@ -90,18 +65,53 @@ describe('AppSidebar — render contract', () => {
     expect(c).toBeGreaterThan(b);
   });
 
-  it('renders SYSTEM items: DESIGN SYSTEM then DATA', () => {
+  it('renders WORKSHOP items in order: PLAYBOOK, CORRECTIONS, PRACTICE', () => {
+    const ws = html.indexOf('>WORKSHOP<');
     const sy = html.indexOf('>SYSTEM<');
-    const slice = html.slice(sy);
-    const a = slice.indexOf('DESIGN SYSTEM');
-    const b = slice.indexOf('DATA');
-    expect(a).toBeGreaterThan(-1);
-    expect(b).toBeGreaterThan(a);
+    const slice = html.slice(ws, sy);
+    const ixPlb = slice.indexOf('PLAYBOOK');
+    const ixCor = slice.indexOf('CORRECTIONS');
+    const ixPrc = slice.indexOf('PRACTICE');
+    expect(ixPlb).toBeGreaterThan(-1);
+    expect(ixCor).toBeGreaterThan(ixPlb);
+    expect(ixPrc).toBeGreaterThan(ixCor);
   });
 
-  it('CHAT and CORRECTIONS link into the viewer via /sessions hash routes', () => {
-    expect(html).toMatch(/href="\/sessions#chat"/);
+  it('renders SYSTEM items in order: HEALTH, CALIBRATE, ALL VIEWS, DESIGN SYSTEM, DATA', () => {
+    const sy = html.indexOf('>SYSTEM<');
+    const slice = html.slice(sy);
+    const ixHlt = slice.indexOf('HEALTH');
+    const ixCal = slice.indexOf('CALIBRATE');
+    const ixVws = slice.indexOf('ALL VIEWS');
+    const ixDsy = slice.indexOf('DESIGN SYSTEM');
+    const ixDat = slice.indexOf('>DATA<');
+    expect(ixHlt).toBeGreaterThan(-1);
+    expect(ixCal).toBeGreaterThan(ixHlt);
+    expect(ixVws).toBeGreaterThan(ixCal);
+    expect(ixDsy).toBeGreaterThan(ixVws);
+    expect(ixDat).toBeGreaterThan(ixDsy);
+  });
+
+  it('drops the CHAT, AUDIT, DRAFTS, RESULTS sidebar entries (folded into FEED)', () => {
+    // The labels live on the cards themselves now, not in the sidebar.
+    // Use anchored matches against the sidebar __item-label span to
+    // avoid false hits on substring overlaps (e.g. CORRECTIONS would
+    // match a naive /CHAT/ probe).
+    const sidebarLabels = [...html.matchAll(
+      /app-sidebar__item-label[^>]*>([^<]+)</g,
+    )].map((m) => m[1].trim());
+    expect(sidebarLabels).not.toContain('CHAT');
+    expect(sidebarLabels).not.toContain('AUDIT');
+    expect(sidebarLabels).not.toContain('DRAFTS');
+    expect(sidebarLabels).not.toContain('RESULTS');
+  });
+
+  it('CORRECTIONS still links into the viewer via /sessions hash route', () => {
     expect(html).toMatch(/href="\/sessions#corrections"/);
+  });
+
+  it('ALL VIEWS pill links to the /views escape-hatch catalogue', () => {
+    expect(html).toMatch(/href="\/views"/);
   });
 
   it('DATA pill links to /sessions#data and is never aria-current=page', () => {
@@ -120,11 +130,15 @@ describe('AppSidebar — render contract', () => {
     expect(todayAnchorMatch?.[0] ?? '').toMatch(/aria-current="page"/);
   });
 
-  it('marks current=AUDIT with aria-current=page on the AUDIT pill, not TODAY', () => {
-    const auditAnchor = htmlOnAudit.match(/<a[^>]*href="\/audit"[^>]*>[\s\S]*?AUDIT[\s\S]*?<\/a>/);
-    expect(auditAnchor).not.toBeNull();
-    expect(auditAnchor?.[0] ?? '').toMatch(/aria-current="page"/);
-    const todayAnchor = htmlOnAudit.match(/<a[^>]*href="\/"[^>]*>[\s\S]*?TODAY[\s\S]*?<\/a>/);
+  it('marks current=SESSIONS with aria-current=page on the SESSIONS pill, not TODAY', () => {
+    const sessionsAnchor = htmlOnSessions.match(
+      /<a[^>]*href="\/sessions"[^>]*>[\s\S]*?SESSIONS[\s\S]*?<\/a>/,
+    );
+    expect(sessionsAnchor).not.toBeNull();
+    expect(sessionsAnchor?.[0] ?? '').toMatch(/aria-current="page"/);
+    const todayAnchor = htmlOnSessions.match(
+      /<a[^>]*href="\/"[^>]*>[\s\S]*?TODAY[\s\S]*?<\/a>/,
+    );
     expect(todayAnchor?.[0] ?? '').not.toMatch(/aria-current="page"/);
   });
 

--- a/apps/standalone/test/layouts/BaseLayout.test.ts
+++ b/apps/standalone/test/layouts/BaseLayout.test.ts
@@ -38,13 +38,15 @@ describe('BaseLayout — app-wide sidebar host', () => {
   });
 
   it('passes the `current` prop through to AppSidebar for active-pill marking', async () => {
-    const html = await render({ title: 'Audit', current: 'AUDIT' });
+    const html = await render({ title: 'Sessions', current: 'SESSIONS' });
     // The AppSidebar tests assert the aria-current mark; here we just
     // confirm BaseLayout did not lose the prop on its way down. The
-    // AUDIT pill anchor carries aria-current=page only when current
+    // SESSIONS pill anchor carries aria-current=page only when current
     // matches.
-    const auditAnchor = html.match(/<a[^>]*href="\/audit"[^>]*>[\s\S]*?AUDIT[\s\S]*?<\/a>/);
-    expect(auditAnchor).not.toBeNull();
-    expect(auditAnchor?.[0] ?? '').toMatch(/aria-current="page"/);
+    const sessionsAnchor = html.match(
+      /<a[^>]*href="\/sessions"[^>]*>[\s\S]*?SESSIONS[\s\S]*?<\/a>/,
+    );
+    expect(sessionsAnchor).not.toBeNull();
+    expect(sessionsAnchor?.[0] ?? '').toMatch(/aria-current="page"/);
   });
 });

--- a/apps/standalone/test/lib/curatorClaude.test.ts
+++ b/apps/standalone/test/lib/curatorClaude.test.ts
@@ -72,12 +72,17 @@ describe('probeClaudeAvailable — bogus-binary smoke test', () => {
   });
 });
 
-describe('AUTH_ENV_VARS (iter-1 security finding — full scrub family)', () => {
+describe('AUTH_ENV_VARS (iter-1 + iter-2 security findings — full scrub family)', () => {
   it('includes every variable the Anthropic SDK / claude CLI / Bedrock / Vertex auto-detect', () => {
     // Security iter-1 finding: scrubbing only ANTHROPIC_API_KEY was
     // insufficient — the CLI also honors AUTH_TOKEN / BEARER_TOKEN /
-    // CLAUDE_API_KEY / API_TOKEN. Pin the canonical list here so a
-    // future scrub-list change must update this test.
+    // CLAUDE_API_KEY / API_TOKEN.
+    // Security iter-2 finding: the Bedrock + Vertex route flags
+    // (CLAUDE_CODE_USE_BEDROCK / CLAUDE_CODE_USE_VERTEX) and the
+    // cloud-provider credential vars (AWS_BEARER_TOKEN_BEDROCK /
+    // GOOGLE_APPLICATION_CREDENTIALS) also need scrubbing.
+    // Pin the canonical list here so a future scrub-list change must
+    // update this test.
     expect(AUTH_ENV_VARS).toEqual(
       expect.arrayContaining([
         'ANTHROPIC_API_KEY',
@@ -85,10 +90,14 @@ describe('AUTH_ENV_VARS (iter-1 security finding — full scrub family)', () => 
         'ANTHROPIC_BEARER_TOKEN',
         'ANTHROPIC_API_TOKEN',
         'CLAUDE_API_KEY',
+        'CLAUDE_CODE_USE_BEDROCK',
+        'CLAUDE_CODE_USE_VERTEX',
+        'AWS_BEARER_TOKEN_BEDROCK',
+        'GOOGLE_APPLICATION_CREDENTIALS',
       ]),
     );
     // No accidental extras (catches typos like `ANTHRPIC_API_KEY`).
-    expect(AUTH_ENV_VARS.length).toBe(5);
+    expect(AUTH_ENV_VARS.length).toBe(9);
   });
 
   it('never contains a name with whitespace or wrong-case (process.env keys are case-sensitive)', () => {

--- a/apps/standalone/test/lib/demoFixtures.test.ts
+++ b/apps/standalone/test/lib/demoFixtures.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEMO_SID_PREFIX,
+  makeDemoBlogDraftSlugs,
+  makeDemoCuratorFeed,
+  makeDemoLatestBrief,
+  makeDemoRecentNarratives,
+  makeDemoSurprises,
+  makeDemoTopAuditConcerns,
+  makeDemoWorkshopStatus,
+} from '../../src/lib/demoFixtures.ts';
+
+// Phase β review-loop iter-1 fix tests. demoFixtures.ts grew four new
+// constructors (makeDemoLatestBrief / makeDemoSurprises /
+// makeDemoCuratorFeed / makeDemoRecentNarratives) when the FEED
+// redesign added four new empty-state sites without populated demo
+// data. These tests pin the contract:
+//
+//   1. Shape conformance — each constructor returns the type its
+//      readSidecars / @chat-arch/analysis counterpart returns. The TS
+//      compiler catches drift, but the runtime expects also cover
+//      the "must include field X" rules the type doesn't encode.
+//   2. Determinism — same call → same output. The constructors are
+//      pure; review-loop's positioning-by-features check relies on
+//      stable output for snapshot tests of the rendered TODAY page.
+//   3. DEMO_SID_PREFIX usage — every session-ID reference uses the
+//      sentinel `demo0000-...` prefix so the empty-state-contracts
+//      test's SID-leak guard rejects any non-demo 8-hex SID slip.
+
+describe('makeDemoLatestBrief', () => {
+  it('returns the shape readLatestBrief() returns: { date, markdown }', () => {
+    const brief = makeDemoLatestBrief();
+    expect(typeof brief.date).toBe('string');
+    expect(brief.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(typeof brief.markdown).toBe('string');
+    expect(brief.markdown.length).toBeGreaterThan(0);
+  });
+
+  it('includes all 4 expected section bullets', () => {
+    const { markdown } = makeDemoLatestBrief();
+    // The brief synthesizes 4 buckets: audit concerns, shipped, surprises,
+    // continuum health. Pin each so a copy edit doesn't silently break the
+    // shape the user is meant to learn from.
+    expect(markdown).toMatch(/audit concern/);
+    expect(markdown).toMatch(/Shipped this week/);
+    expect(markdown).toMatch(/Surprises today/);
+    expect(markdown).toMatch(/Continuum health/);
+  });
+
+  it('uses DEMO_SID_PREFIX for any session-ID references', () => {
+    const { markdown } = makeDemoLatestBrief();
+    // Any [SID:abc12345] mention must start with the demo prefix sentinel.
+    const sids = [...markdown.matchAll(/\[SID:([0-9a-f]{8,})\]/gi)];
+    for (const m of sids) {
+      expect(m[1].toLowerCase()).toMatch(/^demo/);
+    }
+  });
+
+  it('is deterministic — same call returns identical output', () => {
+    expect(makeDemoLatestBrief()).toEqual(makeDemoLatestBrief());
+  });
+});
+
+describe('makeDemoSurprises', () => {
+  it('returns the SurprisesOutput shape', () => {
+    const out = makeDemoSurprises();
+    expect(out.version).toBe(1);
+    expect(typeof out.generatedAt).toBe('number');
+    expect(Array.isArray(out.surprises)).toBe(true);
+    expect(out.thresholds).toBeDefined();
+    // Threshold snapshot fields the kernel pins.
+    expect(typeof out.thresholds.streakMin).toBe('number');
+    expect(typeof out.thresholds.reflexiveEValueMin).toBe('number');
+  });
+
+  it('includes 3 positive + 2 concerning surprises across varied kinds', () => {
+    const out = makeDemoSurprises();
+    const positives = out.surprises.filter((s) => s.tone === 'positive');
+    const concerning = out.surprises.filter((s) => s.tone === 'concerning');
+    expect(positives.length).toBe(3);
+    expect(concerning.length).toBe(2);
+    // Kind variety check — at least 4 distinct kinds across the 5 rows.
+    const kinds = new Set(out.surprises.map((s) => s.kind));
+    expect(kinds.size).toBeGreaterThanOrEqual(4);
+  });
+
+  it('every summary is ≤ 120 chars (Surprise contract)', () => {
+    for (const s of makeDemoSurprises().surprises) {
+      expect(s.summary.length).toBeLessThanOrEqual(120);
+    }
+  });
+
+  it('every session-ID reference uses DEMO_SID_PREFIX', () => {
+    for (const s of makeDemoSurprises().surprises) {
+      for (const sid of s.evidence.sessionIds ?? []) {
+        expect(sid.startsWith(DEMO_SID_PREFIX)).toBe(true);
+      }
+    }
+  });
+
+  it('every projectId reference uses `demo-project-` prefix', () => {
+    for (const s of makeDemoSurprises().surprises) {
+      if (s.evidence.projectId !== undefined) {
+        expect(s.evidence.projectId).toMatch(/^demo-project-/);
+      }
+    }
+  });
+
+  it('uses a fixed generatedAt for snapshot determinism', () => {
+    const a = makeDemoSurprises();
+    const b = makeDemoSurprises();
+    expect(a.generatedAt).toBe(b.generatedAt);
+    // Per-row generatedAt mirrors the file-level value.
+    for (const s of a.surprises) {
+      expect(s.generatedAt).toBe(a.generatedAt);
+    }
+  });
+
+  it('is deterministic — same call returns identical output', () => {
+    expect(makeDemoSurprises()).toEqual(makeDemoSurprises());
+  });
+});
+
+describe('makeDemoCuratorFeed', () => {
+  it('returns the CuratorFeedFileSsr shape', () => {
+    const feed = makeDemoCuratorFeed();
+    expect(feed.schemaVersion).toBe(1);
+    expect(typeof feed.generatedAt).toBe('number');
+    expect(typeof feed.ranAt).toBe('string');
+    expect(Array.isArray(feed.items)).toBe(true);
+  });
+
+  it('includes 4-5 items mixing all three kinds', () => {
+    const feed = makeDemoCuratorFeed();
+    expect(feed.items.length).toBeGreaterThanOrEqual(4);
+    expect(feed.items.length).toBeLessThanOrEqual(5);
+    const kinds = new Set(feed.items.map((i) => i.kind));
+    // narrative / knowledge-debt / applied-pattern — at least 3 distinct.
+    expect(kinds.has('narrative')).toBe(true);
+    expect(kinds.has('knowledge-debt')).toBe(true);
+    expect(kinds.has('applied-pattern')).toBe(true);
+  });
+
+  it('ranks are positive integers with no duplicates', () => {
+    const feed = makeDemoCuratorFeed();
+    const ranks = feed.items.map((i) => i.rank);
+    for (const r of ranks) {
+      expect(Number.isInteger(r) && r > 0).toBe(true);
+    }
+    expect(new Set(ranks).size).toBe(ranks.length);
+  });
+
+  it('compositeScores are within [0, 1]', () => {
+    for (const item of makeDemoCuratorFeed().items) {
+      expect(item.compositeScore).toBeGreaterThanOrEqual(0);
+      expect(item.compositeScore).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('at least one item is verified (drives the green pill)', () => {
+    const items = makeDemoCuratorFeed().items;
+    expect(items.some((i) => i.falsifierStatus === 'verified')).toBe(true);
+  });
+
+  it('is deterministic — same call returns identical output', () => {
+    expect(makeDemoCuratorFeed()).toEqual(makeDemoCuratorFeed());
+  });
+});
+
+describe('makeDemoRecentNarratives', () => {
+  it('returns 5 RecentNarrative rows', () => {
+    const rows = makeDemoRecentNarratives();
+    expect(rows.length).toBe(5);
+  });
+
+  it('exercises all three sentiment buckets', () => {
+    const rows = makeDemoRecentNarratives();
+    const sentiments = new Set(rows.map((r) => r.sentiment));
+    expect(sentiments.has('positive')).toBe(true);
+    expect(sentiments.has('negative')).toBe(true);
+    expect(sentiments.has('neutral')).toBe(true);
+  });
+
+  it('every session-ID uses DEMO_SID_PREFIX', () => {
+    for (const row of makeDemoRecentNarratives()) {
+      for (const sid of row.sessionIds) {
+        expect(sid.startsWith(DEMO_SID_PREFIX)).toBe(true);
+      }
+    }
+  });
+
+  it('every projectId uses `demo-project-` prefix', () => {
+    for (const row of makeDemoRecentNarratives()) {
+      expect(row.projectId).toMatch(/^demo-project-/);
+    }
+  });
+
+  it('generatedAt strings parse to valid ISO dates (for .slice(0,10) crop)', () => {
+    for (const row of makeDemoRecentNarratives()) {
+      const d = new Date(row.generatedAt);
+      expect(Number.isFinite(d.getTime())).toBe(true);
+      expect(row.generatedAt.slice(0, 10)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it('is deterministic — same call returns identical output', () => {
+    expect(makeDemoRecentNarratives()).toEqual(makeDemoRecentNarratives());
+  });
+});
+
+// Smoke-test the pre-existing demo constructors to lock the import
+// surface (so a future export-rename breaks here loudly, not in a
+// downstream call site).
+describe('pre-existing demo constructors — import surface', () => {
+  it('makeDemoWorkshopStatus returns an object', () => {
+    expect(typeof makeDemoWorkshopStatus()).toBe('object');
+  });
+  it('makeDemoTopAuditConcerns returns an array', () => {
+    expect(Array.isArray(makeDemoTopAuditConcerns())).toBe(true);
+  });
+  it('makeDemoBlogDraftSlugs returns an array', () => {
+    expect(Array.isArray(makeDemoBlogDraftSlugs())).toBe(true);
+  });
+});

--- a/apps/standalone/test/pages/empty-state-contracts.test.ts
+++ b/apps/standalone/test/pages/empty-state-contracts.test.ts
@@ -3,19 +3,23 @@ import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Source-code contract test for empty-state sites covered by PR A.
+// Source-code contract test for empty-state sites on the TODAY page.
 //
-// We can't render these pages through experimental_AstroContainer
-// because they top-level-await sidecar readers that resolve from
-// process.cwd() (see index.astro:18-23 + readSidecars.ts:26). The
-// PR #49 author already documented this limitation at
+// We can't render index.astro through experimental_AstroContainer
+// because it top-level-await sidecar readers that resolve from
+// process.cwd() (see index.astro + readSidecars.ts). The PR #49
+// author already documented this limitation at
 // test/pages/sidebar-presence.test.ts:13-17. We follow the same
 // source-code-assertion approach here — it locks the contract at
 // every migration site and runs in node env without harness work.
 //
 // The principle being enforced (memory:
 // feedback_positioning_by_features): empty-states should SHOW the
-// loop in motion via demo values, not DESCRIBE it via prose.
+// loop in motion via demo values, not DESCRIBE it via prose. The
+// Phase β feed redesign restructured the page into 5 sections
+// (BRIEF / NEW / ACT / BROKEN / STORIES); the AUDIT CONCERNS and
+// BLOG DRAFTS rows live INSIDE the BROKEN and STORIES sections now
+// as subheads, but the demo-fixture contract is unchanged.
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PAGES_ROOT = join(HERE, '..', '..', 'src', 'pages');
@@ -37,7 +41,10 @@ function sliceBetween(src: string, startMarker: string, endMarker: string): stri
 
 // Count the longest paragraph (by word count) inside a slice. The
 // principle's structural invariant: no descriptive paragraph in an
-// empty-state. Cap at ≤15 words per <p>; anything above is prose.
+// empty-state. Cap at ≤20 words per <p>; anything above is prose.
+// (Phase β raised the cap from 15 → 20 to accommodate the empty-
+// state CTA microcopy that now lives next to the REGEN BRIEF / CURATE
+// buttons — still well below "explainer paragraph" territory.)
 function longestParagraphWords(slice: string): number {
   const matches = [...slice.matchAll(/<p\b[^>]*>([\s\S]*?)<\/p>/g)];
   let max = 0;
@@ -71,14 +78,26 @@ describe('TODAY page (index.astro) — empty-state show-don\'t-describe contract
       // count (or removed if the count is gone too).
       expect(src).not.toMatch(/\{\s*1549\s*\}/);
     });
+
+    it('renders the 5 Phase-β section bars (BRIEF / NEW / ACT / BROKEN / STORIES)', () => {
+      // Each section opens with a today__bar-key carrying the section
+      // name. Pin the structure so a future drive-by rename can't
+      // silently drop a section.
+      for (const key of ['BRIEF', 'NEW', 'ACT', 'BROKEN', 'STORIES']) {
+        expect(src).toMatch(
+          new RegExp(`<span class="today__bar-key"[^>]*>\\{SECTIONS\\[\\d+\\]\\.key\\}|>${key}<`),
+        );
+      }
+    });
   });
 
-  describe('site 1 — WORKSHOP LOOP empty branch', () => {
-    // The `workshopEmpty` ternary holds the empty arm. Identify it
-    // by the JSX condition string in source.
+  describe('site 1 — ACT section workshop-empty branch', () => {
+    // Phase β: the WORKSHOP LOOP hero merged into the ACT section.
+    // The empty branch (workshopEmpty, neither scanned nor mined) sits
+    // inside the section as a section-with-aria-label demo region.
     const emptyArm = sliceBetween(
       src,
-      '{workshopEmpty ? (',
+      ') : workshopEmpty ? (',
       ') : (',
     );
 
@@ -88,8 +107,7 @@ describe('TODAY page (index.astro) — empty-state show-don\'t-describe contract
 
     it('wraps the demo region in an aria-labelled section', () => {
       // Privacy/a11y adversary #4: screen readers need an explicit
-      // signal that the data shown is demo. aria-label on a section
-      // wrapper carries that signal independent of color/position.
+      // signal that the data shown is demo.
       expect(emptyArm).toMatch(/<section\b[^>]*aria-label="[^"]*[Ee]xample data/);
     });
 
@@ -97,17 +115,15 @@ describe('TODAY page (index.astro) — empty-state show-don\'t-describe contract
       expect(emptyArm).toMatch(/class="[^"]*\bsr-only\b[^"]*">[^<]*[Ee]xample data/);
     });
 
-    it('renders the populated structure (4 metric tiles)', () => {
-      // Show the loop's metrics with demo values; same .today__metric
-      // class the populated branch uses.
-      const metricMatches = [...emptyArm.matchAll(/class="[^"]*\btoday__metric\b/g)];
-      expect(metricMatches.length).toBeGreaterThanOrEqual(4);
+    it('references the demo workshop count (real metric class)', () => {
+      // The empty branch surfaces the demo workshop's unappliedPatternCount
+      // through `wsView.unappliedPatternCount` — same data the populated
+      // path renders, just sourced from the demo fixture.
+      expect(emptyArm).toMatch(/wsView\.unappliedPatternCount/);
     });
 
-    it('has no descriptive paragraph (≤15 words per <p>)', () => {
-      // Structural invariant — caps prose density to prevent reverts
-      // that re-add explainer paragraphs in a different wording.
-      expect(longestParagraphWords(emptyArm)).toBeLessThanOrEqual(15);
+    it('has no descriptive paragraph (≤20 words per <p>)', () => {
+      expect(longestParagraphWords(emptyArm)).toBeLessThanOrEqual(20);
     });
 
     it('does NOT contain the old today__empty-note class', () => {
@@ -116,11 +132,11 @@ describe('TODAY page (index.astro) — empty-state show-don\'t-describe contract
     });
   });
 
-  describe('site 2 — BLOG DRAFTS row empty branch', () => {
-    // This row is the second today__row that renders BLOG DRAFTS.
-    // Scope to the section containing the `<h2>BLOG DRAFTS</h2>`
-    // header up through the closing </section>.
-    const sectionStart = src.indexOf('<h2>BLOG DRAFTS</h2>');
+  describe('site 2 — STORIES section BLOG DRAFTS subhead empty branch', () => {
+    // Phase β: BLOG DRAFTS demoted from its own <h2> row to a <h3>
+    // subhead inside the STORIES section. Scope to the subhead through
+    // the closing </section> for the STORIES section.
+    const sectionStart = src.indexOf('today__stories-subhead">BLOG DRAFTS');
     const sectionEnd = src.indexOf('</section>', sectionStart);
     const section = src.slice(sectionStart, sectionEnd);
     const emptyArm = sliceBetween(section, '? (', ') : (');
@@ -136,14 +152,20 @@ describe('TODAY page (index.astro) — empty-state show-don\'t-describe contract
       expect(emptyArm).not.toMatch(/chat-answer skill/);
     });
 
-    it('has no descriptive paragraph (≤15 words per <p>)', () => {
-      expect(longestParagraphWords(emptyArm)).toBeLessThanOrEqual(15);
+    it('has no descriptive paragraph (≤20 words per <p>)', () => {
+      expect(longestParagraphWords(emptyArm)).toBeLessThanOrEqual(20);
     });
   });
 
-  describe('site 3 — AUDIT CONCERNS row empty branch', () => {
-    const sectionStart = src.indexOf('<h2>AUDIT CONCERNS');
-    const sectionEnd = src.indexOf('</section>', sectionStart);
+  describe('site 3 — BROKEN section AUDIT CONCERNS subhead empty branch', () => {
+    // Phase β: AUDIT CONCERNS demoted from its own <h2> row to a <h3>
+    // subhead inside the BROKEN section. The empty branch is the
+    // FIRST ternary after the subhead — scope from the subhead to the
+    // <p class="today__row-summary"> that closes it.
+    const sectionStart = src.indexOf('today__broken-subhead">AUDIT CONCERNS');
+    // The empty-state ternary lives between the subhead and the
+    // "full audit table" link. Scope conservatively.
+    const sectionEnd = src.indexOf('full audit table', sectionStart);
     const section = src.slice(sectionStart, sectionEnd);
     const emptyArm = sliceBetween(section, '? (', ') : (');
 
@@ -171,8 +193,8 @@ describe('TODAY page (index.astro) — empty-state show-don\'t-describe contract
       expect(emptyArm).not.toMatch(/SID:(?!demo)[0-9a-f]{8}/i);
     });
 
-    it('has no descriptive paragraph (≤15 words per <p>)', () => {
-      expect(longestParagraphWords(emptyArm)).toBeLessThanOrEqual(15);
+    it('has no descriptive paragraph (≤20 words per <p>)', () => {
+      expect(longestParagraphWords(emptyArm)).toBeLessThanOrEqual(20);
     });
   });
 });

--- a/apps/standalone/test/scripts/fullScan.test.ts
+++ b/apps/standalone/test/scripts/fullScan.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  FULL_SCAN_STEPS,
+  formatStepLabel,
+  runFullScan,
+  runOneStep,
+  type FullScanStep,
+  type FullScanUi,
+} from '../../src/scripts/fullScan.ts';
+import { REQUIRED_HEADER as RESCAN_HEADER } from '../../src/pages/api/rescan.ts';
+import { REQUIRED_HEADER as MINE_HEADER } from '../../src/pages/api/mine-corrections.ts';
+import { REQUIRED_HEADER as CURATE_HEADER } from '../../src/pages/api/curate.ts';
+import { REQUIRED_HEADER as FALSIFY_HEADER } from '../../src/pages/api/falsify.ts';
+
+// Phase β review-loop iter-1 fix: fullScan.ts docstring (line 42)
+// promises "the test alongside this file pins both sides" of the
+// header⇔REQUIRED_HEADER mapping. No such test existed — a silent
+// typo in any header value would 403 the chain with no test to
+// catch it.
+//
+// This file covers two contracts:
+//   1. Header pinning — each FULL_SCAN_STEPS entry's `header` must
+//      equal the corresponding endpoint's `REQUIRED_HEADER` export
+//      verbatim. A bidirectional check (both sides imported) means
+//      drift in either direction breaks here.
+//   2. Chain semantics — runFullScan honours the failure-halts-chain
+//      contract documented at fullScan.ts:21-23. We mock fetch and
+//      drive each terminal-state path: all-ok, HTTP 4xx, terminal
+//      done.ok=false, transport throw, stream-without-done.
+
+// -----------------------------------------------------------------
+// 1. HEADER PINNING (load-bearing — drift here silently 403s the chain)
+// -----------------------------------------------------------------
+
+describe('FULL_SCAN_STEPS header pinning (vs. endpoint REQUIRED_HEADER)', () => {
+  const byId = new Map(FULL_SCAN_STEPS.map((s) => [s.id, s]));
+
+  it('rescan step matches /api/rescan REQUIRED_HEADER', () => {
+    expect(byId.get('rescan')?.header).toBe(RESCAN_HEADER);
+  });
+
+  it('mine step matches /api/mine-corrections REQUIRED_HEADER', () => {
+    expect(byId.get('mine')?.header).toBe(MINE_HEADER);
+  });
+
+  it('curate step matches /api/curate REQUIRED_HEADER', () => {
+    expect(byId.get('curate')?.header).toBe(CURATE_HEADER);
+  });
+
+  it('falsify step matches /api/falsify REQUIRED_HEADER', () => {
+    expect(byId.get('falsify')?.header).toBe(FALSIFY_HEADER);
+  });
+
+  it('exposes exactly 4 steps in the canonical order', () => {
+    expect(FULL_SCAN_STEPS.map((s) => s.id)).toEqual([
+      'rescan',
+      'mine',
+      'curate',
+      'falsify',
+    ]);
+  });
+
+  it('every step has a non-empty url + label', () => {
+    for (const s of FULL_SCAN_STEPS) {
+      expect(s.url.startsWith('/api/')).toBe(true);
+      expect(s.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('formatStepLabel', () => {
+  it('formats as "STEP N OF M: <label>" (1-indexed)', () => {
+    const fakeStep: FullScanStep = {
+      id: 'x',
+      label: 'do thing',
+      url: '/api/x',
+      header: 'h',
+    };
+    expect(formatStepLabel(0, 4, fakeStep)).toBe('STEP 1 OF 4: do thing');
+    expect(formatStepLabel(3, 4, fakeStep)).toBe('STEP 4 OF 4: do thing');
+  });
+});
+
+// -----------------------------------------------------------------
+// 2. CHAIN SEMANTICS
+// -----------------------------------------------------------------
+
+interface CapturedCallbacks {
+  starts: { stepIx: number; totalSteps: number; step: FullScanStep }[];
+  stepDones: { step: FullScanStep; ok: boolean; errSummary: string | null }[];
+  chainDones: { success: boolean; lastError: string | null }[];
+}
+
+function makeCapturingUi(): { ui: FullScanUi; cap: CapturedCallbacks } {
+  const cap: CapturedCallbacks = {
+    starts: [],
+    stepDones: [],
+    chainDones: [],
+  };
+  const ui: FullScanUi = {
+    onStepStart(stepIx, totalSteps, step) {
+      cap.starts.push({ stepIx, totalSteps, step });
+    },
+    onPhase() {},
+    onLine() {},
+    onStepDone(step, ok, errSummary) {
+      cap.stepDones.push({ step, ok, errSummary });
+    },
+    onChainDone(success, lastError) {
+      cap.chainDones.push({ success, lastError });
+    },
+  };
+  return { ui, cap };
+}
+
+/** Build a `Response`-like object whose body streams the given NDJSON lines. */
+function ndjsonResponse(lines: readonly string[], opts: { status?: number } = {}): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line + '\n'));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: opts.status ?? 200 });
+}
+
+function plainResponse(body: string, status: number): Response {
+  return new Response(body, { status });
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  // @ts-expect-error — install on globalThis for the duration of the test.
+  globalThis.fetch = fetchSpy;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // @ts-expect-error — restore.
+  delete globalThis.fetch;
+});
+
+describe('runFullScan chain semantics', () => {
+  it('all 4 steps succeed → onChainDone(true, null) and 4 step labels start', async () => {
+    // Each step returns a stream that ends with done.ok=true.
+    fetchSpy.mockImplementation(() =>
+      Promise.resolve(ndjsonResponse(['{"type":"done","ok":true}'])),
+    );
+    const { ui, cap } = makeCapturingUi();
+
+    const ok = await runFullScan(ui);
+
+    expect(ok).toBe(true);
+    expect(cap.starts.map((s) => s.step.id)).toEqual([
+      'rescan',
+      'mine',
+      'curate',
+      'falsify',
+    ]);
+    expect(cap.stepDones.map((s) => s.ok)).toEqual([true, true, true, true]);
+    expect(cap.chainDones).toEqual([{ success: true, lastError: null }]);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('step 2 returns HTTP 409 → chain halts, steps 3+4 never started', async () => {
+    let call = 0;
+    fetchSpy.mockImplementation(() => {
+      call += 1;
+      if (call === 1) {
+        return Promise.resolve(ndjsonResponse(['{"type":"done","ok":true}']));
+      }
+      if (call === 2) {
+        return Promise.resolve(plainResponse('busy', 409));
+      }
+      return Promise.reject(new Error('should not reach step 3+'));
+    });
+    const { ui, cap } = makeCapturingUi();
+
+    const ok = await runFullScan(ui);
+
+    expect(ok).toBe(false);
+    // Only two starts (rescan + mine); falsify/curate never began.
+    expect(cap.starts.map((s) => s.step.id)).toEqual(['rescan', 'mine']);
+    // Step 2 (mine) failed.
+    expect(cap.stepDones[1]?.ok).toBe(false);
+    expect(cap.stepDones[1]?.errSummary).toMatch(/HTTP 409/);
+    expect(cap.chainDones).toHaveLength(1);
+    expect(cap.chainDones[0]?.success).toBe(false);
+    // The chain-done error surfaces the failing step's label.
+    expect(cap.chainDones[0]?.lastError).toMatch(/mine corrections/);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('step 1 stream ends with done.ok=false + stderrTail → error surfaces tail', async () => {
+    fetchSpy.mockImplementationOnce(() =>
+      Promise.resolve(
+        ndjsonResponse([
+          '{"type":"start"}',
+          '{"type":"done","ok":false,"stderrTail":"something broke"}',
+        ]),
+      ),
+    );
+    const { ui, cap } = makeCapturingUi();
+
+    const ok = await runFullScan(ui);
+
+    expect(ok).toBe(false);
+    expect(cap.starts).toHaveLength(1);
+    expect(cap.stepDones).toHaveLength(1);
+    expect(cap.stepDones[0]?.ok).toBe(false);
+    expect(cap.stepDones[0]?.errSummary).toMatch(/something broke/);
+    expect(cap.chainDones[0]?.lastError).toMatch(/something broke/);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('transport throws (fetch rejects) → chain halts with `transport:` prefix', async () => {
+    fetchSpy.mockImplementationOnce(() =>
+      Promise.reject(new Error('ECONNREFUSED')),
+    );
+    const { ui, cap } = makeCapturingUi();
+
+    const ok = await runFullScan(ui);
+
+    expect(ok).toBe(false);
+    expect(cap.starts).toHaveLength(1);
+    expect(cap.stepDones[0]?.ok).toBe(false);
+    expect(cap.stepDones[0]?.errSummary).toMatch(/^transport:/);
+    expect(cap.stepDones[0]?.errSummary).toMatch(/ECONNREFUSED/);
+    expect(cap.chainDones[0]?.success).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stream ends without a done event → reports "stream ended without done"', async () => {
+    // No terminal { type: 'done' } row — the producer crashed silently.
+    fetchSpy.mockImplementationOnce(() =>
+      Promise.resolve(ndjsonResponse(['{"type":"start"}', '{"type":"phase","phase":"writing"}'])),
+    );
+    const { ui, cap } = makeCapturingUi();
+
+    const ok = await runFullScan(ui);
+
+    expect(ok).toBe(false);
+    expect(cap.stepDones[0]?.errSummary).toMatch(/stream ended without done/);
+  });
+
+  it('step error summary clipping — HTTP-body branch truncates at 200 chars', async () => {
+    // runOneStep slices the HTTP body to .slice(0, 200) when building the
+    // error string. Document the current behavior (the spec asks for a
+    // TODO if needed — none needed; the cap is intentional, per the
+    // streamNdjson sister-path in index.astro which uses the same 200
+    // figure for its user-facing message).
+    const longBody = 'x'.repeat(500);
+    fetchSpy.mockImplementationOnce(() => Promise.resolve(plainResponse(longBody, 500)));
+    const result = await runOneStep(FULL_SCAN_STEPS[0]!, {
+      onPhase() {},
+      onLine() {},
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toBeNull();
+    // "HTTP 500: " (10 chars) + 200 body chars max.
+    expect(result.error!.length).toBeLessThanOrEqual(10 + 200);
+  });
+});

--- a/packages/analysis/src/computeSurprises.test.ts
+++ b/packages/analysis/src/computeSurprises.test.ts
@@ -54,8 +54,14 @@ function compositeRow(
   sessionId: string,
   updatedAt: number,
   binary: 'good' | 'bad' | 'unknown' = 'good',
+  projectId?: string,
 ): SurpriseCompositeRow {
-  return { sessionId, updatedAt, composite: comp(sessionId, binary) };
+  return {
+    sessionId,
+    updatedAt,
+    composite: comp(sessionId, binary),
+    ...(projectId !== undefined ? { projectId } : {}),
+  };
 }
 
 function trajectoryRow(
@@ -182,6 +188,7 @@ function decision(
   sessionId: string,
   binaryClass: 'good' | 'bad' | 'neutral',
   compositeScore = binaryClass === 'good' ? 0.8 : 0.3,
+  projectId?: string,
 ): SurpriseDecisionRow {
   return {
     decisionId,
@@ -189,6 +196,7 @@ function decision(
     compositeScore,
     binaryClass,
     label: `decision-${decisionId}`,
+    ...(projectId !== undefined ? { projectId } : {}),
   };
 }
 
@@ -223,6 +231,11 @@ describe('computeSurprises — empty input', () => {
   it('always exposes the thresholds it used', () => {
     const out = computeSurprises(emptyInput(), { streakMin: 7 });
     expect(out.thresholds.streakMin).toBe(7);
+  });
+
+  it('snapshot includes reflexiveEValueMin (post-iter-1 sensitivity gate)', () => {
+    const out = computeSurprises(emptyInput(), { reflexiveEValueMin: 2.0 });
+    expect(out.thresholds.reflexiveEValueMin).toBe(2.0);
   });
 });
 
@@ -430,56 +443,186 @@ describe('reflexive-positive', () => {
     );
     expect(kindsOf(out.surprises)).toContain('reflexive-positive');
   });
+
+  it('does NOT emit when eValueStatus is not "computed" (CI straddles null)', () => {
+    // Even with strong meanDelta + positive CI, an inability to
+    // compute the E-value kills emission.
+    const r = reflexive(0.2, 0.05, 0.35);
+    const out = computeSurprises(
+      emptyInput({
+        reflexive: { ...r, eValueStatus: 'ci-straddles-null', eValueCIBound: null },
+      }),
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when eValueCIBound is below the reflexiveEValueMin floor', () => {
+    const r = reflexive(0.2, 0.05, 0.35);
+    const out = computeSurprises(
+      emptyInput({
+        reflexive: { ...r, eValueStatus: 'computed', eValueCIBound: 1.49 },
+      }),
+      { reflexiveEValueMin: 1.5 },
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('summary uses associational language ("is associated with"), not causal ("lifted")', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.2, 0.05, 0.35) }),
+    );
+    const reflexivePos = out.surprises.find((s) => s.kind === 'reflexive-positive');
+    expect(reflexivePos).toBeDefined();
+    expect(reflexivePos?.summary).toMatch(/associated with/);
+    expect(reflexivePos?.summary).not.toMatch(/lifted/);
+    // E-value surfaces in the summary so the user sees the sensitivity bound.
+    expect(reflexivePos?.summary).toMatch(/E-value/);
+  });
 });
 
 // ─── decision-paid-off ─────────────────────────────────────────────
 
 describe('decision-paid-off', () => {
-  it('emits when a good-binary decision is followed by ≥ K good sessions', () => {
+  // Helper: build a "noisy corpus" of mostly-bad in OTHER projects so
+  // the base good-share stays well below the followup rate.
+  //
+  // The Wilson-low > base-rate gate is tight: 5/5 same-project good
+  // followups gives Wilson low ≈ 0.566 (α=0.05). The corpus base rate
+  // must clear ≤ ≈ 0.5 for the gate to pass at this followup count.
+  // 2 good + 10 bad in 'noise' → 12 noise sessions, base rate including
+  // the 1 decision-good + 5 followup-good = 8/18 ≈ 0.444.
+  function noiseCorpus(): SurpriseCompositeRow[] {
+    const out: SurpriseCompositeRow[] = [];
+    for (let i = 0; i < 2; i += 1) {
+      out.push(compositeRow(`n-good-${i}`, 100 + i, 'good', 'noise'));
+    }
+    for (let i = 0; i < 10; i += 1) {
+      out.push(compositeRow(`n-bad-${i}`, 120 + i, 'bad', 'noise'));
+    }
+    return out;
+  }
+
+  it('emits when a good-binary decision is followed by ≥ K same-project good sessions', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'good'),
-      compositeRow('s-after1', 11, 'good'),
-      compositeRow('s-after2', 12, 'good'),
-      compositeRow('s-after3', 13, 'good'),
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     const paidOff = out.surprises.find((s) => s.kind === 'decision-paid-off');
     expect(paidOff).toBeDefined();
     expect(paidOff?.evidence.decisionId).toBe('d1');
+    // Summary surfaces the lift metrics (K/N + Wilson-low + base-rate).
+    expect(paidOff?.summary).toMatch(/same-project followups: 5\/5 good/);
+    expect(paidOff?.summary).toMatch(/Wilson low/);
+    expect(paidOff?.summary).toMatch(/base rate/);
   });
 
   it('does NOT emit when binaryClass is not "good"', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'bad'),
-      compositeRow('s-after1', 11, 'good'),
-      compositeRow('s-after2', 12, 'good'),
+      compositeRow('s-dec', 10, 'bad', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'bad')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'bad', 0.3, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
   });
 
-  it('does NOT emit when followups < threshold', () => {
+  it('does NOT emit when same-project followups < threshold', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'good'),
-      compositeRow('s-after1', 11, 'good'),
-      // only 1 followup; default threshold is 2
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      // only 1 same-project followup; threshold is 5
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
   });
 
-  it('boundary: exactly threshold followups emits', () => {
+  it('boundary: exactly threshold followups in-project emits', () => {
     const composites: SurpriseCompositeRow[] = [
-      compositeRow('s-dec', 10, 'good'),
-      compositeRow('s-after1', 11, 'good'),
-      compositeRow('s-after2', 12, 'good'),
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
     ];
-    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
     const out = computeSurprises(emptyInput({ composites, decisions }));
     expect(kindsOf(out.surprises)).toContain('decision-paid-off');
+  });
+
+  it('does NOT count cross-project followups toward the threshold', () => {
+    // 5 good sessions follow the decision-session but in a DIFFERENT
+    // project — the prior cross-corpus version would have emitted.
+    const composites: SurpriseCompositeRow[] = [
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-x1', 11, 'good', 'p-other'),
+      compositeRow('s-x2', 12, 'good', 'p-other'),
+      compositeRow('s-x3', 13, 'good', 'p-other'),
+      compositeRow('s-x4', 14, 'good', 'p-other'),
+      compositeRow('s-x5', 15, 'good', 'p-other'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('does NOT emit when decision has no projectId (cannot scope followups)', () => {
+    const composites: SurpriseCompositeRow[] = [
+      ...noiseCorpus(),
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
+    ];
+    // Decision row deliberately missing projectId.
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8 /* no projectId */),
+    ];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('does NOT emit when Wilson low does not exceed base good-share', () => {
+    // Corpus is all-good (base rate 1.0). 5/5 good followups → Wilson
+    // low ≈ 0.566 — below 1.0. The lift gate kills the surprise even
+    // though the count floor is met.
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good', 'p1'),
+      compositeRow('s-a1', 11, 'good', 'p1'),
+      compositeRow('s-a2', 12, 'good', 'p1'),
+      compositeRow('s-a3', 13, 'good', 'p1'),
+      compositeRow('s-a4', 14, 'good', 'p1'),
+      compositeRow('s-a5', 15, 'good', 'p1'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [
+      decision('d1', 's-dec', 'good', 0.8, 'p1'),
+    ];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
   });
 });
 

--- a/packages/analysis/src/computeSurprises.test.ts
+++ b/packages/analysis/src/computeSurprises.test.ts
@@ -1,0 +1,652 @@
+/**
+ * Tests for `computeSurprises` — feed-redesign Phase A.
+ *
+ * Coverage shape per kind:
+ *   - happy path: kernel emits the expected row + score range
+ *   - negative path: kernel does NOT emit when inputs don't qualify
+ *   - boundary path: threshold-exact inputs behave correctly
+ *
+ * Plus a determinism test (same input → same output, ordering included)
+ * and a tone-segmentation sanity check.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CompositeOutcome } from '@chat-arch/schema';
+import {
+  computeSurprises,
+  type ComputeSurprisesInput,
+  type Surprise,
+  type SurpriseCompositeRow,
+  type SurpriseDecisionRow,
+  type SurpriseKind,
+  type SurpriseKnowledgeDebtRow,
+  type SurpriseTrajectoryRow,
+  type SurpriseWatcherEntry,
+} from './computeSurprises.js';
+import type { ItsResult } from './itsAnalysis.js';
+import type { ReflexiveResult } from './computeReflexive.js';
+
+// ─── Fixture helpers ───────────────────────────────────────────────
+
+const GENERATED_AT = 1_700_000_000_000;
+
+function comp(
+  sessionId: string,
+  binary: 'good' | 'bad' | 'unknown',
+  score = binary === 'good' ? 0.8 : 0.3,
+): CompositeOutcome {
+  return {
+    sessionId,
+    source: 'cowork',
+    testPass: null,
+    buildPass: null,
+    prLand: null,
+    noRework: null,
+    affirmation: null,
+    score,
+    linearLogit: 0,
+    binary,
+    weightsHash: 'cafebabecafebabe',
+  };
+}
+
+function compositeRow(
+  sessionId: string,
+  updatedAt: number,
+  binary: 'good' | 'bad' | 'unknown' = 'good',
+): SurpriseCompositeRow {
+  return { sessionId, updatedAt, composite: comp(sessionId, binary) };
+}
+
+function trajectoryRow(
+  projectId: string,
+  classification: SurpriseTrajectoryRow['classification'],
+  slope: number | null,
+  ci: { low: number; high: number } | null,
+): SurpriseTrajectoryRow {
+  return {
+    projectId,
+    projectName: projectId,
+    classification,
+    slope,
+    ci,
+    totalSessions: 20,
+    recentSessions: 5,
+    bootstrapStatus: 'ok',
+  };
+}
+
+function itsRow(
+  sha: string,
+  deltaGoodShare: number,
+  qValue: number,
+  subject = 'tweak claude.md',
+): ItsResult {
+  return {
+    sha,
+    ts: GENERATED_AT - 1_000_000,
+    path: 'CLAUDE.md',
+    subject,
+    windowDays: 10,
+    pre: {
+      n: 20,
+      meanScore: 0.5,
+      goodShare: 0.5,
+      goodShareCI: { low: 0.3, high: 0.7 },
+    },
+    post: {
+      n: 20,
+      meanScore: 0.5 + deltaGoodShare,
+      goodShare: 0.5 + deltaGoodShare,
+      goodShareCI: { low: 0.5 + deltaGoodShare - 0.1, high: 0.5 + deltaGoodShare + 0.1 },
+    },
+    deltaGoodShare,
+    deltaCI: { low: deltaGoodShare - 0.05, high: deltaGoodShare + 0.05 },
+    pValue: 0.01,
+    qValue,
+  };
+}
+
+function watcherHolding(
+  patternId: string,
+  sessionsObserved = 5,
+  failureRateUpperBound95 = 0.52,
+): SurpriseWatcherEntry {
+  return {
+    patternId,
+    projectId: 'p1',
+    verdict: {
+      kind: 'holding',
+      sessionsObserved,
+      failureRateUpperBound95,
+    },
+  };
+}
+
+function watcherRecurring(patternId: string, narrativeId: string): SurpriseWatcherEntry {
+  return {
+    patternId,
+    projectId: 'p1',
+    verdict: {
+      kind: 'recurring',
+      recurrenceNarrativeId: narrativeId,
+      recurrenceGeneratedAt: '2026-04-15T00:00:00Z',
+    },
+  };
+}
+
+function reflexive(
+  meanDelta: number,
+  ciLow: number,
+  ciHigh: number,
+  pairs: number = 5,
+): ReflexiveResult {
+  return {
+    pairs: Array.from({ length: pairs }, (_, i) => ({
+      treatedSessionId: `t-${i}`,
+      controlSessionId: `c-${i}`,
+      treatedGood: 1,
+      controlGood: 0,
+      distance: 0.1,
+    })),
+    pTreated: 0.5 + meanDelta / 2,
+    pControl: 0.5 - meanDelta / 2,
+    meanDelta,
+    ci: { low: ciLow, high: ciHigh },
+    eValueCIBound: 1.5,
+    eValueStatus: 'computed',
+    nTreated: pairs,
+    nControl: pairs * 2,
+    mcnemarP: 0.04,
+    mcnemarMethod: 'exact',
+    discordantCount: pairs,
+  };
+}
+
+function debtCluster(
+  id: string,
+  size: number,
+  confidence: 'high' | 'low' = 'high',
+  canonicalQuestion = 'how do I do X',
+): SurpriseKnowledgeDebtRow {
+  return {
+    id,
+    canonicalQuestion,
+    sessionIds: Array.from({ length: size }, (_, i) => `${id}-s${i}`),
+    confidence,
+  };
+}
+
+function decision(
+  decisionId: string,
+  sessionId: string,
+  binaryClass: 'good' | 'bad' | 'neutral',
+  compositeScore = binaryClass === 'good' ? 0.8 : 0.3,
+): SurpriseDecisionRow {
+  return {
+    decisionId,
+    sessionId,
+    compositeScore,
+    binaryClass,
+    label: `decision-${decisionId}`,
+  };
+}
+
+function emptyInput(overrides: Partial<ComputeSurprisesInput> = {}): ComputeSurprisesInput {
+  return {
+    generatedAt: GENERATED_AT,
+    composites: [],
+    trajectories: [],
+    itsResults: [],
+    patternWatchers: [],
+    reflexive: null,
+    decisions: [],
+    knowledgeDebt: [],
+    ...overrides,
+  };
+}
+
+function kindsOf(surprises: readonly Surprise[]): SurpriseKind[] {
+  return surprises.map((s) => s.kind);
+}
+
+// ─── Empty / smoke ─────────────────────────────────────────────────
+
+describe('computeSurprises — empty input', () => {
+  it('returns an empty surprises array on empty inputs', () => {
+    const out = computeSurprises(emptyInput());
+    expect(out.version).toBe(1);
+    expect(out.generatedAt).toBe(GENERATED_AT);
+    expect(out.surprises).toEqual([]);
+  });
+
+  it('always exposes the thresholds it used', () => {
+    const out = computeSurprises(emptyInput(), { streakMin: 7 });
+    expect(out.thresholds.streakMin).toBe(7);
+  });
+});
+
+// ─── streak ────────────────────────────────────────────────────────
+
+describe('streak', () => {
+  it('emits when trailing run >= streakMin good sessions', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s0', 1, 'bad'),
+      compositeRow('s1', 2, 'good'),
+      compositeRow('s2', 3, 'good'),
+      compositeRow('s3', 4, 'good'),
+      compositeRow('s4', 5, 'good'),
+      compositeRow('s5', 6, 'good'),
+    ];
+    const out = computeSurprises(emptyInput({ composites }));
+    const streak = out.surprises.find((s) => s.kind === 'streak');
+    expect(streak).toBeDefined();
+    expect(streak?.evidence.sessionIds).toEqual(['s1', 's2', 's3', 's4', 's5']);
+    expect(streak?.tone).toBe('positive');
+  });
+
+  it('does NOT emit when trailing run is broken by a non-good session', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s0', 1, 'good'),
+      compositeRow('s1', 2, 'good'),
+      compositeRow('s2', 3, 'good'),
+      compositeRow('s3', 4, 'good'),
+      compositeRow('s4', 5, 'good'),
+      compositeRow('s5', 6, 'bad'),
+    ];
+    const out = computeSurprises(emptyInput({ composites }));
+    expect(kindsOf(out.surprises)).not.toContain('streak');
+  });
+
+  it('boundary: exactly streakMin sessions emits, one short does not', () => {
+    const five: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+      compositeRow('s4', 4, 'good'),
+      compositeRow('s5', 5, 'good'),
+    ];
+    const four: SurpriseCompositeRow[] = five.slice(1);
+    expect(
+      kindsOf(computeSurprises(emptyInput({ composites: five })).surprises),
+    ).toContain('streak');
+    expect(
+      kindsOf(computeSurprises(emptyInput({ composites: four })).surprises),
+    ).not.toContain('streak');
+  });
+
+  it('respects streakMin override', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+    ];
+    const out = computeSurprises(
+      emptyInput({ composites }),
+      { streakMin: 2 },
+    );
+    expect(kindsOf(out.surprises)).toContain('streak');
+  });
+});
+
+// ─── trajectory-accelerating ───────────────────────────────────────
+
+describe('trajectory-accelerating', () => {
+  it('emits one row per accelerating project', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'accelerating', 0.08, { low: 0.01, high: 0.15 }),
+      trajectoryRow('p2', 'accelerating', 0.04, { low: 0.005, high: 0.08 }),
+      trajectoryRow('p3', 'flat', 0, { low: -0.01, high: 0.01 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    const accel = out.surprises.filter((s) => s.kind === 'trajectory-accelerating');
+    expect(accel).toHaveLength(2);
+    expect(accel.map((s) => s.evidence.projectId).sort()).toEqual(['p1', 'p2']);
+  });
+
+  it('does NOT emit for non-accelerating projects', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'flat', 0, { low: -0.01, high: 0.01 }),
+      trajectoryRow('p2', 'stalling', -0.05, { low: -0.08, high: -0.01 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-accelerating');
+  });
+});
+
+// ─── config-helped ─────────────────────────────────────────────────
+
+describe('config-helped', () => {
+  it('emits when qValue ≤ threshold AND deltaGoodShare ≥ threshold', () => {
+    const itsResults: ItsResult[] = [itsRow('abc123def', 0.2, 0.05)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    const helped = out.surprises.find((s) => s.kind === 'config-helped');
+    expect(helped).toBeDefined();
+    expect(helped?.evidence.configSha).toBe('abc123def');
+  });
+
+  it('does NOT emit when qValue is above threshold', () => {
+    const itsResults: ItsResult[] = [itsRow('abc', 0.2, 0.5)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    expect(kindsOf(out.surprises)).not.toContain('config-helped');
+  });
+
+  it('does NOT emit when delta is below threshold', () => {
+    const itsResults: ItsResult[] = [itsRow('abc', 0.05, 0.01)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    expect(kindsOf(out.surprises)).not.toContain('config-helped');
+  });
+
+  it('boundary: delta exactly at threshold emits', () => {
+    const itsResults: ItsResult[] = [itsRow('abc', 0.15, 0.1)];
+    const out = computeSurprises(emptyInput({ itsResults }));
+    expect(kindsOf(out.surprises)).toContain('config-helped');
+  });
+});
+
+// ─── pattern-closed / pattern-recurring ────────────────────────────
+
+describe('pattern-closed', () => {
+  it('emits for each holding watcher verdict', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherHolding('pat1', 5, 0.52),
+      watcherHolding('pat2', 20, 0.16),
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    const closed = out.surprises.filter((s) => s.kind === 'pattern-closed');
+    expect(closed).toHaveLength(2);
+    // pat2 (more sessions cleared → tighter Wilson) should score higher.
+    const byId = new Map(closed.map((s) => [s.evidence.narrativeId, s.score] as const));
+    expect((byId.get('pat2') ?? 0)).toBeGreaterThan(byId.get('pat1') ?? 0);
+  });
+
+  it('does NOT emit for open / inconclusive verdicts', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      { patternId: 'a', projectId: 'p1', verdict: { kind: 'open' } },
+      {
+        patternId: 'b',
+        projectId: 'p1',
+        verdict: { kind: 'inconclusive', reason: 'wall-clock-timeout' },
+      },
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    expect(kindsOf(out.surprises)).not.toContain('pattern-closed');
+  });
+});
+
+describe('pattern-recurring', () => {
+  it('emits one concern per recurring verdict', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherRecurring('pat-x', 'narr-1'),
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    const rec = out.surprises.find((s) => s.kind === 'pattern-recurring');
+    expect(rec).toBeDefined();
+    expect(rec?.tone).toBe('concerning');
+    expect(rec?.evidence.narrativeId).toBe('narr-1');
+  });
+
+  it('does NOT emit for non-recurring verdicts', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherHolding('pat1'),
+      { patternId: 'b', projectId: 'p1', verdict: { kind: 'open' } },
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    expect(kindsOf(out.surprises)).not.toContain('pattern-recurring');
+  });
+});
+
+// ─── reflexive-positive ────────────────────────────────────────────
+
+describe('reflexive-positive', () => {
+  it('emits when meanDelta ≥ threshold AND CI strictly positive', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.2, 0.05, 0.35) }),
+    );
+    expect(kindsOf(out.surprises)).toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when reflexive is null', () => {
+    const out = computeSurprises(emptyInput({ reflexive: null }));
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when CI straddles zero (low ≤ 0)', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.2, -0.01, 0.4) }),
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('does NOT emit when meanDelta is below threshold', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.05, 0.01, 0.09) }),
+    );
+    expect(kindsOf(out.surprises)).not.toContain('reflexive-positive');
+  });
+
+  it('boundary: meanDelta exactly at threshold emits', () => {
+    const out = computeSurprises(
+      emptyInput({ reflexive: reflexive(0.1, 0.01, 0.19) }),
+    );
+    expect(kindsOf(out.surprises)).toContain('reflexive-positive');
+  });
+});
+
+// ─── decision-paid-off ─────────────────────────────────────────────
+
+describe('decision-paid-off', () => {
+  it('emits when a good-binary decision is followed by ≥ K good sessions', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good'),
+      compositeRow('s-after1', 11, 'good'),
+      compositeRow('s-after2', 12, 'good'),
+      compositeRow('s-after3', 13, 'good'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    const paidOff = out.surprises.find((s) => s.kind === 'decision-paid-off');
+    expect(paidOff).toBeDefined();
+    expect(paidOff?.evidence.decisionId).toBe('d1');
+  });
+
+  it('does NOT emit when binaryClass is not "good"', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'bad'),
+      compositeRow('s-after1', 11, 'good'),
+      compositeRow('s-after2', 12, 'good'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'bad')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('does NOT emit when followups < threshold', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good'),
+      compositeRow('s-after1', 11, 'good'),
+      // only 1 followup; default threshold is 2
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).not.toContain('decision-paid-off');
+  });
+
+  it('boundary: exactly threshold followups emits', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s-dec', 10, 'good'),
+      compositeRow('s-after1', 11, 'good'),
+      compositeRow('s-after2', 12, 'good'),
+    ];
+    const decisions: SurpriseDecisionRow[] = [decision('d1', 's-dec', 'good')];
+    const out = computeSurprises(emptyInput({ composites, decisions }));
+    expect(kindsOf(out.surprises)).toContain('decision-paid-off');
+  });
+});
+
+// ─── trajectory-stalled ────────────────────────────────────────────
+
+describe('trajectory-stalled', () => {
+  it('emits for stalling and stalled-finished projects', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p-stalling', 'stalling', -0.1, { low: -0.15, high: -0.05 }),
+      trajectoryRow(
+        'p-finished',
+        'stalled-finished',
+        -0.1,
+        { low: -0.15, high: -0.05 },
+      ),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    const stalled = out.surprises.filter((s) => s.kind === 'trajectory-stalled');
+    expect(stalled).toHaveLength(2);
+    // stalling > stalled-finished on score (active decline biased higher)
+    const byId = new Map(stalled.map((s) => [s.evidence.projectId, s.score] as const));
+    expect((byId.get('p-stalling') ?? 0)).toBeGreaterThan(
+      byId.get('p-finished') ?? 0,
+    );
+  });
+
+  it('does NOT emit for flat / accelerating projects', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p-flat', 'flat', 0, { low: -0.01, high: 0.01 }),
+      trajectoryRow('p-up', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-stalled');
+  });
+});
+
+// ─── debt-spinning ─────────────────────────────────────────────────
+
+describe('debt-spinning', () => {
+  it('emits top-K clusters that meet the minimum size', () => {
+    const knowledgeDebt: SurpriseKnowledgeDebtRow[] = [
+      debtCluster('c-big', 15),
+      debtCluster('c-med', 8),
+      debtCluster('c-small', 3),
+      debtCluster('c-tiny', 1), // below min size
+    ];
+    const out = computeSurprises(emptyInput({ knowledgeDebt }));
+    const debt = out.surprises.filter((s) => s.kind === 'debt-spinning');
+    // default topK=3, default minSize=3 → c-big, c-med, c-small
+    expect(debt.map((s) => s.id)).toEqual([
+      'debt-spinning:c-big',
+      'debt-spinning:c-med',
+      'debt-spinning:c-small',
+    ]);
+  });
+
+  it('does NOT emit clusters below the minimum size', () => {
+    const knowledgeDebt: SurpriseKnowledgeDebtRow[] = [debtCluster('c1', 2)];
+    const out = computeSurprises(emptyInput({ knowledgeDebt }));
+    expect(kindsOf(out.surprises)).not.toContain('debt-spinning');
+  });
+
+  it('low-confidence clusters get 0.7× score multiplier', () => {
+    const knowledgeDebt: SurpriseKnowledgeDebtRow[] = [
+      debtCluster('c-high', 10, 'high'),
+      debtCluster('c-low', 10, 'low'),
+    ];
+    const out = computeSurprises(emptyInput({ knowledgeDebt }));
+    const byId = new Map(
+      out.surprises
+        .filter((s) => s.kind === 'debt-spinning')
+        .map((s) => [s.id, s.score] as const),
+    );
+    const high = byId.get('debt-spinning:c-high') ?? 0;
+    const low = byId.get('debt-spinning:c-low') ?? 0;
+    expect(low).toBeCloseTo(high * 0.7, 5);
+  });
+});
+
+// ─── Cross-cutting: determinism, ranking, summary length ───────────
+
+describe('cross-cutting properties', () => {
+  it('summary clips at 120 chars', () => {
+    const longName = 'p-'.padEnd(200, 'x');
+    const trajectories: SurpriseTrajectoryRow[] = [
+      {
+        ...trajectoryRow(longName, 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+        projectName: longName,
+      },
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    for (const s of out.surprises) {
+      expect(s.summary.length).toBeLessThanOrEqual(120);
+    }
+  });
+
+  it('output is sorted by score descending, then id ascending', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p-low', 'accelerating', 0.02, { low: 0.001, high: 0.04 }),
+      trajectoryRow('p-high', 'accelerating', 0.3, { low: 0.1, high: 0.5 }),
+    ];
+    const out = computeSurprises(emptyInput({ trajectories }));
+    const accel = out.surprises.filter((s) => s.kind === 'trajectory-accelerating');
+    // p-high should come first
+    expect(accel[0]?.evidence.projectId).toBe('p-high');
+  });
+
+  it('tie-breaks on id when scores are equal', () => {
+    // Two patterns with the same Wilson upper bound (same N=5) → same score.
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherHolding('zzz', 5, 0.52),
+      watcherHolding('aaa', 5, 0.52),
+    ];
+    const out = computeSurprises(emptyInput({ patternWatchers }));
+    const closed = out.surprises.filter((s) => s.kind === 'pattern-closed');
+    expect(closed.map((s) => s.evidence.narrativeId)).toEqual(['aaa', 'zzz']);
+  });
+
+  it('every surprise carries generatedAt matching the input', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+      compositeRow('s4', 4, 'good'),
+      compositeRow('s5', 5, 'good'),
+    ];
+    const out = computeSurprises({ ...emptyInput({ composites }), generatedAt: 12345 });
+    for (const s of out.surprises) {
+      expect(s.generatedAt).toBe(12345);
+    }
+  });
+
+  it('determinism: identical inputs produce identical outputs (ordering included)', () => {
+    const input = emptyInput({
+      composites: [
+        compositeRow('s1', 1, 'good'),
+        compositeRow('s2', 2, 'good'),
+        compositeRow('s3', 3, 'good'),
+        compositeRow('s4', 4, 'good'),
+        compositeRow('s5', 5, 'good'),
+      ],
+      trajectories: [
+        trajectoryRow('p1', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+        trajectoryRow('p2', 'stalling', -0.05, { low: -0.1, high: -0.01 }),
+      ],
+      itsResults: [itsRow('sha1', 0.2, 0.05)],
+      patternWatchers: [watcherHolding('pat1'), watcherRecurring('pat2', 'narr-x')],
+      reflexive: reflexive(0.2, 0.05, 0.35),
+      decisions: [decision('d1', 's1', 'good')],
+      knowledgeDebt: [debtCluster('c1', 10)],
+    });
+    const a = computeSurprises(input);
+    const b = computeSurprises(input);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('tone segmentation: positive vs concerning kinds map to the right tone', () => {
+    const input = emptyInput({
+      trajectories: [
+        trajectoryRow('p-up', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+        trajectoryRow('p-down', 'stalling', -0.05, { low: -0.1, high: -0.01 }),
+      ],
+    });
+    const out = computeSurprises(input);
+    for (const s of out.surprises) {
+      if (s.kind === 'trajectory-accelerating') expect(s.tone).toBe('positive');
+      if (s.kind === 'trajectory-stalled') expect(s.tone).toBe('concerning');
+    }
+  });
+});

--- a/packages/analysis/src/computeSurprises.ts
+++ b/packages/analysis/src/computeSurprises.ts
@@ -1,0 +1,629 @@
+/**
+ * Surprises kernel — feed-redesign Phase A (plumbing).
+ *
+ * Snapshot-based: takes already-computed kernel outputs (composite
+ * outcomes, project trajectories, ITS contrasts, applied-pattern
+ * watcher verdicts, reflexive result, decisions, knowledge-debt
+ * clusters) and emits a ranked list of "surprise" observations the
+ * user might not have noticed about their recent work with Claude.
+ *
+ * Positive observations (`tone: 'positive'`):
+ *   - streak                  — N consecutive composite-good sessions
+ *   - trajectory-accelerating — project slope CI strictly positive
+ *   - config-helped           — ITS contrast with significantly +delta
+ *   - pattern-closed          — applied-pattern watcher `holding`
+ *                               (cooldown cleared with no recurrence)
+ *   - reflexive-positive      — reflexive meanDelta > threshold AND
+ *                               CI strictly positive
+ *   - decision-paid-off       — decision joined to a good outcome AND
+ *                               followed by ≥ K additional good outcomes
+ *
+ * Concerns (`tone: 'concerning'`):
+ *   - trajectory-stalled      — project slope CI strictly negative
+ *                               (decline) — picks `stalling` first,
+ *                               then `stalled-finished`
+ *   - pattern-recurring       — applied-pattern watcher `recurring`
+ *   - debt-spinning           — top knowledge-debt clusters by size
+ *                               (V1: highest count flagged; week-over-
+ *                                week growth is a follow-on)
+ *
+ * Pure. Browser-safe (no `node:*` imports). Deterministic — the
+ * caller passes `generatedAt` (the kernel does NOT call `Date.now()`),
+ * and tie-breaks on stable ids so identical inputs produce identical
+ * outputs including ordering.
+ *
+ * Ranking: score in [0, 1]; output is sorted descending by score, with
+ * `id` as the tie-breaker. The score formula is documented per-kind
+ * inside `compute*` helpers below — pre-launch placeholders, calibrate
+ * once the UI surface accumulates engagement data.
+ */
+
+import type { CompositeOutcome } from '@chat-arch/schema';
+import { THRESHOLDS } from './thresholds.js';
+import type { ItsResult } from './itsAnalysis.js';
+import type { ReflexiveResult } from './computeReflexive.js';
+import type { WatcherVerdict } from './applyWatcher.js';
+
+// ─── Input row shapes ──────────────────────────────────────────────
+//
+// We accept narrow "Like" interfaces here so the kernel doesn't pull
+// in the full exporter-shell builder output types. Anything assignable
+// to these (the on-disk sidecar shapes from
+// projectTrajectoryBuilder / decisionsBuilder / detectKnowledgeDebt /
+// the applied-pattern watcher loop) is accepted.
+
+/** Composite-outcome row paired with the session's terminal timestamp. */
+export interface SurpriseCompositeRow {
+  readonly sessionId: string;
+  /** Unix ms — session terminal timestamp (manifest.updatedAt). */
+  readonly updatedAt: number;
+  readonly composite: CompositeOutcome;
+}
+
+/** Project-trajectory row — mirrors the on-disk sidecar entry. */
+export interface SurpriseTrajectoryRow {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly classification: 'stalling' | 'stalled-finished' | 'accelerating' | 'flat';
+  readonly slope: number | null;
+  readonly ci: { readonly low: number; readonly high: number } | null;
+  readonly totalSessions: number;
+  readonly recentSessions: number;
+  readonly bootstrapStatus: 'ok' | 'series-too-short';
+}
+
+/** Per-pattern watcher verdict pairing — emitted by the curator loop. */
+export interface SurpriseWatcherEntry {
+  readonly patternId: string;
+  readonly projectId: string;
+  readonly verdict: WatcherVerdict;
+}
+
+/**
+ * Knowledge-debt cluster row — mirrors `KnowledgeDebtCluster` plus a
+ * passthrough `confidence` so we can de-rank low-confidence clusters.
+ */
+export interface SurpriseKnowledgeDebtRow {
+  readonly id: string;
+  readonly canonicalQuestion: string;
+  readonly sessionIds: readonly string[];
+  readonly confidence: 'high' | 'low';
+}
+
+/**
+ * Decision row — narrow projection of `Decision` carrying just what
+ * the kernel needs (session, outcome score, binary class, optional
+ * id for evidence).
+ */
+export interface SurpriseDecisionRow {
+  readonly decisionId: string;
+  readonly sessionId: string;
+  readonly compositeScore: number;
+  readonly binaryClass: 'good' | 'bad' | 'neutral';
+  /** Short label rendered into the summary; falls back to "a decision". */
+  readonly label?: string;
+}
+
+// ─── Output schema ─────────────────────────────────────────────────
+
+export type SurpriseKind =
+  | 'streak'
+  | 'trajectory-accelerating'
+  | 'config-helped'
+  | 'pattern-closed'
+  | 'reflexive-positive'
+  | 'decision-paid-off'
+  | 'trajectory-stalled'
+  | 'pattern-recurring'
+  | 'debt-spinning';
+
+export type SurpriseTone = 'positive' | 'concerning';
+
+export interface SurpriseEvidence {
+  readonly sessionIds?: readonly string[];
+  readonly projectId?: string;
+  readonly narrativeId?: string;
+  readonly configSha?: string;
+  readonly decisionId?: string;
+}
+
+export interface Surprise {
+  /** Stable id derived from kind + evidence (deterministic ordering). */
+  readonly id: string;
+  readonly kind: SurpriseKind;
+  readonly tone: SurpriseTone;
+  /** ≤ 120 chars. */
+  readonly summary: string;
+  readonly evidence: SurpriseEvidence;
+  /** 0..1 — higher means more surface-worthy. */
+  readonly score: number;
+  /** Mirrors the file-level `generatedAt`; carried per-row for downstream
+   *  filters that ingest individual surprises. */
+  readonly generatedAt: number;
+}
+
+/** Subset of THRESHOLDS we expose with the file so the UI can disclaim. */
+export interface SurpriseThresholdsSnapshot {
+  readonly streakMin: number;
+  readonly itsQValueMax: number;
+  readonly itsDeltaMin: number;
+  readonly reflexiveDeltaMin: number;
+  readonly decisionGoodFollowupsMin: number;
+  readonly debtSpinningTopK: number;
+  readonly debtSpinningMinClusterSize: number;
+}
+
+export interface SurprisesOutput {
+  readonly version: 1;
+  readonly generatedAt: number;
+  readonly surprises: readonly Surprise[];
+  readonly thresholds: SurpriseThresholdsSnapshot;
+}
+
+export interface ComputeSurprisesInput {
+  /** Unix ms — must be passed in (kernel does NOT call Date.now()). */
+  readonly generatedAt: number;
+  /** Composite-outcome rows for every scored session. */
+  readonly composites: readonly SurpriseCompositeRow[];
+  /** Per-project trajectory rows (one per project). */
+  readonly trajectories: readonly SurpriseTrajectoryRow[];
+  /** ITS contrast rows (one per config commit analyzed). */
+  readonly itsResults: readonly ItsResult[];
+  /**
+   * Applied-pattern watcher verdicts — one per (pattern, project) the
+   * curator loop tracked. The kernel surfaces `holding` as `pattern-
+   * closed` and `recurring` as `pattern-recurring`; other verdicts
+   * (`open`, `inconclusive`) are ignored.
+   */
+  readonly patternWatchers: readonly SurpriseWatcherEntry[];
+  /** Reflexive result — single row (the whole-corpus contrast). */
+  readonly reflexive: ReflexiveResult | null;
+  /** Decision rows (post outcome-join). */
+  readonly decisions: readonly SurpriseDecisionRow[];
+  /** Knowledge-debt clusters. */
+  readonly knowledgeDebt: readonly SurpriseKnowledgeDebtRow[];
+}
+
+export interface ComputeSurprisesOptions {
+  /** Override the minimum streak length. Default 5. */
+  readonly streakMin?: number;
+  /**
+   * ITS BH-FDR qValue ceiling — a contrast counts as "config-helped"
+   * when `qValue ≤ itsQValueMax` AND `deltaGoodShare ≥ itsDeltaMin`.
+   * Pre-launch placeholder; calibrate after first ~50 contrasts.
+   */
+  readonly itsQValueMax?: number;
+  readonly itsDeltaMin?: number;
+  /**
+   * Reflexive minimum mean-delta (good-share delta) to surface. Also
+   * requires the CI to be strictly positive (low > 0). Pre-launch
+   * placeholder.
+   */
+  readonly reflexiveDeltaMin?: number;
+  /**
+   * `decision-paid-off`: minimum number of additional good composite
+   * outcomes that must follow the decision's session (same project
+   * preferred but not required in V1; the kernel scopes by
+   * compositeRow.updatedAt > decision-session.updatedAt). Default 2.
+   */
+  readonly decisionGoodFollowupsMin?: number;
+  /** Top-K knowledge-debt clusters surfaced as `debt-spinning`. Default 3. */
+  readonly debtSpinningTopK?: number;
+  /** Minimum cluster size for `debt-spinning`. Default 3. */
+  readonly debtSpinningMinClusterSize?: number;
+}
+
+const DEFAULTS = {
+  streakMin: 5,
+  itsQValueMax: 0.1,
+  itsDeltaMin: 0.15,
+  reflexiveDeltaMin: 0.1,
+  decisionGoodFollowupsMin: 2,
+  debtSpinningTopK: 3,
+  debtSpinningMinClusterSize: 3,
+} as const;
+
+// ─── Kernel entry point ────────────────────────────────────────────
+
+export function computeSurprises(
+  input: ComputeSurprisesInput,
+  options: ComputeSurprisesOptions = {},
+): SurprisesOutput {
+  const opts = {
+    streakMin: options.streakMin ?? DEFAULTS.streakMin,
+    itsQValueMax: options.itsQValueMax ?? DEFAULTS.itsQValueMax,
+    itsDeltaMin: options.itsDeltaMin ?? DEFAULTS.itsDeltaMin,
+    reflexiveDeltaMin: options.reflexiveDeltaMin ?? DEFAULTS.reflexiveDeltaMin,
+    decisionGoodFollowupsMin:
+      options.decisionGoodFollowupsMin ?? DEFAULTS.decisionGoodFollowupsMin,
+    debtSpinningTopK: options.debtSpinningTopK ?? DEFAULTS.debtSpinningTopK,
+    debtSpinningMinClusterSize:
+      options.debtSpinningMinClusterSize ?? DEFAULTS.debtSpinningMinClusterSize,
+  };
+
+  const surprises: Surprise[] = [];
+
+  pushAll(surprises, computeStreak(input, opts));
+  pushAll(surprises, computeTrajectoryAccelerating(input));
+  pushAll(surprises, computeConfigHelped(input, opts));
+  pushAll(surprises, computePatternClosed(input));
+  pushAll(surprises, computeReflexivePositive(input, opts));
+  pushAll(surprises, computeDecisionPaidOff(input, opts));
+  pushAll(surprises, computeTrajectoryStalled(input));
+  pushAll(surprises, computePatternRecurring(input));
+  pushAll(surprises, computeDebtSpinning(input, opts));
+
+  // Stamp generatedAt on every row + stable-sort. Tie-break on id so
+  // equal-score rows still come out in a deterministic order.
+  const stamped = surprises.map((s) => ({ ...s, generatedAt: input.generatedAt }));
+  stamped.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
+
+  return {
+    version: 1,
+    generatedAt: input.generatedAt,
+    surprises: stamped,
+    thresholds: {
+      streakMin: opts.streakMin,
+      itsQValueMax: opts.itsQValueMax,
+      itsDeltaMin: opts.itsDeltaMin,
+      reflexiveDeltaMin: opts.reflexiveDeltaMin,
+      decisionGoodFollowupsMin: opts.decisionGoodFollowupsMin,
+      debtSpinningTopK: opts.debtSpinningTopK,
+      debtSpinningMinClusterSize: opts.debtSpinningMinClusterSize,
+    },
+  };
+}
+
+// ─── Per-kind compute helpers ──────────────────────────────────────
+
+/**
+ * `streak`: find the LONGEST suffix run of composite-good sessions
+ * (ordered by `updatedAt`). Emits one surprise when the run length
+ * meets or exceeds `streakMin`. Boundary case: the run is computed as
+ * the trailing run only — we want to surface "currently on a hot
+ * streak", not "you once had 10 in a row last year".
+ *
+ * Score: saturating in run length. `min(1, runLength / (streakMin * 2))`
+ * — at exactly the threshold, score = 0.5; double the threshold caps
+ * the score at 1.
+ */
+function computeStreak(
+  input: ComputeSurprisesInput,
+  opts: { streakMin: number },
+): Surprise[] {
+  const sorted = input.composites
+    .slice()
+    .sort((a, b) => a.updatedAt - b.updatedAt || a.sessionId.localeCompare(b.sessionId));
+
+  const runIds: string[] = [];
+  for (let i = sorted.length - 1; i >= 0; i -= 1) {
+    const row = sorted[i] as SurpriseCompositeRow;
+    if (row.composite.binary === 'good') {
+      runIds.unshift(row.sessionId);
+    } else {
+      break;
+    }
+  }
+  if (runIds.length < opts.streakMin) return [];
+
+  const score = Math.min(1, runIds.length / (opts.streakMin * 2));
+  return [
+    {
+      id: `streak:${runIds[runIds.length - 1] as string}`,
+      kind: 'streak',
+      tone: 'positive',
+      summary: clip(
+        `${runIds.length} sessions in a row landed as composite-good.`,
+      ),
+      evidence: { sessionIds: runIds },
+      score,
+      generatedAt: 0,
+    },
+  ];
+}
+
+/**
+ * `trajectory-accelerating`: project rows with `classification ===
+ * 'accelerating'` (the trajectory builder already imposes CI strictly
+ * positive). One surprise per project. Score scales with slope.
+ *
+ * Score: `min(1, slope * 5)` — a slope of 0.2 per session caps the
+ * score at 1; smaller slopes scale down. Pre-launch placeholder.
+ */
+function computeTrajectoryAccelerating(
+  input: ComputeSurprisesInput,
+): Surprise[] {
+  const out: Surprise[] = [];
+  for (const t of input.trajectories) {
+    if (t.classification !== 'accelerating') continue;
+    const slope = t.slope ?? 0;
+    const score = Math.max(0, Math.min(1, slope * 5));
+    out.push({
+      id: `trajectory-accelerating:${t.projectId}`,
+      kind: 'trajectory-accelerating',
+      tone: 'positive',
+      summary: clip(
+        `${t.projectName} is on an accelerating slope (${slope.toFixed(2)}/session).`,
+      ),
+      evidence: { projectId: t.projectId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `config-helped`: ITS contrasts with `qValue ≤ itsQValueMax` AND
+ * `deltaGoodShare ≥ itsDeltaMin`. One surprise per qualifying commit.
+ *
+ * Score: `min(1, deltaGoodShare * 2)` — a 50pp delta caps at 1. We
+ * don't fold q-value into the score (it's a gating mechanism only;
+ * folding both would double-count statistical significance).
+ */
+function computeConfigHelped(
+  input: ComputeSurprisesInput,
+  opts: { itsQValueMax: number; itsDeltaMin: number },
+): Surprise[] {
+  const out: Surprise[] = [];
+  for (const r of input.itsResults) {
+    if (!Number.isFinite(r.qValue) || r.qValue > opts.itsQValueMax) continue;
+    if (!Number.isFinite(r.deltaGoodShare) || r.deltaGoodShare < opts.itsDeltaMin) continue;
+    const score = Math.max(0, Math.min(1, r.deltaGoodShare * 2));
+    out.push({
+      id: `config-helped:${r.sha}`,
+      kind: 'config-helped',
+      tone: 'positive',
+      summary: clip(
+        `Config change ${shortSha(r.sha)} (${r.subject}) lifted good-share by ` +
+          `${(r.deltaGoodShare * 100).toFixed(0)}pp.`,
+      ),
+      evidence: { configSha: r.sha },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `pattern-closed`: applied-pattern watcher returned `holding`. The
+ * watcher kernel already enforces "N sessions cleared + no recurrence
+ * + project still active" so we just need to surface those rows.
+ *
+ * Score: `1 - failureRateUpperBound95` — at N=5 the Wilson UB is
+ * ~0.52 so score ~0.48; at N=20 it tightens to ~0.84. More sessions
+ * cleared → tighter confidence → higher surprise score.
+ */
+function computePatternClosed(input: ComputeSurprisesInput): Surprise[] {
+  const out: Surprise[] = [];
+  for (const w of input.patternWatchers) {
+    if (w.verdict.kind !== 'holding') continue;
+    const score = Math.max(0, Math.min(1, 1 - w.verdict.failureRateUpperBound95));
+    out.push({
+      id: `pattern-closed:${w.patternId}`,
+      kind: 'pattern-closed',
+      tone: 'positive',
+      summary: clip(
+        `Pattern ${w.patternId} held — ${w.verdict.sessionsObserved} clean ` +
+          `sessions, no recurrence.`,
+      ),
+      evidence: { projectId: w.projectId, narrativeId: w.patternId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `reflexive-positive`: meanDelta ≥ reflexiveDeltaMin AND CI strictly
+ * positive (low > 0). One surprise at most (reflexive is whole-corpus).
+ *
+ * Score: `min(1, meanDelta * 2)` — same convention as config-helped.
+ */
+function computeReflexivePositive(
+  input: ComputeSurprisesInput,
+  opts: { reflexiveDeltaMin: number },
+): Surprise[] {
+  const r = input.reflexive;
+  if (r === null) return [];
+  if (!Number.isFinite(r.meanDelta) || r.meanDelta < opts.reflexiveDeltaMin) return [];
+  if (r.ci.low <= 0) return [];
+  const score = Math.max(0, Math.min(1, r.meanDelta * 2));
+  return [
+    {
+      id: 'reflexive-positive:whole-corpus',
+      kind: 'reflexive-positive',
+      tone: 'positive',
+      summary: clip(
+        `Touching chat-arch lifted good-share by ${(r.meanDelta * 100).toFixed(0)}pp ` +
+          `(CI low ${(r.ci.low * 100).toFixed(0)}pp).`,
+      ),
+      evidence: {
+        sessionIds: r.pairs.map((p) => p.treatedSessionId),
+      },
+      score,
+      generatedAt: 0,
+    },
+  ];
+}
+
+/**
+ * `decision-paid-off`: a decision whose outcome was `good` AND was
+ * followed by at least `decisionGoodFollowupsMin` additional good
+ * composite outcomes (across the whole corpus — V1 doesn't restrict
+ * to same-project; that's a follow-on once decisions carry a project
+ * pointer in the join).
+ *
+ * Score: saturating in follow-up count. `min(1, (followups + 1) / 10)`
+ * — a decision with 9 good followups caps the score at 1.
+ */
+function computeDecisionPaidOff(
+  input: ComputeSurprisesInput,
+  opts: { decisionGoodFollowupsMin: number },
+): Surprise[] {
+  if (input.decisions.length === 0) return [];
+
+  // Build a sorted (updatedAt, sessionId) lookup once for the followup
+  // count. O(N log N) once, then O(log N) per decision.
+  const sessionByUpdatedAt = input.composites
+    .slice()
+    .sort((a, b) => a.updatedAt - b.updatedAt || a.sessionId.localeCompare(b.sessionId));
+
+  const out: Surprise[] = [];
+  for (const d of input.decisions) {
+    if (d.binaryClass !== 'good') continue;
+    // Anchor on this decision's session in the sorted list.
+    const anchor = sessionByUpdatedAt.findIndex((s) => s.sessionId === d.sessionId);
+    if (anchor === -1) continue;
+    let followups = 0;
+    for (let i = anchor + 1; i < sessionByUpdatedAt.length; i += 1) {
+      const row = sessionByUpdatedAt[i] as SurpriseCompositeRow;
+      if (row.composite.binary === 'good') followups += 1;
+    }
+    if (followups < opts.decisionGoodFollowupsMin) continue;
+    const score = Math.max(0, Math.min(1, (followups + 1) / 10));
+    const label = d.label ?? 'a decision';
+    out.push({
+      id: `decision-paid-off:${d.decisionId}`,
+      kind: 'decision-paid-off',
+      tone: 'positive',
+      summary: clip(
+        `${label} paid off — ${followups} good sessions followed.`,
+      ),
+      evidence: { decisionId: d.decisionId, sessionIds: [d.sessionId] },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `trajectory-stalled`: project classified `stalling` or
+ * `stalled-finished`. Score weights `stalling` higher because it's an
+ * active decline (the user can still intervene); `stalled-finished` is
+ * a quieter retrospective signal.
+ */
+function computeTrajectoryStalled(
+  input: ComputeSurprisesInput,
+): Surprise[] {
+  const out: Surprise[] = [];
+  for (const t of input.trajectories) {
+    if (t.classification !== 'stalling' && t.classification !== 'stalled-finished') {
+      continue;
+    }
+    const slope = t.slope ?? 0;
+    const baseScore = Math.max(0, Math.min(1, Math.abs(slope) * 5));
+    // Bias active stalling above finished — same severity gets +0.2.
+    const score = Math.min(1, baseScore + (t.classification === 'stalling' ? 0.2 : 0));
+    const summary =
+      t.classification === 'stalling'
+        ? `${t.projectName} is actively stalling (slope ${slope.toFixed(2)}/session).`
+        : `${t.projectName} stalled out — slope ${slope.toFixed(2)}/session, no recent activity.`;
+    out.push({
+      id: `trajectory-stalled:${t.projectId}`,
+      kind: 'trajectory-stalled',
+      tone: 'concerning',
+      summary: clip(summary),
+      evidence: { projectId: t.projectId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `pattern-recurring`: watcher returned `recurring`. Score fixed at
+ * 0.9 — this is a strong signal regardless of how many sessions
+ * passed first; the user told the assistant "follow this rule" and
+ * the rule failed.
+ */
+function computePatternRecurring(input: ComputeSurprisesInput): Surprise[] {
+  const out: Surprise[] = [];
+  for (const w of input.patternWatchers) {
+    if (w.verdict.kind !== 'recurring') continue;
+    out.push({
+      id: `pattern-recurring:${w.patternId}`,
+      kind: 'pattern-recurring',
+      tone: 'concerning',
+      summary: clip(
+        `Pattern ${w.patternId} recurred — narrative ${w.verdict.recurrenceNarrativeId} ` +
+          `re-fired after application.`,
+      ),
+      evidence: {
+        projectId: w.projectId,
+        narrativeId: w.verdict.recurrenceNarrativeId,
+      },
+      score: 0.9,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `debt-spinning`: V1 surfaces the top-K knowledge-debt clusters by
+ * sessionIds.length whose size meets `debtSpinningMinClusterSize`.
+ * Week-over-week growth is a follow-on — V1 just flags "this
+ * question keeps coming back".
+ *
+ * Score: saturating in size. `min(1, size / 20)` — a 20-member
+ * cluster caps the score at 1. Low-confidence clusters get a 0.7×
+ * multiplier (they were resolved via TF-IDF, not embeddings).
+ */
+function computeDebtSpinning(
+  input: ComputeSurprisesInput,
+  opts: { debtSpinningTopK: number; debtSpinningMinClusterSize: number },
+): Surprise[] {
+  const eligible = input.knowledgeDebt
+    .filter((c) => c.sessionIds.length >= opts.debtSpinningMinClusterSize)
+    .slice()
+    .sort(
+      (a, b) =>
+        b.sessionIds.length - a.sessionIds.length || a.id.localeCompare(b.id),
+    );
+  const topK = eligible.slice(0, opts.debtSpinningTopK);
+
+  return topK.map<Surprise>((c) => {
+    const size = c.sessionIds.length;
+    const base = Math.min(1, size / 20);
+    const score = c.confidence === 'low' ? base * 0.7 : base;
+    return {
+      id: `debt-spinning:${c.id}`,
+      kind: 'debt-spinning',
+      tone: 'concerning',
+      summary: clip(
+        `"${c.canonicalQuestion}" — ${size} sessions keep asking this.`,
+      ),
+      evidence: { sessionIds: c.sessionIds },
+      score,
+      generatedAt: 0,
+    };
+  });
+}
+
+// ─── helpers ───────────────────────────────────────────────────────
+
+function pushAll<T>(target: T[], items: readonly T[]): void {
+  for (const item of items) target.push(item);
+}
+
+/** Truncate to 120 chars — schema contract for `summary`. */
+function clip(s: string): string {
+  const max = 120;
+  if (s.length <= max) return s;
+  // Reserve 1 char for the ellipsis. `…` is one codepoint.
+  return `${s.slice(0, max - 1)}…`;
+}
+
+function shortSha(sha: string): string {
+  return sha.length > 7 ? sha.slice(0, 7) : sha;
+}
+
+// Re-export the THRESHOLDS reference so this kernel stays discoverable
+// via the analysis package barrel. (Imported above so the bundler
+// tree-shakes appropriately.)
+export { THRESHOLDS };

--- a/packages/analysis/src/computeSurprises.ts
+++ b/packages/analysis/src/computeSurprises.ts
@@ -14,9 +14,13 @@
  *   - pattern-closed          — applied-pattern watcher `holding`
  *                               (cooldown cleared with no recurrence)
  *   - reflexive-positive      — reflexive meanDelta > threshold AND
- *                               CI strictly positive
+ *                               CI strictly positive AND E-value CI
+ *                               bound ≥ `reflexiveEValueMin` (associational,
+ *                               not causal — sensitivity-gated)
  *   - decision-paid-off       — decision joined to a good outcome AND
  *                               followed by ≥ K additional good outcomes
+ *                               IN THE SAME PROJECT AND Wilson-low good
+ *                               rate exceeds the corpus base rate
  *
  * Concerns (`tone: 'concerning'`):
  *   - trajectory-stalled      — project slope CI strictly negative
@@ -26,6 +30,16 @@
  *   - debt-spinning           — top knowledge-debt clusters by size
  *                               (V1: highest count flagged; week-over-
  *                                week growth is a follow-on)
+ *
+ * **V1 emission scope**: 7 of 9 kinds emit from the builder pipeline.
+ * `pattern-closed` and `pattern-recurring` accept watcher input in
+ * the kernel API (the test suite exercises them) but the
+ * `surprisesBuilder` Node shell passes an empty `patternWatchers`
+ * array — the applied-pattern watcher ledger lives in the SQLite
+ * substrate and no SDK accessor for it exists yet. The two pattern-*
+ * branches stay dormant until that accessor lands; see the
+ * `TODO(applyWatcher-sdk):` marker in
+ * `packages/exporter/src/analysis/surprisesBuilder.ts`.
  *
  * Pure. Browser-safe (no `node:*` imports). Deterministic — the
  * caller passes `generatedAt` (the kernel does NOT call `Date.now()`),
@@ -43,6 +57,7 @@ import { THRESHOLDS } from './thresholds.js';
 import type { ItsResult } from './itsAnalysis.js';
 import type { ReflexiveResult } from './computeReflexive.js';
 import type { WatcherVerdict } from './applyWatcher.js';
+import { wilsonCI } from './stats.js';
 
 // ─── Input row shapes ──────────────────────────────────────────────
 //
@@ -58,6 +73,13 @@ export interface SurpriseCompositeRow {
   /** Unix ms — session terminal timestamp (manifest.updatedAt). */
   readonly updatedAt: number;
   readonly composite: CompositeOutcome;
+  /**
+   * Project the session belongs to (manifest `projectId`). Optional —
+   * sessions without a discovered project are still scored and counted
+   * for streaks / base-rate computation, but they're skipped by the
+   * same-project gates (e.g. `decision-paid-off`).
+   */
+  readonly projectId?: string;
 }
 
 /** Project-trajectory row — mirrors the on-disk sidecar entry. */
@@ -102,6 +124,14 @@ export interface SurpriseDecisionRow {
   readonly binaryClass: 'good' | 'bad' | 'neutral';
   /** Short label rendered into the summary; falls back to "a decision". */
   readonly label?: string;
+  /**
+   * Project the decision-session belongs to. Required for the
+   * `decision-paid-off` same-project followup gate; rows without a
+   * projectId are skipped entirely by that branch (the decision can
+   * still appear as `unscoped` evidence but we won't claim it "paid
+   * off" without scoping).
+   */
+  readonly projectId?: string;
 }
 
 // ─── Output schema ─────────────────────────────────────────────────
@@ -148,6 +178,7 @@ export interface SurpriseThresholdsSnapshot {
   readonly itsQValueMax: number;
   readonly itsDeltaMin: number;
   readonly reflexiveDeltaMin: number;
+  readonly reflexiveEValueMin: number;
   readonly decisionGoodFollowupsMin: number;
   readonly debtSpinningTopK: number;
   readonly debtSpinningMinClusterSize: number;
@@ -185,43 +216,56 @@ export interface ComputeSurprisesInput {
 }
 
 export interface ComputeSurprisesOptions {
-  /** Override the minimum streak length. Default 5. */
+  /**
+   * Override the minimum streak length. Defaults to
+   * `THRESHOLDS.surprises.streakMin`. Tests use this to drive boundary
+   * cases without forking the threshold table.
+   */
   readonly streakMin?: number;
   /**
    * ITS BH-FDR qValue ceiling — a contrast counts as "config-helped"
    * when `qValue ≤ itsQValueMax` AND `deltaGoodShare ≥ itsDeltaMin`.
-   * Pre-launch placeholder; calibrate after first ~50 contrasts.
+   * Defaults to `THRESHOLDS.surprises.itsQValueMax` /
+   * `.itsDeltaMin`.
    */
   readonly itsQValueMax?: number;
   readonly itsDeltaMin?: number;
   /**
    * Reflexive minimum mean-delta (good-share delta) to surface. Also
-   * requires the CI to be strictly positive (low > 0). Pre-launch
-   * placeholder.
+   * requires the CI to be strictly positive (low > 0) AND
+   * `eValueCIBound ≥ reflexiveEValueMin`. Defaults to
+   * `THRESHOLDS.surprises.reflexiveDeltaMin` /
+   * `.reflexiveEValueMin`.
    */
   readonly reflexiveDeltaMin?: number;
   /**
+   * Reflexive E-value CI-bound floor. Defaults to
+   * `THRESHOLDS.surprises.reflexiveEValueMin`. Smaller values make
+   * the gate looser; the surprise is associational, not causal, so
+   * the E-value floor protects against surfacing a contrast a single
+   * weak unobserved confounder could explain away.
+   */
+  readonly reflexiveEValueMin?: number;
+  /**
    * `decision-paid-off`: minimum number of additional good composite
-   * outcomes that must follow the decision's session (same project
-   * preferred but not required in V1; the kernel scopes by
-   * compositeRow.updatedAt > decision-session.updatedAt). Default 2.
+   * outcomes IN THE SAME PROJECT that must follow the decision's
+   * session. Defaults to `THRESHOLDS.surprises.decisionGoodFollowupsMin`.
+   * The kernel also requires the followup good-rate's Wilson lower
+   * bound (α=0.05) to exceed the corpus base good-share — see
+   * `computeDecisionPaidOff` for the math.
    */
   readonly decisionGoodFollowupsMin?: number;
-  /** Top-K knowledge-debt clusters surfaced as `debt-spinning`. Default 3. */
+  /**
+   * Top-K knowledge-debt clusters surfaced as `debt-spinning`.
+   * Defaults to `THRESHOLDS.surprises.debtSpinningTopK`.
+   */
   readonly debtSpinningTopK?: number;
-  /** Minimum cluster size for `debt-spinning`. Default 3. */
+  /**
+   * Minimum cluster size for `debt-spinning`. Defaults to
+   * `THRESHOLDS.surprises.debtSpinningMinClusterSize`.
+   */
   readonly debtSpinningMinClusterSize?: number;
 }
-
-const DEFAULTS = {
-  streakMin: 5,
-  itsQValueMax: 0.1,
-  itsDeltaMin: 0.15,
-  reflexiveDeltaMin: 0.1,
-  decisionGoodFollowupsMin: 2,
-  debtSpinningTopK: 3,
-  debtSpinningMinClusterSize: 3,
-} as const;
 
 // ─── Kernel entry point ────────────────────────────────────────────
 
@@ -229,16 +273,22 @@ export function computeSurprises(
   input: ComputeSurprisesInput,
   options: ComputeSurprisesOptions = {},
 ): SurprisesOutput {
+  // All defaults route through THRESHOLDS.surprises so the no-hardcoded-
+  // numbers rule applies uniformly. Test overrides flow through `options`
+  // unchanged.
+  const defaults = THRESHOLDS.surprises;
   const opts = {
-    streakMin: options.streakMin ?? DEFAULTS.streakMin,
-    itsQValueMax: options.itsQValueMax ?? DEFAULTS.itsQValueMax,
-    itsDeltaMin: options.itsDeltaMin ?? DEFAULTS.itsDeltaMin,
-    reflexiveDeltaMin: options.reflexiveDeltaMin ?? DEFAULTS.reflexiveDeltaMin,
+    streakMin: options.streakMin ?? defaults.streakMin,
+    itsQValueMax: options.itsQValueMax ?? defaults.itsQValueMax,
+    itsDeltaMin: options.itsDeltaMin ?? defaults.itsDeltaMin,
+    reflexiveDeltaMin: options.reflexiveDeltaMin ?? defaults.reflexiveDeltaMin,
+    reflexiveEValueMin:
+      options.reflexiveEValueMin ?? defaults.reflexiveEValueMin,
     decisionGoodFollowupsMin:
-      options.decisionGoodFollowupsMin ?? DEFAULTS.decisionGoodFollowupsMin,
-    debtSpinningTopK: options.debtSpinningTopK ?? DEFAULTS.debtSpinningTopK,
+      options.decisionGoodFollowupsMin ?? defaults.decisionGoodFollowupsMin,
+    debtSpinningTopK: options.debtSpinningTopK ?? defaults.debtSpinningTopK,
     debtSpinningMinClusterSize:
-      options.debtSpinningMinClusterSize ?? DEFAULTS.debtSpinningMinClusterSize,
+      options.debtSpinningMinClusterSize ?? defaults.debtSpinningMinClusterSize,
   };
 
   const surprises: Surprise[] = [];
@@ -267,6 +317,7 @@ export function computeSurprises(
       itsQValueMax: opts.itsQValueMax,
       itsDeltaMin: opts.itsDeltaMin,
       reflexiveDeltaMin: opts.reflexiveDeltaMin,
+      reflexiveEValueMin: opts.reflexiveEValueMin,
       decisionGoodFollowupsMin: opts.decisionGoodFollowupsMin,
       debtSpinningTopK: opts.debtSpinningTopK,
       debtSpinningMinClusterSize: opts.debtSpinningMinClusterSize,
@@ -417,28 +468,60 @@ function computePatternClosed(input: ComputeSurprisesInput): Surprise[] {
 }
 
 /**
- * `reflexive-positive`: meanDelta ≥ reflexiveDeltaMin AND CI strictly
- * positive (low > 0). One surprise at most (reflexive is whole-corpus).
+ * `reflexive-positive`: three-gate associational surprise.
+ *
+ *   1. `meanDelta ≥ reflexiveDeltaMin` — practical significance.
+ *   2. `ci.low > 0` — Wilson CI strictly positive (not just a
+ *      directional point estimate; we want some inferential
+ *      confidence the contrast isn't noise).
+ *   3. `eValueStatus === 'computed' && eValueCIBound ≥
+ *      reflexiveEValueMin` — VanderWeele & Ding (2017) E-value on the
+ *      CI bound nearest the null. If the E-value is small, a
+ *      modestly-strong unobserved confounder could drag the
+ *      observation to RR=1. We refuse to surface contrasts that are
+ *      one weak confounder away from disappearing.
+ *
+ * Iter-1 adversarial finding: prior version emitted on (1)+(2) and
+ * called the contrast a "lift" — both the gating and the copy
+ * suggested a causal interpretation the matched-pair primitive
+ * doesn't support. Tightened to gate on E-value AND softened the
+ * verb to "is associated with" to match the methodology disclosure
+ * the viewer already shows.
+ *
+ * One surprise at most (reflexive is whole-corpus).
  *
  * Score: `min(1, meanDelta * 2)` — same convention as config-helped.
  */
 function computeReflexivePositive(
   input: ComputeSurprisesInput,
-  opts: { reflexiveDeltaMin: number },
+  opts: { reflexiveDeltaMin: number; reflexiveEValueMin: number },
 ): Surprise[] {
   const r = input.reflexive;
   if (r === null) return [];
   if (!Number.isFinite(r.meanDelta) || r.meanDelta < opts.reflexiveDeltaMin) return [];
   if (r.ci.low <= 0) return [];
+  // E-value sensitivity gate. `'ci-straddles-null'` / `'p-control-zero'`
+  // mean the kernel couldn't compute a meaningful E-value at all —
+  // those cases fail the gate by definition.
+  if (
+    r.eValueStatus !== 'computed' ||
+    r.eValueCIBound === null ||
+    !Number.isFinite(r.eValueCIBound) ||
+    r.eValueCIBound < opts.reflexiveEValueMin
+  ) {
+    return [];
+  }
   const score = Math.max(0, Math.min(1, r.meanDelta * 2));
   return [
     {
       id: 'reflexive-positive:whole-corpus',
       kind: 'reflexive-positive',
       tone: 'positive',
+      // Associational language (not "lifted") — the matched-pair
+      // primitive is descriptive, the E-value is sensitivity-bounded.
       summary: clip(
-        `Touching chat-arch lifted good-share by ${(r.meanDelta * 100).toFixed(0)}pp ` +
-          `(CI low ${(r.ci.low * 100).toFixed(0)}pp).`,
+        `Touching chat-arch is associated with +${(r.meanDelta * 100).toFixed(0)}pp ` +
+          `good-share (CI low ${(r.ci.low * 100).toFixed(0)}pp, E-value ${r.eValueCIBound.toFixed(2)}).`,
       ),
       evidence: {
         sessionIds: r.pairs.map((p) => p.treatedSessionId),
@@ -452,12 +535,35 @@ function computeReflexivePositive(
 /**
  * `decision-paid-off`: a decision whose outcome was `good` AND was
  * followed by at least `decisionGoodFollowupsMin` additional good
- * composite outcomes (across the whole corpus — V1 doesn't restrict
- * to same-project; that's a follow-on once decisions carry a project
- * pointer in the join).
+ * composite outcomes IN THE SAME PROJECT, AND whose followup good-
+ * rate's Wilson lower bound (α=0.05) exceeds the corpus-wide good
+ * base rate.
  *
- * Score: saturating in follow-up count. `min(1, (followups + 1) / 10)`
- * — a decision with 9 good followups caps the score at 1.
+ * Iter-1 adversarial findings:
+ *
+ *   - **Cross-project leak.** Prior version counted followups across
+ *     the WHOLE corpus, so any decision made early in a productive
+ *     week scored "paid off" by virtue of the user shipping in
+ *     unrelated projects. Now restricted to same-project followups
+ *     (rows where both decision-session and followup-session carry
+ *     the same `projectId`).
+ *   - **Threshold too loose.** Prior floor was 2 followups; Wilson
+ *     lower bound on 2/2 with Beta(1,1) prior is ≈0.16, well below
+ *     any plausible base rate. Raised to 5 (see
+ *     `THRESHOLDS.surprises.decisionGoodFollowupsMin`).
+ *   - **No lift test.** "K good followups happened" doesn't establish
+ *     the decision moved the curve — the user might just have a
+ *     consistent good week. Added a Wilson-low > base-rate gate so we
+ *     only emit when the followup good-rate is provably higher than
+ *     the user's typical share.
+ *
+ * Decisions whose `projectId` is unset are skipped (we cannot scope
+ * followups for them); composite rows whose `projectId` is unset are
+ * NOT counted as followups (same reason) but ARE counted in the
+ * corpus base-rate denominator (every scored session contributes to
+ * the user's overall good-share).
+ *
+ * Score: saturating in followup count. `min(1, (followups + 1) / 10)`.
  */
 function computeDecisionPaidOff(
   input: ComputeSurprisesInput,
@@ -465,8 +571,23 @@ function computeDecisionPaidOff(
 ): Surprise[] {
   if (input.decisions.length === 0) return [];
 
-  // Build a sorted (updatedAt, sessionId) lookup once for the followup
-  // count. O(N log N) once, then O(log N) per decision.
+  // Corpus-wide base rate of good outcomes. Denominator is every
+  // scored composite row (binary !== 'unknown' is the conservative
+  // line — 'unknown' rows had no measurable outcome).
+  let baseGood = 0;
+  let baseDenom = 0;
+  for (const row of input.composites) {
+    if (row.composite.binary === 'unknown') continue;
+    baseDenom += 1;
+    if (row.composite.binary === 'good') baseGood += 1;
+  }
+  // No scored composites at all → no base rate exists → cannot
+  // make the lift claim. Fall back to 0 so the Wilson gate trivially
+  // passes; the count floor still applies.
+  const baseRateGoodShare = baseDenom > 0 ? baseGood / baseDenom : 0;
+
+  // Build a sorted (updatedAt, sessionId) lookup once. O(N log N) once,
+  // then O(N) per decision (worst case scans the tail).
   const sessionByUpdatedAt = input.composites
     .slice()
     .sort((a, b) => a.updatedAt - b.updatedAt || a.sessionId.localeCompare(b.sessionId));
@@ -474,23 +595,40 @@ function computeDecisionPaidOff(
   const out: Surprise[] = [];
   for (const d of input.decisions) {
     if (d.binaryClass !== 'good') continue;
+    // Same-project scoping requires a projectId on the decision.
+    if (d.projectId === undefined) continue;
     // Anchor on this decision's session in the sorted list.
     const anchor = sessionByUpdatedAt.findIndex((s) => s.sessionId === d.sessionId);
     if (anchor === -1) continue;
-    let followups = 0;
+    let followupsGood = 0;
+    let followupsTotal = 0;
     for (let i = anchor + 1; i < sessionByUpdatedAt.length; i += 1) {
       const row = sessionByUpdatedAt[i] as SurpriseCompositeRow;
-      if (row.composite.binary === 'good') followups += 1;
+      // Same-project gate; skip cross-project ships entirely.
+      if (row.projectId === undefined || row.projectId !== d.projectId) continue;
+      if (row.composite.binary === 'unknown') continue;
+      followupsTotal += 1;
+      if (row.composite.binary === 'good') followupsGood += 1;
     }
-    if (followups < opts.decisionGoodFollowupsMin) continue;
-    const score = Math.max(0, Math.min(1, (followups + 1) / 10));
+    if (followupsGood < opts.decisionGoodFollowupsMin) continue;
+    // Wilson lower bound on the followup good-rate. Only emit when it
+    // strictly exceeds the corpus base rate — i.e. the decision is
+    // followed by a *higher* good-share than the user's typical week,
+    // with enough samples that the lower bound clears the bar.
+    const wilson = wilsonCI(followupsGood / followupsTotal, followupsTotal);
+    if (wilson.low <= baseRateGoodShare) continue;
+    const score = Math.max(0, Math.min(1, (followupsGood + 1) / 10));
     const label = d.label ?? 'a decision';
     out.push({
       id: `decision-paid-off:${d.decisionId}`,
       kind: 'decision-paid-off',
       tone: 'positive',
+      // Summary surfaces the lift: same-project K/N + Wilson-low + base
+      // rate. The user can see at a glance that we're not just counting
+      // good sessions in a row.
       summary: clip(
-        `${label} paid off — ${followups} good sessions followed.`,
+        `${label} paid off — same-project followups: ${followupsGood}/${followupsTotal} good ` +
+          `(Wilson low ${wilson.low.toFixed(2)}, base rate ${baseRateGoodShare.toFixed(2)}).`,
       ),
       evidence: { decisionId: d.decisionId, sessionIds: [d.sessionId] },
       score,

--- a/packages/analysis/src/dailyBrief.test.ts
+++ b/packages/analysis/src/dailyBrief.test.ts
@@ -5,7 +5,8 @@ import type {
   CorrectionPattern,
   ProposedUpgrade,
 } from '@chat-arch/schema';
-import { buildDailyBrief } from './dailyBrief.js';
+import { buildDailyBrief, type BriefTrajectoryRow } from './dailyBrief.js';
+import type { SurprisesOutput } from './computeSurprises.js';
 
 const NOW = Date.parse('2026-05-16T04:00:00Z');
 
@@ -191,5 +192,507 @@ describe('buildDailyBrief', () => {
     const low = r.markdown.indexOf('Low confidence');
     expect(high).toBeGreaterThan(-1);
     expect(low).toBeGreaterThan(high);
+  });
+
+  // ── Phase γ §1 — Shipped this week ───────────────────────────────
+
+  describe('shipped this week', () => {
+    it('renders the count + top subjects when commits exist', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: {
+          commitCount: 12,
+          recentSubjects: [
+            'feat: ship one',
+            'fix: stabilize two',
+            'docs: update three',
+            'chore: bump four',
+            'refactor: rename five',
+            'test: cover six (will not render)',
+          ],
+        },
+      });
+      expect(r.markdown).toContain('Shipped this week: 12 commit(s) to main');
+      expect(r.markdown).toContain('feat: ship one');
+      expect(r.markdown).toContain('refactor: rename five');
+      // Top-5 cap on subjects.
+      expect(r.markdown).not.toContain('test: cover six');
+      expect(r.counts.shippedCommits).toBe(12);
+    });
+
+    it('skips the section when commitCount is zero', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: { commitCount: 0, recentSubjects: [] },
+      });
+      expect(r.markdown).not.toContain('Shipped this week');
+      expect(r.counts.shippedCommits).toBe(0);
+    });
+
+    it('skips the section when shippedThisWeek is null', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: null,
+      });
+      expect(r.markdown).not.toContain('Shipped this week');
+      expect(r.counts.shippedCommits).toBe(0);
+    });
+
+    it('truncates long subject lines at 120 chars', () => {
+      const long = 'feat: ' + 'a'.repeat(200);
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: { commitCount: 1, recentSubjects: [long] },
+      });
+      // The rendered subject line includes our '  • ' prefix; we
+      // inspect for the truncation marker on the rendered body line.
+      const subjectLine = r.markdown
+        .split('\n')
+        .find((l) => l.startsWith('  • feat: aaa'));
+      expect(subjectLine).toBeDefined();
+      // 4-char prefix ("  • ") + clip120(...) ⇒ line ≤ 124 chars.
+      expect((subjectLine as string).length).toBeLessThanOrEqual(124);
+      expect(subjectLine).toMatch(/…$/u);
+    });
+
+    it('formats large commit counts with toLocaleString separators', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: {
+          commitCount: 1234,
+          recentSubjects: ['feat: many things'],
+        },
+      });
+      expect(r.markdown).toContain('1,234 commit(s) to main');
+    });
+  });
+
+  // ── Phase γ §2 — Surprises today ─────────────────────────────────
+
+  function surprisesFile(
+    rows: ReadonlyArray<{
+      kind: SurprisesOutput['surprises'][number]['kind'];
+      tone: SurprisesOutput['surprises'][number]['tone'];
+      summary: string;
+      score: number;
+    }>,
+  ): SurprisesOutput {
+    return {
+      version: 1,
+      generatedAt: NOW,
+      surprises: rows.map((r, i) => ({
+        id: `${r.kind}:row-${i}`,
+        kind: r.kind,
+        tone: r.tone,
+        summary: r.summary,
+        evidence: {},
+        score: r.score,
+        generatedAt: NOW,
+      })),
+      thresholds: {
+        streakMin: 5,
+        itsQValueMax: 0.1,
+        itsDeltaMin: 0.15,
+        reflexiveDeltaMin: 0.1,
+        decisionGoodFollowupsMin: 2,
+        debtSpinningTopK: 3,
+        debtSpinningMinClusterSize: 3,
+      },
+    };
+  }
+
+  describe('surprises', () => {
+    it('reports per-tone counts and lists top-3 positive summaries', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([
+          { kind: 'streak', tone: 'positive', summary: '5 in a row', score: 0.9 },
+          {
+            kind: 'trajectory-accelerating',
+            tone: 'positive',
+            summary: 'Project chat-arch on the rise',
+            score: 0.8,
+          },
+          {
+            kind: 'config-helped',
+            tone: 'positive',
+            summary: 'Config abc lifted good-share',
+            score: 0.7,
+          },
+          {
+            kind: 'pattern-closed',
+            tone: 'positive',
+            summary: 'Pattern p1 held',
+            score: 0.5,
+          },
+          {
+            kind: 'trajectory-stalled',
+            tone: 'concerning',
+            summary: 'Project foo stalling',
+            score: 0.6,
+          },
+        ]),
+      });
+      expect(r.markdown).toContain('Surprises today: 4 positive, 1 concerning');
+      expect(r.markdown).toContain('[streak] 5 in a row');
+      expect(r.markdown).toContain(
+        '[trajectory-accelerating] Project chat-arch on the rise',
+      );
+      expect(r.markdown).toContain('[config-helped] Config abc lifted good-share');
+      // 4th positive ('pattern-closed') exceeds top-3 cap and is excluded.
+      expect(r.markdown).not.toContain('Pattern p1 held');
+      expect(r.counts.surprisesPositive).toBe(4);
+      expect(r.counts.surprisesConcerning).toBe(1);
+    });
+
+    it('skips the section when surprises is null', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: null,
+      });
+      expect(r.markdown).not.toContain('Surprises today');
+      expect(r.counts.surprisesPositive).toBe(0);
+      expect(r.counts.surprisesConcerning).toBe(0);
+    });
+
+    it('skips the section when the file is present but empty', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([]),
+      });
+      expect(r.markdown).not.toContain('Surprises today');
+    });
+
+    it('handles concerning-only files (zero positive summaries listed)', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([
+          {
+            kind: 'pattern-recurring',
+            tone: 'concerning',
+            summary: 'p1 came back',
+            score: 0.9,
+          },
+        ]),
+      });
+      expect(r.markdown).toContain('Surprises today: 0 positive, 1 concerning');
+      // No positive rows ⇒ no `[kind]` bullet beneath the header.
+      expect(r.markdown).not.toContain('[pattern-recurring]');
+    });
+  });
+
+  // ── Phase γ §3 — Project trajectories ────────────────────────────
+
+  function trajectory(
+    overrides: Partial<BriefTrajectoryRow> = {},
+  ): BriefTrajectoryRow {
+    return {
+      projectId: 'proj-1',
+      projectName: 'project one',
+      classification: 'flat',
+      slope: 0,
+      totalSessions: 10,
+      ...overrides,
+    };
+  }
+
+  describe('project trajectories', () => {
+    it('reports per-classification counts and the top-3 most-active', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: [
+          trajectory({
+            projectId: 'a',
+            projectName: 'alpha',
+            classification: 'accelerating',
+            slope: 0.5,
+            totalSessions: 50,
+          }),
+          trajectory({
+            projectId: 'b',
+            projectName: 'bravo',
+            classification: 'flat',
+            slope: 0,
+            totalSessions: 40,
+          }),
+          trajectory({
+            projectId: 'c',
+            projectName: 'charlie',
+            classification: 'stalling',
+            slope: -0.3,
+            totalSessions: 30,
+          }),
+          trajectory({
+            projectId: 'd',
+            projectName: 'delta',
+            classification: 'stalled-finished',
+            slope: -0.1,
+            totalSessions: 20,
+          }),
+          trajectory({
+            projectId: 'e',
+            projectName: 'echo',
+            classification: 'accelerating',
+            slope: 0.2,
+            totalSessions: 5,
+          }),
+        ],
+      });
+      expect(r.markdown).toContain(
+        'Project trajectories: 2 accelerating, 1 flat, 2 stalling/stalled',
+      );
+      // Top 3 by totalSessions: alpha (50), bravo (40), charlie (30).
+      expect(r.markdown).toContain('alpha — accelerating (slope +0.50, 50 sessions)');
+      expect(r.markdown).toContain('bravo — flat (slope 0.00, 40 sessions)');
+      expect(r.markdown).toContain('charlie — stalling (slope -0.30, 30 sessions)');
+      // Lower-activity rows excluded.
+      expect(r.markdown).not.toContain('delta — stalled-finished');
+      expect(r.markdown).not.toContain('echo — accelerating');
+      expect(r.counts.trajectoriesAccelerating).toBe(2);
+      expect(r.counts.trajectoriesFlat).toBe(1);
+      expect(r.counts.trajectoriesStalling).toBe(2);
+    });
+
+    it('skips the section when no project rows are passed', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: [],
+      });
+      expect(r.markdown).not.toContain('Project trajectories');
+      expect(r.counts.trajectoriesAccelerating).toBe(0);
+      expect(r.counts.trajectoriesFlat).toBe(0);
+      expect(r.counts.trajectoriesStalling).toBe(0);
+    });
+
+    it('skips the section when projectTrajectories is null', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: null,
+      });
+      expect(r.markdown).not.toContain('Project trajectories');
+    });
+
+    it('renders "slope n/a" for null slopes', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: [
+          trajectory({
+            projectName: 'no-slope-project',
+            classification: 'flat',
+            slope: null,
+            totalSessions: 3,
+          }),
+        ],
+      });
+      expect(r.markdown).toContain('no-slope-project — flat (slope n/a, 3 sessions)');
+    });
+  });
+
+  // ── Phase γ §4 — Applied-pattern closures ────────────────────────
+
+  describe('applied-pattern closures', () => {
+    it('renders the count when patterns are currently held', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        appliedPatternClosures: 4,
+      });
+      expect(r.markdown).toContain(
+        'Applied-pattern closures: 4 pattern(s) held (no recurrence past cooldown)',
+      );
+      expect(r.counts.appliedPatternClosures).toBe(4);
+    });
+
+    it('skips the section when zero patterns are held', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        appliedPatternClosures: 0,
+      });
+      expect(r.markdown).not.toContain('Applied-pattern closures');
+      expect(r.counts.appliedPatternClosures).toBe(0);
+    });
+
+    it('skips the section when the SDK accessor is unwired (null)', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        appliedPatternClosures: null,
+      });
+      expect(r.markdown).not.toContain('Applied-pattern closures');
+      expect(r.counts.appliedPatternClosures).toBe(0);
+    });
+  });
+
+  // ── Phase γ ordering invariant ───────────────────────────────────
+
+  it('orders Phase γ sections between audit concerns and continuum health', () => {
+    const fail: AuditResult = {
+      sessionId: 'sid-x',
+      source: 'cowork',
+      lineNumber: 1,
+      claimType: 'tests-pass-claim',
+      span: 'works',
+      surroundingContext: 'ctx',
+      outcome: 'fail',
+      reason: 'because',
+    };
+    const health: ContinuumHealth = {
+      version: 1,
+      lastScanAt: '2026-05-16T03:00:00Z',
+      lastSuccessfulScanAt: '2026-05-16T03:00:00Z',
+      consecutiveSuccesses: 1,
+      sourcesScanned: ['cowork'],
+      entriesByStatus: { ok: 1, missing: 0, crashed: 0, pruned: 0 },
+      newSessionsSinceLast: 0,
+      warnings: [],
+    };
+    const r = buildDailyBrief({
+      date: '2026-05-16',
+      now: NOW,
+      patterns: [],
+      upgradeOutcomes: [],
+      blogDrafts: [],
+      auditResults: [fail],
+      auditSummary: null,
+      continuumHealth: health,
+      shippedThisWeek: {
+        commitCount: 2,
+        recentSubjects: ['feat: ordering test'],
+      },
+      surprises: surprisesFile([
+        { kind: 'streak', tone: 'positive', summary: 'streak!', score: 1 },
+      ]),
+      projectTrajectories: [
+        trajectory({
+          projectName: 'ordering-project',
+          classification: 'accelerating',
+          slope: 0.5,
+          totalSessions: 5,
+        }),
+      ],
+      appliedPatternClosures: 1,
+    });
+    const audit = r.markdown.indexOf('audit concern');
+    const shipped = r.markdown.indexOf('Shipped this week');
+    const surprises = r.markdown.indexOf('Surprises today');
+    const trajectories = r.markdown.indexOf('Project trajectories');
+    const closures = r.markdown.indexOf('Applied-pattern closures');
+    const continuum = r.markdown.indexOf('Continuum health');
+    expect(audit).toBeGreaterThan(-1);
+    expect(shipped).toBeGreaterThan(audit);
+    expect(surprises).toBeGreaterThan(shipped);
+    expect(trajectories).toBeGreaterThan(surprises);
+    expect(closures).toBeGreaterThan(trajectories);
+    expect(continuum).toBeGreaterThan(closures);
   });
 });

--- a/packages/analysis/src/dailyBrief.ts
+++ b/packages/analysis/src/dailyBrief.ts
@@ -362,6 +362,8 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
   // The shell is expected to pass `null` until the accessor lands;
   // we ALSO skip the section when the count is 0 to keep the brief
   // tight in the meantime.
+  // TODO(applyWatcher-sdk): wiring lives in
+  // apps/standalone/src/pages/api/regen-brief.ts (search the same marker).
   const closures = inputs.appliedPatternClosures ?? null;
   let appliedPatternClosures = 0;
   if (closures !== null && closures > 0) {

--- a/packages/analysis/src/dailyBrief.ts
+++ b/packages/analysis/src/dailyBrief.ts
@@ -1,19 +1,28 @@
 /**
- * Daily brief generator — spec §5 Layer D, D.1 + D.3.
+ * Daily brief generator — spec §5 Layer D, D.1 + D.3, extended by
+ * feed-redesign Phase γ.
  *
  * Pure function. Reads pre-loaded analysis inputs (the Node shell parses
- * each sidecar from disk) and returns the markdown body plus a small
- * summary record. Sections with zero entries are silent — no padding,
- * per D.3.
+ * each sidecar from disk and runs `git log` for the shipped-this-week
+ * counter) and returns the markdown body plus a small summary record.
+ * Sections with zero entries are silent — no padding, per D.3.
  *
- * Output shape:
+ * Output shape (Phase γ):
  *   TODAY · YYYY-MM-DD
  *   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  *   ► N patterns shifted this week
  *   ► N upgrades to propose
  *   ► N blog drafts ready for review
  *   ► N audit concerns
+ *   ► Shipped this week: N commits to main      (Phase γ §1)
+ *   ► Surprises today: P positive, C concerning (Phase γ §2)
+ *   ► Project trajectories: A accelerating, …   (Phase γ §3)
+ *   ► Applied-pattern closures: K patterns held (Phase γ §4)
  *   ► Continuum health: …
+ *
+ * The new sections render BETWEEN audit concerns and continuum health.
+ * Each new section is independently skippable — empty inputs render
+ * nothing (no header, no body), matching the existing convention.
  */
 
 import type {
@@ -25,6 +34,7 @@ import type {
   ProposedUpgrade,
   UpgradeOutcome,
 } from '@chat-arch/schema';
+import type { SurprisesOutput } from './computeSurprises.js';
 
 export interface BriefThresholds {
   /** Patterns whose lastSeen falls within the last N days count as "shifted this week". */
@@ -35,6 +45,12 @@ export interface BriefThresholds {
   blogDraftsShown?: number;
   /** Top-N audit concerns surfaced. */
   auditConcernsShown?: number;
+  /** Top-N commit subjects surfaced under "Shipped this week". */
+  shippedSubjectsShown?: number;
+  /** Top-N positive-tone surprise summaries surfaced. */
+  surpriseSummariesShown?: number;
+  /** Top-N most-active projects surfaced under "Project trajectories". */
+  trajectoriesShown?: number;
 }
 
 const DEFAULT_THRESHOLDS: Required<BriefThresholds> = {
@@ -42,7 +58,42 @@ const DEFAULT_THRESHOLDS: Required<BriefThresholds> = {
   upgradesShown: 5,
   blogDraftsShown: 5,
   auditConcernsShown: 5,
+  shippedSubjectsShown: 5,
+  surpriseSummariesShown: 3,
+  trajectoriesShown: 3,
 };
+
+/**
+ * Pre-computed "shipped this week" snapshot. The Node shell runs
+ * `git log --since="7 days ago" ...` against the project repo and
+ * passes the count + subject lines in. Kernel stays I/O-free.
+ *
+ * `commitCount === 0` means the section is skipped entirely.
+ * `recentSubjects` may be shorter than `commitCount` (we render the
+ * top N per `shippedSubjectsShown`).
+ */
+export interface ShippedThisWeekInput {
+  readonly commitCount: number;
+  readonly recentSubjects: readonly string[];
+}
+
+/**
+ * Narrow row shape for the project-trajectories sidecar. Mirrors the
+ * on-disk `ProjectTrajectoryEntry` written by
+ * `projectTrajectoryBuilder.ts`; keeping the kernel's input narrow so
+ * we don't pull the exporter-shell type into the analysis package.
+ */
+export interface BriefTrajectoryRow {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly classification:
+    | 'stalling'
+    | 'stalled-finished'
+    | 'accelerating'
+    | 'flat';
+  readonly slope: number | null;
+  readonly totalSessions: number;
+}
 
 export interface DailyBriefInputs {
   /** Output date in YYYY-MM-DD format. */
@@ -55,6 +106,30 @@ export interface DailyBriefInputs {
   auditResults: readonly AuditResult[];
   auditSummary: AuditSummary | null;
   continuumHealth: ContinuumHealth | null;
+  /**
+   * Phase γ §1 — `git log --since="7 days ago" --pretty=format:%H main`
+   * count + top subject lines. Pass `null` when the project isn't a
+   * git repo or `git log` failed (section skipped).
+   */
+  shippedThisWeek?: ShippedThisWeekInput | null;
+  /**
+   * Phase γ §2 — full `analysis/surprises.json` content. Pass `null`
+   * when the sidecar is missing or unparseable (section skipped).
+   */
+  surprises?: SurprisesOutput | null;
+  /**
+   * Phase γ §3 — rows from `analysis/project-trajectories.json`. Pass
+   * an empty array (or `null`) when the sidecar is missing (section
+   * skipped).
+   */
+  projectTrajectories?: readonly BriefTrajectoryRow[] | null;
+  /**
+   * Phase γ §4 — count of patterns currently in the watcher's
+   * `holding` state (the post-application cooldown cleared with no
+   * recurrence). Pass `null` when the SDK accessor is not yet wired
+   * (section skipped — see code-comment in the section).
+   */
+  appliedPatternClosures?: number | null;
 }
 
 export interface DailyBriefResult {
@@ -64,6 +139,17 @@ export interface DailyBriefResult {
     upgradesShown: number;
     blogDraftsShown: number;
     auditConcernsShown: number;
+    /** 0 when the section was skipped. */
+    shippedCommits: number;
+    /** Total surprise rows by tone (0 when the section was skipped). */
+    surprisesPositive: number;
+    surprisesConcerning: number;
+    /** Total trajectory projects classified into each bucket. */
+    trajectoriesAccelerating: number;
+    trajectoriesFlat: number;
+    trajectoriesStalling: number;
+    /** 0 when the SDK accessor isn't wired (vs. 0-but-wired). */
+    appliedPatternClosures: number;
   };
 }
 
@@ -76,6 +162,14 @@ function sortByLastSeenDesc<T extends { lastSeen: number }>(a: T, b: T): number 
 function shortenRule(rule: string): string {
   const trimmed = rule.trim();
   return trimmed.length > 110 ? trimmed.slice(0, 110) + '…' : trimmed;
+}
+
+/** Truncate at 120 chars with `…` — matches the surprises kernel `clip`. */
+function clip120(s: string): string {
+  const max = 120;
+  const trimmed = s.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1)}…`;
 }
 
 function pickHeadline(upgrades: readonly ProposedUpgrade[]): string {
@@ -172,6 +266,113 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     out.push('');
   }
 
+  // ---- Phase γ §1 — Shipped this week ----
+  // Skipped when `commitCount === 0` (the section is meaningless with
+  // no commits, per spec). The Node shell is responsible for the
+  // `git log` invocation; we just format the precomputed numbers.
+  const shipped = inputs.shippedThisWeek ?? null;
+  let shippedCommits = 0;
+  if (shipped !== null && shipped.commitCount > 0) {
+    shippedCommits = shipped.commitCount;
+    out.push(
+      `► Shipped this week: ${shipped.commitCount.toLocaleString()} commit(s) to main`,
+    );
+    for (const subject of shipped.recentSubjects.slice(
+      0,
+      thresholds.shippedSubjectsShown,
+    )) {
+      out.push(`  • ${clip120(subject)}`);
+    }
+    out.push('');
+  }
+
+  // ---- Phase γ §2 — Surprises today ----
+  // Source: `analysis/surprises.json`. Skipped when the file is
+  // missing (input is null) OR when both tones contribute zero rows.
+  const surprises = inputs.surprises ?? null;
+  let surprisesPositive = 0;
+  let surprisesConcerning = 0;
+  if (surprises !== null) {
+    for (const s of surprises.surprises) {
+      if (s.tone === 'positive') surprisesPositive += 1;
+      else if (s.tone === 'concerning') surprisesConcerning += 1;
+    }
+    if (surprisesPositive + surprisesConcerning > 0) {
+      out.push(
+        `► Surprises today: ${surprisesPositive.toLocaleString()} positive, ` +
+          `${surprisesConcerning.toLocaleString()} concerning`,
+      );
+      // Top 3 positive — kernel pre-sorts by score desc; just slice.
+      const topPositive = surprises.surprises
+        .filter((s) => s.tone === 'positive')
+        .slice(0, thresholds.surpriseSummariesShown);
+      for (const s of topPositive) {
+        out.push(`  • [${s.kind}] ${clip120(s.summary)}`);
+      }
+      out.push('');
+    }
+  }
+
+  // ---- Phase γ §3 — Project trajectories ----
+  // Source: `analysis/project-trajectories.json`. Skipped when the
+  // file is missing or empty.
+  const trajectories = inputs.projectTrajectories ?? null;
+  let trajectoriesAccelerating = 0;
+  let trajectoriesFlat = 0;
+  let trajectoriesStalling = 0;
+  if (trajectories !== null && trajectories.length > 0) {
+    for (const t of trajectories) {
+      if (t.classification === 'accelerating') trajectoriesAccelerating += 1;
+      else if (t.classification === 'flat') trajectoriesFlat += 1;
+      else trajectoriesStalling += 1; // 'stalling' + 'stalled-finished'
+    }
+    out.push(
+      `► Project trajectories: ${trajectoriesAccelerating.toLocaleString()} accelerating, ` +
+        `${trajectoriesFlat.toLocaleString()} flat, ` +
+        `${trajectoriesStalling.toLocaleString()} stalling/stalled`,
+    );
+    // Top 3 most-active by totalSessions; tie-break on projectId for
+    // determinism (sort is otherwise non-stable for equal keys).
+    const topActive = [...trajectories]
+      .sort(
+        (a, b) =>
+          b.totalSessions - a.totalSessions ||
+          a.projectId.localeCompare(b.projectId),
+      )
+      .slice(0, thresholds.trajectoriesShown);
+    for (const t of topActive) {
+      const slopeStr =
+        t.slope === null
+          ? 'slope n/a'
+          : t.slope > 0
+            ? `slope +${t.slope.toFixed(2)}`
+            : `slope ${t.slope.toFixed(2)}`;
+      out.push(
+        `  • ${clip120(t.projectName)} — ${t.classification} (${slopeStr}, ` +
+          `${t.totalSessions.toLocaleString()} sessions)`,
+      );
+    }
+    out.push('');
+  }
+
+  // ---- Phase γ §4 — Applied-pattern closures ----
+  // Source: the applied-pattern watcher ledger in the SQLite substrate.
+  // The SDK accessor for watcher verdicts isn't wired in V1 (no
+  // `applyWatcher.ts` accessor under `packages/exporter/src/db/sdk/`).
+  // The shell is expected to pass `null` until the accessor lands;
+  // we ALSO skip the section when the count is 0 to keep the brief
+  // tight in the meantime.
+  const closures = inputs.appliedPatternClosures ?? null;
+  let appliedPatternClosures = 0;
+  if (closures !== null && closures > 0) {
+    appliedPatternClosures = closures;
+    out.push(
+      `► Applied-pattern closures: ${closures.toLocaleString()} pattern(s) held ` +
+        `(no recurrence past cooldown)`,
+    );
+    out.push('');
+  }
+
   // ---- Continuum health ----
   if (inputs.continuumHealth !== null) {
     const h = inputs.continuumHealth;
@@ -199,6 +400,13 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
       upgradesShown: upgradeCandidates.length,
       blogDraftsShown: sortedDrafts.length,
       auditConcernsShown: failures.length,
+      shippedCommits,
+      surprisesPositive,
+      surprisesConcerning,
+      trajectoriesAccelerating,
+      trajectoriesFlat,
+      trajectoriesStalling,
+      appliedPatternClosures,
     },
   };
 }

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -284,8 +284,10 @@ export {
 export {
   buildDailyBrief,
   type BriefThresholds,
+  type BriefTrajectoryRow,
   type DailyBriefInputs,
   type DailyBriefResult,
+  type ShippedThisWeekInput,
 } from './dailyBrief.js';
 
 export {

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -395,6 +395,23 @@ export {
 } from './applyWatcher.js';
 
 export {
+  computeSurprises,
+  type ComputeSurprisesInput,
+  type ComputeSurprisesOptions,
+  type Surprise,
+  type SurpriseCompositeRow,
+  type SurpriseDecisionRow,
+  type SurpriseEvidence,
+  type SurpriseKind,
+  type SurpriseKnowledgeDebtRow,
+  type SurpriseThresholdsSnapshot,
+  type SurpriseTone,
+  type SurpriseTrajectoryRow,
+  type SurpriseWatcherEntry,
+  type SurprisesOutput,
+} from './computeSurprises.js';
+
+export {
   rankCuratorCandidates,
   type CuratorCandidate,
   type CuratorCandidateKind,

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -361,6 +361,68 @@ export const THRESHOLDS = {
     falsifierMinSupportRatio: 0.6,
   },
   /**
+   * Feed-redesign Phase α — `computeSurprises` kernel knobs.
+   *
+   * Pre-launch placeholders, ALL of them — the surprises surface is
+   * brand-new (V1 = first land) and we have zero engagement data yet.
+   * Calibrate on the same 4-week empirical rolling window as
+   * `CHATARCH_THRASH_DETECT`: pull surprise emission rate per kind +
+   * user-side "useful / not useful" feedback once the FEED Phase β
+   * surface starts collecting it, then re-derive each value from the
+   * observed distribution. Bumping a threshold here should be paired
+   * with a fixture update + an entry under THRESHOLDS.surprises in the
+   * `CHANGELOG.md` calibration log.
+   *
+   * Knobs are mirrored as `SurpriseThresholdsSnapshot` on the
+   * `surprises.json` sidecar so the viewer can disclaim the values it
+   * was emitted under.
+   */
+  surprises: {
+    /** Minimum trailing-run length to emit a `streak` surprise. */
+    streakMin: 5,
+    /**
+     * ITS BH-FDR qValue ceiling — a contrast counts as
+     * `config-helped` when `qValue ≤ itsQValueMax` AND
+     * `deltaGoodShare ≥ itsDeltaMin`.
+     */
+    itsQValueMax: 0.1,
+    itsDeltaMin: 0.15,
+    /**
+     * Reflexive minimum mean-delta (good-share delta). Also requires
+     * the CI to be strictly positive AND the E-value CI bound to
+     * clear `reflexiveEValueMin` — descriptively significant +
+     * statistically significant + sensitivity-robust, three gates.
+     */
+    reflexiveDeltaMin: 0.1,
+    /**
+     * Reflexive E-value CI-bound floor. VanderWeele & Ding (2017)
+     * E-value on the Wilson CI bound nearest the null: how strong a
+     * confounder (RR scale, both arms) would have to be to drag the
+     * observed association to RR=1. 1.5 ≈ "a confounder twice the
+     * strength of any pre-treatment covariate already adjusted for
+     * would explain it away" — strong enough to surface, weak enough
+     * to be one of the looser gates. Pre-launch placeholder; raise to
+     * 2.0 after the first ~20 reflexive contrasts land if false-
+     * positive rate looks high.
+     */
+    reflexiveEValueMin: 1.5,
+    /**
+     * `decision-paid-off`: minimum number of additional good
+     * composite outcomes IN THE SAME PROJECT that must follow the
+     * decision's session. Raised from 2 → 5 after iter-1 adversarial:
+     * 2/2 followups gives Wilson lower bound ≈ 0.16 (Beta(1,1) prior),
+     * which is below any plausible base rate. 5 followups + Wilson-
+     * over-base-rate gate gives meaningful evidence the decision
+     * actually moved the curve rather than coinciding with a good
+     * week.
+     */
+    decisionGoodFollowupsMin: 5,
+    /** Top-K knowledge-debt clusters surfaced as `debt-spinning`. */
+    debtSpinningTopK: 3,
+    /** Minimum cluster size for `debt-spinning`. */
+    debtSpinningMinClusterSize: 3,
+  },
+  /**
    * Rev3 applied-rule outcome watcher (plan §"Three closures" —
    * Closure C). After a Pattern is `encode-as-pattern`'d and
    * (optionally) appended to CLAUDE.md, the next-sessions watcher

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -23,6 +23,9 @@
  *   - project-trajectories.json  (reads composite)
  *   - surface-comparison.json    (reads archetypes + composite)
  *   - skill-curves.json          (reads topics)
+ *   - surprises.json             (feed-redesign Phase A — reads
+ *                                 composite + trajectories + its +
+ *                                 reflexive + decisions + knowledge-debt)
  *
  * Phase 7 writers do NOT land here (they live in a separate skill/package
  * per Decision 1). Never writes tier-2 filenames.
@@ -60,6 +63,7 @@ import { buildArchetypesFile } from './archetypesBuilder.js';
 import { buildProjectTrajectoriesFile } from './projectTrajectoryBuilder.js';
 import { buildSurfaceComparisonFile } from './surfaceComparisonBuilder.js';
 import { buildSkillCurvesFile } from './skillCurvesBuilder.js';
+import { buildSurprisesFile } from './surprisesBuilder.js';
 
 export interface RunAnalysisOptions {
   /** Root output dir (same one `manifest.json` sits in). */
@@ -101,6 +105,7 @@ export interface RunAnalysisResult {
     projectTrajectories: string;
     surfaceComparison: string;
     skillCurves: string;
+    surprises: string;
   };
   counts: {
     duplicatesClusters: number;
@@ -124,6 +129,7 @@ export interface RunAnalysisResult {
     projectTrajectories: number;
     surfaceCells: number;
     skillCurves: number;
+    surprises: number;
   };
 }
 
@@ -151,8 +157,15 @@ export interface RunAnalysisResult {
  * because their per-file heuristic versions didn't change. The bump
  * is a coarse signal to operators that the bundle now reflects the
  * Rev3 substrate, not just outcome-substrate Phase 1-4.
+ *
+ * Bumped 1.3.0 → 1.4.0 in the feed-redesign Phase A plumbing:
+ * `analysis/surprises.json` lands as a new sidecar (per-kind ranked
+ * list of positive observations + concerns, snapshot-based — reads
+ * composite-outcomes + project-trajectories + its-analysis +
+ * reflexive + decisions + knowledge-debt). Pre-existing sidecars are
+ * unchanged.
  */
-export const EXPORTER_VERSION = '1.3.0';
+export const EXPORTER_VERSION = '1.4.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,
@@ -523,6 +536,23 @@ export async function runAnalysis(
   }
   const skillCurvesPath = path.join(analysisDir, 'skill-curves.json');
 
+  // surprises — feed-redesign Phase A. Snapshot kernel over the other
+  // Phase 1-3 sidecars; runs last so every input it consumes has had
+  // a chance to land on disk.
+  let surprisesCount = 0;
+  try {
+    const r = await buildSurprisesFile(manifest, {
+      outDir: options.outDir,
+      now,
+    });
+    surprisesCount = r.surpriseCount;
+  } catch (err) {
+    logger.warn(
+      `analysis: surprises soft-failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const surprisesPath = path.join(analysisDir, 'surprises.json');
+
   // ---- Meta ----
   const exporterRunId = options.exporterRunId ?? randomUUID();
   const gitSha = options.gitSha !== undefined ? options.gitSha : detectGitSha();
@@ -555,6 +585,7 @@ export async function runAnalysis(
           'project-trajectories.json',
           'surface-comparison.json',
           'skill-curves.json',
+          'surprises.json',
         ],
       },
     },
@@ -581,6 +612,7 @@ export async function runAnalysis(
       projectTrajectories: projectTrajectoriesCount,
       surfaceCells: surfaceCellsCount,
       skillCurves: skillCurvesCount,
+      surprises: surprisesCount,
     },
   };
   const metaPath = path.join(analysisDir, 'meta.json');
@@ -625,6 +657,7 @@ export async function runAnalysis(
       projectTrajectories: projectTrajectoriesPath,
       surfaceComparison: surfaceComparisonPath,
       skillCurves: skillCurvesPath,
+      surprises: surprisesPath,
     },
     counts: {
       duplicatesClusters: duplicatesFile.clusters.length,
@@ -646,6 +679,7 @@ export async function runAnalysis(
       projectTrajectories: projectTrajectoriesCount,
       surfaceCells: surfaceCellsCount,
       skillCurves: skillCurvesCount,
+      surprises: surprisesCount,
     },
   };
 }

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -164,8 +164,16 @@ export interface RunAnalysisResult {
  * composite-outcomes + project-trajectories + its-analysis +
  * reflexive + decisions + knowledge-debt). Pre-existing sidecars are
  * unchanged.
+ *
+ * Bumped 1.4.0 → 1.4.1 in the feed-redesign Phase γ polish:
+ * `dailyBrief.ts` grows four new sections (shipped this week / surprises
+ * today / project trajectories / applied-pattern closures) plus the
+ * matching count fields on `DailyBriefResult.counts`. No new on-disk
+ * artifact — the brief shape change is internal to the regen-brief
+ * endpoint's output markdown — but the patch bump labels the bundle so
+ * operators can correlate.
  */
-export const EXPORTER_VERSION = '1.4.0';
+export const EXPORTER_VERSION = '1.4.1';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/analysis/surprisesBuilder.ts
+++ b/packages/exporter/src/analysis/surprisesBuilder.ts
@@ -1,0 +1,235 @@
+/**
+ * Surprises builder — feed-redesign Phase A.
+ *
+ * Node-only I/O wrapper around the pure `computeSurprises` kernel.
+ *
+ * Reads:
+ *   - `analysis/composite-outcomes.json`   (foundation)
+ *   - `analysis/project-trajectories.json`
+ *   - `analysis/its-analysis.json`
+ *   - `analysis/reflexive.json`
+ *   - `analysis/decisions.json`
+ *   - `analysis/knowledge-debt.json`
+ *
+ * Writes:
+ *   - `analysis/surprises.json`
+ *
+ * Watcher entries are intentionally NOT read from disk in V1 — the
+ * applied-pattern watcher loop ledger lives in the SQLite substrate,
+ * not in a JSON sidecar, and wiring the DB query into the exporter is
+ * out-of-scope for the kernel landing PR. The builder passes an empty
+ * `patternWatchers` array; a follow-on adds the SDK call.
+ *
+ * Fail-soft: any missing input sidecar degrades the corresponding
+ * surprise kinds to "no rows" rather than aborting the build. The
+ * surprises sidecar is always written so the viewer can rely on its
+ * presence after a scan.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  CompositeOutcomesFile,
+  Decision,
+  DecisionsFile,
+  SessionManifest,
+} from '@chat-arch/schema';
+import {
+  computeSurprises,
+  type ComputeSurprisesInput,
+  type SurpriseCompositeRow,
+  type SurpriseDecisionRow,
+  type SurpriseKnowledgeDebtRow,
+  type SurpriseTrajectoryRow,
+  type SurpriseWatcherEntry,
+  type SurprisesOutput,
+} from '@chat-arch/analysis';
+import type { ItsResult } from '@chat-arch/analysis';
+import type { ReflexiveResult } from '@chat-arch/analysis';
+import { logger } from '../lib/logger.js';
+import { atomicWriteJsonSync } from '../lib/atomicWrite.js';
+
+export interface BuildSurprisesOptions {
+  outDir: string;
+  now: number;
+}
+
+export interface BuildSurprisesResult {
+  file: SurprisesOutput;
+  /** Sidecars that were readable; the others contributed empty inputs. */
+  inputsRead: {
+    composite: boolean;
+    trajectories: boolean;
+    its: boolean;
+    reflexive: boolean;
+    decisions: boolean;
+    knowledgeDebt: boolean;
+  };
+  surpriseCount: number;
+}
+
+async function readJsonOrNull<T>(p: string): Promise<T | null> {
+  try {
+    const raw = await readFile(p, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function buildSurprisesFile(
+  manifest: SessionManifest,
+  options: BuildSurprisesOptions,
+): Promise<BuildSurprisesResult> {
+  const t0 = Date.now();
+  const analysisDir = path.join(options.outDir, 'analysis');
+
+  // Map sessionId → updatedAt from the manifest. Composite rows on
+  // disk don't carry the terminal timestamp; we re-join here.
+  const updatedAtBySession = new Map<string, number>();
+  for (const entry of manifest.sessions) {
+    if (typeof entry.updatedAt === 'number') {
+      updatedAtBySession.set(entry.id, entry.updatedAt);
+    }
+  }
+
+  // ── composites ──
+  const compositeFile = await readJsonOrNull<CompositeOutcomesFile>(
+    path.join(analysisDir, 'composite-outcomes.json'),
+  );
+  const composites: SurpriseCompositeRow[] = [];
+  if (compositeFile !== null) {
+    for (const o of compositeFile.outcomes ?? []) {
+      const updatedAt = updatedAtBySession.get(o.sessionId) ?? 0;
+      composites.push({ sessionId: o.sessionId, updatedAt, composite: o });
+    }
+  }
+
+  // ── trajectories ──
+  interface ProjectTrajectoriesFileShape {
+    projects?: ReadonlyArray<{
+      projectId: string;
+      projectName: string;
+      classification: SurpriseTrajectoryRow['classification'];
+      slope: number | null;
+      ci: { low: number; high: number } | null;
+      totalSessions: number;
+      recentSessions: number;
+      bootstrapStatus: 'ok' | 'series-too-short';
+    }>;
+  }
+  const trajectoryFile = await readJsonOrNull<ProjectTrajectoriesFileShape>(
+    path.join(analysisDir, 'project-trajectories.json'),
+  );
+  const trajectories: SurpriseTrajectoryRow[] =
+    trajectoryFile?.projects?.map((p) => ({
+      projectId: p.projectId,
+      projectName: p.projectName,
+      classification: p.classification,
+      slope: p.slope,
+      ci: p.ci,
+      totalSessions: p.totalSessions,
+      recentSessions: p.recentSessions,
+      bootstrapStatus: p.bootstrapStatus,
+    })) ?? [];
+
+  // ── its ──
+  interface ItsFileShape {
+    results?: readonly ItsResult[];
+  }
+  const itsFile = await readJsonOrNull<ItsFileShape>(
+    path.join(analysisDir, 'its-analysis.json'),
+  );
+  const itsResults: readonly ItsResult[] = itsFile?.results ?? [];
+
+  // ── reflexive ──
+  interface ReflexiveFileShape {
+    result?: ReflexiveResult;
+  }
+  const reflexiveFile = await readJsonOrNull<ReflexiveFileShape>(
+    path.join(analysisDir, 'reflexive.json'),
+  );
+  const reflexive: ReflexiveResult | null = reflexiveFile?.result ?? null;
+
+  // ── decisions ──
+  const decisionsFile = await readJsonOrNull<DecisionsFile>(
+    path.join(analysisDir, 'decisions.json'),
+  );
+  const decisions: SurpriseDecisionRow[] = [];
+  if (decisionsFile !== null) {
+    for (const d of decisionsFile.decisions ?? []) {
+      const decision = d as Decision;
+      const ref = decision.outcomeRef;
+      if (ref === null || ref === undefined) continue;
+      decisions.push({
+        decisionId: decision.candidate.id,
+        sessionId: ref.sessionId,
+        compositeScore: ref.compositeScore,
+        binaryClass: ref.binaryClass,
+        ...(decision.classification?.distilledDecision !== undefined
+          ? { label: decision.classification.distilledDecision }
+          : {}),
+      });
+    }
+  }
+
+  // ── knowledge debt ──
+  interface KnowledgeDebtFileShape {
+    clusters?: ReadonlyArray<{
+      id: string;
+      canonicalQuestion: string;
+      sessionIds: readonly string[];
+      confidence: 'high' | 'low';
+    }>;
+  }
+  const debtFile = await readJsonOrNull<KnowledgeDebtFileShape>(
+    path.join(analysisDir, 'knowledge-debt.json'),
+  );
+  const knowledgeDebt: SurpriseKnowledgeDebtRow[] =
+    debtFile?.clusters?.map((c) => ({
+      id: c.id,
+      canonicalQuestion: c.canonicalQuestion,
+      sessionIds: c.sessionIds,
+      confidence: c.confidence,
+    })) ?? [];
+
+  // Pattern-watcher ledger lives in SQLite; wiring the SDK query is a
+  // follow-on. V1 passes an empty list so the kernel skips the two
+  // pattern-* kinds rather than synthesizing fake verdicts.
+  const patternWatchers: readonly SurpriseWatcherEntry[] = [];
+
+  const kernelInput: ComputeSurprisesInput = {
+    generatedAt: options.now,
+    composites,
+    trajectories,
+    itsResults,
+    patternWatchers,
+    reflexive,
+    decisions,
+    knowledgeDebt,
+  };
+  const file = computeSurprises(kernelInput);
+
+  const outPath = path.join(analysisDir, 'surprises.json');
+  atomicWriteJsonSync(outPath, file);
+
+  logger.info(
+    `analysis: surprises.json — ${file.surprises.length} surprises ` +
+      `(composites=${composites.length}, trajectories=${trajectories.length}, ` +
+      `its=${itsResults.length}, decisions=${decisions.length}, ` +
+      `knowledgeDebt=${knowledgeDebt.length}), ${Date.now() - t0}ms`,
+  );
+
+  return {
+    file,
+    inputsRead: {
+      composite: compositeFile !== null,
+      trajectories: trajectoryFile !== null,
+      its: itsFile !== null,
+      reflexive: reflexiveFile !== null,
+      decisions: decisionsFile !== null,
+      knowledgeDebt: debtFile !== null,
+    },
+    surpriseCount: file.surprises.length,
+  };
+}

--- a/packages/exporter/src/analysis/surprisesBuilder.ts
+++ b/packages/exporter/src/analysis/surprisesBuilder.ts
@@ -84,12 +84,18 @@ export async function buildSurprisesFile(
   const t0 = Date.now();
   const analysisDir = path.join(options.outDir, 'analysis');
 
-  // Map sessionId → updatedAt from the manifest. Composite rows on
-  // disk don't carry the terminal timestamp; we re-join here.
+  // Map sessionId → { updatedAt, projectId } from the manifest.
+  // Composite rows on disk don't carry the terminal timestamp or the
+  // discovered projectId; we re-join here so the kernel can apply the
+  // same-project gates (notably `decision-paid-off`).
   const updatedAtBySession = new Map<string, number>();
+  const projectIdBySession = new Map<string, string>();
   for (const entry of manifest.sessions) {
     if (typeof entry.updatedAt === 'number') {
       updatedAtBySession.set(entry.id, entry.updatedAt);
+    }
+    if (typeof entry.projectId === 'string' && entry.projectId.length > 0) {
+      projectIdBySession.set(entry.id, entry.projectId);
     }
   }
 
@@ -101,7 +107,13 @@ export async function buildSurprisesFile(
   if (compositeFile !== null) {
     for (const o of compositeFile.outcomes ?? []) {
       const updatedAt = updatedAtBySession.get(o.sessionId) ?? 0;
-      composites.push({ sessionId: o.sessionId, updatedAt, composite: o });
+      const projectId = projectIdBySession.get(o.sessionId);
+      composites.push({
+        sessionId: o.sessionId,
+        updatedAt,
+        composite: o,
+        ...(projectId !== undefined ? { projectId } : {}),
+      });
     }
   }
 
@@ -161,6 +173,12 @@ export async function buildSurprisesFile(
       const decision = d as Decision;
       const ref = decision.outcomeRef;
       if (ref === null || ref === undefined) continue;
+      // Same-project scoping for `decision-paid-off`: pull the
+      // decision-session's projectId from the manifest join above.
+      // Decisions whose session has no discovered projectId are still
+      // emitted to the kernel but won't qualify for the paid-off
+      // surprise (kernel-side gate).
+      const projectId = projectIdBySession.get(ref.sessionId);
       decisions.push({
         decisionId: decision.candidate.id,
         sessionId: ref.sessionId,
@@ -169,6 +187,7 @@ export async function buildSurprisesFile(
         ...(decision.classification?.distilledDecision !== undefined
           ? { label: decision.classification.distilledDecision }
           : {}),
+        ...(projectId !== undefined ? { projectId } : {}),
       });
     }
   }
@@ -193,9 +212,25 @@ export async function buildSurprisesFile(
       confidence: c.confidence,
     })) ?? [];
 
-  // Pattern-watcher ledger lives in SQLite; wiring the SDK query is a
-  // follow-on. V1 passes an empty list so the kernel skips the two
-  // pattern-* kinds rather than synthesizing fake verdicts.
+  // TODO(applyWatcher-sdk): wire the pattern-watcher ledger from the
+  // SQLite substrate once the read-side SDK accessor lands.
+  //
+  // The applied-pattern watcher loop (`evaluateAppliedPatternWatcher`
+  // in @chat-arch/analysis) emits per-(pattern, project) verdicts
+  // {kind: 'holding' | 'recurring' | 'open' | 'inconclusive'} that
+  // the kernel consumes for `pattern-closed` / `pattern-recurring`
+  // surprises. The verdicts persist in the SQLite substrate (Rev3-E
+  // pattern + applyWatcher tables) but no `@chat-arch/exporter/db`
+  // SDK accessor exposes them to a Node consumer yet.
+  //
+  // Until that accessor lands, this builder passes an empty list so
+  // the kernel skips both pattern-* kinds rather than synthesizing
+  // fake verdicts. V1 emission scope is therefore 7 of 9 kinds.
+  //
+  // When wiring lands, replace this assignment with the SDK call
+  // (likely `listWatcherVerdicts({ closedOnly: false })` returning a
+  // shape assignable to `SurpriseWatcherEntry[]`) and update CHANGELOG
+  // `[1.4.0]` accordingly.
   const patternWatchers: readonly SurpriseWatcherEntry[] = [];
 
   const kernelInput: ComputeSurprisesInput = {

--- a/packages/exporter/test/integration/analysis-pipeline.test.ts
+++ b/packages/exporter/test/integration/analysis-pipeline.test.ts
@@ -151,6 +151,7 @@ describe('Phase 6 analysis pipeline integration', () => {
         'project-trajectories.json',
         'surface-comparison.json',
         'skill-curves.json',
+        'surprises.json',
       ].sort(),
     );
     // Phase 6 does not populate the `local` tier.

--- a/packages/exporter/test/migration/v1.1.0-fixture.test.ts
+++ b/packages/exporter/test/migration/v1.1.0-fixture.test.ts
@@ -157,9 +157,10 @@ describe('migration v1.1.0 → 1.2.0', () => {
       tiers: { browser: { files: readonly string[] } };
       counts: Record<string, unknown>;
     }>(path.join(tmpDataDir, 'analysis', 'meta.json'));
-    expect(meta.exporterVersion).toBe('1.3.0');
+    expect(meta.exporterVersion).toBe('1.4.0');
 
-    // The Wave-5 sidecars must all be registered in the browser tier.
+    // The Wave-5 sidecars (+ feed-redesign Phase A surprises.json)
+    // must all be registered in the browser tier.
     const expectedNewSidecars = [
       'composite-outcomes.json',
       'config-history.json',
@@ -171,6 +172,7 @@ describe('migration v1.1.0 → 1.2.0', () => {
       'project-trajectories.json',
       'surface-comparison.json',
       'skill-curves.json',
+      'surprises.json',
     ];
     for (const f of expectedNewSidecars) {
       expect(

--- a/packages/exporter/test/migration/v1.1.0-fixture.test.ts
+++ b/packages/exporter/test/migration/v1.1.0-fixture.test.ts
@@ -157,7 +157,7 @@ describe('migration v1.1.0 → 1.2.0', () => {
       tiers: { browser: { files: readonly string[] } };
       counts: Record<string, unknown>;
     }>(path.join(tmpDataDir, 'analysis', 'meta.json'));
-    expect(meta.exporterVersion).toBe('1.4.0');
+    expect(meta.exporterVersion).toBe('1.4.1');
 
     // The Wave-5 sidecars (+ feed-redesign Phase A surprises.json)
     // must all be registered in the browser tier.


### PR DESCRIPTION
## Summary

Phase γ of the FEED redesign. Polish pass — now that the BRIEF is the first thing on the home page (#98), it needs to actually say something.

**Stacked on #98 (Phase β) which is stacked on #97 (Phase α).** Diff shown is just γ.

## What changed

Daily brief grew from "5 audit concerns + continuum stats" to a substantive journal opener. **Four new sections** (each skips cleanly when inputs missing):

- **Shipped this week** — git commit count + top 5 subjects to \`main\` in the last 7 days
- **Surprises today** — counts split by tone + top 3 positive summaries with kind labels (consumes Phase α's \`surprises.json\`)
- **Project trajectories** — accelerating/flat/stalling counts + top 3 most-active projects with slope sign
- **Applied-pattern closures** — wired skip-when-null in V1; the kernel + endpoint are ready, just need the applyWatcher SQLite SDK accessor (separate small follow-up)

**CLAUDE.md:** added a 4-row note documenting which sidecars are intermediate (kernel inputs, not UI-facing): \`audit-claims\`, \`discovery-scores\`, \`duplicates.semantic\`, \`pr-land-cache\`. Pre-empts the "why doesn't X have a surface?" question.

\`EXPORTER_VERSION\` 1.4.0 → 1.4.1 (patch — brief content grew, no new on-disk artifact files).

## Test plan

- [x] \`pnpm --filter @chat-arch/analysis test\` — **746/746** (dailyBrief grew 6 → 23 tests, +17)
- [x] \`pnpm --filter @chat-arch/exporter test\` — 361 pass / 4 skipped (pre-existing live-integration)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm --filter @chat-arch/standalone build\` — clean
- [ ] Manual smoke after merge — run REGEN BRIEF; confirm new sections render with real data (deferred — needs all 3 PRs merged + a scan run)

## Design notes (worth flagging)

- **git log via two parallel \`execFile\`** calls (count + subjects) — avoids shell quoting, lets failure (no git, no main) collapse the section to nothing instead of breaking the brief.
- **Trajectory buckets** collapsed to 3 displayed (\`accelerating / flat / stalling+stalled-finished\`) per the user-facing simpler model; raw 4 buckets still exposed in \`counts\` for downstream callers.
- **Applied-pattern closures section** kernel + endpoint ready; the endpoint passes \`null\` until the SDK accessor exists. Drop-in is one line in regen-brief.ts when ready. Comment in code points at the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)