### PR TITLE
feat(feed-ui): UI improvements pass (waves 1-3) — confidence + drill-ins + delta surprises + brief richness + visual cohesion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,107 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-05-25
+
+Feed-redesign Wave 2 #1 — delta surprises. The `computeSurprises`
+kernel grows an optional `priorSurprises` input that, when provided,
+unlocks five new surprise kinds that compare the current snapshot
+against the most recent prior snapshot (loaded by the builder from a
+new `analysis/archive/` sidecar family). On a first-ever scan no
+prior exists and the delta kinds skip cleanly; the kernel's V1
+snapshot behavior is byte-identical to the pre-bump output when
+`priorSurprises === null`.
+
+### Added
+
+- **`analysis/archive/surprises-YYYY-MM-DD.json`** — per-scan
+  snapshot of the surprises sidecar. Written by `surprisesBuilder`
+  after each rescan via `atomicWriteJsonSync`. PII-bearing under the
+  same rules as `surprises.json` itself (carries summary text +
+  evidence session IDs). Covered by the existing
+  `apps/standalone/public/chat-arch-data/*` gitignore wildcard.
+- **Five delta surprise kinds** in the `computeSurprises` kernel:
+  - `streak-extended` (positive) — current streak's terminal session
+    matches prior's AND the run grew. Score = `clamp(diff/5, 0, 1)`.
+  - `streak-broken` (concerning) — prior had a streak row, current
+    does not. Score = `clamp(priorCount/10, 0, 1)`.
+  - `trajectory-flip-up` (positive) — project was stalled / absent
+    in prior, now accelerating. Score = `clamp(slope*10, 0, 1)`.
+  - `trajectory-flip-down` (concerning) — mirror of flip-up.
+  - `pattern-recurrence-resumed` (concerning) — pattern was
+    `pattern-closed` in prior, `pattern-recurring` in current. Fixed
+    score 0.85 (high-attention signal).
+- **`THRESHOLDS.surprises.archiveRetentionDays = 30`** — filename-
+  based prune horizon. Pre-launch placeholder; calibrate when the
+  rescan cadence stabilizes (e.g. lower if user scans every few
+  days, raise if multiple scans per day).
+- **`loadMostRecentArchive` + `archiveAndPrune` helpers** exported
+  from `surprisesBuilder.ts` so the per-scan archive lifecycle is
+  unit-testable end-to-end.
+- **UI mappings** for the five new kinds in
+  `apps/standalone/src/pages/index.astro` (`SURPRISE_KIND_LABEL` +
+  `SURPRISE_DRILL_IN`). Drill-ins reuse the parent surfaces of each
+  snapshot sibling (effectiveness for streaks, trends for
+  trajectories, corrections for the pattern-recurrence resumption).
+
+### Changed
+
+- `ComputeSurprisesInput` gains an optional `priorSurprises:
+  SurprisesOutput | null` field. Callers that omit the field continue
+  to receive V1 snapshot-only output — back-compat is preserved.
+- `surprisesBuilder` orchestrates the archive lifecycle internally:
+  read the most-recent-prior on entry, write today's snapshot to
+  `archive/` after the primary file lands, prune archive entries
+  older than `archiveRetentionDays`. The orchestrator
+  (`packages/exporter/src/analysis/index.ts`) does not need to
+  change.
+- `surprisesBuilder` info log gains a `priorArchive=none|loaded`
+  marker so operators can confirm whether the delta kinds had any
+  prior to compare against.
+
+### Notes
+
+- **Race window:** archive write + prune are separate filesystem
+  ops. A concurrent rescan racing the prune could lose at most one
+  day of archive history (never today's freshly-written file —
+  today is always within the retention window by definition).
+  Read-side is tolerant: a partial / malformed archive returns null
+  and the delta kinds skip cleanly.
+- **Date stamps:** UTC YYYY-MM-DD via `Date#toISOString()`.
+  Lexicographic sort = chronological sort under ISO-8601, so prune
+  + "most recent" both work by filename without depending on mtime
+  (which `git checkout` resets).
+- **CLAUDE.md sidecar table** documents the new artifact under the
+  outcome-substrate sidecars section as PII-bearing.
+
+### Changed — daily brief reads as a journal, not a status panel (Wave 2 #4)
+
+- The brief now opens with a single short paragraph that names the
+  week's headline — shipped commits if any, otherwise the top STRONG
+  positive surprise, otherwise a "quiet week" disclaimer — and each
+  section's leader line is re-cast in narrative voice ("you shipped
+  7 commits to main this week" not "► Shipped this week: 7
+  commit(s) to main"). The Surprises section gains optional "The
+  standout positive: …" and "Worth attention: …" framing sentences
+  gated on STRONG-tier rows (score ≥ `SURPRISE_TIER_STRONG_MIN` =
+  0.75). All count gates are preserved — zero-input sections still
+  render nothing.
+- `DailyBriefInputs` gains `topStrongPositiveSurprise?: string |
+  null`; the `regen-brief.ts` shell extracts it from
+  `analysis/surprises.json` by finding the first positive row whose
+  score meets the STRONG floor. Kernel stays decoupled from the tier
+  helper.
+- Singular/plural now routes through a `pluralize(n, singular)`
+  helper so the brief reads "1 commit", "1 claim", "1 pattern"
+  without the `(s)` suffix pattern leaking into prose.
+- 12 new tests in `dailyBrief.test.ts` (35 total, up from 23)
+  covering opener paths (commits / strong-signal / quiet-week /
+  shipped-wins-over-strong), STRONG-tier promotion gating,
+  singular-form discipline, and audit-count truncation honesty.
+- Shape-coherent with the 1.4.1 → 1.5.0 bump above; the brief
+  markdown is shell-produced (not exporter-produced), so this change
+  itself doesn't drive the version bump.
+
 ## [1.4.1] — 2026-05-24
 
 Feed-redesign Phase γ polish — enriches the daily brief now that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,23 @@ analysis/` (gitignored — locally generated, carry PII):
   finding claim text + cited session turn excerpts. Read by the
   curator ranker as a tie-breaker / surfacing gate.
 
+### Wave 2 #1 delta-surprises archive (EXPORTER_VERSION 1.5.0)
+
+One additional sidecar family under
+`apps/standalone/public/chat-arch-data/analysis/archive/` (gitignored
+under the same wildcard — locally generated, PII-bearing):
+
+- `surprises-YYYY-MM-DD.json` — per-scan snapshot copy of
+  `analysis/surprises.json`. Written by `surprisesBuilder` after
+  each rescan; pruned to `THRESHOLDS.surprises.archiveRetentionDays`
+  (default 30) by filename — NOT mtime, because `git checkout` resets
+  timestamps and would otherwise evict the archive. Read by the next
+  scan as `priorSurprises` so the kernel can emit delta kinds
+  (`streak-extended`, `streak-broken`, `trajectory-flip-up`,
+  `trajectory-flip-down`, `pattern-recurrence-resumed`). PII: same
+  shape as `surprises.json` itself (summary text + evidence session
+  IDs).
+
 The pre-launch `thrash-fires.json` audit log (Phase 4 #8 thrash hook)
 and the `chat-arch-data/exports/` Obsidian-target directory (Phase 4
 #12 post-mortems + knowledge-debt) are also gitignored. The wildcard
@@ -392,8 +409,9 @@ out of date and needs an update:
 4. **What sidecars under `analysis/` carry PII vs aggregate-only?**
    - PII-bearing (most files): composite-outcomes, knowledge-debt,
      reflexive, decisions, archetypes, project-trajectories,
-     skill-curves, surprises, curator-feed, falsifier-verdicts,
-     correction-candidates, corrections, correction-status-*.
+     skill-curves, surprises, archive/surprises-YYYY-MM-DD,
+     curator-feed, falsifier-verdicts, correction-candidates,
+     corrections, correction-status-*.
    - Aggregate-numbers-only (lower-PII): its-analysis, surface-
      comparison. These are gitignored conservatively anyway.
 5. **What's the difference between hosted (`chat-arch.dev`) and

--- a/apps/standalone/src/lib/demoFixtures.ts
+++ b/apps/standalone/src/lib/demoFixtures.ts
@@ -269,9 +269,12 @@ export function makeDemoSurprises(): SurprisesOutput {
         tone: 'positive',
         // Score parked in the WEAK band so the FEED's three-tier
         // confidence ribbon (STRONG / MODERATE / WEAK) renders every
-        // tier at least once across the 5 demo surprises (Wave 1
-        // Fix A).
-        summary: 'Adopting ripgrep dropped average re-prompt rate by 23% on demo-project-B.',
+        // tier at least once across the 5 demo surprises. Copy hedged
+        // (single-session, weak evidence) so the WEAK tier label and
+        // the summary's claim-strength agree — earlier copy asserted
+        // a confident measured outcome that visually contradicted the
+        // WEAK badge.
+        summary: 'Single-session signal: ripgrep adoption coincided with -23% re-prompts on demo-project-B (n=1, weak evidence).',
         evidence: {
           decisionId: 'dec_demo_ripgrep',
           projectId: 'demo-project-B',

--- a/apps/standalone/src/lib/demoFixtures.ts
+++ b/apps/standalone/src/lib/demoFixtures.ts
@@ -267,13 +267,17 @@ export function makeDemoSurprises(): SurprisesOutput {
         id: 'sur_demo_decision_paid_1',
         kind: 'decision-paid-off',
         tone: 'positive',
+        // Score parked in the WEAK band so the FEED's three-tier
+        // confidence ribbon (STRONG / MODERATE / WEAK) renders every
+        // tier at least once across the 5 demo surprises (Wave 1
+        // Fix A).
         summary: 'Adopting ripgrep dropped average re-prompt rate by 23% on demo-project-B.',
         evidence: {
           decisionId: 'dec_demo_ripgrep',
           projectId: 'demo-project-B',
           sessionIds: [demoSid('d1')],
         },
-        score: 0.71,
+        score: 0.42,
         generatedAt: DEMO_GENERATED_AT_MS,
       },
       {
@@ -285,6 +289,7 @@ export function makeDemoSurprises(): SurprisesOutput {
           projectId: 'demo-project-C',
           sessionIds: [demoSid('c1'), demoSid('c2')],
         },
+        // MODERATE-band concerning surprise.
         score: 0.66,
         generatedAt: DEMO_GENERATED_AT_MS,
       },
@@ -292,11 +297,13 @@ export function makeDemoSurprises(): SurprisesOutput {
         id: 'sur_demo_debt_spin_1',
         kind: 'debt-spinning',
         tone: 'concerning',
+        // STRONG-band concerning surprise — boosted above 0.75 so the
+        // BROKEN grid also exercises the STRONG ribbon (Wave 1 Fix A).
         summary: '"how do I bind a port in Astro?" asked 9 times this month across 4 projects.',
         evidence: {
           sessionIds: [demoSid('k1'), demoSid('k2'), demoSid('k3')],
         },
-        score: 0.58,
+        score: 0.83,
         generatedAt: DEMO_GENERATED_AT_MS,
       },
     ],

--- a/apps/standalone/src/pages/api/regen-brief.ts
+++ b/apps/standalone/src/pages/api/regen-brief.ts
@@ -16,6 +16,7 @@ import { dirname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import {
   buildDailyBrief,
+  SURPRISE_TIER_STRONG_MIN,
   type BriefTrajectoryRow,
   type SurprisesOutput,
 } from '@chat-arch/analysis';
@@ -168,6 +169,16 @@ export const POST: APIRoute = async ({ request }) => {
   const surprises = await readJsonOrNull<SurprisesOutput>(
     join(analysisDir, 'surprises.json'),
   );
+  // Wave 2 — top STRONG positive summary for the journal-y opener.
+  // Kernel's `computeSurprises` pre-sorts by score desc, so the first
+  // positive row meeting the STRONG floor (score ≥
+  // SURPRISE_TIER_STRONG_MIN) is the highest-confidence surprise the
+  // user shipped this week. Passed as a precomputed string so the
+  // kernel stays decoupled from the surprise-tier helper.
+  const topStrongPositiveSurprise: string | null =
+    surprises?.surprises.find(
+      (s) => s.tone === 'positive' && s.score >= SURPRISE_TIER_STRONG_MIN,
+    )?.summary ?? null;
   // Phase γ §3 — `analysis/project-trajectories.json` (produced by the
   // project-trajectory builder). Narrowed inline so we don't pull the
   // exporter type across.
@@ -215,6 +226,7 @@ export const POST: APIRoute = async ({ request }) => {
     surprises,
     projectTrajectories,
     appliedPatternClosures,
+    topStrongPositiveSurprise,
   });
 
   const outPath = join(briefsDir, `${date}.md`);

--- a/apps/standalone/src/pages/calibrate.astro
+++ b/apps/standalone/src/pages/calibrate.astro
@@ -104,46 +104,202 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 </BaseLayout>
 
 <style>
-  .calibrate { padding: 1.5rem; max-width: 1100px; margin: 0 auto; }
-  .calibrate__head h1 { margin-top: 0; }
-  .calibrate__sub { color: var(--lcars-dim, #888); font-size: 0.9rem; }
+  /* LCARS-chrome page styles — token literals match the convention used
+     by health.astro / playbook.astro / audit.astro / views.astro /
+     index.astro. Earlier revisions of this file reached for
+     `var(--lcars-dim, #888)` / `var(--lcars-accent, #f80)` etc., but
+     those CSS variables are only declared inside `.lcars-root` (the
+     React viewer's scope) and this Astro page never enters that
+     scope, so every reference fell back to the gray/white/orange
+     literals — visually a different app from the rest of the
+     LCARS chrome (Wave 3 cohesion audit). Sunflower #FFCC99 is the
+     primary text token; #FFCC9999 / cc / 44 / 33 / 22 / 11 are the
+     muted ramps. A/B accents reach for the viewer's ice (#99CCFF)
+     and violet (#CC99CC) so the LCARS palette is preserved end-to-
+     end. */
+  main.calibrate {
+    padding: 32px 24px 64px;
+    max-width: 1100px;
+    margin: 0 auto;
+    color: #FFCC99;
+    font-family: 'IBM Plex Sans', sans-serif;
+  }
+  .calibrate__head h1 {
+    font-family: 'Antonio', sans-serif;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    font-size: 28px;
+    margin: 0 0 16px;
+  }
+  .calibrate__head code,
+  .calibrate__sweep code {
+    background: #FFCC9911;
+    padding: 1px 6px;
+    border-radius: 2px;
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 12px;
+  }
+  .calibrate__sub { color: #FFCC9999; font-size: 13px; line-height: 1.6; }
   .calibrate__state { padding: 2rem 0; }
-  .calibrate__error { color: #d44; font-weight: bold; }
-  .calibrate__error-detail { background: rgba(255,80,80,0.1); padding: 0.5rem; border-radius: 4px; font-family: ui-monospace, monospace; font-size: 0.85rem; white-space: pre-wrap; }
+  .calibrate__error { color: #f08080; font-weight: 700; font-family: 'Antonio', sans-serif; letter-spacing: 0.08em; }
+  .calibrate__error-detail {
+    background: #0a0a0a;
+    border: 1px solid #FFCC9933;
+    border-left: 3px solid #f08080;
+    padding: 12px 14px;
+    border-radius: 3px;
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 12px;
+    color: #FFCC99cc;
+    white-space: pre-wrap;
+  }
 
   .calibrate__progress { display: flex; align-items: center; gap: 1rem; margin: 1rem 0; }
-  .calibrate__progress-bar { flex: 1; height: 6px; background: rgba(255,255,255,0.06); border-radius: 3px; overflow: hidden; }
-  .calibrate__progress-fill { height: 100%; background: var(--lcars-accent, #f80); transition: width 0.2s ease; width: 0%; }
+  .calibrate__progress-bar {
+    flex: 1;
+    height: 6px;
+    background: #FFCC9922;
+    border-radius: 3px;
+    overflow: hidden;
+  }
+  .calibrate__progress-fill {
+    height: 100%;
+    background: #FFCC99;
+    transition: width 0.2s ease;
+    width: 0%;
+  }
 
-  .calibrate__cos { font-family: ui-monospace, monospace; font-size: 0.95rem; color: var(--lcars-dim, #888); margin-bottom: 1rem; }
-  .calibrate__cos span { color: var(--lcars-fg, #fff); font-weight: bold; }
+  .calibrate__cos {
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 13px;
+    color: #FFCC9999;
+    margin-bottom: 1rem;
+  }
+  .calibrate__cos span { color: #FFCC99; font-weight: 700; }
 
   .calibrate__sessions { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem; }
-  .calibrate__session { background: rgba(255,255,255,0.04); padding: 1rem; border-radius: 6px; border-left: 3px solid; min-height: 8rem; }
-  .calibrate__session--a { border-left-color: #6cc; }
-  .calibrate__session--b { border-left-color: #c6c; }
-  .calibrate__session h2 { font-size: 1rem; margin: 0 0 0.5rem; }
-  .calibrate__preview { margin: 0; font-size: 0.9rem; line-height: 1.45; color: var(--lcars-dim-fg, #ccc); }
+  .calibrate__session {
+    background: #0a0a0a;
+    border: 1px solid #FFCC9933;
+    padding: 14px 16px;
+    border-radius: 3px;
+    border-left: 3px solid;
+    min-height: 8rem;
+  }
+  /* A/B distinction — borrows the viewer's `--lcars-ice` (#99CCFF)
+     and `--lcars-violet` (#CC99CC) tokens so the accent fits the LCARS
+     palette instead of arbitrary cyan/magenta. */
+  .calibrate__session--a { border-left-color: #99CCFF; }
+  .calibrate__session--b { border-left-color: #CC99CC; }
+  .calibrate__session h2 {
+    font-family: 'Antonio', sans-serif;
+    font-size: 14px;
+    letter-spacing: 0.12em;
+    color: #FFCC99;
+    margin: 0 0 8px;
+  }
+  .calibrate__preview { margin: 0; font-size: 13px; line-height: 1.5; color: #FFCC99cc; }
 
   .calibrate__actions { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
-  .calibrate__btn { padding: 0.5rem 1rem; border-radius: 4px; border: 1px solid var(--lcars-dim, #555); background: rgba(255,255,255,0.03); color: var(--lcars-fg, #fff); cursor: pointer; font-size: 0.95rem; transition: background 0.15s ease, transform 0.05s ease; }
-  .calibrate__btn:hover { background: rgba(255,255,255,0.08); }
+  .calibrate__btn {
+    padding: 8px 16px;
+    border-radius: 2px;
+    border: 1px solid #FFCC9955;
+    background: transparent;
+    color: #FFCC99;
+    cursor: pointer;
+    font-family: 'Antonio', sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    transition: background 80ms linear, border-color 80ms linear, transform 0.05s ease;
+  }
+  .calibrate__btn:hover { background: #FFCC9911; border-color: #FFCC9988; }
   .calibrate__btn:active { transform: translateY(1px); }
-  .calibrate__btn--y { border-color: #4a4; }
-  .calibrate__btn--n { border-color: #a44; }
-  .calibrate__btn kbd { display: inline-block; padding: 0 0.4em; margin-right: 0.4em; background: rgba(255,255,255,0.1); border-radius: 3px; font-family: ui-monospace, monospace; font-size: 0.85em; }
+  /* Y/N semantic accents — match audit.astro's pass/fail tones
+     (#88e088 / #f08080). Peach (#FF9933) reserved for destructive
+     elsewhere; here Y is pass, N is reject. */
+  .calibrate__btn--y { border-color: #88e088; color: #88e088; }
+  .calibrate__btn--y:hover { background: rgba(136, 224, 136, 0.1); border-color: #88e088; }
+  .calibrate__btn--n { border-color: #f08080; color: #f08080; }
+  .calibrate__btn--n:hover { background: rgba(240, 128, 128, 0.1); border-color: #f08080; }
+  .calibrate__btn kbd {
+    display: inline-block;
+    padding: 0 0.4em;
+    margin-right: 0.4em;
+    background: #FFCC9922;
+    border-radius: 2px;
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 0.85em;
+  }
 
-  .calibrate__hint { font-size: 0.85rem; color: var(--lcars-dim, #888); margin-top: 0.5rem; }
+  .calibrate__hint { font-size: 12px; color: #FFCC9999; margin-top: 0.5rem; line-height: 1.5; }
   .calibrate__dim { opacity: 0.6; }
 
-  .calibrate__buckets { list-style: none; padding: 0; margin: 0.75rem 0 0; display: flex; flex-wrap: wrap; gap: 0.5rem; font-family: ui-monospace, monospace; font-size: 0.8rem; color: var(--lcars-dim, #888); }
-  .calibrate__buckets li { padding: 0.2rem 0.5rem; background: rgba(255,255,255,0.04); border-radius: 3px; }
-  .calibrate__buckets li.deficit { color: #d8a; }
+  .calibrate__buckets {
+    list-style: none;
+    padding: 0;
+    margin: 0.75rem 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 11px;
+    color: #FFCC9999;
+  }
+  .calibrate__buckets li {
+    padding: 4px 8px;
+    background: #0a0a0a;
+    border: 1px solid #FFCC9922;
+    border-radius: 2px;
+  }
+  .calibrate__buckets li.deficit { color: #FF9933; border-color: #FF993355; }
 
-  .calibrate__sweep-table { border-collapse: collapse; margin-top: 1rem; }
-  .calibrate__sweep-table th, .calibrate__sweep-table td { padding: 0.4rem 1rem; border-bottom: 1px solid rgba(255,255,255,0.06); text-align: left; font-family: ui-monospace, monospace; font-size: 0.9rem; }
-  .calibrate__sweep-table th { color: var(--lcars-dim, #888); font-weight: normal; }
-  .calibrate__sweep-row--target { background: rgba(76, 175, 80, 0.12); font-weight: bold; }
+  .calibrate__sweep h2 {
+    font-family: 'Antonio', sans-serif;
+    font-size: 14px;
+    letter-spacing: 0.12em;
+    color: #FFCC99;
+    margin: 20px 0 8px;
+  }
+  .calibrate__sweep-table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
+  .calibrate__sweep-table th,
+  .calibrate__sweep-table td {
+    padding: 6px 14px;
+    border-bottom: 1px solid #FFCC9922;
+    text-align: left;
+    font-family: 'JetBrains Mono', 'Consolas', monospace;
+    font-size: 12px;
+  }
+  .calibrate__sweep-table th {
+    color: #FFCC9999;
+    font-weight: 600;
+    font-family: 'Antonio', sans-serif;
+    letter-spacing: 0.08em;
+  }
+  .calibrate__sweep-row--target {
+    background: rgba(136, 224, 136, 0.12);
+    color: #FFCC99;
+    font-weight: 700;
+  }
+
+  /* `#show-sweep` button on the empty state — matches the secondary
+     ghost-button pattern playbook.astro uses for its copy button. */
+  #show-sweep {
+    background: transparent;
+    color: #FFCC99;
+    border: 1px solid #FFCC9955;
+    padding: 8px 14px;
+    border-radius: 2px;
+    font-family: 'Antonio', sans-serif;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    transition: background 80ms linear, border-color 80ms linear;
+  }
+  #show-sweep:hover {
+    background: #FFCC9911;
+    border-color: #FFCC9988;
+  }
 </style>
 
 <script>

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -169,6 +169,12 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
   'trajectory-stalled': 'stalled',
   'pattern-recurring': 'pattern recurring',
   'debt-spinning': 'debt spinning',
+  // Wave 2 #1 — delta kinds.
+  'streak-extended': 'streak extended',
+  'streak-broken': 'streak broken',
+  'trajectory-flip-up': 'flipped up',
+  'trajectory-flip-down': 'flipped down',
+  'pattern-recurrence-resumed': 'recurrence resumed',
 };
 
 // Wave 1 Fix B: per-kind drill-in target for the "→ in context" link
@@ -187,6 +193,14 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
   'pattern-closed': '/sessions#corrections',
   'pattern-recurring': '/sessions#corrections',
   'debt-spinning': '/sessions#insights',
+  // Wave 2 #1 — delta kinds reuse the same parent surfaces as their
+  // snapshot siblings (effectiveness for streaks, trends for
+  // trajectories, corrections for the pattern-recurrence resumption).
+  'streak-extended': '/sessions#effectiveness',
+  'streak-broken': '/sessions#effectiveness',
+  'trajectory-flip-up': '/sessions#trends',
+  'trajectory-flip-down': '/sessions#trends',
+  'pattern-recurrence-resumed': '/sessions#corrections',
 };
 ---
 <BaseLayout title="Chat Archaeologist — Today" current="TODAY">

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -17,6 +17,7 @@
 export const prerender = false;
 
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { surpriseConfidenceTier } from '@chat-arch/analysis';
 import {
   listBlogDraftSlugs,
   pickSurprises,
@@ -40,20 +41,38 @@ import {
 } from '../lib/demoFixtures.ts';
 
 const NOW = Date.now();
-const workshop = await readWorkshopStatus(NOW);
-const concerns = await readTopAuditConcerns(5);
-const drafts = await listBlogDraftSlugs();
-const brief = await readLatestBrief();
-const health = await readContinuumHealth();
-const candidatesSummary = await readCorrectionCandidatesSummary();
+// Wave 1 Fix D: the 9 outer-frontmatter sidecar reads were sequential
+// awaits (~10 disk hits, dominated first-paint cost on this
+// `prerender = false` page). They're independent of each other, so
+// batch them in a single Promise.all. Anything with internal nesting
+// (readWorkshopStatus does 3 chained reads internally) stays chained
+// inside its wrapper; only the OUTER fan-out changes. candidatesSummary
+// is destructured into candidateCount post-await as before.
+const [
+  workshop,
+  concerns,
+  drafts,
+  brief,
+  health,
+  candidatesSummary,
+  surprisesFile,
+  curatorFeed,
+  recentNarratives,
+] = await Promise.all([
+  readWorkshopStatus(NOW),
+  readTopAuditConcerns(5),
+  listBlogDraftSlugs(),
+  readLatestBrief(),
+  readContinuumHealth(),
+  readCorrectionCandidatesSummary(),
+  readSurprises(),
+  readCuratorFeed(),
+  readRecentNarratives(5),
+]);
 const candidateCount = candidatesSummary?.candidateCount ?? 0;
 
-const surprisesFile = await readSurprises();
 const surprisesNew = pickSurprises(surprisesFile, 'positive', 5);
 const surprisesBroken = pickSurprises(surprisesFile, 'concerning', 5);
-
-const curatorFeed = await readCuratorFeed();
-const recentNarratives = await readRecentNarratives(5);
 
 // Workshop sub-detection (preserved from prior page — drives the ACT
 // section's "corrections to APPLY" line + the "mine next" CTA wiring).
@@ -145,6 +164,24 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
   'pattern-recurring': 'pattern recurring',
   'debt-spinning': 'debt spinning',
 };
+
+// Wave 1 Fix B: per-kind drill-in target for the "→ in context" link
+// at the bottom of each surprise card. Each kind routes to the parent
+// kernel-detail surface so the user can see the surprise IN CONTEXT
+// (effectiveness ledger, trends table, decisions table, etc.) without
+// hunting through the left-nav. Missing kinds fall back to the
+// catalogue page.
+const SURPRISE_DRILL_IN: Record<string, string> = {
+  streak: '/sessions#effectiveness',
+  'trajectory-accelerating': '/sessions#trends',
+  'trajectory-stalled': '/sessions#trends',
+  'config-helped': '/sessions#insights',
+  'reflexive-positive': '/sessions#insights',
+  'decision-paid-off': '/sessions#decisions',
+  'pattern-closed': '/sessions#corrections',
+  'pattern-recurring': '/sessions#corrections',
+  'debt-spinning': '/sessions#insights',
+};
 ---
 <BaseLayout title="Chat Archaeologist — Today" current="TODAY">
   <main class="today">
@@ -159,6 +196,12 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
           SCAN
         </button>
         <button id="action-brief" type="button">REGEN BRIEF</button>
+        {/* Wave 1 Fix C: combined wipe + scan. Secondary visual weight
+            (destructive — intentional click required). Confirmation
+            handled in the click handler via window.confirm. */}
+        <button id="action-wipe-scan" type="button" class="today__btn-secondary">
+          WIPE + SCAN
+        </button>
         <span id="action-status" class="today__action-status"></span>
       </div>
 
@@ -231,11 +274,77 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
             preview of positive surprises this kernel surfaces.
           </p>
           <ul class="today__cards">
-            {surprisesNewView.map((s) => (
+            {surprisesNewView.map((s) => {
+              const tier = surpriseConfidenceTier(s.score);
+              const drillIn = SURPRISE_DRILL_IN[s.kind];
+              return (
+                <li class={`today__card today__card--${s.kind}`}>
+                  <div class="today__card-head">
+                    <span class={`today__kind today__kind--${s.tone}`}>
+                      {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                    </span>
+                    <span
+                      class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                      title={`raw score ${s.score.toFixed(3)}`}
+                    >
+                      {tier}
+                    </span>
+                    <span class="today__card-score">
+                      score {(s.score * 100).toFixed(0)}
+                    </span>
+                  </div>
+                  <p class="today__card-summary">{s.summary}</p>
+                  {s.evidence.sessionIds && s.evidence.sessionIds.length > 0 ? (
+                    <p class="today__card-evidence">
+                      <span class="today__card-evlabel">sessions:</span>
+                      {s.evidence.sessionIds.slice(0, 4).map((sid, ix) => (
+                        <>
+                          {ix > 0 ? ' · ' : ' '}
+                          <a href={`/sessions#session/${sid}`}>{sid.slice(0, 8)}</a>
+                        </>
+                      ))}
+                    </p>
+                  ) : null}
+                  {s.evidence.projectId ? (
+                    <p class="today__card-evidence">
+                      <span class="today__card-evlabel">project:</span>{' '}
+                      <a href={`/projects/${s.evidence.projectId}`}>
+                        {s.evidence.projectId}
+                      </a>
+                    </p>
+                  ) : null}
+                  {s.evidence.decisionId ? (
+                    <p class="today__card-evidence">
+                      <span class="today__card-evlabel">decision:</span>{' '}
+                      <code>{s.evidence.decisionId}</code>
+                    </p>
+                  ) : null}
+                  {drillIn ? (
+                    <p class="today__card-drill today__row-secondary">
+                      → <a href={drillIn}>in context</a>
+                    </p>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : (
+        <ul class="today__cards">
+          {surprisesNewView.map((s) => {
+            const tier = surpriseConfidenceTier(s.score);
+            const drillIn = SURPRISE_DRILL_IN[s.kind];
+            return (
               <li class={`today__card today__card--${s.kind}`}>
                 <div class="today__card-head">
                   <span class={`today__kind today__kind--${s.tone}`}>
                     {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                  </span>
+                  <span
+                    class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                    title={`raw score ${s.score.toFixed(3)}`}
+                  >
+                    {tier}
                   </span>
                   <span class="today__card-score">
                     score {(s.score * 100).toFixed(0)}
@@ -251,6 +360,9 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
                         <a href={`/sessions#session/${sid}`}>{sid.slice(0, 8)}</a>
                       </>
                     ))}
+                    {s.evidence.sessionIds.length > 4 ? (
+                      <span> · +{s.evidence.sessionIds.length - 4} more</span>
+                    ) : null}
                   </p>
                 ) : null}
                 {s.evidence.projectId ? (
@@ -261,65 +373,26 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
                     </a>
                   </p>
                 ) : null}
+                {s.evidence.configSha ? (
+                  <p class="today__card-evidence">
+                    <span class="today__card-evlabel">config:</span>{' '}
+                    <code>{s.evidence.configSha.slice(0, 7)}</code>
+                  </p>
+                ) : null}
                 {s.evidence.decisionId ? (
                   <p class="today__card-evidence">
                     <span class="today__card-evlabel">decision:</span>{' '}
                     <code>{s.evidence.decisionId}</code>
                   </p>
                 ) : null}
+                {drillIn ? (
+                  <p class="today__card-drill today__row-secondary">
+                    → <a href={drillIn}>in context</a>
+                  </p>
+                ) : null}
               </li>
-            ))}
-          </ul>
-        </section>
-      ) : (
-        <ul class="today__cards">
-          {surprisesNewView.map((s) => (
-            <li class={`today__card today__card--${s.kind}`}>
-              <div class="today__card-head">
-                <span class={`today__kind today__kind--${s.tone}`}>
-                  {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
-                </span>
-                <span class="today__card-score">
-                  score {(s.score * 100).toFixed(0)}
-                </span>
-              </div>
-              <p class="today__card-summary">{s.summary}</p>
-              {s.evidence.sessionIds && s.evidence.sessionIds.length > 0 ? (
-                <p class="today__card-evidence">
-                  <span class="today__card-evlabel">sessions:</span>
-                  {s.evidence.sessionIds.slice(0, 4).map((sid, ix) => (
-                    <>
-                      {ix > 0 ? ' · ' : ' '}
-                      <a href={`/sessions#session/${sid}`}>{sid.slice(0, 8)}</a>
-                    </>
-                  ))}
-                  {s.evidence.sessionIds.length > 4 ? (
-                    <span> · +{s.evidence.sessionIds.length - 4} more</span>
-                  ) : null}
-                </p>
-              ) : null}
-              {s.evidence.projectId ? (
-                <p class="today__card-evidence">
-                  <span class="today__card-evlabel">project:</span>{' '}
-                  <a href={`/projects/${s.evidence.projectId}`}>
-                    {s.evidence.projectId}
-                  </a>
-                </p>
-              ) : null}
-              {s.evidence.configSha ? (
-                <p class="today__card-evidence">
-                  <span class="today__card-evlabel">config:</span>{' '}
-                  <code>{s.evidence.configSha.slice(0, 7)}</code>
-                </p>
-              ) : null}
-              {s.evidence.decisionId ? (
-                <p class="today__card-evidence">
-                  <span class="today__card-evlabel">decision:</span>{' '}
-                  <code>{s.evidence.decisionId}</code>
-                </p>
-              ) : null}
-            </li>
-          ))}
+            );
+          })}
         </ul>
       )}
     </section>
@@ -472,11 +545,60 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
               preview of concerning-surprise cards this kernel surfaces.
             </p>
             <ul class="today__cards">
-              {surprisesBrokenView.map((s) => (
+              {surprisesBrokenView.map((s) => {
+                const tier = surpriseConfidenceTier(s.score);
+                const drillIn = SURPRISE_DRILL_IN[s.kind];
+                return (
+                  <li class={`today__card today__card--alert today__card--${s.kind}`}>
+                    <div class="today__card-head">
+                      <span class={`today__kind today__kind--${s.tone}`}>
+                        {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                      </span>
+                      <span
+                        class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                        title={`raw score ${s.score.toFixed(3)}`}
+                      >
+                        {tier}
+                      </span>
+                      <span class="today__card-score">
+                        score {(s.score * 100).toFixed(0)}
+                      </span>
+                    </div>
+                    <p class="today__card-summary">{s.summary}</p>
+                    {s.evidence.projectId ? (
+                      <p class="today__card-evidence">
+                        <span class="today__card-evlabel">project:</span>{' '}
+                        <a href={`/projects/${s.evidence.projectId}`}>
+                          {s.evidence.projectId}
+                        </a>
+                      </p>
+                    ) : null}
+                    {drillIn ? (
+                      <p class="today__card-drill today__row-secondary">
+                        → <a href={drillIn}>in context</a>
+                      </p>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ) : (
+          <ul class="today__cards">
+            {surprisesBrokenView.map((s) => {
+              const tier = surpriseConfidenceTier(s.score);
+              const drillIn = SURPRISE_DRILL_IN[s.kind];
+              return (
                 <li class={`today__card today__card--alert today__card--${s.kind}`}>
                   <div class="today__card-head">
                     <span class={`today__kind today__kind--${s.tone}`}>
                       {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                    </span>
+                    <span
+                      class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                      title={`raw score ${s.score.toFixed(3)}`}
+                    >
+                      {tier}
                     </span>
                     <span class="today__card-score">
                       score {(s.score * 100).toFixed(0)}
@@ -491,39 +613,20 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
                       </a>
                     </p>
                   ) : null}
+                  {s.evidence.narrativeId ? (
+                    <p class="today__card-evidence">
+                      <span class="today__card-evlabel">narrative:</span>{' '}
+                      <code>{s.evidence.narrativeId}</code>
+                    </p>
+                  ) : null}
+                  {drillIn ? (
+                    <p class="today__card-drill today__row-secondary">
+                      → <a href={drillIn}>in context</a>
+                    </p>
+                  ) : null}
                 </li>
-              ))}
-            </ul>
-          </section>
-        ) : (
-          <ul class="today__cards">
-            {surprisesBrokenView.map((s) => (
-              <li class={`today__card today__card--alert today__card--${s.kind}`}>
-                <div class="today__card-head">
-                  <span class={`today__kind today__kind--${s.tone}`}>
-                    {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
-                  </span>
-                  <span class="today__card-score">
-                    score {(s.score * 100).toFixed(0)}
-                  </span>
-                </div>
-                <p class="today__card-summary">{s.summary}</p>
-                {s.evidence.projectId ? (
-                  <p class="today__card-evidence">
-                    <span class="today__card-evlabel">project:</span>{' '}
-                    <a href={`/projects/${s.evidence.projectId}`}>
-                      {s.evidence.projectId}
-                    </a>
-                  </p>
-                ) : null}
-                {s.evidence.narrativeId ? (
-                  <p class="today__card-evidence">
-                    <span class="today__card-evlabel">narrative:</span>{' '}
-                    <code>{s.evidence.narrativeId}</code>
-                  </p>
-                ) : null}
-              </li>
-            ))}
+              );
+            })}
           </ul>
         )
       ) : null}
@@ -726,6 +829,7 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
       document.getElementById('action-brief-cta'),
       document.getElementById('action-mine-cta'),
       document.getElementById('action-curate-cta'),
+      document.getElementById('action-wipe-scan'),
     ].filter((b): b is HTMLButtonElement => b !== null);
 
     const STAGE_LABELS: Record<string, string> = {
@@ -1067,6 +1171,54 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
       await runFullScan(ui);
     }
 
+    // Wave 1 Fix C: WIPE + SCAN — destructive flow that POSTs kitchen-
+    // sink wipe to /api/clear (empty body == wipe everything per the
+    // handler's "kitchen-sink mode"), then chains into runFullScanFlow.
+    // window.confirm is the intentionality guard (no separate modal —
+    // the action is rare enough that the browser native is fine and
+    // the prompt copy enumerates exactly what dies). NuclearReset's
+    // selective-wipe surface in DATA panel is preserved for the "clear
+    // without rescan" path.
+    async function runWipeAndScan(): Promise<void> {
+      const proceed = window.confirm(
+        'Wipe all local data and rescan? This deletes the SQLite ledger, sidecars, and cached PR data.',
+      );
+      if (!proceed) return;
+      showProgress('wipe local data');
+      setButtonsDisabled(true);
+      const startedAt = Date.now();
+      startElapsedTicker(startedAt);
+      setPhase('writing');
+      try {
+        const res = await fetch('/api/clear', {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'chat-arch-clear',
+            'content-type': 'application/json',
+          },
+          // Empty body == kitchen-sink wipe (see clear.ts handler).
+          body: '{}',
+        });
+        if (!res.ok) {
+          const body = await res.text().catch(() => '');
+          hideProgress();
+          setButtonsDisabled(false);
+          setStatus(`wipe failed: ${res.status} ${body.slice(0, 160)}`, true);
+          return;
+        }
+      } catch (err) {
+        hideProgress();
+        setButtonsDisabled(false);
+        setStatus(`wipe failed: ${(err as Error).message ?? String(err)}`, true);
+        return;
+      }
+      // Clear succeeded — hand off to the full-scan chain. It manages
+      // its own progress UI, button state, and reload-on-success.
+      hideProgress();
+      setButtonsDisabled(false);
+      await runFullScanFlow();
+    }
+
     // SCAN button runs the full chain (exporter → mine-corrections → curate
     // → falsify). The user's mental model is "scan = everything refreshed";
     // having a separate FULL SCAN button next to RESCAN was redundant chrome.
@@ -1075,6 +1227,9 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
     // whole chain.
     document.getElementById('action-rescan')?.addEventListener('click', () => {
       void runFullScanFlow();
+    });
+    document.getElementById('action-wipe-scan')?.addEventListener('click', () => {
+      void runWipeAndScan();
     });
     document.getElementById('action-mine-cta')?.addEventListener('click', () => { void runMine(); });
     document.getElementById('action-curate-cta')?.addEventListener('click', () => { void runCurate(); });
@@ -1182,6 +1337,20 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
     font-weight: 700;
   }
   .today__btn-primary:hover { background: #ffdb5c !important; }
+  /* Wave 1 Fix C: WIPE + SCAN — destructive secondary. Outlined,
+     not filled, so it reads as "use sparingly" against the SCAN
+     primary. Hover slightly tints in to signal interactivity
+     without promoting it to a CTA. */
+  .today__btn-secondary {
+    background: transparent !important;
+    color: #FFCC99 !important;
+    border: 1px solid #FFCC9966 !important;
+    padding: 7px 14px !important;
+  }
+  .today__btn-secondary:hover {
+    background: #FFCC9911 !important;
+    border-color: #FFCC99 !important;
+  }
   .today__actions button:hover { background: #ffd680; }
   .today__actions button:disabled {
     opacity: 0.5;
@@ -1354,6 +1523,47 @@ const SURPRISE_KIND_LABEL: Record<string, string> = {
     font-family: 'JetBrains Mono', monospace;
     font-size: 10px;
     color: #FFCC9999;
+  }
+  /* Wave 1 Fix A: confidence tier ribbon. Sits inline between the
+     kind badge (left) and the numeric score (right). Same Antonio
+     small-caps treatment as other LCARS pills; color encodes tier
+     (sunflower-gold STRONG / butterscotch MODERATE / muted WEAK)
+     so the user reads load-bearing vs speculative at a glance even
+     when scores are close. Tooltip surfaces the raw 3-decimal score
+     on hover for the pedant. */
+  .today__card-tier {
+    display: inline-block;
+    font-family: 'Antonio', sans-serif;
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    padding: 2px 6px;
+    border-radius: 2px;
+    font-weight: 700;
+  }
+  .today__card-tier--strong {
+    background: #FFCC33;
+    color: #0a0a0a;
+  }
+  .today__card-tier--moderate {
+    background: #FFCC99;
+    color: #0a0a0a;
+  }
+  .today__card-tier--weak {
+    background: #FFCC9933;
+    color: #FFCC9999;
+  }
+  /* Wave 1 Fix B: per-card "→ in context" drill-in link. Smaller +
+     muted vs the evidence rows so it reads as an exit, not a CTA;
+     mirrors the page-level today__row-secondary treatment. */
+  .today__card-drill {
+    margin: 8px 0 0;
+    font-size: 11px;
+    color: #FFCC9988;
+  }
+  .today__card-drill a {
+    color: #FFCC99aa;
+    text-decoration: none;
+    border-bottom: 1px dashed #FFCC9944;
   }
   .today__card-summary {
     margin: 4px 0 8px;

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -99,10 +99,16 @@ const draftPrompts = draftsView.filter((d) => d.isPrompt).length;
 const briefEmpty = brief === null;
 const newEmpty = surprisesNew.length === 0;
 const curatorEmpty = curatorFeed === null || curatorFeed.items.length === 0;
-const brokenEmpty =
-  surprisesBroken.length === 0 &&
-  concerns.length === 0 &&
-  (health === null || health.warnings.length === 0);
+// brokenEmpty gates whether the page falls back to demo concerning cards
+// or renders real BROKEN data. Wave-1 review iter-1 fix: previously this
+// required ALL three (surprises-concerning + audit concerns + health
+// warnings) to be empty, which meant the demo MODERATE/STRONG concerning
+// cards never rendered on any populated install — the demo tier-2/3
+// pedagogy was hidden behind a never-true gate. Now only the surprises-
+// concerning slot drives the swap; audit concerns + health warnings
+// render alongside the demo cards when present, which is the actual
+// "is this BROKEN section empty?" question the user is asking.
+const brokenEmpty = surprisesBroken.length === 0;
 const narrativesEmpty = recentNarratives.length === 0;
 
 // Phase β review-loop iter-1 fix: the four new FEED sections (BRIEF /
@@ -280,15 +286,17 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
               return (
                 <li class={`today__card today__card--${s.kind}`}>
                   <div class="today__card-head">
-                    <span class={`today__kind today__kind--${s.tone}`}>
-                      {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
-                    </span>
-                    <span
-                      class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
-                      title={`raw score ${s.score.toFixed(3)}`}
-                    >
-                      {tier}
-                    </span>
+                    <div class="today__card-head-left">
+                      <span class={`today__kind today__kind--${s.tone}`}>
+                        {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                      </span>
+                      <span
+                        class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                        title={`raw score ${s.score.toFixed(3)}`}
+                      >
+                        {tier}
+                      </span>
+                    </div>
                     <span class="today__card-score">
                       score {(s.score * 100).toFixed(0)}
                     </span>
@@ -591,15 +599,17 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
               return (
                 <li class={`today__card today__card--alert today__card--${s.kind}`}>
                   <div class="today__card-head">
-                    <span class={`today__kind today__kind--${s.tone}`}>
-                      {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
-                    </span>
-                    <span
-                      class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
-                      title={`raw score ${s.score.toFixed(3)}`}
-                    >
-                      {tier}
-                    </span>
+                    <div class="today__card-head-left">
+                      <span class={`today__kind today__kind--${s.tone}`}>
+                        {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                      </span>
+                      <span
+                        class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                        title={`raw score ${s.score.toFixed(3)}`}
+                      >
+                        {tier}
+                      </span>
+                    </div>
                     <span class="today__card-score">
                       score {(s.score * 100).toFixed(0)}
                     </span>
@@ -1180,8 +1190,15 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
     // selective-wipe surface in DATA panel is preserved for the "clear
     // without rescan" path.
     async function runWipeAndScan(): Promise<void> {
+      // Wave-1 review iter-1 fix: confirm copy tightened to actual scope.
+      // /api/clear only wipes the server-side data dir + SQLite ledger;
+      // it does NOT touch the three IndexedDB databases (uploaded ZIP
+      // bytes, semantic-label cache, bench results) — that's
+      // NuclearReset's job in the DATA panel. Saying "all local data"
+      // here implied IndexedDB ZIPs would also go, which is false.
       const proceed = window.confirm(
-        'Wipe all local data and rescan? This deletes the SQLite ledger, sidecars, and cached PR data.',
+        'Wipe local chat-arch-data/ (SQLite ledger + analysis sidecars + manifest + cloud-conversations + exports + cached PR data) and rescan?\n\n' +
+        'Uploaded ZIP bytes in browser storage are NOT affected — use DATA panel for that.',
       );
       if (!proceed) return;
       showProgress('wipe local data');
@@ -1212,10 +1229,16 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
         setStatus(`wipe failed: ${(err as Error).message ?? String(err)}`, true);
         return;
       }
-      // Clear succeeded — hand off to the full-scan chain. It manages
-      // its own progress UI, button state, and reload-on-success.
+      // Wave-1 review iter-1 fix: previously called setButtonsDisabled(false)
+      // here before handing off to runFullScanFlow, opening a microtask
+      // window where WIPE+SCAN could double-fire and race a second
+      // /api/clear against the in-flight exporter step (worst case:
+      // unlinking the .db file while the exporter has it open). Now keep
+      // buttons disabled across the handoff — runFullScanFlow's own
+      // setButtonsDisabled(true) on entry is idempotent, and the final
+      // success-path reload + the failure-path setButtonsDisabled(false)
+      // inside runFullScanFlow handle reset.
       hideProgress();
-      setButtonsDisabled(false);
       await runFullScanFlow();
     }
 
@@ -1337,19 +1360,22 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
     font-weight: 700;
   }
   .today__btn-primary:hover { background: #ffdb5c !important; }
-  /* Wave 1 Fix C: WIPE + SCAN — destructive secondary. Outlined,
-     not filled, so it reads as "use sparingly" against the SCAN
-     primary. Hover slightly tints in to signal interactivity
-     without promoting it to a CTA. */
+  /* Wave-1 review iter-1 fix: secondary visual weight wasn't enough —
+     the button read as "another way to scan" rather than "destructive."
+     Switched the border + label to the same peach tone the page already
+     uses for alert cards + concerning-kind badges, so it reads as
+     in-system "warn" affordance at a glance even before the confirm
+     dialog fires. Filled outline only on hover to keep the destructive
+     framing without promoting it to a CTA. */
   .today__btn-secondary {
     background: transparent !important;
-    color: #FFCC99 !important;
-    border: 1px solid #FFCC9966 !important;
+    color: #ff9933 !important;
+    border: 1px solid #ff993366 !important;
     padding: 7px 14px !important;
   }
   .today__btn-secondary:hover {
-    background: #FFCC9911 !important;
-    border-color: #FFCC99 !important;
+    background: #ff993315 !important;
+    border-color: #ff9933 !important;
   }
   .today__actions button:hover { background: #ffd680; }
   .today__actions button:disabled {
@@ -1501,9 +1527,18 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
   .today__card--alert {
     border-left-color: #ff9933;
   }
+  /* Wave-1 review iter-1 fix: was 3 children in flex space-between, so
+     the tier badge floated awkwardly at the visual midpoint. Now [kind +
+     tier] cluster on the left (both label-the-card things) and score
+     stays on the right (the metric). flex-wrap so narrow cards stack
+     gracefully instead of crushing. */
   .today__card-head {
     display: flex; align-items: baseline; justify-content: space-between;
-    gap: 8px; margin-bottom: 6px;
+    gap: 8px; margin-bottom: 6px; flex-wrap: wrap;
+  }
+  .today__card-head-left {
+    display: flex; align-items: baseline; gap: 6px;
+    flex: 1 1 auto; min-width: 0;
   }
   .today__kind {
     display: inline-block;
@@ -1531,15 +1566,23 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
      so the user reads load-bearing vs speculative at a glance even
      when scores are close. Tooltip surfaces the raw 3-decimal score
      on hover for the pedant. */
+  /* Wave-1 review iter-1 fix: bump font-size + reduce tracking so the
+     text label (the load-bearing distinguisher under colorblindness)
+     is actually legible — STRONG vs MODERATE are both amber-family at
+     high luminance and color alone collapses under protanopia. */
   .today__card-tier {
     display: inline-block;
     font-family: 'Antonio', sans-serif;
-    font-size: 10px;
-    letter-spacing: 0.12em;
+    font-size: 11px;
+    letter-spacing: 0.08em;
     padding: 2px 6px;
     border-radius: 2px;
     font-weight: 700;
   }
+  /* STRONG: filled gold. MODERATE: filled cream with outline. WEAK:
+     outline only with solid text — gives a shape-channel (filled vs
+     outlined vs outline-only) that's orthogonal to hue, so the three
+     tiers stay distinguishable even when color drops out. */
   .today__card-tier--strong {
     background: #FFCC33;
     color: #0a0a0a;
@@ -1547,23 +1590,33 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
   .today__card-tier--moderate {
     background: #FFCC99;
     color: #0a0a0a;
+    box-shadow: inset 0 0 0 1px #DD9944;
   }
+  /* WEAK was alpha-on-alpha (#FFCC9999 over #FFCC9933 over #0a0a0a)
+     which computed to 4.20:1 — under WCAG AA 4.5:1 for small text.
+     Outline pattern with solid text fixes contrast (FFCC99cc on
+     #0a0a0a ≈ 8.5:1) and adds the shape-distinguisher. */
   .today__card-tier--weak {
-    background: #FFCC9933;
-    color: #FFCC9999;
+    background: transparent;
+    color: #FFCC99cc;
+    box-shadow: inset 0 0 0 1px #FFCC9966;
   }
   /* Wave 1 Fix B: per-card "→ in context" drill-in link. Smaller +
      muted vs the evidence rows so it reads as an exit, not a CTA;
      mirrors the page-level today__row-secondary treatment. */
+  /* Wave-1 review iter-1 fix: was too subtle to find — color #FFCC9988
+     with dashed underline at alpha 44 read as a comment, not a link.
+     Bumped to solid color + alpha-66 underline so it reads as clickable
+     while still subordinate to the primary evidence-row links above. */
   .today__card-drill {
     margin: 8px 0 0;
     font-size: 11px;
-    color: #FFCC9988;
+    color: #FFCC99aa;
   }
   .today__card-drill a {
-    color: #FFCC99aa;
+    color: #FFCC99cc;
     text-decoration: none;
-    border-bottom: 1px dashed #FFCC9944;
+    border-bottom: 1px dashed #FFCC9966;
   }
   .today__card-summary {
     margin: 4px 0 8px;

--- a/apps/standalone/src/pages/index.astro
+++ b/apps/standalone/src/pages/index.astro
@@ -359,15 +359,17 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
             return (
               <li class={`today__card today__card--${s.kind}`}>
                 <div class="today__card-head">
-                  <span class={`today__kind today__kind--${s.tone}`}>
-                    {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
-                  </span>
-                  <span
-                    class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
-                    title={`raw score ${s.score.toFixed(3)}`}
-                  >
-                    {tier}
-                  </span>
+                  <div class="today__card-head-left">
+                    <span class={`today__kind today__kind--${s.tone}`}>
+                      {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                    </span>
+                    <span
+                      class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                      title={`raw score ${s.score.toFixed(3)}`}
+                    >
+                      {tier}
+                    </span>
+                  </div>
                   <span class="today__card-score">
                     score {(s.score * 100).toFixed(0)}
                   </span>
@@ -573,15 +575,17 @@ const SURPRISE_DRILL_IN: Record<string, string> = {
                 return (
                   <li class={`today__card today__card--alert today__card--${s.kind}`}>
                     <div class="today__card-head">
-                      <span class={`today__kind today__kind--${s.tone}`}>
-                        {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
-                      </span>
-                      <span
-                        class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
-                        title={`raw score ${s.score.toFixed(3)}`}
-                      >
-                        {tier}
-                      </span>
+                      <div class="today__card-head-left">
+                        <span class={`today__kind today__kind--${s.tone}`}>
+                          {SURPRISE_KIND_LABEL[s.kind] ?? s.kind}
+                        </span>
+                        <span
+                          class={`today__card-tier today__card-tier--${tier.toLowerCase()}`}
+                          title={`raw score ${s.score.toFixed(3)}`}
+                        >
+                          {tier}
+                        </span>
+                      </div>
                       <span class="today__card-score">
                         score {(s.score * 100).toFixed(0)}
                       </span>

--- a/packages/analysis/src/computeSurprises.test.ts
+++ b/packages/analysis/src/computeSurprises.test.ts
@@ -22,6 +22,7 @@ import {
   type SurpriseKnowledgeDebtRow,
   type SurpriseTrajectoryRow,
   type SurpriseWatcherEntry,
+  type SurprisesOutput,
 } from './computeSurprises.js';
 import type { ItsResult } from './itsAnalysis.js';
 import type { ReflexiveResult } from './computeReflexive.js';
@@ -791,5 +792,372 @@ describe('cross-cutting properties', () => {
       if (s.kind === 'trajectory-accelerating') expect(s.tone).toBe('positive');
       if (s.kind === 'trajectory-stalled') expect(s.tone).toBe('concerning');
     }
+  });
+});
+
+// ─── Wave 2 #1 — delta kinds ───────────────────────────────────────
+
+function priorWith(surprises: readonly Surprise[]): SurprisesOutput {
+  return {
+    version: 1,
+    generatedAt: GENERATED_AT - 86_400_000,
+    surprises,
+    thresholds: {
+      streakMin: 5,
+      itsQValueMax: 0.1,
+      itsDeltaMin: 0.15,
+      reflexiveDeltaMin: 0.1,
+      reflexiveEValueMin: 1.5,
+      decisionGoodFollowupsMin: 5,
+      debtSpinningTopK: 3,
+      debtSpinningMinClusterSize: 3,
+    },
+  };
+}
+
+function streakSurprise(ids: readonly string[]): Surprise {
+  return {
+    id: `streak:${ids[ids.length - 1] as string}`,
+    kind: 'streak',
+    tone: 'positive',
+    summary: `${ids.length} sessions in a row landed as composite-good.`,
+    evidence: { sessionIds: ids },
+    score: 0.5,
+    generatedAt: GENERATED_AT - 86_400_000,
+  };
+}
+
+function trajectorySurprise(
+  projectId: string,
+  kind: 'trajectory-accelerating' | 'trajectory-stalled',
+): Surprise {
+  return {
+    id: `${kind}:${projectId}`,
+    kind,
+    tone: kind === 'trajectory-accelerating' ? 'positive' : 'concerning',
+    summary: `${projectId} surprise.`,
+    evidence: { projectId },
+    score: 0.5,
+    generatedAt: GENERATED_AT - 86_400_000,
+  };
+}
+
+function patternClosedSurprise(patternId: string): Surprise {
+  return {
+    id: `pattern-closed:${patternId}`,
+    kind: 'pattern-closed',
+    tone: 'positive',
+    summary: `Pattern ${patternId} held.`,
+    evidence: { projectId: 'p1', narrativeId: patternId },
+    score: 0.5,
+    generatedAt: GENERATED_AT - 86_400_000,
+  };
+}
+
+describe('streak-extended (delta)', () => {
+  it('emits when prior + current share lastSessionId and current is longer', () => {
+    // Construct a corpus whose trailing-good-run ends on the same id
+    // as the prior snapshot's. Easiest: composites end on s5 in both.
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+      compositeRow('s4', 4, 'good'),
+      compositeRow('s5', 5, 'good'),
+    ];
+    const prior = priorWith([streakSurprise(['s3', 's4', 's5'])]);
+    const out = computeSurprises(
+      { ...emptyInput({ composites }), priorSurprises: prior },
+      { streakMin: 3 },
+    );
+    const ext = out.surprises.find((s) => s.kind === 'streak-extended');
+    expect(ext).toBeDefined();
+    expect(ext?.tone).toBe('positive');
+    // Prior was 3, current is 5 — diff = 2 → score 0.4.
+    expect(ext?.score).toBeCloseTo(0.4, 5);
+  });
+
+  it('does NOT emit when lastSessionId differs (fresh streak, not extension)', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+    ];
+    const prior = priorWith([streakSurprise(['x1', 'x2', 'x3'])]);
+    const out = computeSurprises(
+      { ...emptyInput({ composites }), priorSurprises: prior },
+      { streakMin: 3 },
+    );
+    expect(kindsOf(out.surprises)).not.toContain('streak-extended');
+  });
+
+  it('does NOT emit when prior is null', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+    ];
+    const out = computeSurprises(
+      { ...emptyInput({ composites }), priorSurprises: null },
+      { streakMin: 3 },
+    );
+    expect(kindsOf(out.surprises)).not.toContain('streak-extended');
+  });
+
+  it('does NOT emit when current streak is same length or shorter than prior', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+    ];
+    const prior = priorWith([streakSurprise(['s1', 's2', 's3'])]);
+    const out = computeSurprises(
+      { ...emptyInput({ composites }), priorSurprises: prior },
+      { streakMin: 3 },
+    );
+    expect(kindsOf(out.surprises)).not.toContain('streak-extended');
+  });
+});
+
+describe('streak-broken (delta)', () => {
+  it('emits when prior had a streak and current does NOT', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'bad'),
+    ];
+    const prior = priorWith([streakSurprise(['p1', 'p2', 'p3', 'p4', 'p5'])]);
+    const out = computeSurprises(
+      { ...emptyInput({ composites }), priorSurprises: prior },
+      { streakMin: 5 },
+    );
+    const broken = out.surprises.find((s) => s.kind === 'streak-broken');
+    expect(broken).toBeDefined();
+    expect(broken?.tone).toBe('concerning');
+    expect(broken?.score).toBeCloseTo(0.5, 5); // 5/10
+    expect(broken?.evidence.sessionIds).toEqual(['p1', 'p2', 'p3', 'p4', 'p5']);
+  });
+
+  it('does NOT emit when current ALSO has a streak (continued, not broken)', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+    ];
+    const prior = priorWith([streakSurprise(['p1', 'p2', 'p3'])]);
+    const out = computeSurprises(
+      { ...emptyInput({ composites }), priorSurprises: prior },
+      { streakMin: 3 },
+    );
+    expect(kindsOf(out.surprises)).not.toContain('streak-broken');
+  });
+
+  it('does NOT emit when prior is null', () => {
+    const out = computeSurprises({ ...emptyInput(), priorSurprises: null });
+    expect(kindsOf(out.surprises)).not.toContain('streak-broken');
+  });
+
+  it('does NOT emit when prior had no streak row', () => {
+    const prior = priorWith([]); // prior was empty
+    const out = computeSurprises({ ...emptyInput(), priorSurprises: prior });
+    expect(kindsOf(out.surprises)).not.toContain('streak-broken');
+  });
+});
+
+describe('trajectory-flip-up (delta)', () => {
+  it('emits when a stalled project flips to accelerating', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'accelerating', 0.08, { low: 0.01, high: 0.15 }),
+    ];
+    const prior = priorWith([trajectorySurprise('p1', 'trajectory-stalled')]);
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: prior,
+    });
+    const flip = out.surprises.find((s) => s.kind === 'trajectory-flip-up');
+    expect(flip).toBeDefined();
+    expect(flip?.tone).toBe('positive');
+    expect(flip?.evidence.projectId).toBe('p1');
+    expect(flip?.score).toBeCloseTo(0.8, 5); // 0.08 * 10
+  });
+
+  it('emits when an absent project flips to accelerating', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p-new', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+    ];
+    const prior = priorWith([]); // p-new was not in prior at all
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: prior,
+    });
+    expect(kindsOf(out.surprises)).toContain('trajectory-flip-up');
+  });
+
+  it('does NOT emit when prior was already accelerating', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+    ];
+    const prior = priorWith([trajectorySurprise('p1', 'trajectory-accelerating')]);
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: prior,
+    });
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-flip-up');
+  });
+
+  it('does NOT emit when prior is null', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+    ];
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: null,
+    });
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-flip-up');
+  });
+});
+
+describe('trajectory-flip-down (delta)', () => {
+  it('emits when an accelerating project flips to stalling', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'stalling', -0.06, { low: -0.1, high: -0.02 }),
+    ];
+    const prior = priorWith([
+      trajectorySurprise('p1', 'trajectory-accelerating'),
+    ]);
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: prior,
+    });
+    const flip = out.surprises.find((s) => s.kind === 'trajectory-flip-down');
+    expect(flip).toBeDefined();
+    expect(flip?.tone).toBe('concerning');
+    expect(flip?.evidence.projectId).toBe('p1');
+    expect(flip?.score).toBeCloseTo(0.6, 5); // |-0.06| * 10
+  });
+
+  it('emits for stalled-finished too', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'stalled-finished', -0.04, {
+        low: -0.08,
+        high: -0.01,
+      }),
+    ];
+    const prior = priorWith([
+      trajectorySurprise('p1', 'trajectory-accelerating'),
+    ]);
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: prior,
+    });
+    expect(kindsOf(out.surprises)).toContain('trajectory-flip-down');
+  });
+
+  it('does NOT emit when prior was already stalled', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'stalling', -0.05, { low: -0.1, high: -0.01 }),
+    ];
+    const prior = priorWith([trajectorySurprise('p1', 'trajectory-stalled')]);
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: prior,
+    });
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-flip-down');
+  });
+
+  it('does NOT emit when prior is null', () => {
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'stalling', -0.05, { low: -0.1, high: -0.01 }),
+    ];
+    const out = computeSurprises({
+      ...emptyInput({ trajectories }),
+      priorSurprises: null,
+    });
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-flip-down');
+  });
+});
+
+describe('pattern-recurrence-resumed (delta)', () => {
+  it('emits when pattern-closed in prior is now pattern-recurring in current', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherRecurring('pat-x', 'narr-1'),
+    ];
+    const prior = priorWith([patternClosedSurprise('pat-x')]);
+    const out = computeSurprises({
+      ...emptyInput({ patternWatchers }),
+      priorSurprises: prior,
+    });
+    const resumed = out.surprises.find(
+      (s) => s.kind === 'pattern-recurrence-resumed',
+    );
+    expect(resumed).toBeDefined();
+    expect(resumed?.tone).toBe('concerning');
+    expect(resumed?.score).toBeCloseTo(0.85, 5);
+    expect(resumed?.evidence.narrativeId).toBe('narr-1');
+  });
+
+  it('does NOT emit when pattern is recurring but was not previously closed', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherRecurring('pat-y', 'narr-2'),
+    ];
+    const prior = priorWith([patternClosedSurprise('pat-x')]); // different id
+    const out = computeSurprises({
+      ...emptyInput({ patternWatchers }),
+      priorSurprises: prior,
+    });
+    expect(kindsOf(out.surprises)).not.toContain('pattern-recurrence-resumed');
+  });
+
+  it('does NOT emit when prior is null', () => {
+    const patternWatchers: SurpriseWatcherEntry[] = [
+      watcherRecurring('pat-x', 'narr-1'),
+    ];
+    const out = computeSurprises({
+      ...emptyInput({ patternWatchers }),
+      priorSurprises: null,
+    });
+    expect(kindsOf(out.surprises)).not.toContain('pattern-recurrence-resumed');
+  });
+});
+
+describe('delta kinds — V1 backward compatibility', () => {
+  it('null priorSurprises produces identical output to omitting the field (V1)', () => {
+    const input = emptyInput({
+      composites: [
+        compositeRow('s1', 1, 'good'),
+        compositeRow('s2', 2, 'good'),
+        compositeRow('s3', 3, 'good'),
+        compositeRow('s4', 4, 'good'),
+        compositeRow('s5', 5, 'good'),
+      ],
+      trajectories: [
+        trajectoryRow('p1', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+      ],
+      patternWatchers: [watcherRecurring('pat-x', 'narr-1')],
+    });
+    const v1 = computeSurprises(input);
+    const v1ExplicitNull = computeSurprises({ ...input, priorSurprises: null });
+    expect(JSON.stringify(v1ExplicitNull)).toBe(JSON.stringify(v1));
+  });
+
+  it('determinism: identical prior+current inputs produce identical output ordering', () => {
+    const composites: SurpriseCompositeRow[] = [
+      compositeRow('s1', 1, 'good'),
+      compositeRow('s2', 2, 'good'),
+      compositeRow('s3', 3, 'good'),
+    ];
+    const trajectories: SurpriseTrajectoryRow[] = [
+      trajectoryRow('p1', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
+    ];
+    const prior = priorWith([
+      streakSurprise(['s1', 's2']),
+      trajectorySurprise('p1', 'trajectory-stalled'),
+    ]);
+    const input: ComputeSurprisesInput = {
+      ...emptyInput({ composites, trajectories }),
+      priorSurprises: prior,
+    };
+    const a = computeSurprises(input, { streakMin: 2 });
+    const b = computeSurprises(input, { streakMin: 2 });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
   });
 });

--- a/packages/analysis/src/computeSurprises.test.ts
+++ b/packages/analysis/src/computeSurprises.test.ts
@@ -797,21 +797,33 @@ describe('cross-cutting properties', () => {
 
 // ─── Wave 2 #1 — delta kinds ───────────────────────────────────────
 
-function priorWith(surprises: readonly Surprise[]): SurprisesOutput {
+/**
+ * priorWith — build a SurprisesOutput fixture suitable for the
+ * `priorSurprises` slot. Optional thresholds override lets tests pin
+ * the prior's gates to match the current opts (Wave-2 review iter-1
+ * fix B3 rejects deltas when streakMin drifts between scans, so tests
+ * that pass non-default opts must build a prior with the same gate).
+ */
+function priorWith(
+  surprises: readonly Surprise[],
+  thresholdOverrides: Partial<SurprisesOutput['thresholds']> = {},
+): SurprisesOutput {
+  const baseThresholds = {
+    streakMin: 5,
+    itsQValueMax: 0.1,
+    itsDeltaMin: 0.15,
+    reflexiveDeltaMin: 0.1,
+    reflexiveEValueMin: 1.5,
+    decisionGoodFollowupsMin: 5,
+    debtSpinningTopK: 3,
+    debtSpinningMinClusterSize: 3,
+    archiveRetentionDays: 30,
+  };
   return {
     version: 1,
     generatedAt: GENERATED_AT - 86_400_000,
     surprises,
-    thresholds: {
-      streakMin: 5,
-      itsQValueMax: 0.1,
-      itsDeltaMin: 0.15,
-      reflexiveDeltaMin: 0.1,
-      reflexiveEValueMin: 1.5,
-      decisionGoodFollowupsMin: 5,
-      debtSpinningTopK: 3,
-      debtSpinningMinClusterSize: 3,
-    },
+    thresholds: { ...baseThresholds, ...thresholdOverrides },
   };
 }
 
@@ -865,7 +877,7 @@ describe('streak-extended (delta)', () => {
       compositeRow('s4', 4, 'good'),
       compositeRow('s5', 5, 'good'),
     ];
-    const prior = priorWith([streakSurprise(['s3', 's4', 's5'])]);
+    const prior = priorWith([streakSurprise(['s3', 's4', 's5'])], { streakMin: 3 });
     const out = computeSurprises(
       { ...emptyInput({ composites }), priorSurprises: prior },
       { streakMin: 3 },
@@ -883,7 +895,7 @@ describe('streak-extended (delta)', () => {
       compositeRow('s2', 2, 'good'),
       compositeRow('s3', 3, 'good'),
     ];
-    const prior = priorWith([streakSurprise(['x1', 'x2', 'x3'])]);
+    const prior = priorWith([streakSurprise(['x1', 'x2', 'x3'])], { streakMin: 3 });
     const out = computeSurprises(
       { ...emptyInput({ composites }), priorSurprises: prior },
       { streakMin: 3 },
@@ -910,7 +922,7 @@ describe('streak-extended (delta)', () => {
       compositeRow('s2', 2, 'good'),
       compositeRow('s3', 3, 'good'),
     ];
-    const prior = priorWith([streakSurprise(['s1', 's2', 's3'])]);
+    const prior = priorWith([streakSurprise(['s1', 's2', 's3'])], { streakMin: 3 });
     const out = computeSurprises(
       { ...emptyInput({ composites }), priorSurprises: prior },
       { streakMin: 3 },
@@ -943,7 +955,7 @@ describe('streak-broken (delta)', () => {
       compositeRow('s2', 2, 'good'),
       compositeRow('s3', 3, 'good'),
     ];
-    const prior = priorWith([streakSurprise(['p1', 'p2', 'p3'])]);
+    const prior = priorWith([streakSurprise(['p1', 'p2', 'p3'])], { streakMin: 3 });
     const out = computeSurprises(
       { ...emptyInput({ composites }), priorSurprises: prior },
       { streakMin: 3 },
@@ -980,7 +992,12 @@ describe('trajectory-flip-up (delta)', () => {
     expect(flip?.score).toBeCloseTo(0.8, 5); // 0.08 * 10
   });
 
-  it('emits when an absent project flips to accelerating', () => {
+  // Wave-2 review iter-1 fix B1: the kernel previously emitted flip-up
+  // for absent-in-prior projects, but absence has two meanings (genuinely
+  // new vs prior-flat-so-no-surprise). The narrower rule (only fire when
+  // prior had explicit `trajectory-stalled`) is safer. This test was
+  // inverted from `toContain` → `not.toContain` to match the new contract.
+  it('does NOT emit when project was ABSENT in prior (could be new OR flat)', () => {
     const trajectories: SurpriseTrajectoryRow[] = [
       trajectoryRow('p-new', 'accelerating', 0.05, { low: 0.01, high: 0.1 }),
     ];
@@ -989,7 +1006,7 @@ describe('trajectory-flip-up (delta)', () => {
       ...emptyInput({ trajectories }),
       priorSurprises: prior,
     });
-    expect(kindsOf(out.surprises)).toContain('trajectory-flip-up');
+    expect(kindsOf(out.surprises)).not.toContain('trajectory-flip-up');
   });
 
   it('does NOT emit when prior was already accelerating', () => {
@@ -1091,7 +1108,12 @@ describe('pattern-recurrence-resumed (delta)', () => {
     );
     expect(resumed).toBeDefined();
     expect(resumed?.tone).toBe('concerning');
-    expect(resumed?.score).toBeCloseTo(0.85, 5);
+    // Wave-2 review iter-1 fix B2: score now derives from the prior
+    // pattern-closed score (clamped to [0.5, 0.95]) instead of fixed
+    // 0.85, so weak prior holds don't all surface as STRONG-tier
+    // recurrences. Fixture's prior pattern-closed score is 0.5
+    // (MODERATE-ish hold), so the recurrence floors at 0.5.
+    expect(resumed?.score).toBeCloseTo(0.5, 5);
     expect(resumed?.evidence.narrativeId).toBe('narr-1');
   });
 

--- a/packages/analysis/src/computeSurprises.ts
+++ b/packages/analysis/src/computeSurprises.ts
@@ -338,9 +338,26 @@ export function computeSurprises(
   // null` and returns [] cleanly, so passing the current streak rows
   // (which the streak-extended kernel needs) is safe even on a
   // first-ever scan.
+  //
+  // Wave-2 review iter-1 fix (B3): defend against threshold drift
+  // between scans. If the operator bumped THRESHOLDS.surprises.streakMin
+  // (e.g. 3 → 5) between this scan and the archived prior, the prior
+  // file's `streak` rows were emitted under a looser gate — comparing
+  // them against the current run's tighter gate produces spurious
+  // streak-broken / streak-extended emissions because the corpus is
+  // unchanged but the threshold isn't. The schema exposes prior.thresholds
+  // so we can detect drift and fail soft: skip the affected delta kind
+  // entirely (degrade to V1-snapshot behavior for that kind) when the
+  // gate doesn't match. The streak delta family is the only one with
+  // a single-threshold dependency today; trajectory + pattern deltas
+  // don't yet expose a threshold-snapshot to compare against.
   const prior = input.priorSurprises ?? null;
-  pushAll(surprises, computeStreakExtended(prior, streakRows));
-  pushAll(surprises, computeStreakBroken(prior, streakRows));
+  const streakGateMatches =
+    prior === null || prior.thresholds.streakMin === opts.streakMin;
+  if (streakGateMatches) {
+    pushAll(surprises, computeStreakExtended(prior, streakRows));
+    pushAll(surprises, computeStreakBroken(prior, streakRows));
+  }
   pushAll(surprises, computeTrajectoryFlipUp(input, prior));
   pushAll(surprises, computeTrajectoryFlipDown(input, prior));
   pushAll(surprises, computePatternRecurrenceResumed(input, prior));
@@ -902,10 +919,15 @@ function computeTrajectoryFlipUp(
   for (const t of input.trajectories) {
     if (t.classification !== 'accelerating') continue;
     const priorKind = priorByProject.get(t.projectId);
-    // Flip-up qualifies when prior was stalled OR absent (the project
-    // didn't surface either way). An already-accelerating project is
-    // not a flip.
-    if (priorKind === 'trajectory-accelerating') continue;
+    // Wave-2 review iter-1 fix (B1): tightened from "stalled OR absent
+    // qualifies" to "ONLY stalled qualifies." Reason: a project absent
+    // from prior could be (a) genuinely new, or (b) classified `flat` /
+    // `series-too-short` in prior so the trajectory kernel emitted
+    // nothing. Case (b) is NOT a directional change — the slope just
+    // tightened — so claiming a flip is a false positive. The narrower
+    // gate loses the freshly-discovered-accelerating-project case (V1
+    // tradeoff: better to silently miss than to noisily lie).
+    if (priorKind !== 'trajectory-stalled') continue;
     const slope = t.slope ?? 0;
     const score = Math.max(0, Math.min(1, slope * 10));
     out.push({
@@ -951,7 +973,11 @@ function computeTrajectoryFlipDown(
       continue;
     }
     const priorKind = priorByProject.get(t.projectId);
-    if (priorKind === 'trajectory-stalled') continue;
+    // Wave-2 review iter-1 fix (B1): tightened — only emit when prior
+    // explicitly had `trajectory-accelerating`. Absent-in-prior may be
+    // a project that was `flat` (not a downward direction). See flip-up
+    // for the symmetric rationale.
+    if (priorKind !== 'trajectory-accelerating') continue;
     const slope = t.slope ?? 0;
     const score = Math.max(0, Math.min(1, Math.abs(slope) * 10));
     out.push({
@@ -983,18 +1009,31 @@ function computePatternRecurrenceResumed(
 ): Surprise[] {
   if (prior === null) return [];
 
-  const priorClosedIds = new Set<string>();
+  // Wave-2 review iter-1 fix (B2): track prior pattern-closed SCORE per
+  // patternId (not just ID presence). The closed-score directly encodes
+  // hold strength via `1 - failureRateUpperBound95` — a 5-session hold
+  // that recurs is materially weaker evidence than a 50-session hold
+  // that recurs. Previously fixed score 0.85 forced every recurrence
+  // into the STRONG tier (>= 0.75) regardless of underlying strength,
+  // undermining the confidence ladder feedback_confidence_per_step asks
+  // for. Now we propagate the prior score (floor 0.5 so a closed-then-
+  // recurred surprise stays at least MODERATE — it's still a real
+  // signal even if the prior hold was weak).
+  const priorClosedScoreByPattern = new Map<string, number>();
   for (const s of prior.surprises) {
     if (s.kind !== 'pattern-closed') continue;
     const nid = s.evidence.narrativeId;
-    if (typeof nid === 'string' && nid.length > 0) priorClosedIds.add(nid);
+    if (typeof nid === 'string' && nid.length > 0) {
+      priorClosedScoreByPattern.set(nid, s.score);
+    }
   }
-  if (priorClosedIds.size === 0) return [];
+  if (priorClosedScoreByPattern.size === 0) return [];
 
   const out: Surprise[] = [];
   for (const w of input.patternWatchers) {
     if (w.verdict.kind !== 'recurring') continue;
-    if (!priorClosedIds.has(w.patternId)) continue;
+    const priorScore = priorClosedScoreByPattern.get(w.patternId);
+    if (priorScore === undefined) continue;
     out.push({
       id: `pattern-recurrence-resumed:${w.patternId}`,
       kind: 'pattern-recurrence-resumed',
@@ -1006,7 +1045,10 @@ function computePatternRecurrenceResumed(
         projectId: w.projectId,
         narrativeId: w.verdict.recurrenceNarrativeId,
       },
-      score: 0.85,
+      // Floor at 0.5 so a recurrence is at least MODERATE; ceiling at
+      // 0.95 so an unusually strong prior hold doesn't pin every
+      // recurrence at perfect-1.0 (rooms for genuine 1.0 elsewhere).
+      score: Math.max(0.5, Math.min(0.95, priorScore)),
       generatedAt: 0,
     });
   }

--- a/packages/analysis/src/computeSurprises.ts
+++ b/packages/analysis/src/computeSurprises.ts
@@ -745,6 +745,36 @@ function computeDebtSpinning(
 
 // ─── helpers ───────────────────────────────────────────────────────
 
+/**
+ * UI confidence tier — coarsens a raw [0,1] surprise score into one of
+ * three buckets the FEED renders as a labeled ribbon next to the kind
+ * badge. The mapping is intentionally independent of the per-kind
+ * statistical gates in THRESHOLDS.surprises (those are kernel-emission
+ * floors; this is a downstream presentation layer that ranks the
+ * surfaces that DID emit). The boundaries are pre-launch placeholders
+ * — once we have engagement data we can calibrate WEAK against
+ * "ignored" rate and STRONG against "clicked through" rate.
+ *
+ *   - `STRONG`   — score ≥ 0.75. Highly surface-worthy; load-bearing.
+ *   - `MODERATE` — score ≥ 0.5.  Worth a look; mid-band.
+ *   - `WEAK`     — score <  0.5.  Speculative; surface-but-discount.
+ *
+ * Memory: feedback_confidence_per_step — when the UI ladders rows by
+ * score, the score band must be labeled, not just numerically encoded;
+ * otherwise later rungs inherit the certainty of earlier ones.
+ */
+export type SurpriseConfidenceTier = 'STRONG' | 'MODERATE' | 'WEAK';
+
+export const SURPRISE_TIER_STRONG_MIN = 0.75;
+export const SURPRISE_TIER_MODERATE_MIN = 0.5;
+
+export function surpriseConfidenceTier(score: number): SurpriseConfidenceTier {
+  if (!Number.isFinite(score)) return 'WEAK';
+  if (score >= SURPRISE_TIER_STRONG_MIN) return 'STRONG';
+  if (score >= SURPRISE_TIER_MODERATE_MIN) return 'MODERATE';
+  return 'WEAK';
+}
+
 function pushAll<T>(target: T[], items: readonly T[]): void {
   for (const item of items) target.push(item);
 }

--- a/packages/analysis/src/computeSurprises.ts
+++ b/packages/analysis/src/computeSurprises.ts
@@ -31,15 +31,28 @@
  *                               (V1: highest count flagged; week-over-
  *                                week growth is a follow-on)
  *
- * **V1 emission scope**: 7 of 9 kinds emit from the builder pipeline.
- * `pattern-closed` and `pattern-recurring` accept watcher input in
- * the kernel API (the test suite exercises them) but the
+ * **V1 emission scope**: 7 of 9 snapshot kinds emit from the builder
+ * pipeline. `pattern-closed` and `pattern-recurring` accept watcher
+ * input in the kernel API (the test suite exercises them) but the
  * `surprisesBuilder` Node shell passes an empty `patternWatchers`
  * array — the applied-pattern watcher ledger lives in the SQLite
  * substrate and no SDK accessor for it exists yet. The two pattern-*
  * branches stay dormant until that accessor lands; see the
  * `TODO(applyWatcher-sdk):` marker in
  * `packages/exporter/src/analysis/surprisesBuilder.ts`.
+ *
+ * **Wave 2 #1 — delta kinds.** Five additional kinds compare the
+ * current snapshot against a prior `SurprisesOutput` (loaded from
+ * `analysis/archive/surprises-YYYY-MM-DD.json` by the builder):
+ *   - `streak-extended` (positive) — same continuation, longer run
+ *   - `streak-broken`   (concerning) — prior had a streak, current doesn't
+ *   - `trajectory-flip-up`   (positive)   — stalled / absent → accelerating
+ *   - `trajectory-flip-down` (concerning) — accelerating / absent → stalled
+ *   - `pattern-recurrence-resumed` (concerning) — pattern-closed → -recurring
+ *
+ * Delta kinds are fail-soft: when `priorSurprises === null` (no
+ * archive exists, e.g. first-ever scan) all five skip cleanly and the
+ * kernel behaves identically to V1.
  *
  * Pure. Browser-safe (no `node:*` imports). Deterministic — the
  * caller passes `generatedAt` (the kernel does NOT call `Date.now()`),
@@ -145,7 +158,14 @@ export type SurpriseKind =
   | 'decision-paid-off'
   | 'trajectory-stalled'
   | 'pattern-recurring'
-  | 'debt-spinning';
+  | 'debt-spinning'
+  // Wave 2 #1 — delta kinds (require a `priorSurprises` input). When
+  // the prior snapshot is null the kernel skips all five cleanly.
+  | 'streak-extended'
+  | 'streak-broken'
+  | 'trajectory-flip-up'
+  | 'trajectory-flip-down'
+  | 'pattern-recurrence-resumed';
 
 export type SurpriseTone = 'positive' | 'concerning';
 
@@ -213,6 +233,15 @@ export interface ComputeSurprisesInput {
   readonly decisions: readonly SurpriseDecisionRow[];
   /** Knowledge-debt clusters. */
   readonly knowledgeDebt: readonly SurpriseKnowledgeDebtRow[];
+  /**
+   * Wave 2 #1 — most recent prior `SurprisesOutput` (typically loaded
+   * from `analysis/archive/surprises-YYYY-MM-DD.json` by the builder).
+   * When `null`, the delta kinds (`streak-extended` / `streak-broken` /
+   * `trajectory-flip-up` / `trajectory-flip-down` /
+   * `pattern-recurrence-resumed`) skip cleanly and the kernel behaves
+   * identically to the V1 snapshot-only pipeline.
+   */
+  readonly priorSurprises?: SurprisesOutput | null;
 }
 
 export interface ComputeSurprisesOptions {
@@ -293,7 +322,9 @@ export function computeSurprises(
 
   const surprises: Surprise[] = [];
 
-  pushAll(surprises, computeStreak(input, opts));
+  // Snapshot kinds (V1) — emit regardless of `priorSurprises`.
+  const streakRows = computeStreak(input, opts);
+  pushAll(surprises, streakRows);
   pushAll(surprises, computeTrajectoryAccelerating(input));
   pushAll(surprises, computeConfigHelped(input, opts));
   pushAll(surprises, computePatternClosed(input));
@@ -302,6 +333,17 @@ export function computeSurprises(
   pushAll(surprises, computeTrajectoryStalled(input));
   pushAll(surprises, computePatternRecurring(input));
   pushAll(surprises, computeDebtSpinning(input, opts));
+
+  // Wave 2 #1 — delta kinds. Each helper guards on `priorSurprises ===
+  // null` and returns [] cleanly, so passing the current streak rows
+  // (which the streak-extended kernel needs) is safe even on a
+  // first-ever scan.
+  const prior = input.priorSurprises ?? null;
+  pushAll(surprises, computeStreakExtended(prior, streakRows));
+  pushAll(surprises, computeStreakBroken(prior, streakRows));
+  pushAll(surprises, computeTrajectoryFlipUp(input, prior));
+  pushAll(surprises, computeTrajectoryFlipDown(input, prior));
+  pushAll(surprises, computePatternRecurrenceResumed(input, prior));
 
   // Stamp generatedAt on every row + stable-sort. Tie-break on id so
   // equal-score rows still come out in a deterministic order.
@@ -741,6 +783,234 @@ function computeDebtSpinning(
       generatedAt: 0,
     };
   });
+}
+
+// ─── Delta-kind compute helpers (Wave 2 #1) ────────────────────────
+//
+// Each helper takes the prior `SurprisesOutput` (loaded by the builder
+// from the most recent archive) plus whatever current-scan inputs it
+// needs. All five return [] cleanly when `prior === null` — the kernel
+// stays identical to V1 on a first-ever scan.
+
+/**
+ * `streak-extended` (positive) — the current streak shares its
+ * terminal `lastSessionId` with the prior streak's terminal session AND
+ * has grown in length. Same `lastSessionId` is the continuation
+ * predicate: a new "currently on a streak" with a different terminal
+ * session is a fresh streak, not an extension.
+ *
+ * Score: `clamp(diff / 5, 0, 1)` — a +5-session jump caps at 1.
+ */
+function computeStreakExtended(
+  prior: SurprisesOutput | null,
+  currentStreakRows: readonly Surprise[],
+): Surprise[] {
+  if (prior === null) return [];
+  const priorStreak = prior.surprises.find((s) => s.kind === 'streak');
+  if (priorStreak === undefined) return [];
+  const currentStreak = currentStreakRows.find((s) => s.kind === 'streak');
+  if (currentStreak === undefined) return [];
+
+  const priorIds = priorStreak.evidence.sessionIds ?? [];
+  const currentIds = currentStreak.evidence.sessionIds ?? [];
+  if (priorIds.length === 0 || currentIds.length === 0) return [];
+
+  const priorLast = priorIds[priorIds.length - 1] as string;
+  const currentLast = currentIds[currentIds.length - 1] as string;
+  if (priorLast !== currentLast) return [];
+
+  const diff = currentIds.length - priorIds.length;
+  if (diff <= 0) return [];
+
+  const score = Math.max(0, Math.min(1, diff / 5));
+  return [
+    {
+      id: `streak-extended:${currentLast}`,
+      kind: 'streak-extended',
+      tone: 'positive',
+      summary: clip(
+        `Streak grew by ${diff} session${diff === 1 ? '' : 's'} since last scan (now ${currentIds.length}).`,
+      ),
+      evidence: { sessionIds: currentIds },
+      score,
+      generatedAt: 0,
+    },
+  ];
+}
+
+/**
+ * `streak-broken` (concerning) — the prior snapshot had a `streak` row
+ * and the current snapshot does NOT. The score scales with the size of
+ * the lost streak.
+ *
+ * Score: `clamp(priorStreakCount / 10, 0, 1)`.
+ */
+function computeStreakBroken(
+  prior: SurprisesOutput | null,
+  currentStreakRows: readonly Surprise[],
+): Surprise[] {
+  if (prior === null) return [];
+  const priorStreak = prior.surprises.find((s) => s.kind === 'streak');
+  if (priorStreak === undefined) return [];
+  const currentStreak = currentStreakRows.find((s) => s.kind === 'streak');
+  if (currentStreak !== undefined) return [];
+
+  const priorIds = priorStreak.evidence.sessionIds ?? [];
+  if (priorIds.length === 0) return [];
+
+  const priorLast = priorIds[priorIds.length - 1] as string;
+  const score = Math.max(0, Math.min(1, priorIds.length / 10));
+  return [
+    {
+      id: `streak-broken:${priorLast}`,
+      kind: 'streak-broken',
+      tone: 'concerning',
+      summary: clip(
+        `Streak ended — prior run of ${priorIds.length} good sessions did not continue.`,
+      ),
+      evidence: { sessionIds: priorIds },
+      score,
+      generatedAt: 0,
+    },
+  ];
+}
+
+/**
+ * `trajectory-flip-up` (positive) — a project that was `trajectory-
+ * stalled` (or absent from prior) in the prior snapshot is now
+ * `trajectory-accelerating`. Score scales with the current slope.
+ *
+ * Score: `clamp(currentSlope * 10, 0, 1)`.
+ */
+function computeTrajectoryFlipUp(
+  input: ComputeSurprisesInput,
+  prior: SurprisesOutput | null,
+): Surprise[] {
+  if (prior === null) return [];
+
+  const priorByProject = new Map<string, SurpriseKind>();
+  for (const s of prior.surprises) {
+    if (s.kind !== 'trajectory-accelerating' && s.kind !== 'trajectory-stalled') {
+      continue;
+    }
+    const pid = s.evidence.projectId;
+    if (pid === undefined) continue;
+    priorByProject.set(pid, s.kind);
+  }
+
+  const out: Surprise[] = [];
+  for (const t of input.trajectories) {
+    if (t.classification !== 'accelerating') continue;
+    const priorKind = priorByProject.get(t.projectId);
+    // Flip-up qualifies when prior was stalled OR absent (the project
+    // didn't surface either way). An already-accelerating project is
+    // not a flip.
+    if (priorKind === 'trajectory-accelerating') continue;
+    const slope = t.slope ?? 0;
+    const score = Math.max(0, Math.min(1, slope * 10));
+    out.push({
+      id: `trajectory-flip-up:${t.projectId}`,
+      kind: 'trajectory-flip-up',
+      tone: 'positive',
+      summary: clip(
+        `${t.projectName} flipped to accelerating (slope ${slope.toFixed(2)}/session) since last scan.`,
+      ),
+      evidence: { projectId: t.projectId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `trajectory-flip-down` (concerning) — mirror of flip-up: a project
+ * that was `trajectory-accelerating` (or absent) is now stalled.
+ *
+ * Score: `clamp(|currentSlope| * 10, 0, 1)`.
+ */
+function computeTrajectoryFlipDown(
+  input: ComputeSurprisesInput,
+  prior: SurprisesOutput | null,
+): Surprise[] {
+  if (prior === null) return [];
+
+  const priorByProject = new Map<string, SurpriseKind>();
+  for (const s of prior.surprises) {
+    if (s.kind !== 'trajectory-accelerating' && s.kind !== 'trajectory-stalled') {
+      continue;
+    }
+    const pid = s.evidence.projectId;
+    if (pid === undefined) continue;
+    priorByProject.set(pid, s.kind);
+  }
+
+  const out: Surprise[] = [];
+  for (const t of input.trajectories) {
+    if (t.classification !== 'stalling' && t.classification !== 'stalled-finished') {
+      continue;
+    }
+    const priorKind = priorByProject.get(t.projectId);
+    if (priorKind === 'trajectory-stalled') continue;
+    const slope = t.slope ?? 0;
+    const score = Math.max(0, Math.min(1, Math.abs(slope) * 10));
+    out.push({
+      id: `trajectory-flip-down:${t.projectId}`,
+      kind: 'trajectory-flip-down',
+      tone: 'concerning',
+      summary: clip(
+        `${t.projectName} flipped to ${t.classification} (slope ${slope.toFixed(2)}/session) since last scan.`,
+      ),
+      evidence: { projectId: t.projectId },
+      score,
+      generatedAt: 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * `pattern-recurrence-resumed` (concerning) — a pattern that was
+ * `pattern-closed` in the prior snapshot is now `pattern-recurring` in
+ * the current one (same patternId). High-attention signal: the user
+ * encoded a rule, it held, and now it's failing again.
+ *
+ * Score: fixed at 0.85.
+ */
+function computePatternRecurrenceResumed(
+  input: ComputeSurprisesInput,
+  prior: SurprisesOutput | null,
+): Surprise[] {
+  if (prior === null) return [];
+
+  const priorClosedIds = new Set<string>();
+  for (const s of prior.surprises) {
+    if (s.kind !== 'pattern-closed') continue;
+    const nid = s.evidence.narrativeId;
+    if (typeof nid === 'string' && nid.length > 0) priorClosedIds.add(nid);
+  }
+  if (priorClosedIds.size === 0) return [];
+
+  const out: Surprise[] = [];
+  for (const w of input.patternWatchers) {
+    if (w.verdict.kind !== 'recurring') continue;
+    if (!priorClosedIds.has(w.patternId)) continue;
+    out.push({
+      id: `pattern-recurrence-resumed:${w.patternId}`,
+      kind: 'pattern-recurrence-resumed',
+      tone: 'concerning',
+      summary: clip(
+        `Pattern ${w.patternId} re-fired after previously holding — narrative ${w.verdict.recurrenceNarrativeId}.`,
+      ),
+      evidence: {
+        projectId: w.projectId,
+        narrativeId: w.verdict.recurrenceNarrativeId,
+      },
+      score: 0.85,
+      generatedAt: 0,
+    });
+  }
+  return out;
 }
 
 // ─── helpers ───────────────────────────────────────────────────────

--- a/packages/analysis/src/dailyBrief.test.ts
+++ b/packages/analysis/src/dailyBrief.test.ts
@@ -219,7 +219,8 @@ describe('buildDailyBrief', () => {
           ],
         },
       });
-      expect(r.markdown).toContain('Shipped this week: 12 commit(s) to main');
+      // Wave 2 — narrative opener line (replaces "Shipped this week: …").
+      expect(r.markdown).toContain('► You shipped 12 commits to main this week.');
       expect(r.markdown).toContain('feat: ship one');
       expect(r.markdown).toContain('refactor: rename five');
       // Top-5 cap on subjects.
@@ -239,6 +240,8 @@ describe('buildDailyBrief', () => {
         continuumHealth: null,
         shippedThisWeek: { commitCount: 0, recentSubjects: [] },
       });
+      // No "you shipped …" header line + no original count line.
+      expect(r.markdown).not.toContain('You shipped');
       expect(r.markdown).not.toContain('Shipped this week');
       expect(r.counts.shippedCommits).toBe(0);
     });
@@ -255,6 +258,7 @@ describe('buildDailyBrief', () => {
         continuumHealth: null,
         shippedThisWeek: null,
       });
+      expect(r.markdown).not.toContain('You shipped');
       expect(r.markdown).not.toContain('Shipped this week');
       expect(r.counts.shippedCommits).toBe(0);
     });
@@ -298,7 +302,9 @@ describe('buildDailyBrief', () => {
           recentSubjects: ['feat: many things'],
         },
       });
-      expect(r.markdown).toContain('1,234 commit(s) to main');
+      // Wave 2 — pluralize + locale grouping carry over into the
+      // new narrative phrasing.
+      expect(r.markdown).toContain('You shipped 1,234 commits to main this week.');
     });
   });
 
@@ -375,7 +381,8 @@ describe('buildDailyBrief', () => {
           },
         ]),
       });
-      expect(r.markdown).toContain('Surprises today: 4 positive, 1 concerning');
+      // Wave 2 — header renamed "Surprises today: …" → "Surprises: …".
+      expect(r.markdown).toContain('► Surprises: 4 positive, 1 concerning.');
       expect(r.markdown).toContain('[streak] 5 in a row');
       expect(r.markdown).toContain(
         '[trajectory-accelerating] Project chat-arch on the rise',
@@ -399,7 +406,11 @@ describe('buildDailyBrief', () => {
         continuumHealth: null,
         surprises: null,
       });
+      // Both the pre-Wave-2 header copy AND the new copy are absent
+      // when the section skips — the assertion guards the rename
+      // against accidental re-introduction.
       expect(r.markdown).not.toContain('Surprises today');
+      expect(r.markdown).not.toMatch(/► Surprises:/u);
       expect(r.counts.surprisesPositive).toBe(0);
       expect(r.counts.surprisesConcerning).toBe(0);
     });
@@ -417,6 +428,7 @@ describe('buildDailyBrief', () => {
         surprises: surprisesFile([]),
       });
       expect(r.markdown).not.toContain('Surprises today');
+      expect(r.markdown).not.toMatch(/► Surprises:/u);
     });
 
     it('handles concerning-only files (zero positive summaries listed)', () => {
@@ -438,7 +450,7 @@ describe('buildDailyBrief', () => {
           },
         ]),
       });
-      expect(r.markdown).toContain('Surprises today: 0 positive, 1 concerning');
+      expect(r.markdown).toContain('► Surprises: 0 positive, 1 concerning.');
       // No positive rows ⇒ no `[kind]` bullet beneath the header.
       expect(r.markdown).not.toContain('[pattern-recurring]');
     });
@@ -508,8 +520,11 @@ describe('buildDailyBrief', () => {
           }),
         ],
       });
+      // Wave 2 — header renamed "Project trajectories: …" →
+      // "Project momentum: …" and bucket label normalised
+      // "stalling/stalled" → "stalling".
       expect(r.markdown).toContain(
-        'Project trajectories: 2 accelerating, 1 flat, 2 stalling/stalled',
+        '► Project momentum: 2 accelerating, 1 flat, 2 stalling.',
       );
       // Top 3 by totalSessions: alpha (50), bravo (40), charlie (30).
       expect(r.markdown).toContain('alpha — accelerating (slope +0.50, 50 sessions)');
@@ -536,6 +551,7 @@ describe('buildDailyBrief', () => {
         projectTrajectories: [],
       });
       expect(r.markdown).not.toContain('Project trajectories');
+      expect(r.markdown).not.toContain('Project momentum');
       expect(r.counts.trajectoriesAccelerating).toBe(0);
       expect(r.counts.trajectoriesFlat).toBe(0);
       expect(r.counts.trajectoriesStalling).toBe(0);
@@ -554,6 +570,7 @@ describe('buildDailyBrief', () => {
         projectTrajectories: null,
       });
       expect(r.markdown).not.toContain('Project trajectories');
+      expect(r.markdown).not.toContain('Project momentum');
     });
 
     it('renders "slope n/a" for null slopes', () => {
@@ -594,9 +611,10 @@ describe('buildDailyBrief', () => {
         continuumHealth: null,
         appliedPatternClosures: 4,
       });
-      expect(r.markdown).toContain(
-        'Applied-pattern closures: 4 pattern(s) held (no recurrence past cooldown)',
-      );
+      // Wave 2 — narrative header "K pattern(s) you applied are still
+      // holding." (pre-Wave-2: "Applied-pattern closures: K pattern(s)
+      // held (no recurrence past cooldown)").
+      expect(r.markdown).toContain('► 4 patterns you applied are still holding.');
       expect(r.counts.appliedPatternClosures).toBe(4);
     });
 
@@ -613,6 +631,7 @@ describe('buildDailyBrief', () => {
         appliedPatternClosures: 0,
       });
       expect(r.markdown).not.toContain('Applied-pattern closures');
+      expect(r.markdown).not.toContain('you applied are still holding');
       expect(r.counts.appliedPatternClosures).toBe(0);
     });
 
@@ -629,6 +648,7 @@ describe('buildDailyBrief', () => {
         appliedPatternClosures: null,
       });
       expect(r.markdown).not.toContain('Applied-pattern closures');
+      expect(r.markdown).not.toContain('you applied are still holding');
       expect(r.counts.appliedPatternClosures).toBe(0);
     });
   });
@@ -682,11 +702,15 @@ describe('buildDailyBrief', () => {
       ],
       appliedPatternClosures: 1,
     });
-    const audit = r.markdown.indexOf('audit concern');
-    const shipped = r.markdown.indexOf('Shipped this week');
-    const surprises = r.markdown.indexOf('Surprises today');
-    const trajectories = r.markdown.indexOf('Project trajectories');
-    const closures = r.markdown.indexOf('Applied-pattern closures');
+    // Wave 2 — anchors updated to new section headers. The audit
+    // section's narrative opener leads with the count + "didn't have
+    // supporting tool calls" phrase; the rest of the openers each lift
+    // a unique substring.
+    const audit = r.markdown.indexOf("didn't have supporting tool calls");
+    const shipped = r.markdown.indexOf('You shipped');
+    const surprises = r.markdown.indexOf('► Surprises:');
+    const trajectories = r.markdown.indexOf('Project momentum');
+    const closures = r.markdown.indexOf('you applied are still holding');
     const continuum = r.markdown.indexOf('Continuum health');
     expect(audit).toBeGreaterThan(-1);
     expect(shipped).toBeGreaterThan(audit);
@@ -694,5 +718,332 @@ describe('buildDailyBrief', () => {
     expect(trajectories).toBeGreaterThan(surprises);
     expect(closures).toBeGreaterThan(trajectories);
     expect(continuum).toBeGreaterThan(closures);
+  });
+
+  // ── Wave 2 — journal-y opener paragraph ──────────────────────────
+
+  describe('opener paragraph', () => {
+    it('opens with the shipped-commit narrative when commits exist', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: {
+          commitCount: 7,
+          recentSubjects: [
+            'feat: opener test one',
+            'fix: opener test two',
+            'chore: opener test three',
+          ],
+        },
+      });
+      expect(r.markdown).toContain(
+        'This week you shipped 7 commits to main.',
+      );
+      // Top 1-2 subjects inlined; the 3rd subject is shipped-section
+      // detail only and shouldn't promote into the opener.
+      expect(r.markdown).toContain(
+        'Top of the list: "feat: opener test one" and "fix: opener test two".',
+      );
+      expect(r.markdown.indexOf('Top of the list')).toBeLessThan(
+        r.markdown.indexOf('► You shipped'),
+      );
+    });
+
+    it('inlines a single subject when only one is provided', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: {
+          commitCount: 1,
+          recentSubjects: ['feat: solo commit'],
+        },
+      });
+      expect(r.markdown).toContain('This week you shipped 1 commit to main.');
+      expect(r.markdown).toContain('Top of the list: "feat: solo commit".');
+      // Singular form: no trailing "s" on "commit" anywhere in the
+      // opener line.
+      expect(r.markdown).not.toContain('1 commits');
+    });
+
+    it('opens with the strongest signal when no commits but a STRONG positive', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: null,
+        topStrongPositiveSurprise: '8 sessions in a row landed as composite-good.',
+      });
+      expect(r.markdown).toContain(
+        'The strongest signal: 8 sessions in a row landed as composite-good.',
+      );
+      // The opener-fallback line must NOT appear.
+      expect(r.markdown).not.toContain('Quiet week');
+      expect(r.markdown).not.toContain('This week you shipped');
+    });
+
+    it('opens with a quiet-week disclaimer when neither commits nor strong positives', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: null,
+        topStrongPositiveSurprise: null,
+      });
+      expect(r.markdown).toContain(
+        'Quiet week — no commits to main and no strong positive signals.',
+      );
+      expect(r.markdown).not.toContain('This week you shipped');
+      expect(r.markdown).not.toContain('The strongest signal');
+    });
+
+    it('prefers the shipped-opener when both shipped AND strong positives exist', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: {
+          commitCount: 3,
+          recentSubjects: ['feat: dominant'],
+        },
+        topStrongPositiveSurprise: 'streak summary that should be suppressed',
+      });
+      // Shipped wins; the strongest-signal line does not appear in the
+      // opener (the surprise itself still gets its dedicated section
+      // when surprises != null — but that's a separate concern).
+      expect(r.markdown).toContain('This week you shipped 3 commits to main.');
+      expect(r.markdown).not.toContain('The strongest signal:');
+    });
+  });
+
+  // ── Wave 2 — narrative section openers ───────────────────────────
+
+  describe('audit-concerns narrative opener', () => {
+    it('renders the singular phrasing when one claim fails', () => {
+      const fail: AuditResult = {
+        sessionId: 'sid-x',
+        source: 'cowork',
+        lineNumber: 1,
+        claimType: 'tests-pass-claim',
+        span: 'green',
+        surroundingContext: 'ctx',
+        outcome: 'fail',
+        reason: 'no tool calls',
+      };
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [fail],
+        auditSummary: null,
+        continuumHealth: null,
+      });
+      // Singular "1 claim"; underlying bullet still appears.
+      expect(r.markdown).toContain(
+        "► 1 claim didn't have supporting tool calls this week.",
+      );
+      expect(r.markdown).toContain('[SID:sid-x]');
+      // Singular discipline: never "1 claims".
+      expect(r.markdown).not.toContain('1 claims');
+    });
+
+    it('reports the full failure count even when the bullet list is truncated', () => {
+      // Generate 8 failures — top-N cap is 5 (DEFAULT_THRESHOLDS), so
+      // the bullet list should be 5 long but the opener should report 8.
+      const fails: AuditResult[] = Array.from({ length: 8 }, (_, i) => ({
+        sessionId: `sid-${String(i).padStart(2, '0')}`,
+        source: 'cowork',
+        lineNumber: 1,
+        claimType: 'tests-pass-claim',
+        span: 'green',
+        surroundingContext: 'ctx',
+        outcome: 'fail',
+        reason: `r${i}`,
+      }));
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: fails,
+        auditSummary: null,
+        continuumHealth: null,
+      });
+      expect(r.markdown).toContain(
+        "► 8 claims didn't have supporting tool calls this week.",
+      );
+      // Top-N cap on bullets: ids 00..04 listed, 05..07 not.
+      expect(r.markdown).toContain('[SID:sid-04]');
+      expect(r.markdown).not.toContain('[SID:sid-05]');
+    });
+
+    it('skips the section entirely when no audit failures exist', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+      });
+      expect(r.markdown).not.toContain("didn't have supporting tool calls");
+      expect(r.markdown).not.toContain('audit concern');
+    });
+  });
+
+  describe('surprises STRONG framing', () => {
+    it('promotes a STRONG positive into a "standout positive" sentence', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([
+          {
+            kind: 'streak',
+            tone: 'positive',
+            summary: 'big streak summary',
+            score: 0.9, // STRONG (≥ 0.75)
+          },
+          {
+            kind: 'config-helped',
+            tone: 'positive',
+            summary: 'moderate positive summary',
+            score: 0.6, // MODERATE — must NOT promote
+          },
+        ]),
+      });
+      expect(r.markdown).toContain('The standout positive: big streak summary');
+      // Moderate positive doesn't get a "standout" sentence — but it
+      // still appears in the bulleted list below.
+      expect(r.markdown).not.toContain(
+        'The standout positive: moderate positive summary',
+      );
+      expect(r.markdown).toContain('[config-helped] moderate positive summary');
+    });
+
+    it('promotes a STRONG concerning into a "worth attention" sentence', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([
+          {
+            kind: 'pattern-recurring',
+            tone: 'concerning',
+            summary: 'a pattern recurred',
+            score: 0.95,
+          },
+        ]),
+      });
+      expect(r.markdown).toContain('Worth attention: a pattern recurred');
+    });
+
+    it('omits both STRONG sentences when only MODERATE/WEAK rows exist', () => {
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [],
+        auditSummary: null,
+        continuumHealth: null,
+        surprises: surprisesFile([
+          {
+            kind: 'streak',
+            tone: 'positive',
+            summary: 'mid-band positive',
+            score: 0.6,
+          },
+          {
+            kind: 'trajectory-stalled',
+            tone: 'concerning',
+            summary: 'mid-band concerning',
+            score: 0.55,
+          },
+        ]),
+      });
+      // Count header still appears…
+      expect(r.markdown).toContain('► Surprises: 1 positive, 1 concerning.');
+      // …but neither STRONG promotion sentence does.
+      expect(r.markdown).not.toContain('The standout positive');
+      expect(r.markdown).not.toContain('Worth attention');
+    });
+  });
+
+  describe('singular/plural discipline', () => {
+    it('renders all single-count phrasings with no trailing "s"', () => {
+      const fail: AuditResult = {
+        sessionId: 'sid-solo',
+        source: 'cowork',
+        lineNumber: 1,
+        claimType: 'tests-pass-claim',
+        span: 'green',
+        surroundingContext: 'ctx',
+        outcome: 'fail',
+        reason: 'r',
+      };
+      const r = buildDailyBrief({
+        date: '2026-05-16',
+        now: NOW,
+        patterns: [],
+        upgradeOutcomes: [],
+        blogDrafts: [],
+        auditResults: [fail],
+        auditSummary: null,
+        continuumHealth: null,
+        shippedThisWeek: { commitCount: 1, recentSubjects: ['feat: solo'] },
+        appliedPatternClosures: 1,
+      });
+      // Spot-check the singular forms.
+      expect(r.markdown).toContain('1 commit to main');
+      expect(r.markdown).toContain('1 claim');
+      expect(r.markdown).toContain('1 pattern you applied');
+      // The 6-tuple of "1 NOUNs" we explicitly want to avoid.
+      expect(r.markdown).not.toContain('1 commits');
+      expect(r.markdown).not.toContain('1 claims');
+      expect(r.markdown).not.toContain('1 patterns you applied');
+    });
   });
 });

--- a/packages/analysis/src/dailyBrief.test.ts
+++ b/packages/analysis/src/dailyBrief.test.ts
@@ -794,7 +794,7 @@ describe('buildDailyBrief', () => {
         'The strongest signal: 8 sessions in a row landed as composite-good.',
       );
       // The opener-fallback line must NOT appear.
-      expect(r.markdown).not.toContain('Quiet week');
+      expect(r.markdown).not.toContain('No commits to main this week');
       expect(r.markdown).not.toContain('This week you shipped');
     });
 
@@ -811,8 +811,11 @@ describe('buildDailyBrief', () => {
         shippedThisWeek: null,
         topStrongPositiveSurprise: null,
       });
+      // Wave-2 review iter-1 fix A3: opener rephrased to drop kernel-tier
+      // jargon ("strong positive signals") and to survive concerning-heavy
+      // weeks (where "Quiet" would have been misleading).
       expect(r.markdown).toContain(
-        'Quiet week — no commits to main and no strong positive signals.',
+        'No commits to main this week; the sections below summarize everything else.',
       );
       expect(r.markdown).not.toContain('This week you shipped');
       expect(r.markdown).not.toContain('The strongest signal');

--- a/packages/analysis/src/dailyBrief.ts
+++ b/packages/analysis/src/dailyBrief.ts
@@ -1,28 +1,38 @@
 /**
  * Daily brief generator — spec §5 Layer D, D.1 + D.3, extended by
- * feed-redesign Phase γ.
+ * feed-redesign Phase γ + Wave 2 narrative-voice pass.
  *
  * Pure function. Reads pre-loaded analysis inputs (the Node shell parses
  * each sidecar from disk and runs `git log` for the shipped-this-week
  * counter) and returns the markdown body plus a small summary record.
  * Sections with zero entries are silent — no padding, per D.3.
  *
- * Output shape (Phase γ):
+ * Output shape (Wave 2):
  *   TODAY · YYYY-MM-DD
  *   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ *   <one-paragraph journal opener>        (Wave 2 — see openerLine())
+ *
  *   ► N patterns shifted this week
  *   ► N upgrades to propose
  *   ► N blog drafts ready for review
- *   ► N audit concerns
- *   ► Shipped this week: N commits to main      (Phase γ §1)
- *   ► Surprises today: P positive, C concerning (Phase γ §2)
- *   ► Project trajectories: A accelerating, …   (Phase γ §3)
- *   ► Applied-pattern closures: K patterns held (Phase γ §4)
+ *   ► X claim(s) didn't have supporting tool calls this week.
+ *   ► You shipped N commits to main this week.
+ *   ► Surprises: P positive, C concerning.
+ *   ► Project momentum: A accelerating, F flat, S stalling.
+ *   ► K pattern(s) you applied are still holding.
  *   ► Continuum health: …
  *
- * The new sections render BETWEEN audit concerns and continuum health.
- * Each new section is independently skippable — empty inputs render
- * nothing (no header, no body), matching the existing convention.
+ * Per-section openers now read in narrative voice ("you shipped",
+ * "the standout positive", "worth attention") rather than as a stat
+ * dump. The opener paragraph at the top is a single-line summary that
+ * mentions the week's commits OR the strongest positive signal OR a
+ * quiet-week disclaimer — whichever is most informative.
+ *
+ * Each section is independently skippable — empty inputs render nothing
+ * (no header, no body), matching the existing convention. The opener
+ * paragraph itself only emits prose for the conditions that fire; the
+ * quiet-week fallback emits only when BOTH shipped commits and strong
+ * positive surprises are absent.
  */
 
 import type {
@@ -34,7 +44,7 @@ import type {
   ProposedUpgrade,
   UpgradeOutcome,
 } from '@chat-arch/schema';
-import type { SurprisesOutput } from './computeSurprises.js';
+import { SURPRISE_TIER_STRONG_MIN, type SurprisesOutput } from './computeSurprises.js';
 
 export interface BriefThresholds {
   /** Patterns whose lastSeen falls within the last N days count as "shifted this week". */
@@ -130,6 +140,15 @@ export interface DailyBriefInputs {
    * (section skipped — see code-comment in the section).
    */
   appliedPatternClosures?: number | null;
+  /**
+   * Wave 2 — top STRONG positive surprise summary (tier ≥ STRONG, i.e.
+   * `score ≥ SURPRISE_TIER_STRONG_MIN`). Used to seed the opener
+   * paragraph when commits are absent but a high-confidence positive
+   * signal exists. Pass `null` when no STRONG positive row exists in
+   * `analysis/surprises.json`. The Node shell is responsible for the
+   * tier filter; we just consume the precomputed string.
+   */
+  topStrongPositiveSurprise?: string | null;
 }
 
 export interface DailyBriefResult {
@@ -172,6 +191,21 @@ function clip120(s: string): string {
   return `${trimmed.slice(0, max - 1)}…`;
 }
 
+/**
+ * Singular/plural form helper. `pluralize(1, 'commit')` → `'1 commit'`;
+ * `pluralize(2, 'commit')` → `'2 commits'`. Numbers ≥ 1000 use locale-
+ * grouped formatting so "1,234 commits" reads cleanly.
+ *
+ * For irregular plurals (e.g. "pattern(s)" → "pattern" vs "patterns")
+ * the default 's' suffix is sufficient for everything the brief
+ * currently surfaces. If a future section needs irregular forms, accept
+ * a 3rd `pluralForm` arg rather than introducing an irregular-table.
+ */
+function pluralize(n: number, singular: string): string {
+  const count = n.toLocaleString();
+  return n === 1 ? `${count} ${singular}` : `${count} ${singular}s`;
+}
+
 function pickHeadline(upgrades: readonly ProposedUpgrade[]): string {
   for (const u of upgrades) {
     if (typeof u.headline === 'string' && u.headline.length > 0) return u.headline;
@@ -195,6 +229,42 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
   out.push(`TODAY · ${inputs.date}`);
   out.push(RULE_LINE);
   out.push('');
+
+  // ---- Wave 2 — journal-y opener paragraph ----
+  // Three mutually-exclusive paths, evaluated in priority order:
+  //   1. commits exist     → "This week you shipped N commits to main."
+  //                          (+ inline mention of top 1-2 subjects)
+  //   2. strong+ surprise  → "The strongest signal: <summary>"
+  //   3. neither           → quiet-week disclaimer
+  // The opener is a single short paragraph rendered above the bare
+  // `► section` lines below. Skips entirely if none of the above apply
+  // (currently impossible — branch 3 is the catch-all — but keeping
+  // the gate makes the contract explicit if a future redesign drops
+  // the quiet-week line).
+  const openerShipped = inputs.shippedThisWeek ?? null;
+  const openerStrong = inputs.topStrongPositiveSurprise ?? null;
+  if (openerShipped !== null && openerShipped.commitCount > 0) {
+    const subjects = openerShipped.recentSubjects.slice(0, 2);
+    const parts: string[] = [
+      `This week you shipped ${pluralize(openerShipped.commitCount, 'commit')} to main.`,
+    ];
+    if (subjects.length === 1) {
+      parts.push(`Top of the list: "${clip120(subjects[0] as string)}".`);
+    } else if (subjects.length >= 2) {
+      parts.push(
+        `Top of the list: "${clip120(subjects[0] as string)}" and ` +
+          `"${clip120(subjects[1] as string)}".`,
+      );
+    }
+    out.push(parts.join(' '));
+    out.push('');
+  } else if (openerStrong !== null && openerStrong.length > 0) {
+    out.push(`The strongest signal: ${clip120(openerStrong)}`);
+    out.push('');
+  } else {
+    out.push('Quiet week — no commits to main and no strong positive signals.');
+    out.push('');
+  }
 
   // ---- Patterns shifted ----
   const windowStart = inputs.now - thresholds.patternRecencyDays * 24 * 3600 * 1000;
@@ -253,20 +323,25 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     out.push('');
   }
 
-  // ---- Audit concerns ----
-  const failures = inputs.auditResults
-    .filter((r) => r.outcome === 'fail')
+  // ---- Audit concerns (Wave 2 — narrative opener) ----
+  // Count uses the FULL failures count, not the top-N slice — the
+  // opener reports "this week's misses" honestly even when only the
+  // top 5 are listed below.
+  const allFailures = inputs.auditResults.filter((r) => r.outcome === 'fail');
+  const failures = [...allFailures]
     .sort((a, b) => a.sessionId.localeCompare(b.sessionId))
     .slice(0, thresholds.auditConcernsShown);
   if (failures.length > 0) {
-    out.push(`► ${failures.length} audit concern(s)`);
+    out.push(
+      `► ${pluralize(allFailures.length, 'claim')} didn't have supporting tool calls this week.`,
+    );
     for (const f of failures) {
       out.push(`  • Session [SID:${f.sessionId}] claimed "${f.span}" — ${f.reason}`);
     }
     out.push('');
   }
 
-  // ---- Phase γ §1 — Shipped this week ----
+  // ---- Phase γ §1 — Shipped this week (Wave 2 — narrative opener) ----
   // Skipped when `commitCount === 0` (the section is meaningless with
   // no commits, per spec). The Node shell is responsible for the
   // `git log` invocation; we just format the precomputed numbers.
@@ -275,7 +350,7 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
   if (shipped !== null && shipped.commitCount > 0) {
     shippedCommits = shipped.commitCount;
     out.push(
-      `► Shipped this week: ${shipped.commitCount.toLocaleString()} commit(s) to main`,
+      `► You shipped ${pluralize(shipped.commitCount, 'commit')} to main this week.`,
     );
     for (const subject of shipped.recentSubjects.slice(
       0,
@@ -286,9 +361,17 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     out.push('');
   }
 
-  // ---- Phase γ §2 — Surprises today ----
+  // ---- Phase γ §2 — Surprises today (Wave 2 — narrative opener) ----
   // Source: `analysis/surprises.json`. Skipped when the file is
   // missing (input is null) OR when both tones contribute zero rows.
+  // After the header line we add two optional framing sentences:
+  //   - "The standout positive: <top STRONG positive summary>."
+  //   - "Worth attention: <top STRONG concerning summary>."
+  // STRONG = score ≥ SURPRISE_TIER_STRONG_MIN (0.75 — see
+  // computeSurprises.ts `surpriseConfidenceTier`). The framing only
+  // fires when there's a STRONG row in that tone; mid-band positives
+  // still show up in the bulleted list below but don't get a sentence
+  // promotion. This keeps the prose from over-claiming on weak signals.
   const surprises = inputs.surprises ?? null;
   let surprisesPositive = 0;
   let surprisesConcerning = 0;
@@ -299,9 +382,22 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     }
     if (surprisesPositive + surprisesConcerning > 0) {
       out.push(
-        `► Surprises today: ${surprisesPositive.toLocaleString()} positive, ` +
-          `${surprisesConcerning.toLocaleString()} concerning`,
+        `► Surprises: ${surprisesPositive.toLocaleString()} positive, ` +
+          `${surprisesConcerning.toLocaleString()} concerning.`,
       );
+      // STRONG-tier framing (kernel pre-sorts by score desc).
+      const topStrongPositive = surprises.surprises.find(
+        (s) => s.tone === 'positive' && s.score >= SURPRISE_TIER_STRONG_MIN,
+      );
+      const topStrongConcerning = surprises.surprises.find(
+        (s) => s.tone === 'concerning' && s.score >= SURPRISE_TIER_STRONG_MIN,
+      );
+      if (topStrongPositive !== undefined) {
+        out.push(`  The standout positive: ${clip120(topStrongPositive.summary)}`);
+      }
+      if (topStrongConcerning !== undefined) {
+        out.push(`  Worth attention: ${clip120(topStrongConcerning.summary)}`);
+      }
       // Top 3 positive — kernel pre-sorts by score desc; just slice.
       const topPositive = surprises.surprises
         .filter((s) => s.tone === 'positive')
@@ -327,9 +423,9 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
       else trajectoriesStalling += 1; // 'stalling' + 'stalled-finished'
     }
     out.push(
-      `► Project trajectories: ${trajectoriesAccelerating.toLocaleString()} accelerating, ` +
+      `► Project momentum: ${trajectoriesAccelerating.toLocaleString()} accelerating, ` +
         `${trajectoriesFlat.toLocaleString()} flat, ` +
-        `${trajectoriesStalling.toLocaleString()} stalling/stalled`,
+        `${trajectoriesStalling.toLocaleString()} stalling.`,
     );
     // Top 3 most-active by totalSessions; tie-break on projectId for
     // determinism (sort is otherwise non-stable for equal keys).
@@ -369,8 +465,7 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
   if (closures !== null && closures > 0) {
     appliedPatternClosures = closures;
     out.push(
-      `► Applied-pattern closures: ${closures.toLocaleString()} pattern(s) held ` +
-        `(no recurrence past cooldown)`,
+      `► ${pluralize(closures, 'pattern')} you applied are still holding.`,
     );
     out.push('');
   }

--- a/packages/analysis/src/dailyBrief.ts
+++ b/packages/analysis/src/dailyBrief.ts
@@ -262,7 +262,13 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     out.push(`The strongest signal: ${clip120(openerStrong)}`);
     out.push('');
   } else {
-    out.push('Quiet week — no commits to main and no strong positive signals.');
+    // Wave-2 review iter-1 fix: catch-all opener used to say "no strong
+    // positive signals" — kernel-tier jargon ("signals", "strong") that
+    // a reader doesn't have context for. Also misleading when a STRONG
+    // concerning surprise exists below (reader sees "Quiet" then a wall
+    // of red two lines later). Reworded to neutral framing that survives
+    // a concerning-heavy week.
+    out.push('No commits to main this week; the sections below summarize everything else.');
     out.push('');
   }
 
@@ -272,10 +278,10 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     .filter((p) => p.lastSeen >= windowStart)
     .sort(sortByLastSeenDesc);
   if (shifted.length > 0) {
-    out.push(`► ${shifted.length} pattern(s) shifted in the last ${thresholds.patternRecencyDays} days`);
+    out.push(`► ${pluralize(shifted.length, 'pattern')} shifted in the last ${thresholds.patternRecencyDays} days`);
     for (const p of shifted.slice(0, 5)) {
       out.push(`  • ${shortenRule(p.canonicalRule)}`);
-      out.push(`    (${p.occurrenceCount} occurrence(s), scope=${p.scope.kind})`);
+      out.push(`    (${pluralize(p.occurrenceCount, 'occurrence')}, scope=${p.scope.kind})`);
     }
     out.push('');
   }
@@ -296,7 +302,7 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     })
     .slice(0, thresholds.upgradesShown);
   if (upgradeCandidates.length > 0) {
-    out.push(`► ${upgradeCandidates.length} upgrade(s) to propose`);
+    out.push(`► ${pluralize(upgradeCandidates.length, 'upgrade')} to propose`);
     for (const p of upgradeCandidates) {
       out.push(
         `  • ${pickUpgradeTarget(p.proposedUpgrades)}: "${pickHeadline(p.proposedUpgrades)}"`,
@@ -313,7 +319,7 @@ export function buildDailyBrief(inputs: DailyBriefInputs): DailyBriefResult {
     .sort((a, b) => b.audit.passRate - a.audit.passRate)
     .slice(0, thresholds.blogDraftsShown);
   if (sortedDrafts.length > 0) {
-    out.push(`► ${sortedDrafts.length} blog draft(s) ready for review`);
+    out.push(`► ${pluralize(sortedDrafts.length, 'blog draft')} ready for review`);
     for (const d of sortedDrafts) {
       const pct = (d.audit.passRate * 100).toFixed(0);
       out.push(

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -398,10 +398,14 @@ export {
 
 export {
   computeSurprises,
+  surpriseConfidenceTier,
+  SURPRISE_TIER_MODERATE_MIN,
+  SURPRISE_TIER_STRONG_MIN,
   type ComputeSurprisesInput,
   type ComputeSurprisesOptions,
   type Surprise,
   type SurpriseCompositeRow,
+  type SurpriseConfidenceTier,
   type SurpriseDecisionRow,
   type SurpriseEvidence,
   type SurpriseKind,

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -421,6 +421,19 @@ export const THRESHOLDS = {
     debtSpinningTopK: 3,
     /** Minimum cluster size for `debt-spinning`. */
     debtSpinningMinClusterSize: 3,
+    /**
+     * Wave 2 #1 — delta surprises. The builder archives each rescan's
+     * `surprises.json` to `analysis/archive/surprises-YYYY-MM-DD.json`,
+     * then prunes files older than this many days. The next scan reads
+     * the most recent archive (NOT today's) as `priorSurprises` so the
+     * kernel can emit DELTA observations (`streak-extended`,
+     * `streak-broken`, `trajectory-flip-up`, `trajectory-flip-down`,
+     * `pattern-recurrence-resumed`) on top of the snapshot kinds. When
+     * no prior archive exists the delta kinds skip cleanly (fail-soft).
+     * 30 days ≈ one rescan-per-day month of history; raise if calibrated
+     * cadence is lower.
+     */
+    archiveRetentionDays: 30,
   },
   /**
    * Rev3 applied-rule outcome watcher (plan §"Three closures" —

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -172,8 +172,19 @@ export interface RunAnalysisResult {
  * artifact — the brief shape change is internal to the regen-brief
  * endpoint's output markdown — but the patch bump labels the bundle so
  * operators can correlate.
+ *
+ * Bumped 1.4.1 → 1.5.0 in feed-redesign Wave 2 #1 (delta surprises):
+ * a new `analysis/archive/` sidecar family lands —
+ * `surprises-YYYY-MM-DD.json` daily snapshots that the
+ * `surprisesBuilder` writes after each scan and reads on the NEXT scan
+ * to feed the kernel's new `priorSurprises` input. Five new delta
+ * surprise kinds (streak-extended / streak-broken / trajectory-flip-up
+ * / trajectory-flip-down / pattern-recurrence-resumed) emit when a
+ * prior archive exists; on a first-ever scan they skip cleanly. New
+ * threshold `THRESHOLDS.surprises.archiveRetentionDays = 30` gates the
+ * filename-based prune.
  */
-export const EXPORTER_VERSION = '1.4.1';
+export const EXPORTER_VERSION = '1.5.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/analysis/surprisesBuilder.test.ts
+++ b/packages/exporter/src/analysis/surprisesBuilder.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for `surprisesBuilder` — Wave 2 #1 delta surprises.
+ *
+ * Focuses on the archive read / write / prune lifecycle introduced for
+ * delta-kind detection. The kernel itself is unit-tested in
+ * `computeSurprises.test.ts`; here we exercise the I/O shell.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdir, readdir, readFile, writeFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { THRESHOLDS } from '@chat-arch/analysis';
+import type { SurprisesOutput } from '@chat-arch/analysis';
+import {
+  archiveAndPrune,
+  loadMostRecentArchive,
+} from './surprisesBuilder.js';
+
+const tmpRoot = path.join(
+  os.tmpdir(),
+  `chat-arch-surprises-builder-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+);
+
+function mkOutput(stamp: number): SurprisesOutput {
+  return {
+    version: 1,
+    generatedAt: stamp,
+    surprises: [],
+    thresholds: {
+      streakMin: THRESHOLDS.surprises.streakMin,
+      itsQValueMax: THRESHOLDS.surprises.itsQValueMax,
+      itsDeltaMin: THRESHOLDS.surprises.itsDeltaMin,
+      reflexiveDeltaMin: THRESHOLDS.surprises.reflexiveDeltaMin,
+      reflexiveEValueMin: THRESHOLDS.surprises.reflexiveEValueMin,
+      decisionGoodFollowupsMin: THRESHOLDS.surprises.decisionGoodFollowupsMin,
+      debtSpinningTopK: THRESHOLDS.surprises.debtSpinningTopK,
+      debtSpinningMinClusterSize:
+        THRESHOLDS.surprises.debtSpinningMinClusterSize,
+    },
+  };
+}
+
+function dayMs(days: number): number {
+  return days * 24 * 60 * 60 * 1000;
+}
+
+describe('surprisesBuilder — loadMostRecentArchive', () => {
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns null when archive directory does not exist', async () => {
+    const analysisDir = path.join(tmpRoot, 'no-archive', 'analysis');
+    await mkdir(analysisDir, { recursive: true });
+    const prior = await loadMostRecentArchive(analysisDir);
+    expect(prior).toBeNull();
+  });
+
+  it('returns null when archive directory is empty', async () => {
+    const analysisDir = path.join(tmpRoot, 'empty-archive', 'analysis');
+    await mkdir(path.join(analysisDir, 'archive'), { recursive: true });
+    const prior = await loadMostRecentArchive(analysisDir);
+    expect(prior).toBeNull();
+  });
+
+  it('loads the most recent dated file by filename (lexicographic = chronological)', async () => {
+    const analysisDir = path.join(tmpRoot, 'three-files', 'analysis');
+    const archive = path.join(analysisDir, 'archive');
+    await mkdir(archive, { recursive: true });
+    await writeFile(
+      path.join(archive, 'surprises-2026-04-01.json'),
+      JSON.stringify(mkOutput(1)),
+    );
+    await writeFile(
+      path.join(archive, 'surprises-2026-04-15.json'),
+      JSON.stringify(mkOutput(15)),
+    );
+    await writeFile(
+      path.join(archive, 'surprises-2026-04-10.json'),
+      JSON.stringify(mkOutput(10)),
+    );
+    const prior = await loadMostRecentArchive(analysisDir);
+    expect(prior).not.toBeNull();
+    expect(prior?.generatedAt).toBe(15);
+  });
+
+  it('excludes today\'s stamp from candidates', async () => {
+    const analysisDir = path.join(tmpRoot, 'exclude-today', 'analysis');
+    const archive = path.join(analysisDir, 'archive');
+    await mkdir(archive, { recursive: true });
+    await writeFile(
+      path.join(archive, 'surprises-2026-05-01.json'),
+      JSON.stringify(mkOutput(1)),
+    );
+    await writeFile(
+      path.join(archive, 'surprises-2026-05-24.json'),
+      JSON.stringify(mkOutput(24)),
+    );
+    const prior = await loadMostRecentArchive(analysisDir, {
+      todayStamp: '2026-05-24',
+    });
+    expect(prior).not.toBeNull();
+    expect(prior?.generatedAt).toBe(1);
+  });
+
+  it('returns null when only today\'s file exists', async () => {
+    const analysisDir = path.join(tmpRoot, 'only-today', 'analysis');
+    const archive = path.join(analysisDir, 'archive');
+    await mkdir(archive, { recursive: true });
+    await writeFile(
+      path.join(archive, 'surprises-2026-05-24.json'),
+      JSON.stringify(mkOutput(24)),
+    );
+    const prior = await loadMostRecentArchive(analysisDir, {
+      todayStamp: '2026-05-24',
+    });
+    expect(prior).toBeNull();
+  });
+
+  it('ignores non-matching filenames in the archive directory', async () => {
+    const analysisDir = path.join(tmpRoot, 'mixed-names', 'analysis');
+    const archive = path.join(analysisDir, 'archive');
+    await mkdir(archive, { recursive: true });
+    await writeFile(path.join(archive, 'README.md'), 'noise');
+    await writeFile(path.join(archive, 'surprises.json'), 'noise');
+    await writeFile(
+      path.join(archive, 'surprises-2026-05-01.json'),
+      JSON.stringify(mkOutput(1)),
+    );
+    const prior = await loadMostRecentArchive(analysisDir);
+    expect(prior).not.toBeNull();
+    expect(prior?.generatedAt).toBe(1);
+  });
+
+  it('returns null when most recent file is unparseable JSON (fail-soft)', async () => {
+    const analysisDir = path.join(tmpRoot, 'broken-json', 'analysis');
+    const archive = path.join(analysisDir, 'archive');
+    await mkdir(archive, { recursive: true });
+    await writeFile(
+      path.join(archive, 'surprises-2026-05-15.json'),
+      '{not-json',
+    );
+    const prior = await loadMostRecentArchive(analysisDir);
+    expect(prior).toBeNull();
+  });
+});
+
+describe('surprisesBuilder — archiveAndPrune', () => {
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes today\'s file under archive/ with the YYYY-MM-DD stamp', async () => {
+    const analysisDir = path.join(tmpRoot, 'write', 'analysis');
+    await mkdir(analysisDir, { recursive: true });
+    const now = Date.UTC(2026, 4, 24); // 2026-05-24
+    await archiveAndPrune(analysisDir, mkOutput(now), {
+      now,
+      retentionDays: 30,
+    });
+    const entries = await readdir(path.join(analysisDir, 'archive'));
+    expect(entries).toContain('surprises-2026-05-24.json');
+    const raw = await readFile(
+      path.join(analysisDir, 'archive', 'surprises-2026-05-24.json'),
+      'utf8',
+    );
+    const parsed = JSON.parse(raw) as SurprisesOutput;
+    expect(parsed.generatedAt).toBe(now);
+  });
+
+  it('prunes files older than retentionDays (filename-based)', async () => {
+    const analysisDir = path.join(tmpRoot, 'prune', 'analysis');
+    const archive = path.join(analysisDir, 'archive');
+    await mkdir(archive, { recursive: true });
+    // Pre-seed with several files, half within retention, half outside.
+    const now = Date.UTC(2026, 4, 24); // 2026-05-24
+    const retentionDays = 30;
+    await writeFile(
+      path.join(archive, 'surprises-2026-03-01.json'),
+      JSON.stringify(mkOutput(1)),
+    );
+    await writeFile(
+      path.join(archive, 'surprises-2026-04-01.json'),
+      JSON.stringify(mkOutput(2)),
+    );
+    await writeFile(
+      path.join(archive, 'surprises-2026-04-25.json'),
+      JSON.stringify(mkOutput(3)),
+    );
+    await writeFile(
+      path.join(archive, 'surprises-2026-05-10.json'),
+      JSON.stringify(mkOutput(4)),
+    );
+    await archiveAndPrune(analysisDir, mkOutput(now), {
+      now,
+      retentionDays,
+    });
+    const remaining = (await readdir(archive))
+      .filter((n) => /^surprises-\d{4}-\d{2}-\d{2}\.json$/.test(n))
+      .sort();
+    // Cutoff = today - 30 = 2026-04-24. Anything strictly older than
+    // that is pruned (2026-03-01 + 2026-04-01). 2026-04-25 stays
+    // because 2026-04-25 >= 2026-04-24.
+    expect(remaining).toEqual([
+      'surprises-2026-04-25.json',
+      'surprises-2026-05-10.json',
+      'surprises-2026-05-24.json',
+    ]);
+  });
+
+  it('always retains today\'s freshly-written file (within retention by definition)', async () => {
+    const analysisDir = path.join(tmpRoot, 'today-retained', 'analysis');
+    await mkdir(analysisDir, { recursive: true });
+    const now = Date.UTC(2026, 4, 24);
+    await archiveAndPrune(analysisDir, mkOutput(now), {
+      now,
+      retentionDays: 0, // aggressive; today still survives
+    });
+    const entries = await readdir(path.join(analysisDir, 'archive'));
+    expect(entries).toContain('surprises-2026-05-24.json');
+  });
+
+  it('creates archive/ directory when missing', async () => {
+    const analysisDir = path.join(tmpRoot, 'mkdir', 'analysis');
+    await mkdir(analysisDir, { recursive: true });
+    const now = Date.UTC(2026, 4, 24);
+    await archiveAndPrune(analysisDir, mkOutput(now), {
+      now,
+      retentionDays: 30,
+    });
+    const stat = await readdir(path.join(analysisDir, 'archive'));
+    expect(stat.length).toBeGreaterThan(0);
+  });
+
+  it('next-day call loads yesterday\'s file as most-recent prior', async () => {
+    // Full round-trip: archive day 1, then call loadMostRecentArchive
+    // on day 2 and confirm we get the day-1 snapshot back.
+    const analysisDir = path.join(tmpRoot, 'roundtrip', 'analysis');
+    await mkdir(analysisDir, { recursive: true });
+    const day1 = Date.UTC(2026, 4, 23);
+    const day2 = Date.UTC(2026, 4, 24);
+    await archiveAndPrune(analysisDir, mkOutput(day1), {
+      now: day1,
+      retentionDays: 30,
+    });
+    const prior = await loadMostRecentArchive(analysisDir, {
+      todayStamp: '2026-05-24',
+    });
+    expect(prior).not.toBeNull();
+    expect(prior?.generatedAt).toBe(day1);
+    // Day-2 call also retains its own archive without disturbing day-1.
+    await archiveAndPrune(analysisDir, mkOutput(day2), {
+      now: day2,
+      retentionDays: 30,
+    });
+    const entries = (await readdir(path.join(analysisDir, 'archive'))).sort();
+    expect(entries).toContain('surprises-2026-05-23.json');
+    expect(entries).toContain('surprises-2026-05-24.json');
+  });
+
+  // Sanity check that the retention math uses 24h * 60 * 60 * 1000 = dayMs.
+  it('retention window is measured in 24h days, not calendar weeks', async () => {
+    const analysisDir = path.join(tmpRoot, 'day-math', 'analysis');
+    const archive = path.join(analysisDir, 'archive');
+    await mkdir(archive, { recursive: true });
+    const now = Date.UTC(2026, 4, 24);
+    // 31 days ago → just outside a 30-day window
+    const oldStamp = new Date(now - dayMs(31)).toISOString().slice(0, 10);
+    await writeFile(
+      path.join(archive, `surprises-${oldStamp}.json`),
+      JSON.stringify(mkOutput(1)),
+    );
+    await archiveAndPrune(analysisDir, mkOutput(now), {
+      now,
+      retentionDays: 30,
+    });
+    const remaining = await readdir(archive);
+    expect(remaining).not.toContain(`surprises-${oldStamp}.json`);
+  });
+});

--- a/packages/exporter/src/analysis/surprisesBuilder.ts
+++ b/packages/exporter/src/analysis/surprisesBuilder.ts
@@ -13,6 +13,9 @@
  *
  * Writes:
  *   - `analysis/surprises.json`
+ *   - `analysis/archive/surprises-YYYY-MM-DD.json` (Wave 2 #1 — daily
+ *     snapshot copy for the next scan's delta read; pruned by filename
+ *     to `THRESHOLDS.surprises.archiveRetentionDays`).
  *
  * Watcher entries are intentionally NOT read from disk in V1 — the
  * applied-pattern watcher loop ledger lives in the SQLite substrate,
@@ -26,7 +29,7 @@
  * presence after a scan.
  */
 
-import { readFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, unlink } from 'node:fs/promises';
 import path from 'node:path';
 import type {
   CompositeOutcomesFile,
@@ -36,6 +39,7 @@ import type {
 } from '@chat-arch/schema';
 import {
   computeSurprises,
+  THRESHOLDS,
   type ComputeSurprisesInput,
   type SurpriseCompositeRow,
   type SurpriseDecisionRow,
@@ -74,6 +78,127 @@ async function readJsonOrNull<T>(p: string): Promise<T | null> {
     return JSON.parse(raw) as T;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Wave 2 #1 — delta surprises. Archive filename convention:
+ * `surprises-YYYY-MM-DD.json` in `<analysisDir>/archive/`. ASCII
+ * date stamps sort lexicographically the same as chronologically, so
+ * filename-based recency is deterministic and OS-agnostic (no reliance
+ * on mtime, which moves under `git checkout`).
+ */
+const ARCHIVE_DIR_NAME = 'archive';
+const ARCHIVE_FILE_RE = /^surprises-(\d{4}-\d{2}-\d{2})\.json$/;
+
+function archiveDirOf(analysisDir: string): string {
+  return path.join(analysisDir, ARCHIVE_DIR_NAME);
+}
+
+/** YYYY-MM-DD in UTC — matches the archive filename convention. */
+function dateStampUtc(unixMs: number): string {
+  return new Date(unixMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Read the most recent dated archive (NOT today's, the one before).
+ * Returns null when:
+ *   - the archive directory does not exist,
+ *   - the archive directory contains no `surprises-YYYY-MM-DD.json` files,
+ *   - the most recent file is today's (i.e. the kernel already ran today
+ *     and we don't want it to compare against itself),
+ *   - the most recent file cannot be parsed (malformed JSON / wrong shape).
+ *
+ * Determinism: filenames are sorted descending lexicographically, which
+ * matches chronological order under the ISO-8601 date stamp.
+ *
+ * Race note: this is read-only; concurrent writers to the archive
+ * (e.g. a second `pnpm exporter run start` racing the first) would
+ * land via the atomicWriteJsonSync rename primitive. We tolerate a
+ * mid-flight rename by treating a partial read as "no prior" — the
+ * delta kinds skip cleanly and we degrade to V1 snapshot behavior.
+ */
+export async function loadMostRecentArchive(
+  analysisDir: string,
+  options: { todayStamp?: string } = {},
+): Promise<SurprisesOutput | null> {
+  const dir = archiveDirOf(analysisDir);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  const dated = entries
+    .map((name) => {
+      const m = ARCHIVE_FILE_RE.exec(name);
+      return m === null ? null : { name, stamp: m[1] as string };
+    })
+    .filter((e): e is { name: string; stamp: string } => e !== null);
+  if (dated.length === 0) return null;
+
+  // Exclude today's stamp so a same-day re-scan doesn't read what we
+  // just wrote (the file would be byte-identical to the current run).
+  const today = options.todayStamp;
+  const candidates =
+    today !== undefined ? dated.filter((e) => e.stamp !== today) : dated;
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => b.stamp.localeCompare(a.stamp));
+  const mostRecent = candidates[0] as { name: string; stamp: string };
+  try {
+    const raw = await readFile(path.join(dir, mostRecent.name), 'utf8');
+    return JSON.parse(raw) as SurprisesOutput;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Archive today's surprises file and prune anything older than
+ * `retentionDays`. Pruning is filename-based (NOT mtime) so a `git
+ * checkout` that resets timestamps doesn't accidentally evict the
+ * archive. The today copy uses `atomicWriteJsonSync` for the same
+ * rename-over-target durability as the primary surprises.json write.
+ *
+ * Concurrency: archive + prune are separate filesystem ops, so a
+ * racing prune could delete a sibling that another concurrent
+ * archive operation just wrote. We accept the race — the loss is at
+ * most one day of archive history, never the freshly-written file
+ * (today's stamp is always retained because it's within the
+ * retention window by definition).
+ */
+export async function archiveAndPrune(
+  analysisDir: string,
+  file: SurprisesOutput,
+  options: { now: number; retentionDays: number },
+): Promise<void> {
+  const dir = archiveDirOf(analysisDir);
+  await mkdir(dir, { recursive: true });
+  const stamp = dateStampUtc(options.now);
+  const target = path.join(dir, `surprises-${stamp}.json`);
+  atomicWriteJsonSync(target, file);
+
+  // Prune by filename: any dated entry older than today minus retention.
+  const cutoffMs = options.now - options.retentionDays * 24 * 60 * 60 * 1000;
+  const cutoffStamp = dateStampUtc(cutoffMs);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    const m = ARCHIVE_FILE_RE.exec(name);
+    if (m === null) continue;
+    const entryStamp = m[1] as string;
+    if (entryStamp.localeCompare(cutoffStamp) < 0) {
+      try {
+        await unlink(path.join(dir, name));
+      } catch {
+        // Best-effort prune; a stale lock or concurrent delete is fine.
+      }
+    }
   }
 }
 
@@ -233,6 +358,14 @@ export async function buildSurprisesFile(
   // `[1.4.0]` accordingly.
   const patternWatchers: readonly SurpriseWatcherEntry[] = [];
 
+  // Wave 2 #1 — load the most recent prior archive (excluding today's
+  // stamp) so the kernel can emit delta kinds. Fail-soft: null means
+  // delta kinds skip cleanly and the kernel behaves identically to V1.
+  const todayStamp = new Date(options.now).toISOString().slice(0, 10);
+  const priorSurprises = await loadMostRecentArchive(analysisDir, {
+    todayStamp,
+  });
+
   const kernelInput: ComputeSurprisesInput = {
     generatedAt: options.now,
     composites,
@@ -242,17 +375,36 @@ export async function buildSurprisesFile(
     reflexive,
     decisions,
     knowledgeDebt,
+    priorSurprises,
   };
   const file = computeSurprises(kernelInput);
 
   const outPath = path.join(analysisDir, 'surprises.json');
   atomicWriteJsonSync(outPath, file);
 
+  // Wave 2 #1 — archive today's snapshot for tomorrow's delta read,
+  // then prune anything older than the retention window. Errors here
+  // log + continue: a failed archive write should not break the
+  // surprises sidecar (which already landed via the atomic write
+  // above).
+  try {
+    await archiveAndPrune(analysisDir, file, {
+      now: options.now,
+      retentionDays: THRESHOLDS.surprises.archiveRetentionDays,
+    });
+  } catch (err) {
+    logger.warn(
+      `analysis: surprises archive soft-failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   logger.info(
     `analysis: surprises.json — ${file.surprises.length} surprises ` +
       `(composites=${composites.length}, trajectories=${trajectories.length}, ` +
       `its=${itsResults.length}, decisions=${decisions.length}, ` +
-      `knowledgeDebt=${knowledgeDebt.length}), ${Date.now() - t0}ms`,
+      `knowledgeDebt=${knowledgeDebt.length}, ` +
+      `priorArchive=${priorSurprises === null ? 'none' : 'loaded'}), ` +
+      `${Date.now() - t0}ms`,
   );
 
   return {

--- a/packages/exporter/test/migration/v1.1.0-fixture.test.ts
+++ b/packages/exporter/test/migration/v1.1.0-fixture.test.ts
@@ -150,14 +150,16 @@ describe('migration v1.1.0 → 1.2.0', () => {
 
     // ---- (d) meta.json reflects the current EXPORTER_VERSION ----
     // Bumped 1.2.0 → 1.3.0 in Phase Rev3-I I5 for the Rev3
-    // substrate cutover; this test asserts the migration writes
-    // whatever the constant says, not a hardcoded literal.
+    // substrate cutover; 1.4.0 / 1.4.1 in feed-redesign Phase A / γ;
+    // 1.4.1 → 1.5.0 in Wave 2 #1 for the delta-surprises archive
+    // sidecar family. The migration writes whatever the constant
+    // says, not a hardcoded literal.
     const meta = await readJson<{
       exporterVersion: string;
       tiers: { browser: { files: readonly string[] } };
       counts: Record<string, unknown>;
     }>(path.join(tmpDataDir, 'analysis', 'meta.json'));
-    expect(meta.exporterVersion).toBe('1.4.1');
+    expect(meta.exporterVersion).toBe('1.5.0');
 
     // The Wave-5 sidecars (+ feed-redesign Phase A surprises.json)
     // must all be registered in the browser tier.

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -137,6 +137,12 @@ const HASH_CHAT = '#chat';
 const HASH_CORRECTIONS = '#corrections';
 const HASH_EFFECTIVENESS = '#effectiveness';
 const HASH_INSIGHTS = '#insights';
+// Wave-1 visual-review iter-1 finding: FEED card drill-ins to #trends
+// and #decisions fell through to the default landing mode because no
+// hash readers existed. /views catalogue had the same dead links.
+// Added here so both surfaces light up.
+const HASH_TRENDS = '#trends';
+const HASH_DECISIONS = '#decisions';
 // Action hash — opens the DataPanel modal and strips itself so a
 // back-nav / reload doesn't re-fire the open. Mirrors the standalone
 // app's `/sessions#data` deep-link from the AppSidebar SYSTEM > DATA
@@ -252,6 +258,18 @@ function readEffectivenessHash(): boolean {
 function readInsightsHash(): boolean {
   if (typeof window === 'undefined') return false;
   return window.location.hash === HASH_INSIGHTS;
+}
+
+/** Outcome-substrate trends/trajectory surface — no detail dimension. */
+function readTrendsHash(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.location.hash === HASH_TRENDS;
+}
+
+/** Outcome-substrate decisions surface — no detail dimension. */
+function readDecisionsHash(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.location.hash === HASH_DECISIONS;
 }
 
 /** Action hash — open the DataPanel modal. Stripped after firing. */
@@ -377,6 +395,8 @@ export function ChatArchViewer({
     if (readPracticeHash()) return 'practice';
     if (readEffectivenessHash()) return 'effectiveness';
     if (readInsightsHash()) return 'insights';
+    if (readTrendsHash()) return 'trends';
+    if (readDecisionsHash()) return 'decisions';
     // #data is an action hash, not a surface mode — it opens the
     // DataPanel via the sync useEffect and strips itself. Mode falls
     // through to defaultLandingMode so the underlying page is sane.
@@ -737,6 +757,8 @@ export function ChatArchViewer({
       const onCorrections = readCorrectionsHash();
       const onEffectiveness = readEffectivenessHash();
       const onInsights = readInsightsHash();
+      const onTrends = readTrendsHash();
+      const onDecisions = readDecisionsHash();
       // #data is an action, not a surface — open the panel and strip
       // the hash so a back-nav / reload doesn't re-fire the open. Done
       // BEFORE the unrecognized-hash branch below so the strip doesn't
@@ -766,6 +788,10 @@ export function ChatArchViewer({
         setMode('effectiveness');
       } else if (onInsights) {
         setMode('insights');
+      } else if (onTrends) {
+        setMode('trends');
+      } else if (onDecisions) {
+        setMode('decisions');
       } else {
         // Phase 3 cut COST and CONSTELLATION; a stale `#cost` /
         // `#constellation` bookmark would otherwise sit in the URL


### PR DESCRIPTION
## Summary

**Draft PR — iterating in-place.** Working through the 8 UI improvements surfaced by the first-principles research + design discussion. Landing in three waves with per-wave adversarial visual review.

**Wave 1 (this commit):** confidence tiers + kernel drill-ins + wipe+scan + Promise.all batch
**Wave 2 (pending):** delta-based surprises kernel + richer daily brief narrative
**Wave 3 (pending):** visual cohesion audit (LCARS chrome vs v2 flat seam)

Skipped from the 8: **#5 pattern retrospective view** (needs sign-off on whether PLAYBOOK satisfies the May-22 spec) and **#8 MCP UI question** (strategic decision, not implementation).

## Wave 1 details

**(A) Confidence per card** — STRONG / MODERATE / WEAK tier badges on every surprise card, mapped from score via threshold helper in @chat-arch/analysis. Tooltip surfaces 3-decimal raw score.

**(B) FEED → kernel drill-in** — each surprise kind drills into its parent kernel surface (\`config-helped\` → \`/sessions#insights\`, etc.). Closes the gap where cards only had atomic-evidence links and no path to kernel context.

**(C) WIPE + SCAN** — single-button clear-then-scan flow. Secondary visual weight; window.confirm with explicit "what dies" copy. NuclearReset preserved for clear-only.

**(D) Promise.all batch** — frontmatter's 9 outer sidecar reads no longer sequential.

## Plan for waves 2 + 3

After per-wave visual review + falsifier + fix iteration. Each wave commits + pushes incrementally.

## Test plan

- [x] \`pnpm test\` — 2106/2111 (5 pre-existing skips)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm build\` — clean
- [ ] Wave-1 visual review + falsifier + fix loop (running now)
- [ ] Waves 2 + 3 implementation + review

🤖 Generated with [Claude Code](https://claude.com/claude-code)