### PR TITLE
fix(playbook): show all examples per pattern on expand

### DIFF
--- a/apps/standalone/src/pages/playbook.astro
+++ b/apps/standalone/src/pages/playbook.astro
@@ -269,11 +269,11 @@ function fmtSid(sid: string): string {
 
               <details class="playbook__excerpts">
                 <summary>
-                  show {Math.min(p.hits.length, 3)} of {p.hits.length}{' '}
+                  show all {p.hits.length}{' '}
                   example{p.hits.length === 1 ? '' : 's'}
                 </summary>
                 <ul>
-                  {p.hits.slice(0, 3).map((h) => (
+                  {p.hits.map((h) => (
                     <li class="playbook__excerpt">
                       <code class="playbook__sid">
                         [SID:{fmtSid(h.sessionId)}…]


### PR DESCRIPTION
## Summary

Closes the small gap between the May-22 pattern-retrospective spec and what PLAYBOOK delivers. The page was capping the example list at 3 per pattern even when the user clicked the expander. Now shows all N when expanded.

## Change

- \`apps/standalone/src/pages/playbook.astro\`: dropped \`.slice(0, 3)\` from the hits list; summary copy "show 3 of N examples" → "show all N examples".

The \`<details>\` element still gates DOM visibility, so the rendered HTML cost is paid only on user expand (and Astro is server-rendered so it's all in the response anyway — a pattern with hundreds of hits is still fine on the wire).

## Test plan

- [x] \`pnpm --filter @chat-arch/standalone test\` — 240/240
- [x] \`pnpm --filter @chat-arch/standalone build\` — clean
- [x] \`pnpm lint\` — clean (1 pre-existing warning in apply-correction.ts, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)