### PR TITLE
feat(feed-γ): enrich daily brief + document intermediate sidecars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,49 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-05-24
+
+Feed-redesign Phase γ polish — enriches the daily brief now that
+Phase β promoted it to the top of the TODAY page. Patch bump (no new
+on-disk artifact); the change is internal to the
+`buildDailyBrief` kernel output + the `regen-brief` API endpoint.
+
+### Changed
+
+- `dailyBrief.ts` grows four new sections rendered between the
+  existing "audit concerns" and "continuum health" blocks:
+  - **Shipped this week** — commit count + top 5 subject lines from
+    `git log --since="7 days ago" main`, computed by the
+    `regen-brief.ts` shell and passed in as a precomputed input.
+  - **Surprises today** — per-tone counts (positive / concerning)
+    from `analysis/surprises.json` plus the top 3 positive summaries
+    by score.
+  - **Project trajectories** — per-classification counts from
+    `analysis/project-trajectories.json` plus the top 3 most-active
+    projects by `totalSessions`.
+  - **Applied-pattern closures** — count of patterns currently held
+    in the watcher's `holding` state. SDK accessor not yet wired;
+    section skips cleanly (input is `null` in V1).
+- Each section is independently skippable — empty inputs render
+  nothing, matching the pre-existing convention.
+- `DailyBriefResult.counts` gains seven fields covering the new
+  sections (`shippedCommits`, `surprisesPositive`,
+  `surprisesConcerning`, `trajectoriesAccelerating`,
+  `trajectoriesFlat`, `trajectoriesStalling`,
+  `appliedPatternClosures`). Existing fields unchanged.
+
+### Notes
+
+- The brief stays markdown + deterministic + LLM-free. The kernel
+  remains a pure function; all I/O (sidecar reads + `git log`) lives
+  in the `regen-brief.ts` API endpoint.
+- `CLAUDE.md` "Outcome-substrate sidecars" section gains an
+  **Intermediate sidecars** note documenting which artifacts are
+  consumed internally by kernels / other sidecars rather than read
+  by a UI surface (audit-claims.json, discovery-scores.json,
+  duplicates.semantic.json, pr-land-cache.json). Pre-empts the
+  "why doesn't X have a surface?" question for future contributors.
+
 ## [1.4.0] — 2026-05-24
 
 Feed-redesign Phase A plumbing — adds a new `analysis/surprises.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,3 +413,8 @@ out of date and needs an update:
      `[1.3.0]` for the full ledger of what landed. Bumped 1.3.0
      → 1.4.0 in the feed-redesign Phase A plumbing when
      `analysis/surprises.json` landed; see CHANGELOG.md `[1.4.0]`.
+     Bumped 1.4.0 → 1.4.1 in feed-redesign Phase γ when
+     `buildDailyBrief` gained shipped-this-week / surprises /
+     trajectories / applied-pattern-closures sections (no new on-
+     disk sidecar; brief markdown shape grew); see CHANGELOG.md
+     `[1.4.1]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,20 @@ analysis/` (all gitignored — locally generated, may carry PII):
 - `skill-curves.json` — per-topic weekly ask-count series + Mann-
   Kendall trend test with BH-FDR. PII: topic + time series.
 
+**Intermediate sidecars (no direct UI surface).** A few artifacts
+under `analysis/` exist as inputs to other kernels or downstream
+sidecars rather than as something a UI surface reads. If you're
+wondering why one of these doesn't show up in the viewer, that's
+the reason — not a missing feature, by design. Don't add a surface
+for them; the consuming sidecar is what gets rendered.
+
+| Sidecar | Consumer | Direct surface? |
+|---|---|---|
+| `audit-claims.json` | input to the audit verifier (which writes `audit-results.json`) | no — `/audit` + `/results` read `audit-results.json` |
+| `discovery-scores.json` | input to the curator ranker (which writes `curator-feed.json`) | no |
+| `duplicates.semantic.json` | input to other clustering kernels | no |
+| `pr-land-cache.json` | input to `composite-outcomes.json` (gated by `--enable-pr-join`) | no |
+
 ### Feed-redesign Phase A sidecar (EXPORTER_VERSION 1.4.0)
 
 One additional sidecar under `apps/standalone/public/chat-arch-data/

--- a/apps/standalone/src/pages/api/regen-brief.ts
+++ b/apps/standalone/src/pages/api/regen-brief.ts
@@ -190,6 +190,10 @@ export const POST: APIRoute = async ({ request }) => {
   // no SDK accessor for it ships under `@chat-arch/exporter/db/sdk`
   // yet. We pass `null` so the kernel skips the section instead of
   // pretending zero-is-known; wiring lands when the SDK accessor does.
+  // TODO(applyWatcher-sdk): once `listWatcherVerdicts(db)` (or similar)
+  // exists in @chat-arch/exporter/db/sdk, change this to
+  // `listWatcherVerdicts(db).filter(v => v.verdict === 'no-recurrence').length`.
+  // Companion TODO at packages/analysis/src/dailyBrief.ts line ~360.
   const appliedPatternClosures: number | null = null;
   // Blog-drafts index isn't currently written as a single file — we
   // pass [] for now. The Today page reads blog drafts separately.

--- a/apps/standalone/src/pages/api/regen-brief.ts
+++ b/apps/standalone/src/pages/api/regen-brief.ts
@@ -9,10 +9,16 @@
  * a local hostname AND `X-Requested-With: chat-arch-regen-brief`.
  */
 import type { APIRoute } from 'astro';
+import { execFile } from 'node:child_process';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
-import { buildDailyBrief } from '@chat-arch/analysis';
+import { promisify } from 'node:util';
+import {
+  buildDailyBrief,
+  type BriefTrajectoryRow,
+  type SurprisesOutput,
+} from '@chat-arch/analysis';
 import type {
   AuditResultsFile,
   AuditSummary,
@@ -21,6 +27,24 @@ import type {
   CorrectionsFile,
   UpgradeOutcomesFile,
 } from '@chat-arch/schema';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Project-trajectories sidecar shape. We only need the four fields the
+ * brief renders, so we narrow the on-disk type here instead of pulling
+ * the full `ProjectTrajectoriesFile` from the exporter package (which
+ * would create a cross-app dependency we don't otherwise have).
+ */
+interface ProjectTrajectoriesFileShape {
+  projects?: ReadonlyArray<{
+    projectId: string;
+    projectName: string;
+    classification: BriefTrajectoryRow['classification'];
+    slope: number | null;
+    totalSessions: number;
+  }>;
+}
 
 export const prerender = false;
 
@@ -61,6 +85,55 @@ async function readJsonOrNull<T>(absPath: string): Promise<T | null> {
   }
 }
 
+/**
+ * Locate the repo root by walking up from this file. We mirror the same
+ * 5-level climb that `dataDirAbs()` uses; resolving once and re-using
+ * keeps the two paths consistent.
+ */
+function repoRootAbs(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+/**
+ * Run `git log --since="7 days ago" ... main` against the repo root.
+ * Returns `null` on any failure (not a git repo, no `main` branch,
+ * `git` not on PATH, etc.) so the kernel skips the section cleanly.
+ *
+ * We pass each `git log` flag as a separate argv entry to `execFile`
+ * so no shell quoting is involved. Bounded `maxBuffer` (256KB) caps
+ * the output for very busy weeks; we'd still get the count line even
+ * if the subject lines were truncated.
+ */
+async function shippedThisWeekFromGit(
+  repoRoot: string,
+): Promise<{ commitCount: number; recentSubjects: string[] } | null> {
+  try {
+    const [countResult, subjectsResult] = await Promise.all([
+      execFileAsync(
+        'git',
+        ['log', '--since=7 days ago', '--pretty=format:%H', 'main'],
+        { cwd: repoRoot, maxBuffer: 256 * 1024 },
+      ),
+      execFileAsync(
+        'git',
+        ['log', '--since=7 days ago', '--pretty=format:%s', 'main'],
+        { cwd: repoRoot, maxBuffer: 256 * 1024 },
+      ),
+    ]);
+    const commitCount = countResult.stdout
+      .split('\n')
+      .filter((l) => l.trim().length > 0).length;
+    const recentSubjects = subjectsResult.stdout
+      .split('\n')
+      .filter((l) => l.trim().length > 0)
+      .slice(0, 5);
+    return { commitCount, recentSubjects };
+  } catch {
+    return null;
+  }
+}
+
 export const POST: APIRoute = async ({ request }) => {
   if (!isLocalOrigin(request.headers.get('origin'))) {
     return reject(403, 'Forbidden: non-local origin');
@@ -89,6 +162,35 @@ export const POST: APIRoute = async ({ request }) => {
   const upgradeOutcomes = await readJsonOrNull<UpgradeOutcomesFile>(
     join(analysisDir, 'upgrade-outcomes.json'),
   );
+  // Phase γ §2 — `analysis/surprises.json` (produced by the surprises
+  // builder). Fail-soft: missing/unparseable ⇒ kernel skips the
+  // section.
+  const surprises = await readJsonOrNull<SurprisesOutput>(
+    join(analysisDir, 'surprises.json'),
+  );
+  // Phase γ §3 — `analysis/project-trajectories.json` (produced by the
+  // project-trajectory builder). Narrowed inline so we don't pull the
+  // exporter type across.
+  const trajectoriesFile = await readJsonOrNull<ProjectTrajectoriesFileShape>(
+    join(analysisDir, 'project-trajectories.json'),
+  );
+  const projectTrajectories: BriefTrajectoryRow[] =
+    trajectoriesFile?.projects?.map((p) => ({
+      projectId: p.projectId,
+      projectName: p.projectName,
+      classification: p.classification,
+      slope: p.slope,
+      totalSessions: p.totalSessions,
+    })) ?? [];
+  // Phase γ §1 — `git log` for the shipped-this-week counter. Pure
+  // I/O in the shell; the kernel just formats the numbers.
+  const shippedThisWeek = await shippedThisWeekFromGit(repoRootAbs());
+  // Phase γ §4 — applied-pattern closures. The watcher verdict ledger
+  // lives in the SQLite substrate (see CLAUDE.md "Data on disk"), but
+  // no SDK accessor for it ships under `@chat-arch/exporter/db/sdk`
+  // yet. We pass `null` so the kernel skips the section instead of
+  // pretending zero-is-known; wiring lands when the SDK accessor does.
+  const appliedPatternClosures: number | null = null;
   // Blog-drafts index isn't currently written as a single file — we
   // pass [] for now. The Today page reads blog drafts separately.
   void (null as unknown as BlogDraftsIndexFile);
@@ -105,6 +207,10 @@ export const POST: APIRoute = async ({ request }) => {
     auditResults: auditResults?.results ?? [],
     auditSummary,
     continuumHealth,
+    shippedThisWeek,
+    surprises,
+    projectTrajectories,
+    appliedPatternClosures,
   });
 
   const outPath = join(briefsDir, `${date}.md`);

--- a/packages/analysis/src/dailyBrief.test.ts
+++ b/packages/analysis/src/dailyBrief.test.ts
@@ -5,7 +5,8 @@ import type {
   CorrectionPattern,
   ProposedUpgrade,
 } from '@chat-arch/schema';
-import { buildDailyBrief } from './dailyBrief.js';
+import { buildDailyBrief, type BriefTrajectoryRow } from './dailyBrief.js';
+import type { SurprisesOutput } from './computeSurprises.js';
 
 const NOW = Date.parse('2026-05-16T04:00:00Z');
 
@@ -191,5 +192,507 @@ describe('buildDailyBrief', () => {
     const low = r.markdown.indexOf('Low confidence');
     expect(high).toBeGreaterThan(-1);
     expect(low).toBeGreaterThan(high);
+  });
+
+  // ── Phase γ §1 — Shipped this week ───────────────────────────────
+
+  describe('shipped this week', () => {
+    it('renders the count + top subjects when commits exist', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: {
+          commitCount: 12,
+          recentSubjects: [
+            'feat: ship one',
+            'fix: stabilize two',
+            'docs: update three',
+            'chore: bump four',
+            'refactor: rename five',
+            'test: cover six (will not render)',
+          ],
+        },
+      });
+      expect(r.markdown).toContain('Shipped this week: 12 commit(s) to main');
+      expect(r.markdown).toContain('feat: ship one');
+      expect(r.markdown).toContain('refactor: rename five');
+      // Top-5 cap on subjects.
+      expect(r.markdown).not.toContain('test: cover six');
+      expect(r.counts.shippedCommits).toBe(12);
+    });
+
+    it('skips the section when commitCount is zero', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: { commitCount: 0, recentSubjects: [] },
+      });
+      expect(r.markdown).not.toContain('Shipped this week');
+      expect(r.counts.shippedCommits).toBe(0);
+    });
+
+    it('skips the section when shippedThisWeek is null', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: null,
+      });
+      expect(r.markdown).not.toContain('Shipped this week');
+      expect(r.counts.shippedCommits).toBe(0);
+    });
+
+    it('truncates long subject lines at 120 chars', () => {
+      const long = 'feat: ' + 'a'.repeat(200);
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: { commitCount: 1, recentSubjects: [long] },
+      });
+      // The rendered subject line includes our '  • ' prefix; we
+      // inspect for the truncation marker on the rendered body line.
+      const subjectLine = r.markdown
+        .split('\n')
+        .find((l) => l.startsWith('  • feat: aaa'));
+      expect(subjectLine).toBeDefined();
+      // 4-char prefix ("  • ") + clip120(...) ⇒ line ≤ 124 chars.
+      expect((subjectLine as string).length).toBeLessThanOrEqual(124);
+      expect(subjectLine).toMatch(/…$/u);
+    });
+
+    it('formats large commit counts with toLocaleString separators', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: {
+          commitCount: 1234,
+          recentSubjects: ['feat: many things'],
+        },
+      });
+      expect(r.markdown).toContain('1,234 commit(s) to main');
+    });
+  });
+
+  // ── Phase γ §2 — Surprises today ─────────────────────────────────
+
+  function surprisesFile(
+    rows: ReadonlyArray<{
+      kind: SurprisesOutput['surprises'][number]['kind'];
+      tone: SurprisesOutput['surprises'][number]['tone'];
+      summary: string;
+      score: number;
+    }>,
+  ): SurprisesOutput {
+    return {
+      version: 1,
+      generatedAt: NOW,
+      surprises: rows.map((r, i) => ({
+        id: `${r.kind}:row-${i}`,
+        kind: r.kind,
+        tone: r.tone,
+        summary: r.summary,
+        evidence: {},
+        score: r.score,
+        generatedAt: NOW,
+      })),
+      thresholds: {
+        streakMin: 5,
+        itsQValueMax: 0.1,
+        itsDeltaMin: 0.15,
+        reflexiveDeltaMin: 0.1,
+        decisionGoodFollowupsMin: 2,
+        debtSpinningTopK: 3,
+        debtSpinningMinClusterSize: 3,
+      },
+    };
+  }
+
+  describe('surprises', () => {
+    it('reports per-tone counts and lists top-3 positive summaries', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([
+          { kind: 'streak', tone: 'positive', summary: '5 in a row', score: 0.9 },
+          {
+            kind: 'trajectory-accelerating',
+            tone: 'positive',
+            summary: 'Project chat-arch on the rise',
+            score: 0.8,
+          },
+          {
+            kind: 'config-helped',
+            tone: 'positive',
+            summary: 'Config abc lifted good-share',
+            score: 0.7,
+          },
+          {
+            kind: 'pattern-closed',
+            tone: 'positive',
+            summary: 'Pattern p1 held',
+            score: 0.5,
+          },
+          {
+            kind: 'trajectory-stalled',
+            tone: 'concerning',
+            summary: 'Project foo stalling',
+            score: 0.6,
+          },
+        ]),
+      });
+      expect(r.markdown).toContain('Surprises today: 4 positive, 1 concerning');
+      expect(r.markdown).toContain('[streak] 5 in a row');
+      expect(r.markdown).toContain(
+        '[trajectory-accelerating] Project chat-arch on the rise',
+      );
+      expect(r.markdown).toContain('[config-helped] Config abc lifted good-share');
+      // 4th positive ('pattern-closed') exceeds top-3 cap and is excluded.
+      expect(r.markdown).not.toContain('Pattern p1 held');
+      expect(r.counts.surprisesPositive).toBe(4);
+      expect(r.counts.surprisesConcerning).toBe(1);
+    });
+
+    it('skips the section when surprises is null', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: null,
+      });
+      expect(r.markdown).not.toContain('Surprises today');
+      expect(r.counts.surprisesPositive).toBe(0);
+      expect(r.counts.surprisesConcerning).toBe(0);
+    });
+
+    it('skips the section when the file is present but empty', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([]),
+      });
+      expect(r.markdown).not.toContain('Surprises today');
+    });
+
+    it('handles concerning-only files (zero positive summaries listed)', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([
+          {
+            kind: 'pattern-recurring',
+            tone: 'concerning',
+            summary: 'p1 came back',
+            score: 0.9,
+          },
+        ]),
+      });
+      expect(r.markdown).toContain('Surprises today: 0 positive, 1 concerning');
+      // No positive rows ⇒ no `[kind]` bullet beneath the header.
+      expect(r.markdown).not.toContain('[pattern-recurring]');
+    });
+  });
+
+  // ── Phase γ §3 — Project trajectories ────────────────────────────
+
+  function trajectory(
+    overrides: Partial<BriefTrajectoryRow> = {},
+  ): BriefTrajectoryRow {
+    return {
+      projectId: 'proj-1',
+      projectName: 'project one',
+      classification: 'flat',
+      slope: 0,
+      totalSessions: 10,
+      ...overrides,
+    };
+  }
+
+  describe('project trajectories', () => {
+    it('reports per-classification counts and the top-3 most-active', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: [
+          trajectory({
+            projectId: 'a',
+            projectName: 'alpha',
+            classification: 'accelerating',
+            slope: 0.5,
+            totalSessions: 50,
+          }),
+          trajectory({
+            projectId: 'b',
+            projectName: 'bravo',
+            classification: 'flat',
+            slope: 0,
+            totalSessions: 40,
+          }),
+          trajectory({
+            projectId: 'c',
+            projectName: 'charlie',
+            classification: 'stalling',
+            slope: -0.3,
+            totalSessions: 30,
+          }),
+          trajectory({
+            projectId: 'd',
+            projectName: 'delta',
+            classification: 'stalled-finished',
+            slope: -0.1,
+            totalSessions: 20,
+          }),
+          trajectory({
+            projectId: 'e',
+            projectName: 'echo',
+            classification: 'accelerating',
+            slope: 0.2,
+            totalSessions: 5,
+          }),
+        ],
+      });
+      expect(r.markdown).toContain(
+        'Project trajectories: 2 accelerating, 1 flat, 2 stalling/stalled',
+      );
+      // Top 3 by totalSessions: alpha (50), bravo (40), charlie (30).
+      expect(r.markdown).toContain('alpha — accelerating (slope +0.50, 50 sessions)');
+      expect(r.markdown).toContain('bravo — flat (slope 0.00, 40 sessions)');
+      expect(r.markdown).toContain('charlie — stalling (slope -0.30, 30 sessions)');
+      // Lower-activity rows excluded.
+      expect(r.markdown).not.toContain('delta — stalled-finished');
+      expect(r.markdown).not.toContain('echo — accelerating');
+      expect(r.counts.trajectoriesAccelerating).toBe(2);
+      expect(r.counts.trajectoriesFlat).toBe(1);
+      expect(r.counts.trajectoriesStalling).toBe(2);
+    });
+
+    it('skips the section when no project rows are passed', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: [],
+      });
+      expect(r.markdown).not.toContain('Project trajectories');
+      expect(r.counts.trajectoriesAccelerating).toBe(0);
+      expect(r.counts.trajectoriesFlat).toBe(0);
+      expect(r.counts.trajectoriesStalling).toBe(0);
+    });
+
+    it('skips the section when projectTrajectories is null', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: null,
+      });
+      expect(r.markdown).not.toContain('Project trajectories');
+    });
+
+    it('renders "slope n/a" for null slopes', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        projectTrajectories: [
+          trajectory({
+            projectName: 'no-slope-project',
+            classification: 'flat',
+            slope: null,
+            totalSessions: 3,
+          }),
+        ],
+      });
+      expect(r.markdown).toContain('no-slope-project — flat (slope n/a, 3 sessions)');
+    });
+  });
+
+  // ── Phase γ §4 — Applied-pattern closures ────────────────────────
+
+  describe('applied-pattern closures', () => {
+    it('renders the count when patterns are currently held', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        appliedPatternClosures: 4,
+      });
+      expect(r.markdown).toContain(
+        'Applied-pattern closures: 4 pattern(s) held (no recurrence past cooldown)',
+      );
+      expect(r.counts.appliedPatternClosures).toBe(4);
+    });
+
+    it('skips the section when zero patterns are held', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        appliedPatternClosures: 0,
+      });
+      expect(r.markdown).not.toContain('Applied-pattern closures');
+      expect(r.counts.appliedPatternClosures).toBe(0);
+    });
+
+    it('skips the section when the SDK accessor is unwired (null)', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        appliedPatternClosures: null,
+      });
+      expect(r.markdown).not.toContain('Applied-pattern closures');
+      expect(r.counts.appliedPatternClosures).toBe(0);
+    });
+  });
+
+  // ── Phase γ ordering invariant ───────────────────────────────────
+
+  it('orders Phase γ sections between audit concerns and continuum health', () => {
+    const fail: AuditResult = {
+      sessionId: 'sid-x',
+      source: 'cowork',
+      lineNumber: 1,
+      claimType: 'tests-pass-claim',
+      span: 'works',
+      surroundingContext: 'ctx',
+      outcome: 'fail',
+      reason: 'because',
+    };
+    const health: ContinuumHealth = {
+      version: 1,
+      lastScanAt: '2026-05-16T03:00:00Z',
+      lastSuccessfulScanAt: '2026-05-16T03:00:00Z',
+      consecutiveSuccesses: 1,
+      sourcesScanned: ['cowork'],
+      entriesByStatus: { ok: 1, missing: 0, crashed: 0, pruned: 0 },
+      newSessionsSinceLast: 0,
+      warnings: [],
+    };
+    const r = buildDailyBrief({
+      date: '2026-05-16',
+      now: NOW,
+      patterns: [],
+      upgradeOutcomes: [],
+      blogDrafts: [],
+      auditResults: [fail],
+      auditSummary: null,
+      continuumHealth: health,
+      shippedThisWeek: {
+        commitCount: 2,
+        recentSubjects: ['feat: ordering test'],
+      },
+      surprises: surprisesFile([
+        { kind: 'streak', tone: 'positive', summary: 'streak!', score: 1 },
+      ]),
+      projectTrajectories: [
+        trajectory({
+          projectName: 'ordering-project',
+          classification: 'accelerating',
+          slope: 0.5,
+          totalSessions: 5,
+        }),
+      ],
+      appliedPatternClosures: 1,
+    });
+    const audit = r.markdown.indexOf('audit concern');
+    const shipped = r.markdown.indexOf('Shipped this week');
+    const surprises = r.markdown.indexOf('Surprises today');
+    const trajectories = r.markdown.indexOf('Project trajectories');
+    const closures = r.markdown.indexOf('Applied-pattern closures');
+    const continuum = r.markdown.indexOf('Continuum health');
+    expect(audit).toBeGreaterThan(-1);
+    expect(shipped).toBeGreaterThan(audit);
+    expect(surprises).toBeGreaterThan(shipped);
+    expect(trajectories).toBeGreaterThan(surprises);
+    expect(closures).toBeGreaterThan(trajectories);
+    expect(continuum).toBeGreaterThan(closures);
   });
 });

--- a/packages/analysis/src/dailyBrief.ts
+++ b/packages/analysis/src/dailyBrief.ts
@@ -362,6 +362,8 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
   // The shell is expected to pass `null` until the accessor lands;
   // we ALSO skip the section when the count is 0 to keep the brief
   // tight in the meantime.
+  // TODO(applyWatcher-sdk): wiring lives in
+  // apps/standalone/src/pages/api/regen-brief.ts (search the same marker).
   const closures = inputs.appliedPatternClosures ?? null;
   let appliedPatternClosures = 0;
   if (closures !== null && closures > 0) {

--- a/packages/analysis/src/dailyBrief.ts
+++ b/packages/analysis/src/dailyBrief.ts
@@ -1,19 +1,28 @@
 /**
- * Daily brief generator — spec §5 Layer D, D.1 + D.3.
+ * Daily brief generator — spec §5 Layer D, D.1 + D.3, extended by
+ * feed-redesign Phase γ.
  *
  * Pure function. Reads pre-loaded analysis inputs (the Node shell parses
- * each sidecar from disk) and returns the markdown body plus a small
- * summary record. Sections with zero entries are silent — no padding,
- * per D.3.
+ * each sidecar from disk and runs `git log` for the shipped-this-week
+ * counter) and returns the markdown body plus a small summary record.
+ * Sections with zero entries are silent — no padding, per D.3.
  *
- * Output shape:
+ * Output shape (Phase γ):
  *   TODAY · YYYY-MM-DD
  *   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  *   ► N patterns shifted this week
  *   ► N upgrades to propose
  *   ► N blog drafts ready for review
  *   ► N audit concerns
+ *   ► Shipped this week: N commits to main      (Phase γ §1)
+ *   ► Surprises today: P positive, C concerning (Phase γ §2)
+ *   ► Project trajectories: A accelerating, …   (Phase γ §3)
+ *   ► Applied-pattern closures: K patterns held (Phase γ §4)
  *   ► Continuum health: …
+ *
+ * The new sections render BETWEEN audit concerns and continuum health.
+ * Each new section is independently skippable — empty inputs render
+ * nothing (no header, no body), matching the existing convention.
  */
 
 import type {
@@ -25,6 +34,7 @@ import type {
   ProposedUpgrade,
   UpgradeOutcome,
 } from '@chat-arch/schema';
+import type { SurprisesOutput } from './computeSurprises.js';
 
 export interface BriefThresholds {
   /** Patterns whose lastSeen falls within the last N days count as "shifted this week". */
@@ -35,6 +45,12 @@ export interface BriefThresholds {
   blogDraftsShown?: number;
   /** Top-N audit concerns surfaced. */
   auditConcernsShown?: number;
+  /** Top-N commit subjects surfaced under "Shipped this week". */
+  shippedSubjectsShown?: number;
+  /** Top-N positive-tone surprise summaries surfaced. */
+  surpriseSummariesShown?: number;
+  /** Top-N most-active projects surfaced under "Project trajectories". */
+  trajectoriesShown?: number;
 }
 
 const DEFAULT_THRESHOLDS: Required<BriefThresholds> = {
@@ -42,7 +58,42 @@ const DEFAULT_THRESHOLDS: Required<BriefThresholds> = {
   upgradesShown: 5,
   blogDraftsShown: 5,
   auditConcernsShown: 5,
+  shippedSubjectsShown: 5,
+  surpriseSummariesShown: 3,
+  trajectoriesShown: 3,
 };
+
+/**
+ * Pre-computed "shipped this week" snapshot. The Node shell runs
+ * `git log --since="7 days ago" ...` against the project repo and
+ * passes the count + subject lines in. Kernel stays I/O-free.
+ *
+ * `commitCount === 0` means the section is skipped entirely.
+ * `recentSubjects` may be shorter than `commitCount` (we render the
+ * top N per `shippedSubjectsShown`).
+ */
+export interface ShippedThisWeekInput {
+  readonly commitCount: number;
+  readonly recentSubjects: readonly string[];
+}
+
+/**
+ * Narrow row shape for the project-trajectories sidecar. Mirrors the
+ * on-disk `ProjectTrajectoryEntry` written by
+ * `projectTrajectoryBuilder.ts`; keeping the kernel's input narrow so
+ * we don't pull the exporter-shell type into the analysis package.
+ */
+export interface BriefTrajectoryRow {
+  readonly projectId: string;
+  readonly projectName: string;
+  readonly classification:
+    | 'stalling'
+    | 'stalled-finished'
+    | 'accelerating'
+    | 'flat';
+  readonly slope: number | null;
+  readonly totalSessions: number;
+}
 
 export interface DailyBriefInputs {
   /** Output date in YYYY-MM-DD format. */
@@ -55,6 +106,30 @@ export interface DailyBriefInputs {
   auditResults: readonly AuditResult[];
   auditSummary: AuditSummary | null;
   continuumHealth: ContinuumHealth | null;
+  /**
+   * Phase γ §1 — `git log --since="7 days ago" --pretty=format:%H main`
+   * count + top subject lines. Pass `null` when the project isn't a
+   * git repo or `git log` failed (section skipped).
+   */
+  shippedThisWeek?: ShippedThisWeekInput | null;
+  /**
+   * Phase γ §2 — full `analysis/surprises.json` content. Pass `null`
+   * when the sidecar is missing or unparseable (section skipped).
+   */
+  surprises?: SurprisesOutput | null;
+  /**
+   * Phase γ §3 — rows from `analysis/project-trajectories.json`. Pass
+   * an empty array (or `null`) when the sidecar is missing (section
+   * skipped).
+   */
+  projectTrajectories?: readonly BriefTrajectoryRow[] | null;
+  /**
+   * Phase γ §4 — count of patterns currently in the watcher's
+   * `holding` state (the post-application cooldown cleared with no
+   * recurrence). Pass `null` when the SDK accessor is not yet wired
+   * (section skipped — see code-comment in the section).
+   */
+  appliedPatternClosures?: number | null;
 }
 
 export interface DailyBriefResult {
@@ -64,6 +139,17 @@ export interface DailyBriefResult {
     upgradesShown: number;
     blogDraftsShown: number;
     auditConcernsShown: number;
+    /** 0 when the section was skipped. */
+    shippedCommits: number;
+    /** Total surprise rows by tone (0 when the section was skipped). */
+    surprisesPositive: number;
+    surprisesConcerning: number;
+    /** Total trajectory projects classified into each bucket. */
+    trajectoriesAccelerating: number;
+    trajectoriesFlat: number;
+    trajectoriesStalling: number;
+    /** 0 when the SDK accessor isn't wired (vs. 0-but-wired). */
+    appliedPatternClosures: number;
   };
 }
 
@@ -76,6 +162,14 @@ function sortByLastSeenDesc<T extends { lastSeen: number }>(a: T, b: T): number 
 function shortenRule(rule: string): string {
   const trimmed = rule.trim();
   return trimmed.length > 110 ? trimmed.slice(0, 110) + '…' : trimmed;
+}
+
+/** Truncate at 120 chars with `…` — matches the surprises kernel `clip`. */
+function clip120(s: string): string {
+  const max = 120;
+  const trimmed = s.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1)}…`;
 }
 
 function pickHeadline(upgrades: readonly ProposedUpgrade[]): string {
@@ -172,6 +266,113 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     out.push('');
   }
 
+  // ---- Phase γ §1 — Shipped this week ----
+  // Skipped when `commitCount === 0` (the section is meaningless with
+  // no commits, per spec). The Node shell is responsible for the
+  // `git log` invocation; we just format the precomputed numbers.
+  const shipped = inputs.shippedThisWeek ?? null;
+  let shippedCommits = 0;
+  if (shipped !== null && shipped.commitCount > 0) {
+    shippedCommits = shipped.commitCount;
+    out.push(
+      `► Shipped this week: ${shipped.commitCount.toLocaleString()} commit(s) to main`,
+    );
+    for (const subject of shipped.recentSubjects.slice(
+      0,
+      thresholds.shippedSubjectsShown,
+    )) {
+      out.push(`  • ${clip120(subject)}`);
+    }
+    out.push('');
+  }
+
+  // ---- Phase γ §2 — Surprises today ----
+  // Source: `analysis/surprises.json`. Skipped when the file is
+  // missing (input is null) OR when both tones contribute zero rows.
+  const surprises = inputs.surprises ?? null;
+  let surprisesPositive = 0;
+  let surprisesConcerning = 0;
+  if (surprises !== null) {
+    for (const s of surprises.surprises) {
+      if (s.tone === 'positive') surprisesPositive += 1;
+      else if (s.tone === 'concerning') surprisesConcerning += 1;
+    }
+    if (surprisesPositive + surprisesConcerning > 0) {
+      out.push(
+        `► Surprises today: ${surprisesPositive.toLocaleString()} positive, ` +
+          `${surprisesConcerning.toLocaleString()} concerning`,
+      );
+      // Top 3 positive — kernel pre-sorts by score desc; just slice.
+      const topPositive = surprises.surprises
+        .filter((s) => s.tone === 'positive')
+        .slice(0, thresholds.surpriseSummariesShown);
+      for (const s of topPositive) {
+        out.push(`  • [${s.kind}] ${clip120(s.summary)}`);
+      }
+      out.push('');
+    }
+  }
+
+  // ---- Phase γ §3 — Project trajectories ----
+  // Source: `analysis/project-trajectories.json`. Skipped when the
+  // file is missing or empty.
+  const trajectories = inputs.projectTrajectories ?? null;
+  let trajectoriesAccelerating = 0;
+  let trajectoriesFlat = 0;
+  let trajectoriesStalling = 0;
+  if (trajectories !== null && trajectories.length > 0) {
+    for (const t of trajectories) {
+      if (t.classification === 'accelerating') trajectoriesAccelerating += 1;
+      else if (t.classification === 'flat') trajectoriesFlat += 1;
+      else trajectoriesStalling += 1; // 'stalling' + 'stalled-finished'
+    }
+    out.push(
+      `► Project trajectories: ${trajectoriesAccelerating.toLocaleString()} accelerating, ` +
+        `${trajectoriesFlat.toLocaleString()} flat, ` +
+        `${trajectoriesStalling.toLocaleString()} stalling/stalled`,
+    );
+    // Top 3 most-active by totalSessions; tie-break on projectId for
+    // determinism (sort is otherwise non-stable for equal keys).
+    const topActive = [...trajectories]
+      .sort(
+        (a, b) =>
+          b.totalSessions - a.totalSessions ||
+          a.projectId.localeCompare(b.projectId),
+      )
+      .slice(0, thresholds.trajectoriesShown);
+    for (const t of topActive) {
+      const slopeStr =
+        t.slope === null
+          ? 'slope n/a'
+          : t.slope > 0
+            ? `slope +${t.slope.toFixed(2)}`
+            : `slope ${t.slope.toFixed(2)}`;
+      out.push(
+        `  • ${clip120(t.projectName)} — ${t.classification} (${slopeStr}, ` +
+          `${t.totalSessions.toLocaleString()} sessions)`,
+      );
+    }
+    out.push('');
+  }
+
+  // ---- Phase γ §4 — Applied-pattern closures ----
+  // Source: the applied-pattern watcher ledger in the SQLite substrate.
+  // The SDK accessor for watcher verdicts isn't wired in V1 (no
+  // `applyWatcher.ts` accessor under `packages/exporter/src/db/sdk/`).
+  // The shell is expected to pass `null` until the accessor lands;
+  // we ALSO skip the section when the count is 0 to keep the brief
+  // tight in the meantime.
+  const closures = inputs.appliedPatternClosures ?? null;
+  let appliedPatternClosures = 0;
+  if (closures !== null && closures > 0) {
+    appliedPatternClosures = closures;
+    out.push(
+      `► Applied-pattern closures: ${closures.toLocaleString()} pattern(s) held ` +
+        `(no recurrence past cooldown)`,
+    );
+    out.push('');
+  }
+
   // ---- Continuum health ----
   if (inputs.continuumHealth !== null) {
     const h = inputs.continuumHealth;
@@ -199,6 +400,13 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
       upgradesShown: upgradeCandidates.length,
       blogDraftsShown: sortedDrafts.length,
       auditConcernsShown: failures.length,
+      shippedCommits,
+      surprisesPositive,
+      surprisesConcerning,
+      trajectoriesAccelerating,
+      trajectoriesFlat,
+      trajectoriesStalling,
+      appliedPatternClosures,
     },
   };
 }

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -284,8 +284,10 @@ export {
 export {
   buildDailyBrief,
   type BriefThresholds,
+  type BriefTrajectoryRow,
   type DailyBriefInputs,
   type DailyBriefResult,
+  type ShippedThisWeekInput,
 } from './dailyBrief.js';
 
 export {

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -164,8 +164,16 @@ export interface RunAnalysisResult {
  * composite-outcomes + project-trajectories + its-analysis +
  * reflexive + decisions + knowledge-debt). Pre-existing sidecars are
  * unchanged.
+ *
+ * Bumped 1.4.0 → 1.4.1 in the feed-redesign Phase γ polish:
+ * `dailyBrief.ts` grows four new sections (shipped this week / surprises
+ * today / project trajectories / applied-pattern closures) plus the
+ * matching count fields on `DailyBriefResult.counts`. No new on-disk
+ * artifact — the brief shape change is internal to the regen-brief
+ * endpoint's output markdown — but the patch bump labels the bundle so
+ * operators can correlate.
  */
-export const EXPORTER_VERSION = '1.4.0';
+export const EXPORTER_VERSION = '1.4.1';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/test/migration/v1.1.0-fixture.test.ts
+++ b/packages/exporter/test/migration/v1.1.0-fixture.test.ts
@@ -157,7 +157,7 @@ describe('migration v1.1.0 → 1.2.0', () => {
       tiers: { browser: { files: readonly string[] } };
       counts: Record<string, unknown>;
     }>(path.join(tmpDataDir, 'analysis', 'meta.json'));
-    expect(meta.exporterVersion).toBe('1.4.0');
+    expect(meta.exporterVersion).toBe('1.4.1');
 
     // The Wave-5 sidecars (+ feed-redesign Phase A surprises.json)
     // must all be registered in the browser tier.


### PR DESCRIPTION
## Summary

Phase γ of the FEED redesign — daily brief grew from "audit + health" to a substantive journal opener (shipped-this-week / surprises / trajectories / applied-pattern-closures), plus intermediate-sidecar documentation in CLAUDE.md, plus iter-1 review fix (CLAUDE.md version-history line + TODO markers for applyWatcher SDK accessor).

**Re-opened after #99 closed when its β base branch was deleted at β-merge.** Same content as #99, rebased onto main.

\`EXPORTER_VERSION\` 1.4.0 → 1.4.1.

## Test plan

- [x] \`pnpm --filter @chat-arch/analysis test\` — 746/746
- [x] \`pnpm test\` (monorepo) — 2106 pass / 5 skipped
- [x] \`pnpm lint\` — clean
- [x] \`pnpm build\` — clean
- [x] iter-1 + iter-2 + iter-3 adversarial review all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)