### PR TITLE
feat(persona-mining): per-project persona auto-generation as SCAN chain step 5

### DIFF
--- a/.claude/skills/mine-persona/SKILL.md
+++ b/.claude/skills/mine-persona/SKILL.md
@@ -20,7 +20,7 @@ Parse from the user's message. Defaults in brackets.
 - `--request-id <uuid>` [omitted] — present when invoked from the viewer; correlates status/output with the UI.
 - `--project-id <id>` [omitted] — when present, mine ONLY this project. Everything else stays as-is in `personas.json` (the index is updated in place for that project's row). Used by the PERSONAS surface's REGEN button.
 - `--max-projects <N>` [10] — abort if the work plan would process more than N projects in a single run. Same risk shape as `mine-corrections`'s `--max-sub-agents`: each project is ~4 sub-agents (one per time bucket), so 10 projects = up to 40 sub-agent dispatches. Override only when you know the run is bounded (e.g. small corpus).
-- `--max-llm-usd-per-project <USD>` [0.5] — pre-flight budget guard. Skip a project (status: `budget-exceeded`) when its predicted Stage-2 cost would exceed this cap. **V1 calibration:** the cost model is approximate. The hard guard fires when a project's candidate count exceeds 1500 (≈ a 200-session corpus with average bucket density); refine in V2.
+- `--max-llm-usd-per-project <USD>` [0.5] — pre-flight budget guard. Skip a project (status: `budget-exceeded`) when its predicted Stage-2 cost would exceed this cap. **V1 calibration:** the cost model is a candidate-count proxy enforced via `THRESHOLDS.persona.candidateBudgetProxy` (default 1500 ≈ a 200-session corpus with average bucket density). The actual USD threshold is `THRESHOLDS.persona.maxLlmUsdPerProject` (default $0.50); the proxy is the V1 stand-in until per-Stage-2-run USD measurement lands in V2. Both values live in `packages/analysis/src/thresholds.ts` under the `persona` block.
 
 ## Pipeline
 
@@ -38,7 +38,7 @@ You orchestrate four stages. Update the status file at every transition.
    - Else: list = every project in `persona-candidates.json`.
 7. Per project: gate on session count.
    - `sessionsTotal < 30` (or whatever `THRESHOLDS.persona.minSessionsForGeneration` is — read from the `thresholds` field of `persona-candidates.json` rather than re-deriving): emit `status: insufficient-corpus` and skip Stages 1-3 for that project.
-   - `cappedCandidatesTotal > 1500`: emit `status: budget-exceeded` with the predicted cost note and skip.
+   - `cappedCandidatesTotal > THRESHOLDS.persona.candidateBudgetProxy` (default 1500): emit `status: budget-exceeded` with the predicted cost note and skip. Read the value from `persona-candidates.json`'s `thresholds` block (Stage 1 stamps it there so the skill doesn't need to import the analysis package). Until the V1 calibration pass logs actual USD-per-candidate, this proxy is the gate; re-derive the proxy from observed data in V2.
 8. If the eligible project count exceeds `--max-projects`:
    - **When `--request-id` is set** (viewer-confirmed run): proceed regardless — the user pressed SCAN knowing it would run. Log a warning to status.
    - **Else**: ask before proceeding.

--- a/.claude/skills/mine-persona/SKILL.md
+++ b/.claude/skills/mine-persona/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: mine-persona
+description: Per-project persona auto-generation. SCAN chain step 5. Reads chat-arch-data/analysis/persona-candidates.json (Stage 1 heuristic buckets produced by the exporter), dispatches per-project synthesis sub-agents that mirror the 4-bucket-by-recency strategy used to author research/persona-evals/bryce.md, and writes analysis/personas.json (index) + analysis/personas/<project-id>.md (per-project markdown). Each persona contains 6-10 numbered pattern sections with **Pattern.** / **Evidence.** (≥2 [SID:...] citations per section) / **What this implies.** Local Ollama NOT required (no embeddings).
+---
+
+# /mine-persona
+
+You are running the LLM stage of chat-arch's per-project persona pipeline. The exporter has already produced a heuristic candidate file with 6 buckets per project (`role-expertise` / `preferences` / `project-specific` / `working-rhythm` / `frictions` / `voice`). Your job: synthesize each project's bucketed evidence into a `bryce.md`-shaped persona markdown.
+
+## When to invoke
+
+- The user runs `/mine-persona` (optionally with `--project-id=<id>`).
+- The viewer's "FULL SCAN" or "REGEN PERSONA" buttons POST to `/api/mine-persona`. In that case you'll receive a `--request-id` argument and (for the per-project regen path) a `--project-id` argument.
+
+## Arguments
+
+Parse from the user's message. Defaults in brackets.
+
+- `--data-dir <path>` [defaults to `apps/standalone/public/chat-arch-data` relative to repo root]
+- `--request-id <uuid>` [omitted] — present when invoked from the viewer; correlates status/output with the UI.
+- `--project-id <id>` [omitted] — when present, mine ONLY this project. Everything else stays as-is in `personas.json` (the index is updated in place for that project's row). Used by the PERSONAS surface's REGEN button.
+- `--max-projects <N>` [10] — abort if the work plan would process more than N projects in a single run. Same risk shape as `mine-corrections`'s `--max-sub-agents`: each project is ~4 sub-agents (one per time bucket), so 10 projects = up to 40 sub-agent dispatches. Override only when you know the run is bounded (e.g. small corpus).
+- `--max-llm-usd-per-project <USD>` [0.5] — pre-flight budget guard. Skip a project (status: `budget-exceeded`) when its predicted Stage-2 cost would exceed this cap. **V1 calibration:** the cost model is approximate. The hard guard fires when a project's candidate count exceeds 1500 (≈ a 200-session corpus with average bucket density); refine in V2.
+
+## Pipeline
+
+You orchestrate four stages. Update the status file at every transition.
+
+### Stage 0 — Setup
+
+1. Resolve `--data-dir`. Read `${dataDir}/analysis/persona-candidates.json`. If absent, tell the user to run `pnpm --filter @chat-arch/exporter run start ...` (or click SCAN in the viewer) first.
+2. Read the existing `${dataDir}/analysis/personas.json` if it exists. You'll merge into it rather than overwriting wholesale, so per-project REGENs preserve the rest of the index.
+3. Read `${dataDir}/manifest.json` so you can look up session metadata (titles, transcriptPath, updatedAt) by sessionId during the synthesis stage.
+4. Read the V1 spec at `research/persona-mining-spec.md` so the persona structure stays anchored to the document Bryce signed off on.
+5. Read `research/persona-evals/bryce.md` so you know the structure to mirror: header / 6-10 numbered pattern sections with **Pattern.** / **Evidence.** (≥2 `[SID:...]` citations) / **What this implies.** / coverage notes / optional preserve-automate-get-out-of-the-way table.
+6. Build the project work-list:
+   - If `--project-id` was passed: list = [that project].
+   - Else: list = every project in `persona-candidates.json`.
+7. Per project: gate on session count.
+   - `sessionsTotal < 30` (or whatever `THRESHOLDS.persona.minSessionsForGeneration` is — read from the `thresholds` field of `persona-candidates.json` rather than re-deriving): emit `status: insufficient-corpus` and skip Stages 1-3 for that project.
+   - `cappedCandidatesTotal > 1500`: emit `status: budget-exceeded` with the predicted cost note and skip.
+8. If the eligible project count exceeds `--max-projects`:
+   - **When `--request-id` is set** (viewer-confirmed run): proceed regardless — the user pressed SCAN knowing it would run. Log a warning to status.
+   - **Else**: ask before proceeding.
+9. Write the initial status file at `${dataDir}/analysis/persona-status-${requestId}.json` (skip when no requestId).
+
+### Stage 1 — Per-project time-bucket sub-agents
+
+For each eligible project, dispatch **4 parallel sub-agents**, one per time bucket. Bucket assignment uses the project's session updatedAt distribution (read from manifest.json):
+
+- **founding**: oldest 25% of the project's sampled sessions (earliest mtime).
+- **mid-early**: next 25%.
+- **mid-late**: next 25%.
+- **recent**: newest 25%.
+
+Each sub-agent gets:
+
+- The bucket's session ids + their titles + their updatedAt timestamps.
+- The candidate excerpts assigned to those sessions, grouped by the 6 heuristic buckets (`role-expertise` etc.). Each candidate is a `{sessionId, userTurnIndex, excerpt, bucket, patternKey}` object.
+- The project's display name (for project-specific pattern detection).
+
+Use this exact sub-agent prompt template (substitute the JSON in place of `<<INPUT>>`; the project name in place of `<<PROJECT_NAME>>`; the bucket label in place of `<<TIME_BUCKET>>`):
+
+```
+You are extracting persona signals from one time-bucket of a project's chat history.
+
+PROJECT: <<PROJECT_NAME>>
+TIME BUCKET: <<TIME_BUCKET>> (one of: founding, mid-early, mid-late, recent)
+
+You have been given user-prompt excerpts pre-classified into 6 heuristic categories:
+- role-expertise: claims about the user's profession / experience / stance
+- preferences: direct preference statements / "use X not Y" patterns
+- project-specific: prompts that name this project or its tech surface
+- working-rhythm: process / sequencing / iteration / loop words
+- frictions: negative signals about state of work or tool output
+- voice: terse pings (≤30 chars) or verbose context blocks (≥1200 chars)
+
+Each excerpt is heuristically matched. Some matches will be noise (an "I prefer" in a code paste, a "frustrating" used in the abstract); your job is to filter those out and surface DURABLE patterns that re-appear across multiple sessions in THIS time bucket.
+
+For each of the 6 categories, return:
+{
+  "category": "<one of the 6>",
+  "observations": [
+    {
+      "pattern": "<one-sentence summary of what the user is doing/saying/preferring>",
+      "evidence": [
+        { "sessionId": "<full sid>", "userTurnIndex": <int>, "quote": "<verbatim excerpt, ≤200 chars>" },
+        ...
+      ]
+    }
+  ],
+  "categoryEmpty": false
+}
+
+If a category has no durable pattern in this bucket (e.g. fewer than 2 sessions exhibit the same shape, or all matches are noise), set "observations": [] and "categoryEmpty": true. Do NOT invent patterns to fill the slot.
+
+CONSTRAINTS — non-negotiable:
+- Every quote must be VERBATIM from the input. No paraphrasing, no summarization, no quotes from this prompt.
+- Every evidence entry must cite at least 2 distinct sessionIds across the bucket's observations PER PATTERN. Patterns with only one supporting session do not count as durable; drop them.
+- Group related shapes into ONE pattern. If 8 prompts all say variants of "I prefer terse responses", that's one observation with 4-5 evidence entries, not 8 observations.
+- If you cannot find any durable patterns in a category for this bucket, set categoryEmpty: true. Returning a low-signal observation is worse than an empty bucket.
+
+Output ONLY the JSON array (one entry per category, 6 total).
+
+INPUT:
+<<INPUT>>
+```
+
+Each sub-agent returns its JSON array. Concatenate the four buckets' arrays per project. If any sub-agent fails or returns malformed JSON, retry once; if still bad, drop that bucket with a note in the status log.
+
+### Stage 2 — Cross-bucket synthesis (per project)
+
+For each project, run **one synthesis sub-agent** (no parallelism — coherent prose needs a global view) that takes all four bucket outputs and writes the final persona markdown.
+
+The synthesis sub-agent prompt:
+
+```
+You are writing a data-grounded persona for one project, mirroring the structure of `research/persona-evals/bryce.md` (which you should Read before generating this output).
+
+PROJECT: <<PROJECT_NAME>>
+SESSIONS ANALYZED: <<SESSIONS_ANALYZED>>
+TIME SPAN: <<EARLIEST_DATE>> → <<LATEST_DATE>>
+
+You have been given four time-bucketed observation sets (founding, mid-early, mid-late, recent), each pre-organized into 6 heuristic categories. Your job: produce the persona markdown.
+
+REQUIRED STRUCTURE — match bryce.md verbatim in shape:
+
+1. Header block:
+   # Persona — <Project Name>
+   One-paragraph intro: project name, sessions analyzed, time span, "data-grounded from N sessions" disclaimer, sentence on the persona's purpose.
+
+2. 6-10 numbered pattern sections, each:
+   ## N. <Pattern title>
+   **Pattern.** <One-sentence + supporting sentences describing the pattern.>
+   **Evidence.**
+   - [SID:<prefix>] "<verbatim quote>" — <one-clause hint of why this evidence matters>
+   - ... ≥ 2 evidence rows per section ...
+   **What this implies for <project>.** <One paragraph on what the persona implies for the project's product / workflow / next steps.>
+
+3. Coverage notes:
+   ## Coverage notes
+   - Files scanned, time-bucket spread, false-positive filters, confidence
+   - What this persona does NOT cover
+
+4. Optional: a "What <project> should preserve, automate, or get out of the way of" table at the bottom — ONLY include this when the patterns are durable across ≥3 of the 4 time buckets. If patterns are only recent, skip the table; that's a persona-drift signal, not a stable preference profile.
+
+CONSTRAINTS — non-negotiable:
+- Every `[SID:<prefix>]` citation uses the FIRST 8 CHARS of the sessionId (e.g. `[SID:c9a0169b]`). Match bryce.md's convention.
+- Every quote must be VERBATIM from the bucket observations' evidence entries. No paraphrasing.
+- Patterns that appear in ≥2 time buckets are DURABLE — prioritize those. Patterns that appear only in `recent` are emerging — flag in the section as "this is recent — durability uncertain".
+- 6 to 10 sections total. If you have more than 10 observed shapes, merge the lowest-evidence ones. If fewer than 6, fill from the strongest remaining categoryEmpty=false observations rather than inventing patterns to pad.
+- The section order doesn't have to follow the 6 heuristic-category order from Stage 1; group by what makes coherent reading. Voice can be the last section (matches bryce.md).
+- Use the same voice as bryce.md — neutral observational, no "the user" filler, no flattery, no hedging.
+- Markdown only. No Astro components, no JSX, no HTML tags.
+
+INPUT (four time-bucketed observation arrays):
+<<INPUT>>
+```
+
+The sub-agent returns markdown directly (no JSON wrapper). Write it to `${dataDir}/analysis/personas/<project-id>.md`. Create the `personas/` directory if it doesn't exist.
+
+### Stage 3 — Index + status
+
+After all per-project syntheses complete (or skip):
+
+1. Read the existing `${dataDir}/analysis/personas.json` (if present) to preserve rows the current run didn't touch.
+2. Merge: for each project this run processed, replace its row with the new record:
+   ```json
+   {
+     "projectId": "<id>",
+     "projectName": "<display>",
+     "sessionsAnalyzed": <int>,
+     "sessionsTotal": <int>,
+     "personaPath": "analysis/personas/<id>.md" | null,
+     "generatedAt": <now ms> | null,
+     "status": "generated" | "insufficient-corpus" | "budget-exceeded" | "error",
+     "reason": "<free-form, only when status !== 'generated'>"
+   }
+   ```
+3. Write the merged index back to `${dataDir}/analysis/personas.json` with frontmatter:
+   ```json
+   {
+     "schemaVersion": 1,
+     "generatedAt": <now ms>,
+     "exporterVersion": "<read from analysis/meta.json>",
+     "thresholds": {
+       "minSessionsForGeneration": <from candidates file>,
+       "maxSessionsForCorpus": <from candidates file>,
+       "maxLlmUsdPerProject": <THRESHOLDS.persona.maxLlmUsdPerProject>
+     },
+     "personas": [ <merged records> ]
+   }
+   ```
+4. Update the status file to `complete` with summary counts (generated, skipped, errored).
+
+If a `--request-id` was passed, also write a completion marker at `${dataDir}/analysis/persona-status-${requestId}.json`:
+
+```json
+{ "requestId": "<id>", "status": "complete", "completedAt": <now>, "generatedCount": N, "skippedCount": K, "totalProjects": T }
+```
+
+## Status file format
+
+`${dataDir}/analysis/persona-status-${requestId}.json`:
+
+```json
+{
+  "requestId": "<id or 'manual'>",
+  "status": "starting" | "bucketing" | "synthesizing" | "writing" | "complete" | "error",
+  "progress": { "phase": "<current>", "current": N, "total": M },
+  "startedAt": <ms>,
+  "updatedAt": <ms>,
+  "log": ["<recent message>", "..."],
+  "error": "<message if status=error>"
+}
+```
+
+Update on every stage transition. The viewer polls this for live progress.
+
+## Error handling
+
+- `persona-candidates.json` missing → stop, tell the user to run the exporter first.
+- Sub-agent malformed JSON → retry once, then drop that bucket / project and continue.
+- `--max-projects` exceeded with no `--request-id` → ask, don't proceed silently. With `--request-id` set, proceed (viewer-confirmed run).
+- Any unrecoverable error → write `status: error` with message, exit.
+
+## What you must NOT do
+
+- Don't paraphrase or invent quotes. Every `[SID:...]` evidence line must cite a verbatim user-text excerpt from the input candidates. The Stage-3 follow-up (falsifier extension) will verify this.
+- Don't write to `research/persona-evals/<project-id>.md` even if the project name matches. Hand-authored personas under `research/persona-evals/` stay canonical for the projects they cover (`bryce.md` is the chat-arch canonical). Auto-generated personas live ONLY under `analysis/personas/`.
+- Don't overwrite the entire `personas.json` index. Merge — preserve rows the current run didn't process.
+- Don't dispatch more than `--max-projects` projects worth of sub-agents in one run without explicit user confirmation.
+- Don't run the synthesis sub-agent on a project that hit `insufficient-corpus` or `budget-exceeded` — those skip Stages 1-3 entirely; their `personas.json` row is the only artifact.
+- Don't add "Generated by Claude" footers or "🤖" emoji to the persona markdown. The headers say "data-grounded from N sessions" which is the only attribution needed.
+
+## Implementation notes
+
+- The 4-bucket-by-recency strategy mirrors how Bryce hand-authored `bryce.md`. Don't change the bucket count without updating the spec.
+- The 6 heuristic categories (`role-expertise` / `preferences` / `project-specific` / `working-rhythm` / `frictions` / `voice`) come from the Stage-1 exporter (`packages/exporter/src/analysis/personaCandidates.ts`); the synthesis stage doesn't have to use the same 6 sections in its output — it groups by coherent reading instead.
+- `sessionId` truncation to 8 chars in `[SID:...]` is for readability. The full id is preserved in the candidates JSON so the viewer's drill-down hash router (`/sessions#session/<full-sid>`) can resolve it. The viewer's PERSONAS page should hyperlink the 8-char prefix to the full session.

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,11 @@ out/
 !.claude/skills/curate/SKILL.md
 !.claude/skills/falsify/
 !.claude/skills/falsify/SKILL.md
+# Persona-mining V1 skill (drives /api/mine-persona — the SCAN
+# chain's 5th step). Ships with the repo because the endpoint +
+# UI affordance depend on the contract this SKILL.md pins.
+!.claude/skills/mine-persona/
+!.claude/skills/mine-persona/SKILL.md
 # …except (1) test fixtures, which legitimately contain a `.claude/`
 # subtree that mimics what a real Cowork session directory looks
 # like on disk. These are synthetic (redacted), vital for the
@@ -123,6 +128,14 @@ apps/standalone/public/chat-arch-data/analysis/knowledge-debt-states.json
 # above; listed for the same auditability reason as the others.
 apps/standalone/public/chat-arch-data/analysis/curator-feed.json
 apps/standalone/public/chat-arch-data/analysis/falsifier-verdicts.json
+# Per-project persona-mining V1 output. PII: verbatim user-prompt
+# excerpts cited as [SID:...] inside each per-project markdown file.
+# Stage-1 candidates + Stage-2 index + per-project markdown all covered
+# by the wildcard above; listed explicitly for the same auditability
+# reason as the others.
+apps/standalone/public/chat-arch-data/analysis/persona-candidates.json
+apps/standalone/public/chat-arch-data/analysis/personas.json
+apps/standalone/public/chat-arch-data/analysis/personas/
 apps/standalone/public/chat-arch-data/exports/
 .claude/review-loop.disabled
 .claude/review-loop.disabled-roles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,81 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-05-25
+
+Persona-mining V1 — per-project data-grounded personas, automatically
+generated on every SCAN as the 5th chain step. Models the
+hand-authored `research/persona-evals/bryce.md` workflow as a general
+feature: any project with ≥ `THRESHOLDS.persona.minSessionsForGeneration`
+sessions gets its own persona under
+`analysis/personas/<project-id>.md`, citing verbatim user-prompt
+excerpts with `[SID:...]` anchors. Hand-authored personas under
+`research/persona-evals/` stay canonical for the projects they cover.
+
+### Added
+
+- **`analysis/persona-candidates.json`** — Stage-1 deterministic
+  heuristic extractor (new builder at
+  `packages/exporter/src/analysis/personaCandidates.ts`). Per-project
+  user-prompt excerpts bucketed into 6 heuristic categories:
+  `role-expertise` / `preferences` / `project-specific` /
+  `working-rhythm` / `frictions` / `voice`. Sampled by recency up to
+  `THRESHOLDS.persona.maxSessionsForCorpus` (default 200), with a
+  per-bucket cap of 40 candidates to bound the Stage-2 LLM input.
+  PII-bearing — gitignored under the
+  `apps/standalone/public/chat-arch-data/*` wildcard.
+- **`analysis/personas.json`** — Stage-2 index. One record per
+  project: `{ projectId, projectName, sessionsAnalyzed, sessionsTotal,
+  personaPath, generatedAt, status, reason? }`. `status` is
+  `generated` / `insufficient-corpus` / `budget-exceeded` / `error`.
+  Written by the `/mine-persona` skill; preserved on per-project
+  REGEN runs (merged in place, not overwritten wholesale).
+- **`analysis/personas/<project-id>.md`** — per-project markdown
+  persona, mirroring the structure of
+  `research/persona-evals/bryce.md`: header / 6-10 numbered pattern
+  sections with **Pattern.** / **Evidence.** (≥2 `[SID:...]`
+  citations) / **What this implies.** / coverage notes. PII-bearing.
+- **`/api/mine-persona`** — NDJSON-streaming endpoint (CSRF gate +
+  inFlight serializer + spawn `claude -p` invoking the
+  `mine-persona` skill). Mirror of `/api/mine-corrections`. Accepts
+  `{ projectId? }` for per-project REGEN runs.
+- **`/api/clear-personas`** — selective wipe for
+  `analysis/personas.json` + `analysis/persona-status-*.json` +
+  `analysis/personas/*.md`. Mirror of `/api/clear-corrections`.
+- **`.claude/skills/mine-persona/SKILL.md`** — the Stage-2 LLM
+  skill. Dispatches 4 sub-agents per project (one per time-bucket:
+  founding / mid-early / mid-late / recent), then one synthesis
+  sub-agent that writes the final markdown.
+- **PERSONAS sidebar entry** under WORKSHOP (short label `PER`).
+- **`/personas` page** — sidebar list of generated + skipped
+  projects, body renders the active project's markdown with
+  clickable `[SID:...]` anchors that navigate to
+  `/sessions#session/<full-sid>`. Per-project REGEN button.
+- **`THRESHOLDS.persona`** family:
+  - `minSessionsForGeneration: 30` — below this, projects skip with
+    `insufficient-corpus`.
+  - `maxSessionsForCorpus: 200` — cap on what Stage 2 sees.
+  - `maxLlmUsdPerProject: 0.5` — pre-flight budget guard
+    (placeholder — V1 uses a candidate-count proxy; refine in V2).
+- **5th SCAN chain step.** `FULL_SCAN_STEPS` extends to
+  `[ rescan, mine, curate, falsify, persona ]`. Failure semantics
+  unchanged.
+- **`EXPORTER_VERSION` bumped 1.5.0 → 1.6.0**, recorded in
+  `analysis/meta.json`.
+
+### Out of scope (V1 — explicitly deferred)
+
+- Cross-project composite persona.
+- Persona-drift detection (diffing successive scans).
+- Curator weighting by persona-derived preference vector.
+- Persona-aware skill argument substitution.
+- Falsifier extension to verify persona evidence citations
+  (Stage-3 follow-up).
+- Hand-authored `research/persona-evals/bryce.md` is NOT replaced —
+  it stays canonical for the chat-arch project specifically; auto-
+  generated output lives separately at
+  `analysis/personas/chat-arch.md`.
+
 ## [1.5.1] — 2026-05-25
 
 Auto-brief + SCAN-chain bug fixes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,13 @@ scripts/             One-off audits (audit-correction-recall.mjs) +
   chat-answer/       Drives /api/chat-answer endpoint (the chat
                      page's agent specialization for Q&A against
                      the corpus)
+  mine-persona/      Per-project persona auto-generation V1.
+                     Stage 2 of the persona pipeline: reads
+                     analysis/persona-candidates.json (Stage 1
+                     written by the exporter), dispatches 4 time-
+                     bucketed sub-agents per project, synthesizes
+                     into analysis/personas/<project-id>.md +
+                     updates analysis/personas.json index.
   chat-arch-thrash-detect/  NOT in this repo — lives under
                             ~/.claude/skills/ as a global hook
                             (writes thrash-fires.json into the
@@ -358,6 +365,50 @@ under the same wildcard — locally generated, PII-bearing):
   shape as `surprises.json` itself (summary text + evidence session
   IDs).
 
+### Persona-mining V1 sidecar family (EXPORTER_VERSION 1.6.0)
+
+Three additional artifacts under `apps/standalone/public/chat-arch-data/
+analysis/` (all gitignored — locally generated, PII-bearing):
+
+- `persona-candidates.json` — Stage-1 deterministic heuristic
+  extractor output. Per-project user-prompt excerpts bucketed into
+  6 categories (`role-expertise` / `preferences` / `project-specific` /
+  `working-rhythm` / `frictions` / `voice`). Written by
+  `packages/exporter/src/analysis/personaCandidates.ts` as part of
+  `runAnalysis`. PII: verbatim user-prompt excerpts cited with
+  `sessionId` + `userTurnIndex`. Read by the `/mine-persona` skill.
+- `personas.json` — Stage-2 index. One record per project in the
+  corpus: `{ projectId, projectName, sessionsAnalyzed, sessionsTotal,
+  personaPath, generatedAt, status, reason? }`. `status` is
+  `generated` / `insufficient-corpus` / `budget-exceeded` / `error`.
+  Written by `/mine-persona`. Read by the `/personas` page.
+- `personas/<project-id>.md` — per-project markdown persona,
+  mirroring `research/persona-evals/bryce.md` structure. Header /
+  6-10 numbered pattern sections with **Pattern.** / **Evidence.**
+  (≥2 `[SID:...]` citations per section) / **What this implies.** /
+  coverage notes. PII: high — every Evidence row is a verbatim
+  user-prompt excerpt. Written by `/mine-persona`, rendered by the
+  `/personas` page with clickable SID anchors.
+
+**Hand-authored vs auto-generated personas.** The hand-authored
+`research/persona-evals/bryce.md` stays canonical for the chat-arch
+project specifically (it's the originating prototype). Auto-generated
+output lives separately at `analysis/personas/chat-arch.md` — never
+overwritten by the skill. The four secondary onramp-eval personas
+(`maya.md` / `david.md` / `priya.md` / `sam.md`) are hypothetical
+first-touch walkthroughs for the hosted demo, not user-modeling docs,
+and are unrelated to the auto-generation pipeline.
+
+**Status files.** `persona-status-${requestId}.json` — per-run
+progress file the skill writes during a mining pass. Wiped by
+`/api/clear-personas` alongside the personas/ family.
+
+**Wipe coverage.** `/api/clear-personas` (selective) wipes
+`personas.json` + status files + `personas/*.md`. `/api/clear`
+(kitchen-sink) wipes everything under `chat-arch-data/` via the
+existing `wipeAll` path — no new code needed because the personas
+family lives under the same root.
+
 The pre-launch `thrash-fires.json` audit log (Phase 4 #8 thrash hook)
 and the `chat-arch-data/exports/` Obsidian-target directory (Phase 4
 #12 post-mortems + knowledge-debt) are also gitignored. The wildcard
@@ -411,7 +462,8 @@ out of date and needs an update:
      reflexive, decisions, archetypes, project-trajectories,
      skill-curves, surprises, archive/surprises-YYYY-MM-DD,
      curator-feed, falsifier-verdicts, correction-candidates,
-     corrections, correction-status-*.
+     corrections, correction-status-*, persona-candidates, personas,
+     personas/<project-id>.md, persona-status-*.
    - Aggregate-numbers-only (lower-PII): its-analysis, surface-
      comparison. These are gitignored conservatively anyway.
 5. **What's the difference between hosted (`chat-arch.dev`) and
@@ -435,4 +487,6 @@ out of date and needs an update:
      `buildDailyBrief` gained shipped-this-week / surprises /
      trajectories / applied-pattern-closures sections (no new on-
      disk sidecar; brief markdown shape grew); see CHANGELOG.md
-     `[1.4.1]`.
+     `[1.4.1]`. Bumped 1.5.0 → 1.6.0 in the persona-mining V1 land
+     (`persona-candidates.json` + `personas.json` +
+     `personas/<project-id>.md` family); see CHANGELOG.md `[1.6.0]`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ network access lands only on the local `pnpm dev` checkout.
 | **Mine decisions** + outcome-substrate sidecars | ❌ | ✅ |
 | **SQLite substrate** (`chat-arch.db` entity-states ledger, Rev3-A onward) | ❌ no Node runtime | ✅ |
 | **/curate** + **/falsify** skills (Rev3-F) | ❌ | ✅ |
+| **/mine-persona** (per-project data-grounded personas, V1.6.0) | ❌ | ✅ |
 | **MCP server scaffold** (`@chat-arch/mcp-server`, Rev3-H read-only SDK + working-dir scoping + localhost-bind policy primitives) | ❌ | ⚠️ SDK + policy primitives in tree; stdio / `@modelcontextprotocol/sdk` transport wiring deferred to a follow-on PR (localhost-bind enforced when the transport lands) |
 
 The hosted viewer stays JSON-sidecar-only on purpose — keeps the
@@ -127,6 +128,7 @@ score and slices the corpus six ways:
 | ---- | ------------- |
 | **Results** (`/results`) | Cross-corpus claim-pass rate by claim type / project / session + loop-closure rollup (shipped 1.1.0) |
 | **Playbook** (`/playbook`) | Recurring user-turn phrasings ranked by occurrence × downstream pass-rate; COPY AS MARKDOWN handoff (shipped 1.1.0) |
+| **Personas** (`/personas`) | Per-project data-grounded personas auto-generated on every SCAN. Each renders 6-10 numbered pattern sections with verbatim user-prompt evidence (`[SID:...]` citations clickable into the session). Hand-authored `research/persona-evals/bryce.md` stays canonical for the chat-arch project itself; auto-generated output lives separately under `analysis/personas/`. (shipped 1.6.0) |
 | **Effectiveness** | Per-session composite score (test/build/PR/affirmation signals) + time-series |
 | **Insights** | Interrupted-time-series contrasts of composite score around `.claude/` config changes |
 | **Decisions** | Extracted decisions joined to downstream composite outcome |

--- a/apps/standalone/src/components/AppSidebar.astro
+++ b/apps/standalone/src/components/AppSidebar.astro
@@ -68,6 +68,10 @@ const groups: readonly NavGroup[] = [
       { href: '/playbook', short: 'PLB', label: 'PLAYBOOK' },
       { href: '/sessions#corrections', short: 'COR', label: 'CORRECTIONS' },
       { href: '/practice', short: 'PRC', label: 'PRACTICE' },
+      // PERSONAS — per-project data-grounded personas, generated on
+      // SCAN as chain step 5. Models the "who is the user of this
+      // project" answer from their own session evidence.
+      { href: '/personas', short: 'PER', label: 'PERSONAS' },
     ],
   },
   {

--- a/apps/standalone/src/lib/readSidecars.ts
+++ b/apps/standalone/src/lib/readSidecars.ts
@@ -21,6 +21,7 @@ import type {
   CorrectionPattern,
   CorrectionsFile,
   Narrative,
+  PersonasIndex,
   PlaybookCandidatesFile,
   UpgradeOutcomesFile,
 } from '@chat-arch/schema';
@@ -122,6 +123,31 @@ export async function readAppliedImprovements(): Promise<AppliedImprovementsFile
   return readJson<AppliedImprovementsFile>(
     path.join(analysisDir(), 'applied-improvements.json'),
   );
+}
+
+export async function readPersonasIndex(): Promise<PersonasIndex | null> {
+  return readJson<PersonasIndex>(path.join(analysisDir(), 'personas.json'));
+}
+
+/**
+ * Read a per-project persona markdown by relative `personaPath` (from
+ * `analysis/personas.json`). The file lives under the `analysis/personas/`
+ * subtree; anything resolving outside `chat-arch-data/analysis/personas/`
+ * returns null and never reads from disk — same posture as the dataDirGuard
+ * pattern. The Stage-2 skill writes `personaPath` into `personas.json`,
+ * but treating the index as semi-trusted keeps a buggy or
+ * malformed-skill emission from triggering arbitrary file reads
+ * (mirrors the `isPersonaMarkdown` allow-list in `/api/clear-personas`).
+ */
+export async function readPersonaMarkdown(personaPath: string): Promise<string | null> {
+  const safeRoot = path.resolve(dataDir(), 'analysis', 'personas');
+  const abs = path.resolve(dataDir(), personaPath);
+  if (abs !== safeRoot && !abs.startsWith(safeRoot + path.sep)) return null;
+  try {
+    return await readFile(abs, 'utf8');
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/standalone/src/pages/api/clear-personas.ts
+++ b/apps/standalone/src/pages/api/clear-personas.ts
@@ -1,0 +1,168 @@
+import type { APIRoute } from 'astro';
+import { readdir, rm } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+/**
+ * Wipe the persona-mining pipeline's output files so the user can
+ * re-mine from scratch. Scope mirrors `/api/clear-corrections`:
+ *
+ *   - `analysis/personas.json` — the index (deleted)
+ *   - `analysis/persona-status-*.json` — orphan status files from
+ *     prior runs (deleted)
+ *   - `analysis/personas/*.md` — per-project markdown personas
+ *     (deleted; directory itself preserved)
+ *
+ * NOT touched:
+ *   - `analysis/persona-candidates.json` — the exporter's Stage-1
+ *     output. That is mining INPUT, not output, and regenerating
+ *     it requires re-running the exporter.
+ *   - Any other analysis file.
+ *
+ * CSRF posture matches `/api/clear-corrections`:
+ *   1. Origin parses to a local-only hostname.
+ *   2. Custom `X-Requested-With: chat-arch-clear-personas` header.
+ *
+ * Static-build deploys without this endpoint return 404; the panel
+ * hides the clear button when the GET probe fails.
+ */
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-clear-personas';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/** apps/standalone/src/pages/api/clear-personas.ts → apps/standalone/public/chat-arch-data/analysis/ */
+function analysisDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', 'public', 'chat-arch-data', 'analysis');
+}
+
+/**
+ * Identify a file as belonging to the persona-mining pipeline's
+ * writable set. Conservative on purpose — anything not matching is
+ * left alone so a misconfigured deploy can't accidentally wipe
+ * sibling analysis output.
+ *
+ * NOTE: this allow-list MUST stay in sync with the Stage-2 skill's
+ * writes. Adding a new sidecar pattern in the skill without updating
+ * this predicate leaves orphan files on disk.
+ */
+export function isPersonaArtifact(name: string): boolean {
+  if (name.length === 0) return false;
+  if (name.includes('/') || name.includes('\\')) return false;
+  if (name.split(/[._-]/).includes('..')) return false;
+  if (name === 'personas.json') return true;
+  if (name.startsWith('persona-status-') && name.endsWith('.json')) return true;
+  return false;
+}
+
+/**
+ * Per-project markdown personas live under `analysis/personas/`.
+ * Match `<project-id>.md` for any non-path-traversal id.
+ */
+export function isPersonaMarkdown(name: string): boolean {
+  if (name.length === 0) return false;
+  if (name.includes('/') || name.includes('\\')) return false;
+  if (name.split(/[._-]/).includes('..')) return false;
+  return name.endsWith('.md');
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+
+  const dir = analysisDir();
+  const removed: string[] = [];
+
+  // Top-level analysis/ files (personas.json + status files).
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return new Response(JSON.stringify({ ok: true, removed: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  await Promise.all(
+    entries.map(async (e) => {
+      if (!e.isFile()) return;
+      if (!isPersonaArtifact(e.name)) return;
+      try {
+        await rm(join(dir, e.name), { force: true });
+        removed.push(e.name);
+      } catch {
+        // Best-effort.
+      }
+    }),
+  );
+
+  // Per-project markdown files under analysis/personas/.
+  const personasDir = join(dir, 'personas');
+  try {
+    const mdEntries = await readdir(personasDir, { withFileTypes: true });
+    await Promise.all(
+      mdEntries.map(async (e) => {
+        if (!e.isFile()) return;
+        if (!isPersonaMarkdown(e.name)) return;
+        try {
+          await rm(join(personasDir, e.name), { force: true });
+          removed.push(join('personas', e.name));
+        } catch {
+          // Best-effort.
+        }
+      }),
+    );
+  } catch (err) {
+    // Personas dir not yet created → nothing more to do.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      const msg = err instanceof Error ? err.message : String(err);
+      return new Response(JSON.stringify({ ok: false, error: msg, removed }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true, removed }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify({ ok: true, available: true }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};

--- a/apps/standalone/src/pages/api/mine-persona.ts
+++ b/apps/standalone/src/pages/api/mine-persona.ts
@@ -1,0 +1,459 @@
+import type { APIRoute } from 'astro';
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { resolveClaudeBin } from '../../lib/resolveClaude.js';
+import {
+  assertDataDirContained,
+  handleDataDirGuardError,
+} from '../../lib/dataDirGuard.js';
+
+/**
+ * NDJSON-streaming endpoint that drives the `/mine-persona` skill.
+ * Shape mirrors `/api/mine-corrections` line-for-line — same CSRF
+ * posture, same inFlight serializer, same fallback-prompt path when
+ * the `/slash` form isn't recognized.
+ *
+ * SCAN chain step 5. Reads `analysis/persona-candidates.json`
+ * (Stage 1, written by the exporter), dispatches per-project
+ * sub-agents that synthesize each persona, writes
+ * `analysis/personas.json` (index) + `analysis/personas/<project-id>.md`
+ * (per-project markdown).
+ */
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-mine-persona';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let inFlight: Promise<void> | null = null;
+let inFlightRequestId: string | null = null;
+
+const MAX_LINE_CHARS = 2_000;
+const MAX_TAIL_BYTES = 8 * 1024;
+
+function tailBytes(text: string, max = MAX_TAIL_BYTES): string {
+  if (text.length <= max) return text;
+  return '… (truncated) …\n' + text.slice(-max);
+}
+
+function clampLine(line: string): string {
+  if (line.length <= MAX_LINE_CHARS) return line;
+  return line.slice(0, MAX_LINE_CHARS - 12) + '… (truncated)';
+}
+
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+
+const SLASH_UNSUPPORTED_MARKERS = ['unknown command', 'command not found', 'no such command'];
+
+function looksLikeSlashUnsupported(stdout: string, stderr: string): boolean {
+  const haystack = (stdout + '\n' + stderr).toLowerCase();
+  return SLASH_UNSUPPORTED_MARKERS.some((m) => haystack.includes(m));
+}
+
+interface SpawnOutcome {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  spawnError: Error | null;
+}
+
+export interface PersonaOutcomeProbe {
+  /** `generatedAt` from a `personas.json` on disk, or null. */
+  personasGeneratedAt: number | null;
+  /** `status` from a `persona-status-<requestId>.json` file, or null. */
+  statusFileStatus: string | null;
+  /** `error` from the same status file (set when status is `error`), or null. */
+  statusFileError: string | null;
+}
+
+export interface PersonaMiningVerdict {
+  ok: boolean;
+  reason: string | null;
+}
+
+/**
+ * Same shape as the mine-corrections endpoint: CLI exit code alone
+ * isn't a reliable success signal — the skill can hit a `cap-and-ask`
+ * branch in headless mode, print, and exit 0 without writing. Require
+ * a fresh `personas.json` on disk before reporting success.
+ */
+export function classifyOutcome(
+  startedAt: number,
+  exitCode: number | null,
+  spawnError: Error | null,
+  probe: PersonaOutcomeProbe,
+): PersonaMiningVerdict {
+  if (spawnError !== null) {
+    return { ok: false, reason: `spawn error: ${spawnError.message}` };
+  }
+  if (exitCode !== 0) {
+    return { ok: false, reason: `claude CLI exited with code ${exitCode}` };
+  }
+  if (probe.statusFileStatus === 'error') {
+    const msg = probe.statusFileError ?? '(no message in status file)';
+    return { ok: false, reason: `skill reported error: ${msg}` };
+  }
+  if (
+    probe.personasGeneratedAt === null ||
+    probe.personasGeneratedAt < startedAt
+  ) {
+    const detail =
+      probe.statusFileStatus !== null
+        ? ` (last skill status: ${probe.statusFileStatus})`
+        : ' (no skill status file written — skill likely aborted before initializing)';
+    return {
+      ok: false,
+      reason:
+        `skill exited cleanly but did not write a fresh personas.json${detail}. ` +
+        `This is the "silent abort" failure mode.`,
+    };
+  }
+  return { ok: true, reason: null };
+}
+
+async function readJsonOrNull<T>(path: string): Promise<T | null> {
+  try {
+    const text = await readFile(path, 'utf8');
+    return JSON.parse(text) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function probeOutcome(
+  rootAbs: string,
+  dataDir: string,
+  requestId: string,
+): Promise<PersonaOutcomeProbe> {
+  const dataDirAbs = resolve(rootAbs, dataDir);
+  const personas = await readJsonOrNull<{ generatedAt?: unknown }>(
+    join(dataDirAbs, 'analysis', 'personas.json'),
+  );
+  const status = await readJsonOrNull<{
+    status?: unknown;
+    error?: unknown;
+  }>(join(dataDirAbs, 'analysis', `persona-status-${requestId}.json`));
+  return {
+    personasGeneratedAt:
+      typeof personas?.generatedAt === 'number' ? personas.generatedAt : null,
+    statusFileStatus:
+      typeof status?.status === 'string' ? status.status : null,
+    statusFileError:
+      typeof status?.error === 'string' ? status.error : null,
+  };
+}
+
+interface PersonaParams {
+  requestId: string;
+  dataDir: string;
+  /** Optional single-project override — when present, the skill mines only
+   *  that project. Surfaced through the PERSONAS page's REGEN PERSONA button. */
+  projectId: string | null;
+}
+
+const DEFAULT_DATA_DIR = 'apps/standalone/public/chat-arch-data';
+
+interface MineRequestBody {
+  dataDir?: unknown;
+  projectId?: unknown;
+}
+
+function parseParams(body: MineRequestBody): PersonaParams {
+  const rawDir = body.dataDir;
+  const candidate =
+    typeof rawDir === 'string' && rawDir.trim().length > 0
+      ? rawDir
+      : DEFAULT_DATA_DIR;
+  const dataDir = assertDataDirContained(candidate, repoRoot());
+
+  const projectId =
+    typeof body.projectId === 'string' && body.projectId.trim().length > 0
+      ? body.projectId.trim()
+      : null;
+
+  return {
+    requestId: randomUUID(),
+    dataDir,
+    projectId,
+  };
+}
+
+function runClaudeOnce(
+  prompt: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<SpawnOutcome> {
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // Already closed.
+    }
+  };
+
+  return new Promise<SpawnOutcome>((resolvePromise) => {
+    const allowedTools = 'Read Write Edit Bash Task Glob Grep';
+    const bin = resolveClaudeBin();
+    const args = ['--allowedTools', allowedTools, '-p', prompt];
+    const child = spawn(bin.file, args, {
+      cwd: repoRoot(),
+      env: process.env,
+      shell: bin.useShell,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    const stdoutFull = { v: '' };
+    const stderrFull = { v: '' };
+    let spawnError: Error | null = null;
+
+    const drain = (
+      buf: string,
+      chunk: string,
+      kind: 'stdout' | 'stderr',
+      full: { v: string },
+    ): string => {
+      full.v += chunk;
+      const combined = buf + chunk;
+      const parts = combined.split('\n');
+      const lastFragment = parts.pop() ?? '';
+      for (const raw of parts) {
+        const line = raw.trimEnd();
+        if (line.length === 0) continue;
+        send({ type: kind, line: clampLine(line) });
+        const m = /\[(\d+)\/(\d+)\]\s+(\w[\w-]*)\s*:/.exec(line);
+        if (m) {
+          send({
+            type: 'phase',
+            phase: m[3],
+            ix: Number(m[1]),
+            total: Number(m[2]),
+          });
+        }
+      }
+      return lastFragment;
+    };
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutBuf = drain(stdoutBuf, chunk.toString('utf8'), 'stdout', stdoutFull);
+    });
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderrBuf = drain(stderrBuf, chunk.toString('utf8'), 'stderr', stderrFull);
+    });
+
+    child.on('error', (err) => {
+      spawnError = err;
+    });
+    child.on('close', (code) => {
+      if (stdoutBuf.trim().length > 0) {
+        send({ type: 'stdout', line: clampLine(stdoutBuf.trim()) });
+        stdoutFull.v += stdoutBuf;
+        stdoutBuf = '';
+      }
+      if (stderrBuf.trim().length > 0) {
+        send({ type: 'stderr', line: clampLine(stderrBuf.trim()) });
+        stderrFull.v += stderrBuf;
+        stderrBuf = '';
+      }
+      resolvePromise({
+        exitCode: code,
+        stdout: stdoutFull.v,
+        stderr: stderrFull.v,
+        spawnError,
+      });
+    });
+  });
+}
+
+async function streamMinePersona(
+  params: PersonaParams,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+): Promise<void> {
+  const started = Date.now();
+  const { requestId, dataDir, projectId } = params;
+  const projectArg = projectId !== null ? ` --project-id=${projectId}` : '';
+  const argSuffix = `--request-id=${requestId} --data-dir=${dataDir}${projectArg}`;
+  const slashPrompt = `/mine-persona ${argSuffix}`;
+  const fallbackPrompt =
+    `Read .claude/skills/mine-persona/SKILL.md and execute it with these arguments: ${argSuffix}`;
+
+  const send = (obj: unknown) => {
+    try {
+      controller.enqueue(encoder.encode(JSON.stringify(obj) + '\n'));
+    } catch {
+      // Already closed.
+    }
+  };
+
+  send({
+    type: 'start',
+    command: `claude -p "${slashPrompt}"`,
+    requestId,
+    startedAt: started,
+    projectId,
+  });
+
+  let outcome = await runClaudeOnce(slashPrompt, controller, encoder);
+  let usedFallback = false;
+
+  const slashLooksUnsupported =
+    outcome.exitCode !== 0 && looksLikeSlashUnsupported(outcome.stdout, outcome.stderr);
+
+  if (slashLooksUnsupported) {
+    usedFallback = true;
+    send({ type: 'phase', phase: 'fallback-prompt' });
+    const second = await runClaudeOnce(fallbackPrompt, controller, encoder);
+    outcome = {
+      exitCode: second.exitCode,
+      stdout: outcome.stdout + second.stdout,
+      stderr: outcome.stderr + second.stderr,
+      spawnError: second.spawnError ?? outcome.spawnError,
+    };
+  }
+
+  const extraStderr = outcome.spawnError
+    ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
+    : '';
+
+  const probe = await probeOutcome(repoRoot(), dataDir, requestId);
+  const verdict = classifyOutcome(
+    started,
+    outcome.exitCode,
+    outcome.spawnError,
+    probe,
+  );
+  const verdictNote = verdict.reason !== null ? '\n[outcome] ' + verdict.reason : '';
+
+  send({
+    type: 'done',
+    ok: verdict.ok,
+    exitCode: outcome.exitCode,
+    durationMs: Date.now() - started,
+    requestId,
+    usedFallback,
+    stdoutTail: tailBytes(outcome.stdout),
+    stderrTail: tailBytes(outcome.stderr + extraStderr + verdictNote),
+    command: usedFallback
+      ? `claude -p "${fallbackPrompt}"`
+      : `claude -p "${slashPrompt}"`,
+  });
+
+  try {
+    controller.close();
+  } catch {
+    // Already closed.
+  }
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+
+  let body: MineRequestBody = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) {
+      const parsed: unknown = JSON.parse(text);
+      if (parsed && typeof parsed === 'object') {
+        body = parsed as MineRequestBody;
+      }
+    }
+  } catch {
+    body = {};
+  }
+
+  if (inFlight) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: 'A persona-mining run is already in progress. Wait for it to finish.',
+      }),
+      { status: 409, headers: { 'content-type': 'application/json' } },
+    );
+  }
+
+  let params: PersonaParams;
+  try {
+    params = parseParams(body);
+  } catch (e) {
+    const r = handleDataDirGuardError(e);
+    if (r) return r;
+    throw e;
+  }
+
+  const encoder = new TextEncoder();
+  let done: (() => void) | null = null;
+  const completed = new Promise<void>((res) => {
+    done = res;
+  });
+  inFlight = completed.then(() => undefined);
+  inFlightRequestId = params.requestId;
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        await streamMinePersona(params, controller, encoder);
+      } finally {
+        inFlight = null;
+        inFlightRequestId = null;
+        done?.();
+      }
+    },
+    cancel() {
+      // Client disconnected; CLI keeps running.
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'application/x-ndjson',
+      'cache-control': 'no-store',
+      'x-accel-buffering': 'no',
+    },
+  });
+};
+
+export const GET: APIRoute = () => {
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      available: true,
+      busy: inFlight !== null,
+      busyRequestId: inFlightRequestId,
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json', 'cache-control': 'no-store' },
+    },
+  );
+};

--- a/apps/standalone/src/pages/personas.astro
+++ b/apps/standalone/src/pages/personas.astro
@@ -1,0 +1,573 @@
+---
+// PERSONAS — per-project data-grounded personas, generated as SCAN
+// chain step 5 by the /mine-persona skill. Each persona mirrors the
+// `research/persona-evals/bryce.md` structure: header / 6-10 numbered
+// pattern sections with **Pattern.** / **Evidence.** / **What this
+// implies.** / coverage notes.
+//
+// V1 surface — render-only with a per-project REGEN button. Polish
+// items deferred to V2: cross-project compare, persona-drift diff,
+// inline session-detail drawer on SID click (today's behavior is a
+// hash-route navigation to /sessions#session/<full-sid>).
+export const prerender = false;
+
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { PersonasIndex, SessionManifest } from '@chat-arch/schema';
+
+function dataDir(): string {
+  return path.join(process.cwd(), 'public', 'chat-arch-data');
+}
+
+async function readJson<T>(absPath: string): Promise<T | null> {
+  try {
+    const raw = await readFile(absPath, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function readPersonaMarkdown(personaPath: string): Promise<string | null> {
+  // personaPath is relative to chat-arch-data (e.g. analysis/personas/foo.md).
+  // Resolve under the data dir's parent (the project-relative
+  // chat-arch-data/) NOT under process.cwd() — process.cwd() is
+  // apps/standalone at runtime.
+  const abs = path.join(dataDir(), personaPath);
+  try {
+    return await readFile(abs, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+const url = new URL(Astro.request.url);
+const selectedProjectId = url.searchParams.get('project');
+
+const personas = await readJson<PersonasIndex>(
+  path.join(dataDir(), 'analysis', 'personas.json'),
+);
+const manifest = await readJson<SessionManifest>(
+  path.join(dataDir(), 'manifest.json'),
+);
+
+// Build a map of 8-char session-id prefix → full session id so
+// `[SID:c9a0169b]` in the markdown can resolve to the full id for the
+// `/sessions#session/<full-id>` hash route.
+const prefixToFullSid = new Map<string, string>();
+for (const s of manifest?.sessions ?? []) {
+  if (typeof s.id === 'string' && s.id.length >= 8) {
+    prefixToFullSid.set(s.id.slice(0, 8), s.id);
+  }
+}
+
+// Split generated vs skipped for the sidebar.
+const generated = (personas?.personas ?? [])
+  .filter((p) => p.status === 'generated')
+  .slice()
+  .sort((a, b) => b.sessionsAnalyzed - a.sessionsAnalyzed);
+const skipped = (personas?.personas ?? []).filter(
+  (p) => p.status !== 'generated',
+);
+
+// Pick the active project: explicit ?project= wins; else first generated.
+const activeRecord =
+  generated.find((p) => p.projectId === selectedProjectId) ??
+  (selectedProjectId === null && generated.length > 0 ? generated[0] : null);
+
+const activeMarkdown =
+  activeRecord !== null && activeRecord.personaPath !== null
+    ? await readPersonaMarkdown(activeRecord.personaPath)
+    : null;
+
+// HTML-escape for safe rendering. We render the persona body via
+// set:html so the [SID:...] anchors become real <a> tags; everything
+// else must be escaped first or a stray "<" in user-text would close
+// our wrapping <pre>.
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Transform `[SID:<8 chars>]` into clickable anchors. Anchor target
+// uses the full session id when we can resolve it; otherwise leaves
+// the markdown as plain text (no broken link).
+function renderPersonaBody(md: string): string {
+  // Match [SID:<8 chars from {hex/alnum-dash}>] tolerantly. Persona
+  // markdown emits the 8-char prefix; manifest ids are uuids so
+  // alnum + dashes are enough.
+  return md.replace(
+    /\[SID:([A-Za-z0-9-]{4,32})\]/g,
+    (whole, captured) => {
+      const safePrefix = escapeHtml(captured as string);
+      const full = prefixToFullSid.get(captured as string);
+      if (full === undefined) {
+        return `[SID:${safePrefix}]`;
+      }
+      return `<a class="persona__sid" href="/sessions#session/${encodeURIComponent(full)}">[SID:${safePrefix}]</a>`;
+    },
+  );
+}
+
+// Compose the renderable HTML for the persona body: escape first,
+// then substitute SID anchors (the substitution writes UNESCAPED
+// anchor markup, so we run it AFTER escaping the body text).
+const renderedBody =
+  activeMarkdown !== null
+    ? renderPersonaBody(escapeHtml(activeMarkdown))
+    : null;
+
+function fmtDate(ms: number | null): string {
+  if (ms === null) return '—';
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function skipReasonLabel(p: { status: string; reason?: string }): string {
+  switch (p.status) {
+    case 'insufficient-corpus':
+      return 'fewer sessions than the generation threshold';
+    case 'budget-exceeded':
+      return 'projected LLM cost above the per-project cap';
+    case 'error':
+      return p.reason ?? 'unknown error during generation';
+    default:
+      return p.reason ?? p.status;
+  }
+}
+---
+<BaseLayout title="Chat Archaeologist — Personas" current="PERSONAS">
+  <main class="personas">
+    <header class="personas__header">
+      <h1>PERSONAS</h1>
+      <p class="personas__lede">
+        Per-project data-grounded personas. Each is synthesized from
+        the project's session evidence on every SCAN — verbatim
+        user-prompt excerpts cited inline as
+        <code>[SID:&lt;prefix&gt;]</code> (click any to jump to the
+        session). Hand-authored personas under{' '}
+        <code>research/persona-evals/</code> stay canonical for the
+        projects they cover and supersede the auto-generated output
+        for those specific projects.
+      </p>
+    </header>
+
+    {personas === null ? (
+      <section class="personas__empty">
+        <h2>Sidecar not yet written</h2>
+        <p>
+          <code>analysis/personas.json</code> isn't on disk (or failed
+          to parse). Click <strong>SCAN LOCAL</strong> from the DATA
+          panel, or run <code>pnpm exporter run start</code> followed
+          by <code>/mine-persona</code> — the SCAN chain wires both
+          steps together.
+        </p>
+      </section>
+    ) : personas.personas.length === 0 ? (
+      <section class="personas__empty">
+        <h2>No projects in the corpus yet</h2>
+        <p>
+          The exporter found no projects to extract personas for.
+          Inspect <code>analysis/persona-candidates.json</code> to
+          verify the Stage-1 output.
+        </p>
+      </section>
+    ) : (
+      <div class="personas__layout">
+        <nav class="personas__nav" aria-label="Projects with personas">
+          <div class="personas__nav-group">
+            <h2 class="personas__nav-label">Generated</h2>
+            {generated.length === 0 ? (
+              <p class="personas__nav-empty">No personas generated yet.</p>
+            ) : (
+              <ul class="personas__nav-list">
+                {generated.map((p) => {
+                  const active = activeRecord !== null && p.projectId === activeRecord.projectId;
+                  return (
+                    <li>
+                      <a
+                        class={`personas__nav-item${active ? ' personas__nav-item--active' : ''}`}
+                        href={`/personas?project=${encodeURIComponent(p.projectId)}`}
+                        aria-current={active ? 'page' : undefined}
+                      >
+                        <span class="personas__nav-name">{p.projectName}</span>
+                        <span class="personas__nav-meta">
+                          {p.sessionsAnalyzed} / {p.sessionsTotal} sessions
+                        </span>
+                      </a>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+          {skipped.length > 0 ? (
+            <details class="personas__nav-group personas__nav-skipped">
+              <summary class="personas__nav-label">
+                Not yet generated ({skipped.length})
+              </summary>
+              <ul class="personas__nav-list">
+                {skipped.map((p) => (
+                  <li>
+                    <div class="personas__nav-item personas__nav-item--skipped">
+                      <span class="personas__nav-name">{p.projectName}</span>
+                      <span class="personas__nav-meta">
+                        {skipReasonLabel(p)} ({p.sessionsTotal} sessions)
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          ) : null}
+        </nav>
+
+        <article class="personas__body">
+          {activeRecord === null ? (
+            <section class="personas__empty">
+              <h2>Select a project</h2>
+              <p>Pick a generated persona from the list on the left.</p>
+            </section>
+          ) : renderedBody === null ? (
+            <section class="personas__empty">
+              <h2>Persona markdown missing on disk</h2>
+              <p>
+                The index says this persona was generated, but
+                <code>{activeRecord.personaPath}</code> couldn't be
+                read. Re-run <strong>REGEN PERSONA</strong> to
+                regenerate.
+              </p>
+            </section>
+          ) : (
+            <>
+              <div class="personas__meta">
+                <span class="personas__meta-label">project</span>
+                <span class="personas__meta-value">{activeRecord.projectName}</span>
+                <span class="personas__meta-sep">·</span>
+                <span class="personas__meta-label">sessions analyzed</span>
+                <span class="personas__meta-value">{activeRecord.sessionsAnalyzed}</span>
+                <span class="personas__meta-sep">·</span>
+                <span class="personas__meta-label">generated</span>
+                <span class="personas__meta-value">{fmtDate(activeRecord.generatedAt)}</span>
+              </div>
+              <div class="personas__actions">
+                <button
+                  id="personas-regen"
+                  type="button"
+                  class="personas__regen-btn"
+                  data-project-id={activeRecord.projectId}
+                >
+                  REGEN PERSONA →
+                </button>
+                <span
+                  id="personas-regen-feedback"
+                  class="personas__regen-feedback"
+                  aria-live="polite"
+                ></span>
+              </div>
+              {/*
+                Render the persona markdown via set:html so the
+                `[SID:<prefix>]` substrings become real anchors that
+                navigate to /sessions#session/<full-id>. Body text is
+                pre-escaped to prevent any user-corpus excerpt from
+                injecting markup. <pre> + CSS pre-wrap preserves the
+                markdown layout without pulling in a real markdown
+                renderer (matches the brief's V1 render path on TODAY).
+              */}
+              <pre class="personas__md" set:html={renderedBody}></pre>
+            </>
+          )}
+        </article>
+      </div>
+    )}
+  </main>
+
+  <script is:inline>
+    (function () {
+      const btn = document.getElementById('personas-regen');
+      const feedback = document.getElementById('personas-regen-feedback');
+      if (!btn || !feedback) return;
+      btn.addEventListener('click', function () {
+        const pid = btn.getAttribute('data-project-id');
+        if (!pid) return;
+        btn.setAttribute('disabled', 'true');
+        feedback.textContent = 'starting…';
+        fetch('/api/mine-persona', {
+          method: 'POST',
+          headers: {
+            'X-Requested-With': 'chat-arch-mine-persona',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ projectId: pid }),
+        })
+          .then(async function (res) {
+            if (!res.ok) {
+              const body = await res.text();
+              feedback.textContent =
+                'failed: HTTP ' + res.status + (body ? ' — ' + body.slice(0, 120) : '');
+              btn.removeAttribute('disabled');
+              return;
+            }
+            // Stream NDJSON; on terminal done, reload the page to
+            // show the freshly-written markdown.
+            const reader = res.body && res.body.getReader();
+            if (!reader) {
+              feedback.textContent = 'no stream — reloading…';
+              window.location.reload();
+              return;
+            }
+            const decoder = new TextDecoder();
+            let buf = '';
+            let done = false;
+            let ok = false;
+            while (!done) {
+              const chunk = await reader.read();
+              if (chunk.done) break;
+              buf += decoder.decode(chunk.value, { stream: true });
+              const parts = buf.split('\n');
+              buf = parts.pop() || '';
+              for (const raw of parts) {
+                const line = raw.trim();
+                if (!line) continue;
+                try {
+                  const evt = JSON.parse(line);
+                  if (evt.type === 'phase' && typeof evt.phase === 'string') {
+                    feedback.textContent = evt.phase;
+                  } else if (evt.type === 'done') {
+                    done = true;
+                    ok = evt.ok === true;
+                  }
+                } catch {
+                  // ignore parse errors
+                }
+              }
+            }
+            feedback.textContent = ok ? 'reloading…' : 'failed';
+            btn.removeAttribute('disabled');
+            if (ok) {
+              setTimeout(function () {
+                window.location.reload();
+              }, 500);
+            }
+          })
+          .catch(function (err) {
+            feedback.textContent = 'failed: ' + (err && err.message ? err.message : String(err));
+            btn.removeAttribute('disabled');
+          });
+      });
+    })();
+  </script>
+
+  <style>
+    .personas {
+      padding: 24px clamp(16px, 4vw, 48px);
+      max-width: 1400px;
+      margin: 0 auto;
+      color: #ffcc99;
+    }
+    .personas__header h1 {
+      font-family: 'Antonio', 'Oswald', 'Impact', sans-serif;
+      letter-spacing: 0.18em;
+      font-size: 28px;
+      margin: 0 0 12px;
+    }
+    .personas__lede {
+      max-width: 72ch;
+      line-height: 1.5;
+      color: #d9ad82;
+      margin: 0 0 20px;
+    }
+    .personas__lede code {
+      background: rgba(255, 204, 153, 0.08);
+      padding: 1px 5px;
+      border-radius: 3px;
+    }
+
+    .personas__empty {
+      border: 1px dashed #dd9944;
+      padding: 24px;
+      border-radius: 12px;
+      max-width: 60ch;
+    }
+    .personas__empty h2 {
+      margin: 0 0 8px;
+      font-family: 'Antonio', 'Oswald', 'Impact', sans-serif;
+      font-size: 18px;
+      letter-spacing: 0.12em;
+      color: #ffcc99;
+    }
+    .personas__empty code {
+      background: rgba(255, 204, 153, 0.08);
+      padding: 1px 5px;
+      border-radius: 3px;
+    }
+
+    .personas__layout {
+      display: grid;
+      grid-template-columns: 260px 1fr;
+      gap: 24px;
+      align-items: start;
+    }
+    @media (max-width: 800px) {
+      .personas__layout {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .personas__nav {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      border-right: 1px solid rgba(221, 153, 68, 0.4);
+      padding-right: 16px;
+    }
+    .personas__nav-label {
+      font-family: 'Antonio', 'Oswald', 'Impact', sans-serif;
+      letter-spacing: 0.14em;
+      font-size: 11px;
+      color: #dd9944;
+      margin: 0 0 8px;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+    .personas__nav-empty {
+      font-size: 12px;
+      color: #d9ad82;
+    }
+    .personas__nav-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .personas__nav-item {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      padding: 8px 10px;
+      border-radius: 6px;
+      text-decoration: none;
+      color: #ffcc99;
+      background: rgba(255, 204, 153, 0.05);
+      border: 1px solid transparent;
+    }
+    .personas__nav-item:hover {
+      background: rgba(255, 204, 153, 0.1);
+      border-color: rgba(221, 153, 68, 0.4);
+    }
+    .personas__nav-item--active {
+      background: rgba(255, 153, 51, 0.15);
+      border-color: #ff9933;
+    }
+    .personas__nav-item--skipped {
+      cursor: default;
+      opacity: 0.6;
+    }
+    .personas__nav-item--skipped:hover {
+      background: rgba(255, 204, 153, 0.05);
+      border-color: transparent;
+    }
+    .personas__nav-name {
+      font-weight: 700;
+      font-size: 13px;
+      letter-spacing: 0.04em;
+    }
+    .personas__nav-meta {
+      font-size: 11px;
+      color: #d9ad82;
+    }
+    .personas__nav-skipped[open] .personas__nav-label {
+      color: #ffcc99;
+    }
+
+    .personas__body {
+      min-width: 0;
+    }
+    .personas__meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px 10px;
+      align-items: baseline;
+      font-size: 12px;
+      color: #d9ad82;
+      margin-bottom: 16px;
+    }
+    .personas__meta-label {
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      font-size: 10px;
+      color: #dd9944;
+    }
+    .personas__meta-value {
+      color: #ffcc99;
+      font-weight: 600;
+    }
+    .personas__meta-sep {
+      opacity: 0.4;
+    }
+
+    .personas__actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 20px;
+    }
+    .personas__regen-btn {
+      background: transparent;
+      color: #ff9933;
+      border: 1px solid #ff9933;
+      padding: 8px 14px;
+      border-radius: 6px;
+      font-family: 'Antonio', 'Oswald', 'Impact', sans-serif;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      font-size: 11px;
+      cursor: pointer;
+      text-transform: uppercase;
+    }
+    .personas__regen-btn:hover:not([disabled]) {
+      background: #ff9933;
+      color: #000;
+    }
+    .personas__regen-btn[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+    .personas__regen-feedback {
+      font-size: 12px;
+      color: #d9ad82;
+      font-style: italic;
+    }
+
+    .personas__md {
+      background: rgba(0, 0, 0, 0.4);
+      border: 1px solid rgba(221, 153, 68, 0.3);
+      border-radius: 8px;
+      padding: 18px 22px;
+      white-space: pre-wrap;
+      word-break: break-word;
+      font-family: 'JetBrains Mono', 'Consolas', 'Menlo', monospace;
+      font-size: 13px;
+      line-height: 1.55;
+      color: #f4e1cc;
+      max-height: 80vh;
+      overflow-y: auto;
+      margin: 0;
+    }
+    .personas__sid {
+      color: #99ccff;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+    }
+    .personas__sid:hover {
+      color: #ffcc99;
+      background: rgba(153, 204, 255, 0.1);
+    }
+  </style>
+</BaseLayout>

--- a/apps/standalone/src/pages/personas.astro
+++ b/apps/standalone/src/pages/personas.astro
@@ -14,29 +14,20 @@ export const prerender = false;
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import type { PersonasIndex, SessionManifest } from '@chat-arch/schema';
+import type { SessionManifest } from '@chat-arch/schema';
+import {
+  readPersonaMarkdown,
+  readPersonasIndex,
+} from '../lib/readSidecars.ts';
 
 function dataDir(): string {
   return path.join(process.cwd(), 'public', 'chat-arch-data');
 }
 
-async function readJson<T>(absPath: string): Promise<T | null> {
+async function readManifest(): Promise<SessionManifest | null> {
   try {
-    const raw = await readFile(absPath, 'utf8');
-    return JSON.parse(raw) as T;
-  } catch {
-    return null;
-  }
-}
-
-async function readPersonaMarkdown(personaPath: string): Promise<string | null> {
-  // personaPath is relative to chat-arch-data (e.g. analysis/personas/foo.md).
-  // Resolve under the data dir's parent (the project-relative
-  // chat-arch-data/) NOT under process.cwd() — process.cwd() is
-  // apps/standalone at runtime.
-  const abs = path.join(dataDir(), personaPath);
-  try {
-    return await readFile(abs, 'utf8');
+    const raw = await readFile(path.join(dataDir(), 'manifest.json'), 'utf8');
+    return JSON.parse(raw) as SessionManifest;
   } catch {
     return null;
   }
@@ -45,12 +36,8 @@ async function readPersonaMarkdown(personaPath: string): Promise<string | null> 
 const url = new URL(Astro.request.url);
 const selectedProjectId = url.searchParams.get('project');
 
-const personas = await readJson<PersonasIndex>(
-  path.join(dataDir(), 'analysis', 'personas.json'),
-);
-const manifest = await readJson<SessionManifest>(
-  path.join(dataDir(), 'manifest.json'),
-);
+const personas = await readPersonasIndex();
+const manifest = await readManifest();
 
 // Build a map of 8-char session-id prefix → full session id so
 // `[SID:c9a0169b]` in the markdown can resolve to the full id for the

--- a/apps/standalone/src/scripts/fullScan.ts
+++ b/apps/standalone/src/scripts/fullScan.ts
@@ -1,16 +1,17 @@
 /**
  * FULL SCAN orchestrator — Phase β.
  *
- * Sequentially fires the four NDJSON producers behind the TODAY page's
+ * Sequentially fires the five NDJSON producers behind the TODAY page's
  * single "FULL SCAN" button:
  *
  *   1. /api/rescan           (exporter — writes every analysis sidecar)
  *   2. /api/mine-corrections (corrections skill — classifies candidates)
  *   3. /api/curate           (curator skill — ranks the feed)
  *   4. /api/falsify          (falsifier skill — verifies cited evidence)
+ *   5. /api/mine-persona     (persona skill — per-project personas)
  *
  * Each call is awaited to completion (NDJSON stream end OR HTTP error)
- * before the next starts. The page reloads exactly once after step 4
+ * before the next starts. The page reloads exactly once after step 5
  * succeeds — earlier reloads would interrupt later steps.
  *
  * Pure helpers (no DOM, no `window`) live above the orchestrator so
@@ -35,7 +36,7 @@ export interface FullScanStep {
 }
 
 /**
- * The canonical 4-step sequence. Header values mirror each endpoint's
+ * The canonical 5-step sequence. Header values mirror each endpoint's
  * `REQUIRED_HEADER` constant verbatim — re-export divergence here is a
  * silent 403, so the test alongside this file pins both sides.
  */
@@ -63,6 +64,12 @@ export const FULL_SCAN_STEPS: readonly FullScanStep[] = [
     label: 'falsify findings',
     url: '/api/falsify',
     header: 'chat-arch-falsify',
+  },
+  {
+    id: 'persona',
+    label: 'mine personas',
+    url: '/api/mine-persona',
+    header: 'chat-arch-mine-persona',
   },
 ];
 
@@ -221,8 +228,8 @@ export async function runOneStep(
 }
 
 /**
- * Drive the full chain (5 steps as of #102 — rescan / mine / curate
- * / falsify / persona). Returns true iff every step succeeded.
+ * Drive the full 5-step chain (rescan / mine / curate / falsify /
+ * persona). Returns true iff every step succeeded.
  * On any failure, returns false and stops the chain — the UI port's
  * `onChainDone(false, ...)` is called with the offending step's error.
  *

--- a/apps/standalone/test/api/clear-personas.test.ts
+++ b/apps/standalone/test/api/clear-personas.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REQUIRED_HEADER,
+  isLocalOrigin,
+  isPersonaArtifact,
+  isPersonaMarkdown,
+} from '../../src/pages/api/clear-personas.js';
+
+describe('clear-personas — CSRF gate', () => {
+  it('accepts loopback origins, rejects everything else', () => {
+    expect(isLocalOrigin('http://localhost:4324')).toBe(true);
+    expect(isLocalOrigin('http://127.0.0.1')).toBe(true);
+    expect(isLocalOrigin('http://[::1]')).toBe(true);
+    expect(isLocalOrigin(null)).toBe(false);
+    expect(isLocalOrigin('http://example.com')).toBe(false);
+    expect(isLocalOrigin('file:///')).toBe(false);
+  });
+
+  it('exposes a distinct X-Requested-With header from sibling endpoints', () => {
+    // If this token collides with /api/mine-persona, /api/clear-corrections,
+    // /api/clear, etc., a CSRF that targets one would also fire the
+    // others. Pin them as distinct.
+    expect(REQUIRED_HEADER).toBe('chat-arch-clear-personas');
+  });
+});
+
+describe('clear-personas — isPersonaArtifact allow-list (top-level analysis/)', () => {
+  it('matches the documented top-level patterns', () => {
+    expect(isPersonaArtifact('personas.json')).toBe(true);
+    expect(isPersonaArtifact('persona-status-abc-123.json')).toBe(true);
+    expect(
+      isPersonaArtifact('persona-status-1614337e-5e34-4bb9-b89d-0b1de98cc131.json'),
+    ).toBe(true);
+  });
+
+  it('rejects sibling analysis files we do NOT own', () => {
+    // The Stage-1 candidates file is INPUT, not output — never deleted.
+    expect(isPersonaArtifact('persona-candidates.json')).toBe(false);
+    expect(isPersonaArtifact('manifest.json')).toBe(false);
+    expect(isPersonaArtifact('corrections.json')).toBe(false);
+    expect(isPersonaArtifact('correction-status-foo.json')).toBe(false);
+    expect(isPersonaArtifact('curator-feed.json')).toBe(false);
+    expect(isPersonaArtifact('falsifier-verdicts.json')).toBe(false);
+    expect(isPersonaArtifact('meta.json')).toBe(false);
+  });
+
+  it('rejects look-alike names', () => {
+    expect(isPersonaArtifact('personas.json.bak')).toBe(false);
+    expect(isPersonaArtifact('personas.txt')).toBe(false);
+    expect(isPersonaArtifact('Personas.json')).toBe(false); // case-sensitive
+    expect(isPersonaArtifact('xpersona-status-foo.json')).toBe(false);
+    expect(isPersonaArtifact('persona-status-')).toBe(false);
+    expect(isPersonaArtifact('')).toBe(false);
+  });
+
+  it('rejects directory traversal in the name', () => {
+    expect(isPersonaArtifact('../etc/passwd')).toBe(false);
+    expect(isPersonaArtifact('persona-status-../foo.json')).toBe(false);
+    expect(isPersonaArtifact('../personas.json')).toBe(false);
+  });
+});
+
+describe('clear-personas — isPersonaMarkdown allow-list (analysis/personas/)', () => {
+  it('matches any .md file inside the personas subdir', () => {
+    expect(isPersonaMarkdown('chat-arch.md')).toBe(true);
+    expect(isPersonaMarkdown('shopforge-v4.md')).toBe(true);
+    expect(isPersonaMarkdown('a.md')).toBe(true);
+    // UNASSIGNED project id (per `@chat-arch/schema`).
+    expect(isPersonaMarkdown('__unassigned__.md')).toBe(true);
+  });
+
+  it('rejects non-markdown extensions', () => {
+    expect(isPersonaMarkdown('chat-arch.json')).toBe(false);
+    expect(isPersonaMarkdown('chat-arch.txt')).toBe(false);
+    expect(isPersonaMarkdown('chat-arch')).toBe(false);
+    expect(isPersonaMarkdown('chat-arch.md.bak')).toBe(false);
+    expect(isPersonaMarkdown('')).toBe(false);
+  });
+
+  it('rejects directory traversal in the name', () => {
+    expect(isPersonaMarkdown('../etc/passwd.md')).toBe(false);
+    expect(isPersonaMarkdown('../../foo.md')).toBe(false);
+    expect(isPersonaMarkdown('subdir/foo.md')).toBe(false);
+    expect(isPersonaMarkdown('subdir\\foo.md')).toBe(false);
+  });
+});

--- a/apps/standalone/test/api/mine-persona.test.ts
+++ b/apps/standalone/test/api/mine-persona.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REQUIRED_HEADER,
+  classifyOutcome,
+  isLocalOrigin,
+  type PersonaOutcomeProbe,
+} from '../../src/pages/api/mine-persona.js';
+
+const emptyProbe: PersonaOutcomeProbe = {
+  personasGeneratedAt: null,
+  statusFileStatus: null,
+  statusFileError: null,
+};
+
+// Mirror of mine-corrections.test.ts — the persona endpoint shares the
+// shape line-for-line, and divergence between the two on the CSRF /
+// silent-abort logic would defeat the parity these tests pin. Add a
+// matching case here whenever mine-corrections grows one.
+
+describe('mine-persona — CSRF gate', () => {
+  it('accepts http://localhost:<any>', () => {
+    expect(isLocalOrigin('http://localhost:4324')).toBe(true);
+    expect(isLocalOrigin('http://localhost')).toBe(true);
+    expect(isLocalOrigin('https://localhost:8443')).toBe(true);
+  });
+
+  it('accepts the loopback IPv4 / IPv6 literals', () => {
+    expect(isLocalOrigin('http://127.0.0.1')).toBe(true);
+    expect(isLocalOrigin('http://127.0.0.1:4324')).toBe(true);
+    expect(isLocalOrigin('http://[::1]:4324')).toBe(true);
+  });
+
+  it('rejects null / empty / whitespace', () => {
+    expect(isLocalOrigin(null)).toBe(false);
+    expect(isLocalOrigin('')).toBe(false);
+    expect(isLocalOrigin('   ')).toBe(false);
+  });
+
+  it('rejects non-loopback hostnames', () => {
+    expect(isLocalOrigin('http://example.com')).toBe(false);
+    expect(isLocalOrigin('http://attacker.localhost.evil.com')).toBe(false);
+    expect(isLocalOrigin('http://192.168.1.1')).toBe(false);
+    expect(isLocalOrigin('http://localhost.evil.com')).toBe(false);
+  });
+
+  it('rejects non-http(s) protocols', () => {
+    expect(isLocalOrigin('file:///etc/passwd')).toBe(false);
+    expect(isLocalOrigin('data:text/html,foo')).toBe(false);
+    expect(isLocalOrigin('javascript:alert(1)')).toBe(false);
+    expect(isLocalOrigin('ftp://localhost')).toBe(false);
+  });
+
+  it('rejects malformed URLs without throwing', () => {
+    expect(isLocalOrigin('not-a-url')).toBe(false);
+    expect(isLocalOrigin('://broken')).toBe(false);
+    expect(isLocalOrigin('http://')).toBe(false);
+  });
+
+  it('exposes the X-Requested-With header value', () => {
+    // Pinned so a rename can't silently 403 the SCAN chain's 5th step.
+    expect(REQUIRED_HEADER).toBe('chat-arch-mine-persona');
+  });
+});
+
+describe('mine-persona — classifyOutcome', () => {
+  const started = 1_000_000;
+
+  it('reports success when personas.json is fresh and exit was clean', () => {
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      personasGeneratedAt: started + 5_000,
+      statusFileStatus: 'complete',
+    });
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toBeNull();
+  });
+
+  it('reports success when personas.json generatedAt equals startedAt', () => {
+    // Boundary: skill could write generatedAt = exact start ms.
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      personasGeneratedAt: started,
+      statusFileStatus: 'complete',
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('reports failure when claude CLI exits non-zero', () => {
+    const verdict = classifyOutcome(started, 1, null, {
+      ...emptyProbe,
+      personasGeneratedAt: started + 5_000,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/exited with code 1/);
+  });
+
+  it('reports failure when spawn errored', () => {
+    const verdict = classifyOutcome(
+      started,
+      null,
+      new Error('ENOENT claude'),
+      emptyProbe,
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/spawn error: ENOENT claude/);
+  });
+
+  it('takes status-file `error` precedence over a stale personas.json', () => {
+    // The status file is the skill's own self-report; if it says error,
+    // that's authoritative even when personas.json happens to be fresh
+    // (e.g. a prior successful run sits on disk).
+    const verdict = classifyOutcome(started, 0, null, {
+      personasGeneratedAt: started + 1,
+      statusFileStatus: 'error',
+      statusFileError: 'persona-candidates.json missing',
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/skill reported error: persona-candidates\.json missing/);
+  });
+
+  it('reports the silent-abort failure mode: CLI exits 0 but personas.json is stale', () => {
+    // The "skill exited cleanly but didn't write" path — the failure
+    // mode the corrections endpoint added classifyOutcome to catch.
+    // Persona endpoint inherits the shape; this test pins it.
+    const verdict = classifyOutcome(started, 0, null, {
+      ...emptyProbe,
+      personasGeneratedAt: started - 5_000, // prior run, not refreshed
+      statusFileStatus: null,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/did not write a fresh personas\.json/);
+  });
+
+  it('reports the silent-abort failure mode when personas.json is missing entirely', () => {
+    const verdict = classifyOutcome(started, 0, null, emptyProbe);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/did not write a fresh personas\.json/);
+  });
+});

--- a/apps/standalone/test/components/AppSidebar.test.ts
+++ b/apps/standalone/test/components/AppSidebar.test.ts
@@ -65,16 +65,23 @@ describe('AppSidebar — render contract', () => {
     expect(c).toBeGreaterThan(b);
   });
 
-  it('renders WORKSHOP items in order: PLAYBOOK, CORRECTIONS, PRACTICE', () => {
+  it('renders WORKSHOP items in order: PLAYBOOK, CORRECTIONS, PRACTICE, PERSONAS', () => {
     const ws = html.indexOf('>WORKSHOP<');
     const sy = html.indexOf('>SYSTEM<');
     const slice = html.slice(ws, sy);
     const ixPlb = slice.indexOf('PLAYBOOK');
     const ixCor = slice.indexOf('CORRECTIONS');
     const ixPrc = slice.indexOf('PRACTICE');
+    const ixPer = slice.indexOf('PERSONAS');
     expect(ixPlb).toBeGreaterThan(-1);
     expect(ixCor).toBeGreaterThan(ixPlb);
     expect(ixPrc).toBeGreaterThan(ixCor);
+    expect(ixPer).toBeGreaterThan(ixPrc);
+  });
+
+  it('PERSONAS links to /personas with the 3-letter "PER" short code', () => {
+    expect(html).toMatch(/href="\/personas"/);
+    expect(html).toMatch(/>PER</);
   });
 
   it('renders SYSTEM items in order: HEALTH, CALIBRATE, ALL VIEWS, DESIGN SYSTEM, DATA', () => {

--- a/apps/standalone/test/pages/sidebar-presence.test.ts
+++ b/apps/standalone/test/pages/sidebar-presence.test.ts
@@ -36,6 +36,7 @@ const PAGES: PageCase[] = [
   { file: 'projects.astro', current: 'PROJECTS' },
   { file: 'topics.astro', current: 'TOPICS' },
   { file: 'practice.astro', current: 'PRACTICE' },
+  { file: 'personas.astro', current: 'PERSONAS' },
 ];
 
 function read(rel: string): string {

--- a/apps/standalone/test/scripts/fullScan.test.ts
+++ b/apps/standalone/test/scripts/fullScan.test.ts
@@ -267,7 +267,7 @@ describe('runFullScan chain semantics', () => {
     const ok = await runFullScan(ui);
 
     expect(ok).toBe(true);
-    expect(cap.stepDones.map((s) => s.ok)).toEqual([true, true, true, true]);
+    expect(cap.stepDones.map((s) => s.ok)).toEqual([true, true, true, true, true]);
     expect(cap.chainDones).toEqual([{ success: true, lastError: null }]);
   });
 

--- a/apps/standalone/test/scripts/fullScan.test.ts
+++ b/apps/standalone/test/scripts/fullScan.test.ts
@@ -11,6 +11,7 @@ import { REQUIRED_HEADER as RESCAN_HEADER } from '../../src/pages/api/rescan.ts'
 import { REQUIRED_HEADER as MINE_HEADER } from '../../src/pages/api/mine-corrections.ts';
 import { REQUIRED_HEADER as CURATE_HEADER } from '../../src/pages/api/curate.ts';
 import { REQUIRED_HEADER as FALSIFY_HEADER } from '../../src/pages/api/falsify.ts';
+import { REQUIRED_HEADER as PERSONA_HEADER } from '../../src/pages/api/mine-persona.ts';
 
 // Phase β review-loop iter-1 fix: fullScan.ts docstring (line 42)
 // promises "the test alongside this file pins both sides" of the
@@ -51,12 +52,17 @@ describe('FULL_SCAN_STEPS header pinning (vs. endpoint REQUIRED_HEADER)', () => 
     expect(byId.get('falsify')?.header).toBe(FALSIFY_HEADER);
   });
 
-  it('exposes exactly 4 steps in the canonical order', () => {
+  it('persona step matches /api/mine-persona REQUIRED_HEADER', () => {
+    expect(byId.get('persona')?.header).toBe(PERSONA_HEADER);
+  });
+
+  it('exposes exactly 5 steps in the canonical order', () => {
     expect(FULL_SCAN_STEPS.map((s) => s.id)).toEqual([
       'rescan',
       'mine',
       'curate',
       'falsify',
+      'persona',
     ]);
   });
 
@@ -146,7 +152,7 @@ afterEach(() => {
 });
 
 describe('runFullScan chain semantics', () => {
-  it('all 4 steps succeed → onChainDone(true, null) and 4 step labels start', async () => {
+  it('all 5 steps succeed → onChainDone(true, null) and 5 step labels start', async () => {
     // Each step returns a stream that ends with done.ok=true.
     fetchSpy.mockImplementation(() =>
       Promise.resolve(ndjsonResponse(['{"type":"done","ok":true}'])),
@@ -161,13 +167,14 @@ describe('runFullScan chain semantics', () => {
       'mine',
       'curate',
       'falsify',
+      'persona',
     ]);
-    expect(cap.stepDones.map((s) => s.ok)).toEqual([true, true, true, true]);
+    expect(cap.stepDones.map((s) => s.ok)).toEqual([true, true, true, true, true]);
     expect(cap.chainDones).toEqual([{ success: true, lastError: null }]);
-    expect(fetchSpy).toHaveBeenCalledTimes(4);
+    expect(fetchSpy).toHaveBeenCalledTimes(5);
   });
 
-  it('step 2 returns HTTP 409 → chain halts, steps 3+4 never started', async () => {
+  it('step 2 returns HTTP 409 → chain halts, steps 3+4+5 never started', async () => {
     let call = 0;
     fetchSpy.mockImplementation(() => {
       call += 1;

--- a/packages/analysis/src/thresholds.test.ts
+++ b/packages/analysis/src/thresholds.test.ts
@@ -113,6 +113,21 @@ describe('THRESHOLDS.curator (Rev3 curator / falsifier metrics)', () => {
   });
 });
 
+describe('THRESHOLDS.persona (per-project persona generation V1)', () => {
+  it('minSessionsForGeneration ≥ 1 (no thin personas)', () => {
+    expect(THRESHOLDS.persona.minSessionsForGeneration).toBeGreaterThanOrEqual(1);
+  });
+
+  it('maxSessionsForCorpus ≥ minSessionsForGeneration (cap must accommodate the floor)', () => {
+    const { minSessionsForGeneration, maxSessionsForCorpus } = THRESHOLDS.persona;
+    expect(maxSessionsForCorpus).toBeGreaterThanOrEqual(minSessionsForGeneration);
+  });
+
+  it('maxLlmUsdPerProject > 0 (a $0 cap would skip every project)', () => {
+    expect(THRESHOLDS.persona.maxLlmUsdPerProject).toBeGreaterThan(0);
+  });
+});
+
 describe('THRESHOLDS.appliedRuleWatcher (Rev3 applied-rule outcome watcher — Closure C)', () => {
   it('watcher caps are positive: N sessions, wall-clock days, stale-project days', () => {
     const { watcherSessionsN, watcherWallClockDays, staleProjectDays } =

--- a/packages/analysis/src/thresholds.test.ts
+++ b/packages/analysis/src/thresholds.test.ts
@@ -114,6 +114,12 @@ describe('THRESHOLDS.curator (Rev3 curator / falsifier metrics)', () => {
 });
 
 describe('THRESHOLDS.persona (per-project persona generation V1)', () => {
+  // Smoke checks — these catch typos so egregious they'd break every
+  // consumer immediately. The real V1→V2 calibration harness lives
+  // separately (cite-overlap-on-shared-patterns between bryce.md and
+  // the auto-gen output once mine-persona runs against the same
+  // corpus).
+
   it('minSessionsForGeneration ≥ 1 (no thin personas)', () => {
     expect(THRESHOLDS.persona.minSessionsForGeneration).toBeGreaterThanOrEqual(1);
   });
@@ -125,6 +131,26 @@ describe('THRESHOLDS.persona (per-project persona generation V1)', () => {
 
   it('maxLlmUsdPerProject > 0 (a $0 cap would skip every project)', () => {
     expect(THRESHOLDS.persona.maxLlmUsdPerProject).toBeGreaterThan(0);
+  });
+
+  it('maxSessionsForCorpus divisible by 4 (4-quartile stratified sample takes maxN/4 from each bucket)', () => {
+    // The Stage-1 stratified sampler splits the project's session list
+    // into 4 recency quartiles and draws maxSessionsForCorpus/4 from
+    // each. A cap not divisible by 4 means one bucket carries an
+    // off-by-one — survivable, but worth catching when someone tunes
+    // the cap.
+    expect(THRESHOLDS.persona.maxSessionsForCorpus % 4).toBe(0);
+  });
+
+  it('candidateBudgetProxy ≈ 6 buckets × maxCandidatesPerBucket (budget arithmetic balanced)', () => {
+    // Stage-2 sees at most 6 buckets × maxCandidatesPerBucket
+    // candidates per project. The budget proxy gates skip-on-overflow
+    // and should track that ceiling so the documented relationship is
+    // self-consistent.
+    const { candidateBudgetProxy, maxCandidatesPerBucket } = THRESHOLDS.persona;
+    const ceiling = 6 * maxCandidatesPerBucket;
+    expect(candidateBudgetProxy).toBeGreaterThanOrEqual(ceiling * 0.5);
+    expect(candidateBudgetProxy).toBeLessThanOrEqual(ceiling * 10);
   });
 });
 

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -469,10 +469,42 @@ export const THRESHOLDS = {
   persona: {
     /** Minimum project session count to emit a persona at all. */
     minSessionsForGeneration: 30,
-    /** Cap on how many sessions Stage 2 (LLM) sees, sampled by recency. */
+    /**
+     * Cap on how many sessions Stage 2 (LLM) sees. Stage 1 stratifies
+     * the project's full session list into 4 quartiles by recency and
+     * draws this many sessions split evenly across them — so a project
+     * with > maxSessionsForCorpus sessions still surfaces founding-era
+     * signal, not just recent prompts. The 4-bucket-by-recency strategy
+     * matches the methodology used to author `research/persona-evals/
+     * bryce.md` (Stage 2 also re-buckets by recency for its
+     * time-bucketed sub-agents; the two stages share the same scheme).
+     */
     maxSessionsForCorpus: 200,
     /** Hard budget cap per project for the synthesis stage; skip above. */
     maxLlmUsdPerProject: 0.5,
+    /**
+     * Stage-2 LLM budget proxy. The skill skips a project with
+     * `status: budget-exceeded` when its Stage-1 candidate count
+     * exceeds this value. The 1500 figure ≈ a 200-session corpus
+     * with average per-bucket density and is the candidate-count
+     * proxy for `maxLlmUsdPerProject` until the V2 token-counting
+     * harness lands.
+     *
+     * **Calibration plan**: log actual Stage-2 USD per project after
+     * the first ~10 personas land; recalibrate so the 95th-percentile
+     * USD-per-candidate ratio puts the gate at maxLlmUsdPerProject.
+     * Tracked in CHANGELOG calibration notes when the calibration
+     * pass runs.
+     */
+    candidateBudgetProxy: 1500,
+    /**
+     * Per-bucket cap on candidates per project. Stage 1 selects up
+     * to this many candidates for each of the 6 heuristic buckets
+     * (`role-expertise` / `preferences` / etc.). Bounds Stage 2 LLM
+     * input size: 6 × maxCandidatesPerBucket ≈ candidateBudgetProxy
+     * when buckets are roughly balanced.
+     */
+    maxCandidatesPerBucket: 40,
   },
   appliedRuleWatcher: {
     /** Number of post-application sessions observed before closing. */

--- a/packages/analysis/src/thresholds.ts
+++ b/packages/analysis/src/thresholds.ts
@@ -450,6 +450,30 @@ export const THRESHOLDS = {
    * `narrativeRung.dismissDecay` + `maxDismissals` +
    * `repromotionPenalty`.)
    */
+  /**
+   * Per-project persona generation (feature: persona-mining V1).
+   *
+   * Driven by the `mine-persona` skill / `/api/mine-persona` endpoint
+   * as SCAN chain step 5. Projects below `minSessionsForGeneration`
+   * get a skip-row in `personas.json` with reason `insufficient-corpus`
+   * — no thin personas emitted. Projects whose synthesis would exceed
+   * `maxLlmUsdPerProject` get a `budget-exceeded` skip-row.
+   *
+   * Pre-launch placeholders. `minSessionsForGeneration: 30` reflects
+   * the spec's "below 30 sessions, patterns aren't durable enough to
+   * be useful" judgment — calibrate after the first batch of personas
+   * lands. `maxSessionsForCorpus: 200` caps the Stage-2 LLM input;
+   * the bryce.md prototype was authored from 160 sessions which is
+   * the empirical existence proof.
+   */
+  persona: {
+    /** Minimum project session count to emit a persona at all. */
+    minSessionsForGeneration: 30,
+    /** Cap on how many sessions Stage 2 (LLM) sees, sampled by recency. */
+    maxSessionsForCorpus: 200,
+    /** Hard budget cap per project for the synthesis stage; skip above. */
+    maxLlmUsdPerProject: 0.5,
+  },
   appliedRuleWatcher: {
     /** Number of post-application sessions observed before closing. */
     watcherSessionsN: 5,

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -64,6 +64,7 @@ import { buildProjectTrajectoriesFile } from './projectTrajectoryBuilder.js';
 import { buildSurfaceComparisonFile } from './surfaceComparisonBuilder.js';
 import { buildSkillCurvesFile } from './skillCurvesBuilder.js';
 import { buildSurprisesFile } from './surprisesBuilder.js';
+import { buildPersonaCandidatesFile } from './personaCandidates.js';
 
 export interface RunAnalysisOptions {
   /** Root output dir (same one `manifest.json` sits in). */
@@ -106,6 +107,7 @@ export interface RunAnalysisResult {
     surfaceComparison: string;
     skillCurves: string;
     surprises: string;
+    personaCandidates: string;
   };
   counts: {
     duplicatesClusters: number;
@@ -130,6 +132,8 @@ export interface RunAnalysisResult {
     surfaceCells: number;
     skillCurves: number;
     surprises: number;
+    personaCandidatesTotal: number;
+    personaCandidatesProjects: number;
   };
 }
 
@@ -173,6 +177,17 @@ export interface RunAnalysisResult {
  * endpoint's output markdown — but the patch bump labels the bundle so
  * operators can correlate.
  *
+ * Bumped 1.5.1 → 1.6.0 in the persona-mining V1 land:
+ * `analysis/persona-candidates.json` lands as a new sidecar (per-project
+ * heuristic buckets of user-prompt excerpts that drive the Stage-2 LLM
+ * synthesis in `/mine-persona`), and `analysis/personas.json` +
+ * `analysis/personas/<project-id>.md` files land as the Stage-2 output
+ * (written by the skill, not by `runAnalysis` directly). Pre-existing
+ * sidecars are unchanged. New THRESHOLDS family
+ * `THRESHOLDS.persona.{minSessionsForGeneration, maxSessionsForCorpus,
+ * maxLlmUsdPerProject, candidateBudgetProxy, maxCandidatesPerBucket}`
+ * gates emission.
+ *
  * Bumped 1.4.1 → 1.5.0 in feed-redesign Wave 2 #1 (delta surprises):
  * a new `analysis/archive/` sidecar family lands —
  * `surprises-YYYY-MM-DD.json` daily snapshots that the
@@ -184,7 +199,7 @@ export interface RunAnalysisResult {
  * threshold `THRESHOLDS.surprises.archiveRetentionDays = 30` gates the
  * filename-based prune.
  */
-export const EXPORTER_VERSION = '1.5.1';
+export const EXPORTER_VERSION = '1.6.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,
@@ -572,6 +587,41 @@ export async function runAnalysis(
   }
   const surprisesPath = path.join(analysisDir, 'surprises.json');
 
+  // ---- Persona candidates (V1 — feature: persona-mining) ----
+  //
+  // Stage-1 deterministic extractor. Per-project user-prompt excerpts
+  // bucketed by 6 heuristic categories (role/expertise, preferences,
+  // project-specific, working rhythm, frictions, voice). Input to the
+  // Stage-2 LLM skill `/mine-persona`, which is the SCAN chain's 5th
+  // step and writes `analysis/personas.json` + per-project markdown to
+  // `analysis/personas/<project-id>.md`.
+  //
+  // Reuses the discoverProjects result above for the project → sessions
+  // edges. No SQLite read — the manifest + transcript files are
+  // sufficient (mirrors corrections.ts / playbook builders).
+  let personaCandidatesTotal = 0;
+  let personaCandidatesProjects = 0;
+  try {
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir: options.outDir,
+      now,
+      projects: enrichedProjects,
+      sessionToProject: projectsResult.sessionToProject,
+    });
+    personaCandidatesTotal = r.candidatesTotal;
+    personaCandidatesProjects = r.projectsAnalyzed;
+    await writeFile(
+      path.join(analysisDir, 'persona-candidates.json'),
+      JSON.stringify(r.file, null, 2) + '\n',
+      'utf8',
+    );
+  } catch (err) {
+    logger.warn(
+      `analysis: persona-candidates soft-failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  const personaCandidatesPath = path.join(analysisDir, 'persona-candidates.json');
+
   // ---- Meta ----
   const exporterRunId = options.exporterRunId ?? randomUUID();
   const gitSha = options.gitSha !== undefined ? options.gitSha : detectGitSha();
@@ -605,6 +655,11 @@ export async function runAnalysis(
           'surface-comparison.json',
           'skill-curves.json',
           'surprises.json',
+          // V1 persona-mining sidecars (Stage 1 produced here;
+          // Stage-2 outputs `personas.json` + `personas/<id>.md`
+          // written by the `/mine-persona` skill).
+          'persona-candidates.json',
+          'personas.json',
         ],
       },
     },
@@ -632,6 +687,10 @@ export async function runAnalysis(
       surfaceCells: surfaceCellsCount,
       skillCurves: skillCurvesCount,
       surprises: surprisesCount,
+      personaCandidates: {
+        total: personaCandidatesTotal,
+        projects: personaCandidatesProjects,
+      },
     },
   };
   const metaPath = path.join(analysisDir, 'meta.json');
@@ -677,6 +736,7 @@ export async function runAnalysis(
       surfaceComparison: surfaceComparisonPath,
       skillCurves: skillCurvesPath,
       surprises: surprisesPath,
+      personaCandidates: personaCandidatesPath,
     },
     counts: {
       duplicatesClusters: duplicatesFile.clusters.length,
@@ -699,6 +759,8 @@ export async function runAnalysis(
       surfaceCells: surfaceCellsCount,
       skillCurves: skillCurvesCount,
       surprises: surprisesCount,
+      personaCandidatesTotal,
+      personaCandidatesProjects,
     },
   };
 }

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -606,7 +606,6 @@ export async function runAnalysis(
       outDir: options.outDir,
       now,
       projects: enrichedProjects,
-      sessionToProject: projectsResult.sessionToProject,
     });
     personaCandidatesTotal = r.candidatesTotal;
     personaCandidatesProjects = r.projectsAnalyzed;
@@ -655,11 +654,13 @@ export async function runAnalysis(
           'surface-comparison.json',
           'skill-curves.json',
           'surprises.json',
-          // V1 persona-mining sidecars (Stage 1 produced here;
-          // Stage-2 outputs `personas.json` + `personas/<id>.md`
-          // written by the `/mine-persona` skill).
+          // V1 persona-mining Stage-1 sidecar (Stage-2 outputs
+          // `personas.json` + `personas/<id>.md` are written by the
+          // `/mine-persona` skill, NOT by runAnalysis — they live
+          // under the same analysis/ tree but aren't in this list
+          // for the same reason `corrections.json` isn't:
+          // runAnalysis only registers what it actually emits.).
           'persona-candidates.json',
-          'personas.json',
         ],
       },
     },

--- a/packages/exporter/src/analysis/personaCandidates.ts
+++ b/packages/exporter/src/analysis/personaCandidates.ts
@@ -1,0 +1,647 @@
+/**
+ * Stage-1 persona-candidates writer — heuristic per-project bucket
+ * extraction over user-turn excerpts. Pure data prep: emits
+ * `analysis/persona-candidates.json`. The Claude Code skill
+ * `/mine-persona` consumes this file in Stage 2 (LLM synthesis)
+ * and writes per-project markdown to `analysis/personas/<id>.md`.
+ *
+ * Why the 6 buckets: they mirror the structure of
+ * `research/persona-evals/bryce.md` so the LLM synthesizer has a
+ * pre-segmented input that maps cleanly onto the persona's pattern
+ * sections (role/expertise → §1, preferences → §2, etc.). The
+ * deterministic Stage-1 layer keeps the LLM stage's job small:
+ * "pick verbatim quotes per bucket and write durable Pattern. /
+ * Evidence. / What this implies. paragraphs" instead of "find
+ * patterns in 200 transcripts."
+ *
+ * PII posture: every emitted candidate is a verbatim user-prompt
+ * excerpt. Carries the same PII surface as `correction-candidates.json`
+ * — gitignored under `apps/standalone/public/chat-arch-data/*`.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  PersonaBucket,
+  PersonaCandidate,
+  PersonaCandidateProject,
+  PersonaCandidatesFile,
+  Project,
+  SessionManifest,
+  UnifiedSessionEntry,
+} from '@chat-arch/schema';
+import { THRESHOLDS } from '@chat-arch/analysis';
+import { logger } from '../lib/logger.js';
+
+/**
+ * Bump when a heuristic-bucket regex family changes. Drives no cache
+ * (Stage 1 always re-runs as part of `runAnalysis`), but it labels the
+ * sidecar so the Stage-2 skill can refuse to synthesize against an
+ * incompatible version of the candidate format.
+ */
+export const PERSONA_HEURISTIC_VERSION = 1;
+
+export interface BuildPersonaCandidatesOptions {
+  outDir: string;
+  now: number;
+  /** From `discoverProjects(...)`. Drives bucketing by projectId. */
+  projects: readonly Project[];
+  /** Map: sessionId → projectId (includes UNASSIGNED). */
+  sessionToProject: Map<string, string>;
+  /** Parallelism for transcript reads. Same default as corrections.ts. */
+  ioConcurrency?: number;
+}
+
+export interface BuildPersonaCandidatesResult {
+  file: PersonaCandidatesFile;
+  projectsAnalyzed: number;
+  candidatesTotal: number;
+}
+
+const DEFAULT_IO_CONCURRENCY = 8;
+const MAX_EXCERPT_CHARS = 500;
+const MAX_USER_PROMPT_CHARS = 4000;
+/** Per-bucket cap on candidates per project so the LLM stage's input
+ *  stays bounded even for a corpus with 600+ sessions per project. */
+const MAX_CANDIDATES_PER_BUCKET = 40;
+
+/**
+ * Wrapper prefixes for harness-injected user-role lines (same list as
+ * corrections.ts — duplicated locally rather than imported so neither
+ * builder accidentally depends on the other's internals; the shared
+ * shape lives in the transcript format itself).
+ */
+const WRAPPER_PREFIXES: readonly string[] = [
+  '<command-message>',
+  '<command-name>',
+  '<command-args>',
+  '<system-reminder>',
+  '<local-command-stdout>',
+  '<local-command-stderr>',
+  '<bash-stdout>',
+  '<bash-stderr>',
+  '<task-notification>',
+  '<scheduled-task',
+  '<uploaded_files>',
+  'Base directory for this skill:',
+  '<file>',
+  '<file_path>',
+  '<file_uuid>',
+  'Caveat: The messages below were generated',
+  'This session is being continued from a previous conversation',
+  '[Request interrupted by user',
+];
+
+interface BucketPatternDef {
+  bucket: PersonaBucket;
+  patternKey: string;
+  regex: RegExp;
+}
+
+/**
+ * Heuristic pattern catalogue. Word-boundary `\b` anchors keep matches
+ * tight; case-insensitive `i` because user prompts mix casing freely.
+ * Patterns are intentionally permissive — the Stage-2 LLM trims false
+ * positives, the Stage-1 heuristic just needs broad recall.
+ */
+const BUCKET_PATTERNS: readonly BucketPatternDef[] = [
+  // role-expertise — claims about the user's profession, experience,
+  // or stance on the work. Anchor on first-person + role nouns or
+  // experience-duration tokens.
+  {
+    bucket: 'role-expertise',
+    patternKey: 'first-person-role',
+    regex: /\bI(?:'m| am)\s+(?:an?\s+)?(?:senior|junior|principal|staff|lead|chief)?\s*(?:software\s+)?(?:engineer|developer|designer|scientist|founder|maker|operator|architect|researcher|writer|owner|consultant|cto|ceo|pm|product\s+manager|tech\s+lead)\b/i,
+  },
+  {
+    bucket: 'role-expertise',
+    patternKey: 'years-experience',
+    regex: /\b(?:I(?:'ve| have)\s+been|with|after)\s+(?:writing|building|using|working\s+(?:on|with|in))[^.]*?\b\d+\s*(?:\+\s*)?(?:year|yr)s?\b/i,
+  },
+  {
+    bucket: 'role-expertise',
+    patternKey: 'as-a',
+    regex: /\b(?:as\s+(?:an?|the))\s+(?:engineer|developer|maker|founder|operator|designer|architect|user|owner|scientist)\b/i,
+  },
+  {
+    bucket: 'role-expertise',
+    patternKey: 'this-is-my-first',
+    regex: /\bthis\s+is\s+(?:my\s+)?(?:first|second|third)\s+time\b/i,
+  },
+
+  // preferences — direct preference statements + use-X-not-Y constructs.
+  {
+    bucket: 'preferences',
+    patternKey: 'i-prefer',
+    regex: /\bI\s+(?:prefer|like|love|favou?r|enjoy)\b/i,
+  },
+  {
+    bucket: 'preferences',
+    patternKey: 'i-want',
+    regex: /\bI\s+(?:want|need|expect|require|hope)\b/i,
+  },
+  {
+    bucket: 'preferences',
+    patternKey: 'i-dont-like',
+    regex: /\bI\s+(?:don'?t|do\s+not)\s+(?:like|want|need)\b/i,
+  },
+  {
+    bucket: 'preferences',
+    patternKey: 'use-X-not-Y',
+    regex: /\b(?:use|prefer)\s+\w[\w\-./]*\s+(?:not|over|instead\s+of|rather\s+than)\s+\w[\w\-./]*/i,
+  },
+  {
+    bucket: 'preferences',
+    patternKey: 'always-never',
+    regex: /\b(?:always|never)\s+(?:use|do|run|write|prefer|skip|avoid)\b/i,
+  },
+  {
+    bucket: 'preferences',
+    patternKey: 'default-to',
+    regex: /\bdefault(?:s|ing|ed)?\s+to\b/i,
+  },
+
+  // working-rhythm — process / sequencing / iteration words.
+  {
+    bucket: 'working-rhythm',
+    patternKey: 'lets-first',
+    regex: /\blet'?s\s+(?:first|start|begin|kick|do|build|ship|land|merge)\b/i,
+  },
+  {
+    bucket: 'working-rhythm',
+    patternKey: 'loop-iterate',
+    regex: /\b(?:loop|iterate|continue|keep\s+going|don'?t\s+stop|until\s+(?:it'?s|the)\s+(?:done|complete|fixed|passing))\b/i,
+  },
+  {
+    bucket: 'working-rhythm',
+    patternKey: 'before-after-then',
+    regex: /\b(?:before|after|then|next|finally),\s/i,
+  },
+  {
+    bucket: 'working-rhythm',
+    patternKey: 'step-by-step',
+    regex: /\b(?:step\s+by\s+step|stage|phase|wave)\s+\d+\b/i,
+  },
+  {
+    bucket: 'working-rhythm',
+    patternKey: 'continue-dont-wait',
+    regex: /\bcontinue,?\s+don'?t\s+(?:wait|stop|ask)\b/i,
+  },
+
+  // frictions — negative signals about state of work or tool output.
+  {
+    bucket: 'frictions',
+    patternKey: 'doesnt-work',
+    regex: /\b(?:doesn'?t|does\s+not|did\s+not|didn'?t)\s+(?:work|run|build|compile|pass|render|load)\b/i,
+  },
+  {
+    bucket: 'frictions',
+    patternKey: 'broken-failing',
+    regex: /\b(?:broken|failing|crashes|crashed|hangs|stuck|hangs?\s+forever)\b/i,
+  },
+  {
+    bucket: 'frictions',
+    patternKey: 'frustration-explicit',
+    regex: /\b(?:annoying|frustrating|hate|sucks|garbage|useless|wrong\s+again)\b/i,
+  },
+  {
+    bucket: 'frictions',
+    patternKey: 'wish-shouldnt',
+    regex: /\b(?:I\s+wish|shouldn'?t\s+(?:that|this)|why\s+(?:does|is|isn'?t))\b/i,
+  },
+  {
+    bucket: 'frictions',
+    patternKey: 'lost-my-work',
+    regex: /\b(?:lost\s+my|don'?t\s+lose|don'?t\s+overwrite|preserve\s+my)\b/i,
+  },
+
+  // project-specific — placeholder pattern; the per-project augmentation
+  // (project-name tokens) is wired into the scan loop below since regex
+  // would need to be project-aware.
+  {
+    bucket: 'project-specific',
+    patternKey: 'this-project',
+    regex: /\b(?:this|the)\s+(?:project|repo|app|codebase|tool)\b/i,
+  },
+
+  // voice — terse + verbose are special-cased by length below.
+];
+
+/**
+ * Run `fn` over `items` with a sliding concurrency window. Preserves
+ * input order. Inlined from corrections.ts pattern.
+ */
+async function parallelMap<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let cursor = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workers: Promise<void>[] = [];
+  for (let w = 0; w < workerCount; w += 1) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const i = cursor;
+          cursor += 1;
+          if (i >= items.length) return;
+          out[i] = await fn(items[i] as T, i);
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+  return out;
+}
+
+interface ExtractedTurn {
+  sessionId: string;
+  userTurnIndex: number;
+  text: string;
+}
+
+/**
+ * Read a session's user turns. Mirrors the cloud/JSONL split from
+ * corrections.ts but emits only user-text (no assistant context — the
+ * persona stage works from user voice alone) and applies the same
+ * wrapper / length filters so harness noise doesn't masquerade as
+ * persona signal.
+ */
+async function readUserTurns(
+  entry: UnifiedSessionEntry,
+  outDir: string,
+): Promise<readonly ExtractedTurn[]> {
+  if (entry.transcriptPath === undefined) return [];
+  const baseDir = path.resolve(outDir);
+  const abs = path.resolve(baseDir, entry.transcriptPath);
+  const rel = path.relative(baseDir, abs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return [];
+
+  let raw: string;
+  try {
+    raw = await readFile(abs, 'utf8');
+  } catch {
+    return [];
+  }
+
+  if (entry.source === 'cloud') {
+    return parseCloudUserTurns(entry.id, raw);
+  }
+  return parseJsonlUserTurns(entry.id, raw);
+}
+
+interface CloudShape {
+  chat_messages?: ReadonlyArray<{
+    sender?: string;
+    text?: string;
+    content?: ReadonlyArray<{ type?: string; text?: string }>;
+  }>;
+}
+
+function parseCloudUserTurns(sessionId: string, raw: string): readonly ExtractedTurn[] {
+  let j: CloudShape;
+  try {
+    j = JSON.parse(raw) as CloudShape;
+  } catch {
+    return [];
+  }
+  const turns: ExtractedTurn[] = [];
+  let idx = 0;
+  for (const m of j.chat_messages ?? []) {
+    if (m.sender !== 'human') continue;
+    const text = extractCloudText(m);
+    if (text === null) continue;
+    const trimmed = text.trim();
+    if (trimmed.length === 0) continue;
+    if (trimmed.length > MAX_USER_PROMPT_CHARS) continue;
+    turns.push({ sessionId, userTurnIndex: idx, text: trimmed });
+    idx += 1;
+  }
+  return turns;
+}
+
+function extractCloudText(m: {
+  text?: string;
+  content?: ReadonlyArray<{ type?: string; text?: string }>;
+}): string | null {
+  if (typeof m.text === 'string' && m.text !== '') return m.text;
+  if (Array.isArray(m.content)) {
+    const parts: string[] = [];
+    for (const part of m.content) {
+      if (part.type === 'text' && typeof part.text === 'string') {
+        parts.push(part.text);
+      }
+    }
+    if (parts.length > 0) return parts.join('\n');
+  }
+  return null;
+}
+
+function parseJsonlUserTurns(
+  sessionId: string,
+  raw: string,
+): readonly ExtractedTurn[] {
+  const turns: ExtractedTurn[] = [];
+  let idx = 0;
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    if (line === '') continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (obj === null || typeof obj !== 'object') continue;
+    const rec = obj as Record<string, unknown>;
+    if (rec['type'] !== 'user') continue;
+    const msg = rec['message'];
+    if (msg === null || typeof msg !== 'object') continue;
+    const mrec = msg as Record<string, unknown>;
+    if (mrec['role'] !== 'user') continue;
+    const text = extractJsonlText(mrec['content']);
+    if (text === null) continue;
+    const trimmed = text.trim();
+    if (trimmed.length === 0) continue;
+    if (WRAPPER_PREFIXES.some((p) => trimmed.startsWith(p))) continue;
+    if (trimmed.length > MAX_USER_PROMPT_CHARS) continue;
+    turns.push({ sessionId, userTurnIndex: idx, text: trimmed });
+    idx += 1;
+  }
+  return turns;
+}
+
+function extractJsonlText(content: unknown): string | null {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const part of content) {
+      if (
+        part !== null &&
+        typeof part === 'object' &&
+        (part as Record<string, unknown>)['type'] === 'text' &&
+        typeof (part as Record<string, unknown>)['text'] === 'string'
+      ) {
+        parts.push((part as Record<string, unknown>)['text'] as string);
+      }
+    }
+    if (parts.length > 0) return parts.join('\n');
+  }
+  return null;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + '…';
+}
+
+/**
+ * Match a single user turn against the heuristic catalogue + the per-
+ * project name token, emitting one candidate per (bucket, patternKey)
+ * combination that fires. A long prompt can fire on multiple buckets;
+ * that's deliberate — voice + preferences + frictions can all coexist
+ * in one prompt.
+ */
+function matchTurn(
+  turn: ExtractedTurn,
+  projectNameTokens: readonly string[],
+): readonly PersonaCandidate[] {
+  const out: PersonaCandidate[] = [];
+  const excerpt = truncate(turn.text, MAX_EXCERPT_CHARS);
+
+  for (const def of BUCKET_PATTERNS) {
+    if (def.regex.test(turn.text)) {
+      out.push({
+        sessionId: turn.sessionId,
+        userTurnIndex: turn.userTurnIndex,
+        excerpt,
+        bucket: def.bucket,
+        patternKey: def.patternKey,
+      });
+    }
+  }
+
+  // Project-specific augmentation — the project name itself (and its
+  // lowercase tokens) is the strongest project-specific signal. A
+  // mention of "chat-arch" or "shopforge" in a user turn ALMOST always
+  // means the user is referring to the current project. We dedupe
+  // against the catalogue's `this-project` hit so a turn with both
+  // doesn't get two project-specific rows.
+  if (!out.some((c) => c.bucket === 'project-specific')) {
+    const lowered = turn.text.toLowerCase();
+    for (const token of projectNameTokens) {
+      if (token.length < 4) continue; // skip 1-3 char tokens — too noisy
+      if (lowered.includes(token)) {
+        out.push({
+          sessionId: turn.sessionId,
+          userTurnIndex: turn.userTurnIndex,
+          excerpt,
+          bucket: 'project-specific',
+          patternKey: 'project-name-mention',
+        });
+        break;
+      }
+    }
+  }
+
+  // Voice — terse + verbose by length. One emission per turn at most;
+  // the bucket cap downstream prevents the LLM stage from drowning in
+  // hundreds of short pings.
+  if (turn.text.length <= 30) {
+    out.push({
+      sessionId: turn.sessionId,
+      userTurnIndex: turn.userTurnIndex,
+      excerpt,
+      bucket: 'voice',
+      patternKey: 'terse',
+    });
+  } else if (turn.text.length >= 1200) {
+    out.push({
+      sessionId: turn.sessionId,
+      userTurnIndex: turn.userTurnIndex,
+      excerpt,
+      bucket: 'voice',
+      patternKey: 'verbose',
+    });
+  }
+
+  return out;
+}
+
+/** Tokenize a project displayName for project-specific matching. */
+function projectNameTokens(displayName: string): readonly string[] {
+  return displayName
+    .toLowerCase()
+    .split(/[\s\-_./\\]+/)
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Sample the most recent `maxN` sessions for one project. Stable: sort
+ * by updatedAt desc, take prefix. When the project has fewer sessions
+ * than the cap, returns everything.
+ */
+function sampleRecentSessions(
+  sessionIds: readonly string[],
+  sessionById: Map<string, UnifiedSessionEntry>,
+  maxN: number,
+): readonly UnifiedSessionEntry[] {
+  const entries: UnifiedSessionEntry[] = [];
+  for (const sid of sessionIds) {
+    const e = sessionById.get(sid);
+    if (e !== undefined) entries.push(e);
+  }
+  entries.sort((a, b) => {
+    const av = typeof a.updatedAt === 'number' ? a.updatedAt : 0;
+    const bv = typeof b.updatedAt === 'number' ? b.updatedAt : 0;
+    return bv - av;
+  });
+  return entries.slice(0, maxN);
+}
+
+/**
+ * Cap each bucket to `MAX_CANDIDATES_PER_BUCKET`. Keeps high-recency
+ * candidates first so the LLM stage sees the most representative recent
+ * signal. Returns the bucketed map for one project.
+ */
+function capCandidatesByBucket(
+  raw: readonly PersonaCandidate[],
+  sessionUpdatedAt: Map<string, number>,
+): Record<PersonaBucket, readonly PersonaCandidate[]> {
+  const buckets: Record<PersonaBucket, PersonaCandidate[]> = {
+    'role-expertise': [],
+    preferences: [],
+    'project-specific': [],
+    'working-rhythm': [],
+    frictions: [],
+    voice: [],
+  };
+  for (const c of raw) buckets[c.bucket].push(c);
+  for (const k of Object.keys(buckets) as PersonaBucket[]) {
+    buckets[k].sort((a, b) => {
+      const av = sessionUpdatedAt.get(a.sessionId) ?? 0;
+      const bv = sessionUpdatedAt.get(b.sessionId) ?? 0;
+      return bv - av;
+    });
+    buckets[k] = buckets[k].slice(0, MAX_CANDIDATES_PER_BUCKET);
+  }
+  return buckets;
+}
+
+export async function buildPersonaCandidatesFile(
+  manifest: SessionManifest,
+  options: BuildPersonaCandidatesOptions,
+): Promise<BuildPersonaCandidatesResult> {
+  const t0 = Date.now();
+  const concurrency = options.ioConcurrency ?? DEFAULT_IO_CONCURRENCY;
+  const maxSessions = THRESHOLDS.persona.maxSessionsForCorpus;
+
+  // Index manifest sessions by id for O(1) project→session lookup.
+  const sessionById = new Map<string, UnifiedSessionEntry>();
+  const sessionUpdatedAt = new Map<string, number>();
+  for (const e of manifest.sessions) {
+    sessionById.set(e.id, e);
+    if (typeof e.updatedAt === 'number') {
+      sessionUpdatedAt.set(e.id, e.updatedAt);
+    }
+  }
+
+  const perProject: PersonaCandidateProject[] = [];
+  let totalCandidates = 0;
+
+  for (const project of options.projects) {
+    const sampled = sampleRecentSessions(
+      project.sessionIds,
+      sessionById,
+      maxSessions,
+    );
+    if (sampled.length === 0) {
+      perProject.push({
+        projectId: project.id,
+        projectName: project.displayName,
+        sessionsTotal: project.sessionIds.length,
+        sessionsSampled: 0,
+        sessionsWithCandidates: 0,
+        earliestSampledAt: null,
+        latestSampledAt: null,
+        candidatesByBucket: {
+          'role-expertise': [],
+          preferences: [],
+          'project-specific': [],
+          'working-rhythm': [],
+          frictions: [],
+          voice: [],
+        },
+      });
+      continue;
+    }
+
+    const nameTokens = projectNameTokens(project.displayName);
+
+    const perSessionTurns = await parallelMap(
+      sampled,
+      concurrency,
+      (entry) => readUserTurns(entry, options.outDir),
+    );
+
+    const rawCandidates: PersonaCandidate[] = [];
+    let sessionsWithCandidates = 0;
+    let earliest: number | null = null;
+    let latest: number | null = null;
+    for (let i = 0; i < sampled.length; i += 1) {
+      const entry = sampled[i] as UnifiedSessionEntry;
+      if (typeof entry.updatedAt === 'number') {
+        earliest = earliest === null ? entry.updatedAt : Math.min(earliest, entry.updatedAt);
+        latest = latest === null ? entry.updatedAt : Math.max(latest, entry.updatedAt);
+      }
+      const turns = perSessionTurns[i] ?? [];
+      let hitCount = 0;
+      for (const turn of turns) {
+        const matches = matchTurn(turn, nameTokens);
+        if (matches.length > 0) {
+          hitCount += matches.length;
+          rawCandidates.push(...matches);
+        }
+      }
+      if (hitCount > 0) sessionsWithCandidates += 1;
+    }
+
+    const capped = capCandidatesByBucket(rawCandidates, sessionUpdatedAt);
+    const cappedCount = Object.values(capped).reduce((n, arr) => n + arr.length, 0);
+    totalCandidates += cappedCount;
+
+    perProject.push({
+      projectId: project.id,
+      projectName: project.displayName,
+      sessionsTotal: project.sessionIds.length,
+      sessionsSampled: sampled.length,
+      sessionsWithCandidates,
+      earliestSampledAt: earliest,
+      latestSampledAt: latest,
+      candidatesByBucket: capped,
+    });
+  }
+
+  logger.info(
+    `analysis: persona-candidates — ${perProject.length} projects, ${totalCandidates} candidates, ${Date.now() - t0}ms`,
+  );
+
+  const file: PersonaCandidatesFile = {
+    version: 1,
+    generatedAt: options.now,
+    heuristicVersion: PERSONA_HEURISTIC_VERSION,
+    thresholds: {
+      minSessionsForGeneration: THRESHOLDS.persona.minSessionsForGeneration,
+      maxSessionsForCorpus: THRESHOLDS.persona.maxSessionsForCorpus,
+    },
+    projects: perProject,
+  };
+
+  return {
+    file,
+    projectsAnalyzed: perProject.length,
+    candidatesTotal: totalCandidates,
+  };
+}

--- a/packages/exporter/src/analysis/personaCandidates.ts
+++ b/packages/exporter/src/analysis/personaCandidates.ts
@@ -33,6 +33,8 @@ import type {
 import { THRESHOLDS } from '@chat-arch/analysis';
 import { logger } from '../lib/logger.js';
 
+const NUM_QUARTILES = 4;
+
 /**
  * Bump when a heuristic-bucket regex family changes. Drives no cache
  * (Stage 1 always re-runs as part of `runAnalysis`), but it labels the
@@ -46,8 +48,6 @@ export interface BuildPersonaCandidatesOptions {
   now: number;
   /** From `discoverProjects(...)`. Drives bucketing by projectId. */
   projects: readonly Project[];
-  /** Map: sessionId → projectId (includes UNASSIGNED). */
-  sessionToProject: Map<string, string>;
   /** Parallelism for transcript reads. Same default as corrections.ts. */
   ioConcurrency?: number;
 }
@@ -61,9 +61,6 @@ export interface BuildPersonaCandidatesResult {
 const DEFAULT_IO_CONCURRENCY = 8;
 const MAX_EXCERPT_CHARS = 500;
 const MAX_USER_PROMPT_CHARS = 4000;
-/** Per-bucket cap on candidates per project so the LLM stage's input
- *  stays bounded even for a corpus with 600+ sessions per project. */
-const MAX_CANDIDATES_PER_BUCKET = 40;
 
 /**
  * Wrapper prefixes for harness-injected user-role lines (same list as
@@ -479,11 +476,27 @@ function projectNameTokens(displayName: string): readonly string[] {
 }
 
 /**
- * Sample the most recent `maxN` sessions for one project. Stable: sort
- * by updatedAt desc, take prefix. When the project has fewer sessions
- * than the cap, returns everything.
+ * Stratified-by-recency sample: split the project's session list into
+ * `NUM_QUARTILES` recency buckets (founding → recent), then draw
+ * `maxN / NUM_QUARTILES` sessions from each bucket. Mirrors the
+ * 4-bucket-by-recency methodology used to author
+ * `research/persona-evals/bryce.md` — the auto-gen pipeline's empirical
+ * ground truth.
+ *
+ * Why not recency-only top-N: for a project with 600+ sessions and a
+ * 200-session cap, recency-only would discard ALL founding-era signal,
+ * and Stage 2's "founding" sub-agent would see only the oldest 50 of
+ * those 200 — never the actual founding era of the project. The
+ * stratified sample guarantees each Stage-2 time-bucket has a
+ * representative draw.
+ *
+ * Within each bucket we order newest-first (the Stage-2 sub-agents
+ * expect "this bucket's most recent first" framing). When a bucket has
+ * fewer sessions than maxN/4, we take everything. When the total
+ * project session count ≤ maxN, returns all sessions (every bucket
+ * fits in its share).
  */
-function sampleRecentSessions(
+function sampleSessionsStratifiedByRecency(
   sessionIds: readonly string[],
   sessionById: Map<string, UnifiedSessionEntry>,
   maxN: number,
@@ -493,18 +506,40 @@ function sampleRecentSessions(
     const e = sessionById.get(sid);
     if (e !== undefined) entries.push(e);
   }
+  if (entries.length === 0) return entries;
+
+  // Ascending sort so quartiles run founding → recent.
   entries.sort((a, b) => {
     const av = typeof a.updatedAt === 'number' ? a.updatedAt : 0;
     const bv = typeof b.updatedAt === 'number' ? b.updatedAt : 0;
-    return bv - av;
+    return av - bv;
   });
-  return entries.slice(0, maxN);
+
+  if (entries.length <= maxN) return entries;
+
+  const perBucket = Math.floor(maxN / NUM_QUARTILES);
+  const sampled: UnifiedSessionEntry[] = [];
+  for (let q = 0; q < NUM_QUARTILES; q += 1) {
+    const start = Math.floor((q * entries.length) / NUM_QUARTILES);
+    const end = Math.floor(((q + 1) * entries.length) / NUM_QUARTILES);
+    const bucket = entries.slice(start, end);
+    // Within each bucket, prefer the bucket's most-recent entries —
+    // Stage-2 framing is "newest in this bucket carries more signal".
+    bucket.sort((a, b) => {
+      const av = typeof a.updatedAt === 'number' ? a.updatedAt : 0;
+      const bv = typeof b.updatedAt === 'number' ? b.updatedAt : 0;
+      return bv - av;
+    });
+    sampled.push(...bucket.slice(0, perBucket));
+  }
+  return sampled;
 }
 
 /**
- * Cap each bucket to `MAX_CANDIDATES_PER_BUCKET`. Keeps high-recency
- * candidates first so the LLM stage sees the most representative recent
- * signal. Returns the bucketed map for one project.
+ * Cap each bucket to `THRESHOLDS.persona.maxCandidatesPerBucket`. Keeps
+ * high-recency candidates first so the LLM stage sees the most
+ * representative recent signal. Returns the bucketed map for one
+ * project.
  */
 function capCandidatesByBucket(
   raw: readonly PersonaCandidate[],
@@ -519,13 +554,14 @@ function capCandidatesByBucket(
     voice: [],
   };
   for (const c of raw) buckets[c.bucket].push(c);
+  const cap = THRESHOLDS.persona.maxCandidatesPerBucket;
   for (const k of Object.keys(buckets) as PersonaBucket[]) {
     buckets[k].sort((a, b) => {
       const av = sessionUpdatedAt.get(a.sessionId) ?? 0;
       const bv = sessionUpdatedAt.get(b.sessionId) ?? 0;
       return bv - av;
     });
-    buckets[k] = buckets[k].slice(0, MAX_CANDIDATES_PER_BUCKET);
+    buckets[k] = buckets[k].slice(0, cap);
   }
   return buckets;
 }
@@ -552,7 +588,7 @@ export async function buildPersonaCandidatesFile(
   let totalCandidates = 0;
 
   for (const project of options.projects) {
-    const sampled = sampleRecentSessions(
+    const sampled = sampleSessionsStratifiedByRecency(
       project.sessionIds,
       sessionById,
       maxSessions,
@@ -635,6 +671,8 @@ export async function buildPersonaCandidatesFile(
     thresholds: {
       minSessionsForGeneration: THRESHOLDS.persona.minSessionsForGeneration,
       maxSessionsForCorpus: THRESHOLDS.persona.maxSessionsForCorpus,
+      candidateBudgetProxy: THRESHOLDS.persona.candidateBudgetProxy,
+      maxCandidatesPerBucket: THRESHOLDS.persona.maxCandidatesPerBucket,
     },
     projects: perProject,
   };

--- a/packages/exporter/test/integration/analysis-pipeline.test.ts
+++ b/packages/exporter/test/integration/analysis-pipeline.test.ts
@@ -152,10 +152,10 @@ describe('Phase 6 analysis pipeline integration', () => {
         'surface-comparison.json',
         'skill-curves.json',
         'surprises.json',
-        // V1 persona-mining (Stage 1 produced by exporter; Stage 2
-        // markdown + index produced by /mine-persona skill).
+        // V1 persona-mining Stage 1 only (personas.json + personas/
+        // markdown are skill-emitted and not registered in
+        // meta.tiers.browser.files, mirroring corrections.json).
         'persona-candidates.json',
-        'personas.json',
       ].sort(),
     );
     // Phase 6 does not populate the `local` tier.

--- a/packages/exporter/test/integration/analysis-pipeline.test.ts
+++ b/packages/exporter/test/integration/analysis-pipeline.test.ts
@@ -152,6 +152,10 @@ describe('Phase 6 analysis pipeline integration', () => {
         'surface-comparison.json',
         'skill-curves.json',
         'surprises.json',
+        // V1 persona-mining (Stage 1 produced by exporter; Stage 2
+        // markdown + index produced by /mine-persona skill).
+        'persona-candidates.json',
+        'personas.json',
       ].sort(),
     );
     // Phase 6 does not populate the `local` tier.

--- a/packages/exporter/test/integration/personaCandidates.test.ts
+++ b/packages/exporter/test/integration/personaCandidates.test.ts
@@ -8,6 +8,7 @@ import type {
   SessionManifest,
   UnifiedSessionEntry,
 } from '@chat-arch/schema';
+import { THRESHOLDS } from '@chat-arch/analysis';
 import {
   buildPersonaCandidatesFile,
   PERSONA_HEURISTIC_VERSION,
@@ -146,13 +147,10 @@ describe('persona-candidates heuristic extractor', () => {
       generatedAt: 0,
     } as unknown as SessionManifest;
     const project = mkProject('demo-project', 'demo-project', ['s1']);
-    const sessionToProject = new Map<string, string>([['s1', 'demo-project']]);
-
     const r = await buildPersonaCandidatesFile(manifest, {
       outDir,
       now: 1_700_000_000_000,
       projects: [project],
-      sessionToProject,
     });
 
     expect(r.file.version).toBe(1);
@@ -205,7 +203,6 @@ describe('persona-candidates heuristic extractor', () => {
       outDir,
       now: 1_700_000_000_000,
       projects: [proj],
-      sessionToProject: new Map([['s1', 'quiet']]),
     });
 
     const p = r.file.projects[0]!;
@@ -231,7 +228,6 @@ describe('persona-candidates heuristic extractor', () => {
       outDir,
       now: 1_700_000_000_000,
       projects: [proj],
-      sessionToProject: new Map(),
     });
 
     expect(r.file.projects).toHaveLength(1);
@@ -265,10 +261,145 @@ describe('persona-candidates heuristic extractor', () => {
       outDir,
       now: 1_700_000_000_000,
       projects: [proj],
-      sessionToProject: new Map([['s1', 'dense']]),
     });
 
     const p = r.file.projects[0]!;
-    expect(p.candidatesByBucket.preferences.length).toBeLessThanOrEqual(40);
+    expect(p.candidatesByBucket.preferences.length).toBeLessThanOrEqual(
+      THRESHOLDS.persona.maxCandidatesPerBucket,
+    );
+  });
+});
+
+describe('persona-candidates stratified sampling', () => {
+  it('with > maxSessionsForCorpus sessions, the sampled set spans the full updatedAt range (not just the recent prefix)', async () => {
+    // Plant 240 sessions for one project, updatedAt strictly increasing.
+    // maxSessionsForCorpus is 200; recency-only sampling would lose the
+    // earliest 40. The stratified sampler should still surface
+    // founding-era sessions.
+    const sessions: UnifiedSessionEntry[] = [];
+    const sessionIds: string[] = [];
+    for (let i = 0; i < 240; i += 1) {
+      const id = `s${i.toString().padStart(4, '0')}`;
+      const transcriptPath = await writeTranscript(
+        `cli-direct/strat/${id}.jsonl`,
+        ['placeholder prompt that produces no buckets'],
+      );
+      sessions.push(
+        mkSession(id, transcriptPath, { updatedAt: 1_700_000_000_000 + i * 1000 }),
+      );
+      sessionIds.push(id);
+    }
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions,
+      counts: { total: sessions.length, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const proj = mkProject('strat', 'strat', sessionIds);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000 + 240 * 1000,
+      projects: [proj],
+    });
+
+    const p = r.file.projects[0]!;
+    expect(p.sessionsSampled).toBe(THRESHOLDS.persona.maxSessionsForCorpus);
+    // The earliest sampled session should sit in the project's first
+    // quartile (sessions 0-59 of the 240). Without stratification, the
+    // earliest sampled would be at index 40, which would put earliestSampledAt
+    // > 1_700_000_000_000 + 40 * 1000. Stratified, the founding bucket
+    // (indices 0-59) must contribute, so earliestSampledAt should be
+    // strictly less than that boundary.
+    expect(p.earliestSampledAt).not.toBeNull();
+    expect(p.earliestSampledAt!).toBeLessThan(1_700_000_000_000 + 40 * 1000);
+  });
+});
+
+describe('persona-candidates failure paths', () => {
+  it('session with missing transcript file produces no candidates, no throw', async () => {
+    // Session points at a transcriptPath that doesn't exist on disk.
+    const session = mkSession('ghost', 'cli-direct/ghost/never-written.jsonl');
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions: [session],
+      counts: { total: 1, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const proj = mkProject('ghost', 'ghost', ['ghost']);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000,
+      projects: [proj],
+    });
+
+    const p = r.file.projects[0]!;
+    // No candidates fired in any bucket (the transcript was missing,
+    // so no user turns were extracted).
+    for (const bucket of Object.values(p.candidatesByBucket)) {
+      expect(bucket).toHaveLength(0);
+    }
+  });
+
+  it('malformed JSONL line in the middle is skipped; remaining lines parse', async () => {
+    const abs = path.resolve(outDir, 'cli-direct/mal/s1.jsonl');
+    await mkdir(path.dirname(abs), { recursive: true });
+    // Mix valid lines with garbage; the parser must skip the garbage.
+    const goodTurn = JSON.stringify({
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: 'I prefer terse responses' }] },
+    });
+    await writeFile(
+      abs,
+      [goodTurn, '{ not valid json', goodTurn, ''].join('\n'),
+      'utf8',
+    );
+    const session = mkSession('s1', 'cli-direct/mal/s1.jsonl');
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions: [session],
+      counts: { total: 1, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const proj = mkProject('mal', 'mal', ['s1']);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000,
+      projects: [proj],
+    });
+
+    const p = r.file.projects[0]!;
+    // Both valid user-turn lines matched the `I prefer` pattern.
+    // (Dedup may collapse same-excerpt rows; the load-bearing assertion
+    // is "neither valid line was lost to a parse error AND we didn't
+    // throw on the malformed middle line".)
+    expect(p.candidatesByBucket.preferences.length).toBeGreaterThan(0);
+  });
+
+  it('cloud-source session without transcriptPath yields a clean zero', async () => {
+    // Cloud sessions can come without a transcriptPath (manifest stub
+    // entries). The extractor must handle that without throwing.
+    const session = mkSession('cloud1', 'cloud/missing.json', {
+      source: 'cloud',
+      transcriptPath: undefined,
+    });
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions: [session],
+      counts: { total: 1, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const proj = mkProject('cloud', 'cloud', ['cloud1']);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000,
+      projects: [proj],
+    });
+
+    const p = r.file.projects[0]!;
+    expect(p.sessionsWithCandidates).toBe(0);
   });
 });

--- a/packages/exporter/test/integration/personaCandidates.test.ts
+++ b/packages/exporter/test/integration/personaCandidates.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type {
+  PersonaBucket,
+  Project,
+  SessionManifest,
+  UnifiedSessionEntry,
+} from '@chat-arch/schema';
+import {
+  buildPersonaCandidatesFile,
+  PERSONA_HEURISTIC_VERSION,
+} from '../../src/analysis/personaCandidates.js';
+import { logger } from '../../src/lib/logger.js';
+
+/**
+ * Per-spec test plan: assert the 6 heuristic buckets fill correctly
+ * from a synthetic transcript with known prompt shapes per bucket.
+ *
+ * Fixture is intentionally minimal — one project, one session, one
+ * user turn per bucket-target. The matcher is permissive enough that
+ * each crafted prompt fires on exactly the intended bucket (plus the
+ * always-on voice bucket for very short / very long turns).
+ */
+
+let outDir: string;
+
+beforeEach(async () => {
+  outDir = await mkdtemp(path.join(os.tmpdir(), 'chat-arch-personas-'));
+  logger.setSink(() => {});
+});
+
+afterEach(async () => {
+  logger.resetForTests();
+  await rm(outDir, { recursive: true, force: true });
+});
+
+function mkSession(
+  id: string,
+  transcriptPath: string,
+  overrides: Partial<UnifiedSessionEntry> = {},
+): UnifiedSessionEntry {
+  return {
+    id,
+    source: 'cli-direct',
+    rawSessionId: id,
+    startedAt: 1,
+    updatedAt: 1_700_000_000_000,
+    durationMs: 0,
+    title: `session ${id}`,
+    titleSource: 'fallback',
+    preview: null,
+    userTurns: 1,
+    model: null,
+    modelsUsed: [],
+    cwdKind: 'cli-direct',
+    cwd: null,
+    project: 'demo-project',
+    totalCostUsd: null,
+    tokenTotals: null,
+    transcriptPath,
+    ...overrides,
+  } as unknown as UnifiedSessionEntry;
+}
+
+function mkProject(
+  id: string,
+  displayName: string,
+  sessionIds: readonly string[],
+): Project {
+  return {
+    id,
+    displayName,
+    discoveredAt: new Date(0).toISOString(),
+    lastActivityAt: new Date(0).toISOString(),
+    sessionIds: [...sessionIds],
+    narrativeIds: [],
+    topicIds: [],
+    sentiment: 'neutral',
+    source: 'cli-cwd',
+  };
+}
+
+/** Build a JSONL transcript with one user turn per line. */
+function jsonlTranscript(turns: readonly string[]): string {
+  return turns
+    .map((t, idx) =>
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [{ type: 'text', text: t }],
+        },
+        turnIndex: idx,
+      }),
+    )
+    .join('\n');
+}
+
+async function writeTranscript(
+  rel: string,
+  turns: readonly string[],
+): Promise<string> {
+  const abs = path.resolve(outDir, rel);
+  await mkdir(path.dirname(abs), { recursive: true });
+  await writeFile(abs, jsonlTranscript(turns), 'utf8');
+  return rel;
+}
+
+describe('persona-candidates heuristic extractor', () => {
+  it('fills all 6 buckets from synthetic prompts targeting each pattern family', async () => {
+    const turns = [
+      // role-expertise — first-person-role pattern
+      "I'm a senior software engineer working on a side project",
+      // role-expertise — years-experience pattern
+      "I've been writing Go for ten years but this is my first time touching the React side of this repo",
+      // preferences — i-prefer pattern
+      'I prefer small focused PRs over bundled ones',
+      // preferences — use-X-not-Y pattern
+      'use ripgrep not grep when scanning the corpus',
+      // working-rhythm — loop-iterate pattern
+      'loop until all validated issues are resolved, like before',
+      // working-rhythm — continue-dont-wait pattern
+      'continue, don\'t wait',
+      // frictions — doesnt-work pattern
+      "the auto-brief doesn't render the shipped-this-week section",
+      // frictions — broken-failing pattern
+      'CI is broken — the build crashes on the dist/ rebuild step',
+      // project-specific — project-name-mention (project = "demo-project")
+      'why does demo-project keep regenerating the same sidecar twice on every scan',
+      // voice — terse
+      'continue',
+      // voice — verbose (≥1200 chars)
+      'x'.repeat(1200) + ' this is a long pasted block of context for the persona stage',
+    ];
+    const transcriptPath = await writeTranscript(
+      'cli-direct/demo/s1.jsonl',
+      turns,
+    );
+    const session = mkSession('s1', transcriptPath);
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions: [session],
+      counts: { total: 1, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const project = mkProject('demo-project', 'demo-project', ['s1']);
+    const sessionToProject = new Map<string, string>([['s1', 'demo-project']]);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000,
+      projects: [project],
+      sessionToProject,
+    });
+
+    expect(r.file.version).toBe(1);
+    expect(r.file.heuristicVersion).toBe(PERSONA_HEURISTIC_VERSION);
+    expect(r.file.projects).toHaveLength(1);
+    const p = r.file.projects[0]!;
+    expect(p.projectId).toBe('demo-project');
+    expect(p.sessionsSampled).toBe(1);
+    expect(p.sessionsWithCandidates).toBe(1);
+
+    const buckets = p.candidatesByBucket;
+    const filled: PersonaBucket[] = [];
+    for (const bucket of [
+      'role-expertise',
+      'preferences',
+      'project-specific',
+      'working-rhythm',
+      'frictions',
+      'voice',
+    ] as const) {
+      if (buckets[bucket].length > 0) filled.push(bucket);
+    }
+    // All 6 buckets should fire from the crafted fixture.
+    expect(filled.sort()).toEqual(
+      [
+        'frictions',
+        'preferences',
+        'project-specific',
+        'role-expertise',
+        'voice',
+        'working-rhythm',
+      ].sort(),
+    );
+  });
+
+  it('emits a zero-candidate row when a project has fewer transcripts than expected', async () => {
+    const transcriptPath = await writeTranscript('cli-direct/empty/s1.jsonl', [
+      'hello',
+    ]);
+    const session = mkSession('s1', transcriptPath);
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions: [session],
+      counts: { total: 1, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const proj = mkProject('quiet', 'quiet', ['s1']);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000,
+      projects: [proj],
+      sessionToProject: new Map([['s1', 'quiet']]),
+    });
+
+    const p = r.file.projects[0]!;
+    // 'hello' is 5 chars → terse voice bucket fires. The other 5
+    // buckets should remain empty.
+    expect(p.candidatesByBucket['role-expertise']).toHaveLength(0);
+    expect(p.candidatesByBucket.preferences).toHaveLength(0);
+    expect(p.candidatesByBucket.frictions).toHaveLength(0);
+    expect(p.candidatesByBucket['working-rhythm']).toHaveLength(0);
+    expect(p.candidatesByBucket.voice.length).toBeGreaterThan(0);
+  });
+
+  it('respects sessionsTotal vs sessionsSampled (project with no sessions still gets a row)', async () => {
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions: [],
+      counts: { total: 0, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const proj = mkProject('phantom', 'phantom', []);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000,
+      projects: [proj],
+      sessionToProject: new Map(),
+    });
+
+    expect(r.file.projects).toHaveLength(1);
+    const p = r.file.projects[0]!;
+    expect(p.sessionsTotal).toBe(0);
+    expect(p.sessionsSampled).toBe(0);
+    expect(p.sessionsWithCandidates).toBe(0);
+  });
+
+  it('caps candidates per bucket at MAX_CANDIDATES_PER_BUCKET (40)', async () => {
+    // Build a transcript with 50 "I prefer X" prompts so the
+    // preferences bucket overflows the cap.
+    const turns: string[] = [];
+    for (let i = 0; i < 50; i += 1) {
+      turns.push(`I prefer approach number ${i} for handling edge cases`);
+    }
+    const transcriptPath = await writeTranscript(
+      'cli-direct/dense/s1.jsonl',
+      turns,
+    );
+    const session = mkSession('s1', transcriptPath);
+    const manifest: SessionManifest = {
+      schemaVersion: 2,
+      sessions: [session],
+      counts: { total: 1, bySource: {} },
+      generatedAt: 0,
+    } as unknown as SessionManifest;
+    const proj = mkProject('dense', 'dense', ['s1']);
+
+    const r = await buildPersonaCandidatesFile(manifest, {
+      outDir,
+      now: 1_700_000_000_000,
+      projects: [proj],
+      sessionToProject: new Map([['s1', 'dense']]),
+    });
+
+    const p = r.file.projects[0]!;
+    expect(p.candidatesByBucket.preferences.length).toBeLessThanOrEqual(40);
+  });
+});

--- a/packages/exporter/test/migration/v1.1.0-fixture.test.ts
+++ b/packages/exporter/test/migration/v1.1.0-fixture.test.ts
@@ -159,7 +159,7 @@ describe('migration v1.1.0 → 1.2.0', () => {
       tiers: { browser: { files: readonly string[] } };
       counts: Record<string, unknown>;
     }>(path.join(tmpDataDir, 'analysis', 'meta.json'));
-    expect(meta.exporterVersion).toBe('1.5.1');
+    expect(meta.exporterVersion).toBe('1.6.0');
 
     // The Wave-5 sidecars (+ feed-redesign Phase A surprises.json)
     // must all be registered in the browser tier.

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -20,3 +20,4 @@ export * from './composite-outcome.js';
 export * from './upgrade-outcome.js';
 export * from './duplicates-semantic.js';
 export * from './blog.js';
+export * from './personas.js';

--- a/packages/schema/src/personas.ts
+++ b/packages/schema/src/personas.ts
@@ -1,0 +1,118 @@
+/**
+ * Per-project persona sidecar shapes — V1 (feature: persona-mining).
+ *
+ * The persona-mining pipeline runs as SCAN chain step 5. Two artifacts
+ * land under `apps/standalone/public/chat-arch-data/analysis/`:
+ *
+ *   - `persona-candidates.json` — Stage 1, deterministic heuristic
+ *     extraction. Per-project buckets of user-prompt excerpts grouped
+ *     by 6 categories (role/expertise, preferences, project-specific
+ *     use, working rhythm, frictions, voice). Input to Stage 2.
+ *   - `personas.json` — Stage 2 output index. One record per project
+ *     in the corpus: either `generated` (markdown at the named path)
+ *     or `skipped` with a reason.
+ *
+ * Per-project markdown lives at `analysis/personas/<project-id>.md`
+ * and is rendered by the PERSONAS viewer surface. All persona files
+ * are PII-bearing (verbatim user-prompt excerpts) — gitignored under
+ * the existing `apps/standalone/public/chat-arch-data/*` wildcard.
+ */
+
+/** Six heuristic buckets that segment per-project user prompts. */
+export type PersonaBucket =
+  | 'role-expertise'
+  | 'preferences'
+  | 'project-specific'
+  | 'working-rhythm'
+  | 'frictions'
+  | 'voice';
+
+/**
+ * One detected user-prompt excerpt assigned to a heuristic bucket.
+ * Lightweight by design — Stage 2 (LLM) re-reads the full session
+ * transcript when it needs more context than the excerpt carries.
+ */
+export interface PersonaCandidate {
+  sessionId: string;
+  /** 0-based index into the session's user turns. */
+  userTurnIndex: number;
+  /** Verbatim user-text excerpt (trimmed to ≤500 chars). */
+  excerpt: string;
+  /** Which bucket this candidate fired on. */
+  bucket: PersonaBucket;
+  /** Heuristic pattern key that fired (e.g. 'first-person-preference'). */
+  patternKey: string;
+}
+
+/** One project's heuristic candidates + sampling metadata. */
+export interface PersonaCandidateProject {
+  projectId: string;
+  projectName: string;
+  /** Total sessions in this project (across all sources). */
+  sessionsTotal: number;
+  /** Sessions actually sampled for candidate extraction (≤ THRESHOLDS.persona.maxSessionsForCorpus). */
+  sessionsSampled: number;
+  /** Sessions that produced ≥1 candidate. */
+  sessionsWithCandidates: number;
+  /** Earliest sampled-session updatedAt (ms since epoch). */
+  earliestSampledAt: number | null;
+  /** Latest sampled-session updatedAt (ms since epoch). */
+  latestSampledAt: number | null;
+  /** All extracted candidates, keyed by bucket → array. */
+  candidatesByBucket: Record<PersonaBucket, readonly PersonaCandidate[]>;
+}
+
+/** `analysis/persona-candidates.json` shape. */
+export interface PersonaCandidatesFile {
+  version: 1;
+  generatedAt: number;
+  heuristicVersion: number;
+  thresholds: {
+    minSessionsForGeneration: number;
+    maxSessionsForCorpus: number;
+  };
+  projects: readonly PersonaCandidateProject[];
+}
+
+/**
+ * One persona record in the index. `status === 'generated'` projects
+ * carry a `personaPath` (relative to `apps/standalone/public/chat-arch-
+ * data/`); skipped projects carry a reason instead.
+ */
+export interface PersonaRecord {
+  projectId: string;
+  projectName: string;
+  /** Sessions Stage 2 actually fed to the LLM synthesis. */
+  sessionsAnalyzed: number;
+  /** Sessions in the project at scan time. */
+  sessionsTotal: number;
+  /** Relative path to the per-project markdown, or null when skipped. */
+  personaPath: string | null;
+  /** ms since epoch; null when never generated. */
+  generatedAt: number | null;
+  status: 'generated' | 'insufficient-corpus' | 'budget-exceeded' | 'error';
+  /** Free-form reason when status !== 'generated'. */
+  reason?: string;
+}
+
+/** Per-project metadata embedded in the markdown's frontmatter for the viewer. */
+export interface PersonaMetadata {
+  projectId: string;
+  projectName: string;
+  sessionsAnalyzed: number;
+  generatedAt: number;
+  exporterVersion: string;
+}
+
+/** `analysis/personas.json` shape (the index over per-project records). */
+export interface PersonasIndex {
+  schemaVersion: 1;
+  generatedAt: number;
+  exporterVersion: string;
+  thresholds: {
+    minSessionsForGeneration: number;
+    maxSessionsForCorpus: number;
+    maxLlmUsdPerProject: number;
+  };
+  personas: readonly PersonaRecord[];
+}

--- a/packages/schema/src/personas.ts
+++ b/packages/schema/src/personas.ts
@@ -70,6 +70,12 @@ export interface PersonaCandidatesFile {
   thresholds: {
     minSessionsForGeneration: number;
     maxSessionsForCorpus: number;
+    /** Stage-2 budget proxy. The mine-persona skill skips projects
+     *  whose Stage-1 candidate count exceeds this value (V1 stand-in
+     *  for the USD-cap until token-counting harness lands in V2). */
+    candidateBudgetProxy: number;
+    /** Per-bucket cap on candidates per project at Stage 1. */
+    maxCandidatesPerBucket: number;
   };
   projects: readonly PersonaCandidateProject[];
 }
@@ -93,15 +99,6 @@ export interface PersonaRecord {
   status: 'generated' | 'insufficient-corpus' | 'budget-exceeded' | 'error';
   /** Free-form reason when status !== 'generated'. */
   reason?: string;
-}
-
-/** Per-project metadata embedded in the markdown's frontmatter for the viewer. */
-export interface PersonaMetadata {
-  projectId: string;
-  projectName: string;
-  sessionsAnalyzed: number;
-  generatedAt: number;
-  exporterVersion: string;
 }
 
 /** `analysis/personas.json` shape (the index over per-project records). */

--- a/research/persona-evals/README.md
+++ b/research/persona-evals/README.md
@@ -1,0 +1,36 @@
+# Persona evaluations
+
+Two jobs live in this directory. They sound similar and are easy to conflate; keeping the distinction explicit avoids future drift.
+
+## Primary user-modeling persona
+
+[`bryce.md`](bryce.md) — the maker-operator. Data-grounded from 160 chat-arch CLI sessions across the project's full lifespan (founding era → present). This is the persona chat-arch is **actually for**. Every product decision should ask "does this serve the workflow in `bryce.md`?"
+
+The 10-row "preserve / automate / get out of the way of" table at the bottom of `bryce.md` is the load-bearing product spec for this persona. It supersedes any conflicting positioning copy elsewhere in `research/` — the refocus-plan and other strategy docs predate the data-grounded persona and should be read in that light.
+
+chat-arch's north star (per `research/refocus-plan.md`) is "personal workshop only — not a team product, not a hosted SaaS." `bryce.md` is the operational answer to "what does the personal workshop's single user look like?"
+
+## Secondary onramp-evaluation personas
+
+[`maya.md`](maya.md), [`david.md`](david.md), [`priya.md`](priya.md), [`sam.md`](sam.md) — hypothetical first-touch users used to pressure-test the hosted-demo onramp at `chat-arch.dev`. These are *evaluation walkthroughs*, not user-modeling docs: each picks a viewpoint (daily power user / cloud-only PM / 90-second drive-by / 3-month-stale returner) and surfaces UI frictions a maker-operator wouldn't see from inside the build.
+
+| Persona | What it pressure-tests |
+|---|---|
+| [Maya](maya.md) | Daily-use chrome for a returning power user — closest to "someone Bryce would hand the tool to" |
+| [David](david.md) | Hosted-demo experience for a cloud-only Claude user |
+| [Priya](priya.md) | First-touch from an HN link, 90 seconds before standup |
+| [Sam](sam.md) | Returning user with stale local data after a long absence |
+
+These four remain useful *for the demo / first-touch surfaces specifically*. They should NOT be used to:
+
+- Define the product's primary workflow (that's `bryce.md`'s job)
+- Justify features that don't serve the maker-operator (the personal workshop is the product)
+- Drive prioritization tradeoffs against `bryce.md`-derived work
+
+When a finding from one of the four conflicts with `bryce.md`'s spec, `bryce.md` wins.
+
+## How this resolves the original ambiguity
+
+The first persona-eval pass produced four hypothetical-user walkthroughs without first asking "who is chat-arch fundamentally for?" That's a `bryce.md` question, and answering it after-the-fact reframes the original four as a different (still useful) artifact: onramp evaluations for the hosted demo, not user-modeling docs.
+
+If you arrive at this directory expecting to find personas-of-record for the product, start with `bryce.md`. The others are pressure-test surfaces for a narrower question (does the demo onramp work?), not a wider one (what does the product do?).

--- a/research/persona-evals/bryce.md
+++ b/research/persona-evals/bryce.md
@@ -1,0 +1,188 @@
+# Persona evaluation — Bryce, the maker-operator
+
+Bryce is the author of chat-arch and its heaviest single user. Where Maya / David / Priya / Sam are *user-under-audit* personas (each "what would this user see and miss?"), Bryce is a *maker-operator* persona: he both ships the product and dogfoods it daily, often in the same session. This profile is data-grounded — mined from 160 of his Claude Code CLI sessions across the chat-arch project's full ~5-month lifespan (founding era through PR #105 on 2026-05-25). Each pattern below cites verbatim prompts with `[SID:<session-prefix>]` anchors.
+
+The intent of this doc is not the same as the others': it is not "what does Bryce see when he opens chat-arch?" — he wrote every surface; he already knows. It is "what does Bryce's actual usage say about how he wants the product to work, and which behaviors should chat-arch preserve, automate, or get out of the way of?"
+
+---
+
+## 1. Specification-as-prompt
+
+**Pattern.** Bryce does not converse with Claude; he writes mini-RFCs. Every load-bearing prompt has a scope block, an explicit DO-NOT list, a deliverable definition, and references to file:line evidence. Casual exploratory prompts are rare — even discovery passes are framed as "read-mostly research → single written recommendation."
+
+**Evidence.**
+
+- [SID:c9a0169b] "DO NOT make any code changes" + "Read-only investigation followed by a single written recommendation" — discovery passes are explicit gates, not open-ended chats.
+- [SID:8f66baa2] "Read-mostly; commit changes only if I ask you to act on the plan in a follow-up message."
+- [SID:bcddb358] "Use AskUserQuestion for the open decisions above BEFORE coding" — planning decisions are user-facing gates, not Claude decisions.
+- [SID:session-30, founding era] A 1,288-line E2E test implementation spec with defensive coding requirements ("avoid accidentally arming in a packaged build"), tier-1/tier-2/tier-3 scoping, and explicit permission to ship incomplete: "A useful 80%-fill PR is far better than a stalled 100%-fill PR."
+- [SID:00944d87, this session] "Bundle BOTH fixes into ONE PR. Project convention is small-focused PRs for human-paced work, but Claude-Code-paced bundling is allowed when two fixes share a release."
+
+**What this implies for chat-arch.** The product should make it easy to capture "the prompt that worked" as a reusable artifact. The PRACTICE surface and the `playbook-candidates` pipeline are early gestures in this direction; the natural next step is a "rerun this prompt" or "save this prompt as a skill argument" affordance on session-detail pages. The save-prompt API already exists (`/api/save-prompt`) but the prompt-mining + lift-into-skill pipeline isn't wired through the UI yet.
+
+---
+
+## 2. /loop as control primitive, validation as gate
+
+**Pattern.** `/loop` is his default iteration mechanism — not a slash command he occasionally remembers, but the way he expects sustained work to happen. Loops always run through a validation gate (adversarial review team, falsifier, lint/test/build) before he accepts a step as done.
+
+**Evidence.**
+
+- [SID:fed44166] "Run adversarial review teams against all of the PRs, then /loop until no verified issues are being found and the PRs are all merged."
+- [SID:24986e2f] "Merge it now and continue. Loop until all validated issues are resolved, like before."
+- [SID:eaadc510] "Did you forget to validate and confirm the adversarial results again? These situations are exactly the ones I want to see get flagged by the system."
+- [SID:b1f24301] "Take a look at the PR review comments, then spin up an adversarial review team to fully review the PR. Confirm findings before fixing them."
+- [SID:761dffb1] "Continue, don't wait."
+
+**What this implies for chat-arch.** Bryce trusts a fix only after a falsifier or adversarial review has tried to disprove it. The `/review-loop` global Stop hook, the curator/falsifier kernels, and the `falsifier-verdicts.json` sidecar all encode this discipline — but chat-arch doesn't yet measure *how often validated findings catch issues that would otherwise have shipped*. A "validation ROI" surface (fixes caught by adversarial pass / total fixes) would close the loop on this loop.
+
+---
+
+## 3. Start-of-turn state reconciliation
+
+**Pattern.** Every multi-step session opens with branch / PR / stash audit. He doesn't act on yesterday's context; he reconciles current world state first, then proceeds. This is durable enough that it's a feedback memory.
+
+**Evidence.**
+
+- [SID:023e5e2b] "self-pacing each iteration ... fetch origin, check PRs"
+- [SID:c9a0169b] Lengthy reconciliation prompt: "5 open PRs, an active feature branch with uncommitted dirty work, a stash on top of that"
+- [SID:bcddb358] "State reconciled: on feature/blog-draft-generation"
+- [SID:c9a0169b] "don't lose my in-progress work. The dirty state on feature/outcome-substrate-roadmap includes a real refactor ... that already addresses one security finding."
+
+**What this implies for chat-arch.** The product itself has no state-reconciliation surface — there is no "where am I right now in this corpus?" view that orients him at session start the way `git status` does in a repo. The closest existing equivalent is the TODAY page's daily brief, which is *backward-looking*. A "current state of the workshop" snapshot (open PRs the corrections pipeline touched, the last 3 narratives whose status changed, the curator feed delta since last visit) would mirror in-product what he already does in-repo.
+
+---
+
+## 4. First-principles reset when uncertain
+
+**Pattern.** When a UI direction feels off or a plan looks tangled, he restarts from axioms rather than patching forward. Often coupled with "look through our chats to ensure we're still aligned with the original goals."
+
+**Evidence.**
+
+- [SID:fed44166] "I want to go back to first principles on the UI design of all of this, considering our recent work."
+- [SID:acdae515] "Let's go back to first principles with everything we've discussed and create a new plan."
+- [SID:acdae515] "What if we thought of all of this as an ecosystem of tools, skills, agents, that work collaboratively to build towards our highest tier of analysis?"
+- [SID:f377b754] "Can you look through our chats to ensure we're fulfilling our original goals?"
+- [SID:b964680a] "I want you to look through our recent conversations to understand the direction we've been moving."
+
+**What this implies for chat-arch.** He uses his own chat history as a planning artifact — externalizing direction-of-work into the corpus rather than re-loading it from his head. The `/chat-answer` skill and the chat-history-search workflow are designed for exactly this. A "north-star drift detector" — flagging when current work's vocabulary diverges from the original spec's — would automate a check he does manually every few weeks.
+
+---
+
+## 5. Multi-session handoff via prompt-as-context
+
+**Pattern.** Most non-trivial sessions end with "give me a prompt that will continue this work in a new session, with all needed context." He treats prompts as the durable artifact, not session UUIDs. The persona itself was requested this way in this session: "create my persona as well" with full context expected to live in the next prompt.
+
+**Evidence.**
+
+- [SID:023e5e2b] "Provide me with a prompt that will continue this work in a new session. Provide all needed context in the prompt."
+- [SID:acdae515] "Provide me with a prompt that will kick off a new session that will loop until the plan is fully, verifiably, implemented tested and reviewed."
+- [SID:86ec4c60] "Validate visually that it is all working to spec, iterate until it is, then provide me with a prompt to start the next session."
+
+**What this implies for chat-arch.** The save-prompt endpoint exists; surface integration with session-detail does not. A "next session prompt" affordance that auto-drafts a continuation prompt from the trailing N turns of the current session would short-circuit the manual handoff step he runs at the end of nearly every loop.
+
+---
+
+## 6. Anti-hallucination protocols, scoped by task type
+
+**Pattern.** He has *learned* which tasks Claude hallucinates on (content / narrative work) versus which it doesn't (code review with file:line citations). He activates an explicit anti-hallucination protocol for the former and trusts the inherent gates of the latter.
+
+**Evidence.**
+
+- [SID:session-29, founding era] Activates "ANTI-HALLUCINATION PROTOCOL" for blog post QA
+- [SID:session-31, founding era] Same protocol re-activated for a second content-review pass
+- [SID:session-38, founding era] On code work: "Re-verify each citation before changing code — if the codebase has moved, the cited fix location may have moved too. Verify by reading current code, NOT by trusting this prompt's line numbers blindly."
+
+**What this implies for chat-arch.** The corrections-mining pipeline already classifies pushbacks; classifying them by *task type* (content vs code vs planning) would surface which task-types he most often has to redirect on — and the playbook surface could light up exactly the right anti-hallucination preamble per task type.
+
+---
+
+## 7. Validation against his own automation
+
+**Pattern.** Even when running tools he wrote himself, he treats output as a hypothesis to validate. The auto-brief, the surprises kernel, the curator feed — none of these get a free pass. Every claim is verifiable, and he checks.
+
+**Evidence.**
+
+- [SID:fed44166] "I just ran a scan, can you make sure it went through properly?"
+- [SID:acdae515] "I don't want to take it as truth, but to look to see what we can learn and improve on as well."
+- [SID:acdae515] "It also skipped many chats because they were too big. How are we handling this?"
+- [SID:00944d87, this session] "addressed ≠ delivered. Verify both bugs end-to-end after the fix, not just compile-clean."
+
+**What this implies for chat-arch.** Every kernel output should carry a *how-to-falsify-this* affordance — a "show me the evidence" drill-in that already exists for surprises and trajectories but is missing on the brief. The brief currently presents counts and ranked lists; it doesn't link to a "what would change my mind?" view.
+
+---
+
+## 8. Dogfooding as primary feature-discovery loop
+
+**Pattern.** Most chat-arch features begin life as a friction Bryce hits in his own usage, gets analyzed in a chat-arch session, surfaces as a correction or pattern, and ships as a feature. The product's roadmap and his daily friction log are the same artifact.
+
+**Evidence.**
+
+- [SID:eaadc510] "I think what we're landing on is a correction mining view for chat-arch."
+- [SID:b964680a] "Look through our recent conversations to understand the direction we've been moving."
+- [SID:acdae510] "What if we had a stronger focus on self improvement, both of the user and the system?"
+- This very PR (Bug 1 + Bug 2 → PR #105) followed the loop: friction observed in scan run → bug-pair filed as one task → fix shipped.
+
+**What this implies for chat-arch.** This is the product's strongest competitive moat: a daily-use feedback loop most projects don't have. The corrections-pipeline + applied-watcher + outcome-substrate are deliberate machinery for this loop. But the *time-to-feature* metric (friction filed → fix shipped) isn't measured anywhere. Surfacing it would let him optimize the loop directly.
+
+---
+
+## 9. Voice — terse status checks, elaborate context blocks
+
+**Pattern.** Two distinct prompt shapes. Short status pings during tight iteration ("What's the status?", "Continue, don't wait", "Merge it now"). Elaborate 800-1500-word context blocks at task boundaries (handoff specs, founding-era E2E specs, this session's Bug 1 + Bug 2 brief). No middle register.
+
+**Evidence.**
+
+- Short: [SID:761dffb1] "What's the status?" · [SID:fed44166] "fix all issues first, yes" · [SID:24986e2f] "Merge it now and continue."
+- Long: [SID:00944d87] this session's 1,200-word task block with Symptom / Root cause / Fix / Diagnostic steps sections per bug. [SID:bcddb358] 800-word task definition with read-first / constraints / DO-NOT / deliverables.
+
+**Other voice signals.**
+
+- "I want" + "I don't like" — direct preference, no hedging ([SID:bcddb358], [SID:f377b754]).
+- "Shouldn't that happen automatically?" — challenges the existence of manual steps ([SID:b1f24301]).
+- "I hope none of this is hard coded" — skeptical of magic numbers + brittle heuristics ([SID:b1f24301]).
+- "Drill down to see all of the evidence" — wants depth-on-demand, not pre-summarized verdicts ([SID:fed44166]).
+
+**What this implies for chat-arch.** UI cards in the FEED already implement drill-down-to-evidence (the surprise cards' "→ in context" links). Extending this discipline to the brief sections (every count is clickable into its evidence) would match his evidence-maximalist preference without changing the brief's terseness.
+
+---
+
+## 10. Recurring friction surfaces
+
+The frictions below appear across multiple sessions and are stable enough to ship around.
+
+- **Branch / PR / stash state complexity.** Multiple sessions juggling 3-4 open PRs simultaneously; explicit "don't lose my in-progress work" instructions ([SID:c9a0169b]). Already addressed in the `feedback_state_reconciliation` memory; the product itself has no equivalent surface.
+- **Stale dev server / port collision.** [SID:fed44166] "ports 4321-4334 in use ... leftover dev servers" — happened again *in this very session* (11 ports held by various Astro instances). A "stop all chat-arch dev servers" affordance would be small but high-leverage.
+- **Local PII overrides conflicting with staging discipline.** The `manifest.json` belongs-to-disk-but-not-to-git rule had to be encoded as a hook + a CLAUDE.md memory after it bit once. Still appears as a recurring source of `git status` noise.
+- **Async UI feedback lag.** [SID:9630c445] "wish UI would be responsive instead of saying this" — during long-running endpoint calls, the page status line goes silent. The recent `[SCAN] step N/M failed` console.warn instrumentation is a partial mitigation; structured client-side progress events are the durable fix.
+- **Over-automation distrust.** [SID:8f66baa2] "What can we do to ensure you never take shortcuts like these again? Take a deeper look at root causes, then review this entire development session to see if we took any major wrong turns." When Claude skips a validation step, he doesn't just redirect — he asks for a process-level audit.
+
+---
+
+## Coverage notes
+
+- **Files scanned:** 160 chat-arch CLI sessions out of 627 total (4 buckets × 40 sessions, sampled by `mtime` recency: founding-era → recent).
+- **Source corpus:** `~/.claude/projects/C--Users-Bryce-Projects-chat-arch/*.jsonl`. Cowork sessions not mined for this pass — Bryce uses Cowork primarily for browser-mode tasks (cloud dashboards / signup flows / domain setup per `user_tooling` memory), not for chat-arch development work.
+- **False positives filtered:** `tool_use_id` / `tool_result` content, `<task-notification>` wrappers, TodoWrite items, `isSidechain` / `isApiErrorMessage` lines, `<system-reminder>` / `<command-message>` injections.
+- **Confidence:** High across all 10 patterns. Every pattern appears in at least 2 time buckets (founding + recent OR mid + recent), confirming durability rather than phase-specific drift.
+- **What this persona does NOT cover:** Cowork browser-mode usage; cross-project patterns (his other repos: brycewatson.com, ShopForge, ShopSmith-v2, etc.); off-hours work rhythm (timestamps not parsed in this pass).
+- **Re-mine cadence:** This persona should be refreshed quarterly. The mid-era → recent comparison already shows the `/curate` + `/falsify` skills moving from "newly introduced" to "routine"; expect new tooling patterns to surface over the next quarter that aren't here yet.
+
+---
+
+## What chat-arch should preserve, automate, or get out of the way of
+
+A one-screen TL;DR for product decisions:
+
+| Behavior | Action |
+|---|---|
+| Specification-as-prompt | **Preserve.** Save-prompt + skill-argument lift is the natural ramp; don't replace with chat-style. |
+| /loop + validation gates | **Automate harder.** Measure validation ROI; surface it on PRACTICE. |
+| Start-of-turn reconciliation | **Mirror in product.** "Current state of the workshop" view, like `git status` for the corpus. |
+| First-principles reset | **Detect drift.** Compare current-work vocabulary to founding-era spec; surface divergence. |
+| Multi-session handoff | **Affordance.** Auto-draft "next session prompt" from trailing turns. |
+| Anti-hallucination protocols | **Classify by task type.** Per-task playbook preambles. |
+| Validate his own automation | **How-to-falsify on every kernel output.** Brief sections need drill-ins. |
+| Dogfooding feedback loop | **Measure time-to-feature.** Friction-filed → fix-shipped metric. |
+| Drill-down to evidence | **Extend to brief.** Every count clickable into its evidence. |
+| Dev server port chaos | **One-button "stop all chat-arch dev servers."** |

--- a/research/persona-mining-continuation-prompt.md
+++ b/research/persona-mining-continuation-prompt.md
@@ -1,0 +1,165 @@
+# Continuation prompt — persona-mining feature implementation
+
+Paste the body below into a fresh Claude Code session running in `c:\Users\Bryce\Projects\chat-arch`. The prompt is self-contained and assumes zero context from the session that drafted it.
+
+---
+
+# Implement chat-arch persona-mining feature (V1)
+
+## Why you're here
+
+Bryce hand-authored `research/persona-evals/bryce.md` by mining his own chat-arch session history across 4 time buckets via parallel sub-agents, and found the data-grounded persona substantially more useful than the original hypothetical-user personas (`maya.md`, `david.md`, `priya.md`, `sam.md`). He wants chat-arch to generate equivalent personas **automatically, per project, on every SCAN**. The spec is pinned. Your job is to ship it end-to-end in one bundled PR.
+
+## Read first
+
+**Spec (load-bearing — read fully before doing anything else):**
+- [`research/persona-mining-spec.md`](research/persona-mining-spec.md) — V1 spec with decisions pinned (per-project only, on-SCAN as chain step 5, new PERSONAS sidebar entry). Includes file-changes table, sidecar shapes, skill template, chain integration, UI surface, test plan, decision log.
+
+**Reference artifacts (the persona this work is modeled on):**
+- [`research/persona-evals/bryce.md`](research/persona-evals/bryce.md) — the hand-authored canonical that auto-gen should match in quality. Mirror this structure (header / 6-10 numbered pattern sections with **Pattern.** / **Evidence.** / **What this implies.** / coverage notes / optional preserve-automate-get-out-of-the-way table).
+- [`research/persona-evals/README.md`](research/persona-evals/README.md) — names bryce.md as primary user-modeling persona; the 4 onramp-eval personas (maya/david/priya/sam) are secondary. Auto-generated personas live under `analysis/personas/<project-id>.md` and do NOT supersede the hand-authored `bryce.md` (which stays as the canonical for the chat-arch project specifically).
+
+**Existing patterns to mirror (DO NOT invent new infrastructure):**
+- [`apps/standalone/src/pages/api/mine-corrections.ts`](apps/standalone/src/pages/api/mine-corrections.ts) — NDJSON-streaming endpoint template. `/api/mine-persona` should follow this shape exactly: CSRF gate (Origin + X-Requested-With), `inFlight` serializer, parseParams + auto-window pattern, spawn `claude -p`, emit NDJSON `start` / `phase` / `stdout` / `done` events.
+- [`.claude/skills/mine-corrections/`](.claude/skills/mine-corrections/) — skill structure. Build `.claude/skills/mine-persona/` parallel to it (SKILL.md + lib/).
+- [`apps/standalone/src/scripts/fullScan.ts`](apps/standalone/src/scripts/fullScan.ts) — chain orchestrator. Add 5th entry to `FULL_SCAN_STEPS`; update the corresponding test in [`apps/standalone/test/scripts/fullScan.test.ts`](apps/standalone/test/scripts/fullScan.test.ts).
+- [`packages/exporter/src/analysis/semanticAnalysis.ts`](packages/exporter/src/analysis/semanticAnalysis.ts) — exporter producer template. The heuristic candidate extractor (Stage 1, deterministic) lands in `packages/exporter/src/analysis/personaCandidates.ts` and is wired into `runAnalysis`.
+
+## State reconciliation — DO THIS FIRST
+
+Before any work, run state reconciliation per [`feedback_state_reconciliation`](C:\Users\Bryce\.claude\projects\c--Users-Bryce-Projects-chat-arch\memory\feedback_state_reconciliation.md):
+
+1. `git status` — current branch + uncommitted files
+2. `gh pr list --state open --json number,title,headRefName` — what PRs are open
+3. `gh pr view 105 --json state,statusCheckRollup -q '.state + " | checks: " + (.statusCheckRollup[0].state // "pending")'` — status of in-flight bug-fix PR
+
+**Expected state when this prompt fires:**
+- PR #105 (`fix/auto-brief-and-scan-wiring`) is the in-flight bug-fix PR — may be still open with pending checks, or already merged. **Do NOT add feature work to that branch under any circumstances.**
+- Three unstaged research files may exist on the current branch outside PR #105's scope:
+  - `research/persona-evals/bryce.md`
+  - `research/persona-evals/README.md`
+  - `research/persona-mining-spec.md`
+- These were authored alongside #105 but are not part of its diff.
+
+**Branch hygiene decision tree:**
+
+- **If #105 is already merged into main** → branch off main: `git switch main && git pull && git switch -c feature/persona-mining`. Stage the 3 research files (they're now in your worktree from main if #105 included them — verify with `git ls-files research/persona-evals/`; if not, you'll need to recover them from the previous branch via `git show <prev-branch>:<path>`).
+- **If #105 is still open** → branch off main: `git switch main && git switch -c feature/persona-mining`. Recover the 3 unstaged research files from the `fix/auto-brief-and-scan-wiring` branch: `git show fix/auto-brief-and-scan-wiring:research/persona-evals/bryce.md > research/persona-evals/bryce.md` (etc. for the other two).
+
+**NEVER** force-push or use `git switch --discard-changes` (per [`feedback_git_switch_discard`](C:\Users\Bryce\.claude\projects\c--Users-Bryce-Projects-chat-arch\memory\feedback_git_switch_discard.md)). Use targeted stash + show.
+
+## Implementation plan — 4 waves with sub-agent fan-out
+
+Per [`feedback_claude_code_paced_prs`](C:\Users\Bryce\.claude\projects\c--Users-Bryce-Projects-chat-arch\memory\feedback_claude_code_paced_prs.md): Claude-Code-paced work bundles into 1-2 PRs with sub-agent fan-out per wave. Ship as ONE PR.
+
+### Wave 1 — schema + thresholds + heuristic extractor (deterministic layer)
+
+Sub-agent A:
+- Create `packages/schema/src/personas.ts` with `PersonasIndex`, `PersonaRecord`, `PersonaMetadata` types per spec § Sidecar shapes
+- Wire export through `packages/schema/src/index.ts`
+
+Sub-agent B:
+- Extend `packages/analysis/src/thresholds.ts` with `persona.minSessionsForGeneration` (default 30), `persona.maxSessionsForCorpus` (default 200), `persona.maxLlmUsdPerProject` (default 0.50)
+- Add THRESHOLDS test coverage for new fields
+
+Sub-agent C:
+- Create `packages/exporter/src/analysis/personaCandidates.ts` — heuristic extractor that per-project reads the SQLite substrate via `@chat-arch/exporter/db`, samples up to `maxSessionsForCorpus` recent prompts, classifies into 6 heuristic buckets (role/expertise, preferences, project-specific use, working rhythm, frictions, voice), writes `analysis/persona-candidates.json`
+- Wire into `runAnalysis` in `packages/exporter/src/analysis/index.ts`
+- Add `analysis/persona-candidates.json` + `analysis/personas.json` to meta.tiers.browser.files
+- Bump `EXPORTER_VERSION` 1.5.0 → 1.6.0 in `packages/exporter/src/analysis/index.ts`
+
+Sub-agent D:
+- Write `packages/exporter/test/integration/personaCandidates.test.ts` — fixture-driven, assert 6 buckets fill from a synthetic transcript
+
+**Wave 1 exit gate:** `pnpm lint && pnpm test && pnpm build` clean. 2154+ baseline pass count.
+
+### Wave 2 — skill + API endpoint + chain integration
+
+Sub-agent A:
+- Build `.claude/skills/mine-persona/SKILL.md` modeled on `.claude/skills/mine-corrections/SKILL.md`. The skill consumes `persona-candidates.json`, dispatches per-project sub-agents that mirror the 4-bucket-by-recency strategy used to author `bryce.md`, synthesizes into `analysis/personas/<project-id>.md`.
+- Add `.claude/skills/mine-persona/lib/` helpers as needed for prompt construction.
+
+Sub-agent B:
+- Create `apps/standalone/src/pages/api/mine-persona.ts` following `mine-corrections.ts` template line-for-line: CSRF (REQUIRED_HEADER = `chat-arch-mine-persona`), inFlight, parseParams, spawn `claude -p` invoking the skill, NDJSON stream.
+- Create `apps/standalone/src/pages/api/clear-personas.ts` — selective wipe for `analysis/personas/` family
+
+Sub-agent C:
+- Update `apps/standalone/src/scripts/fullScan.ts`: append 5th entry to `FULL_SCAN_STEPS` `{ id: 'persona', label: 'mine personas', url: '/api/mine-persona', header: 'chat-arch-mine-persona' }`
+- Update `apps/standalone/test/scripts/fullScan.test.ts`: header-pinning entry + all chain-semantics tests run as 5-step
+- Update `apps/standalone/src/pages/api/clear.ts` to extend orphan-sweep to `analysis/personas/`
+
+**Wave 2 exit gate:** lint + test + build clean. Chain test confirms 5-step variant works.
+
+### Wave 3 — viewer surface (PERSONAS page + sidebar)
+
+Sub-agent A:
+- Create `apps/standalone/src/pages/personas.astro` per spec § UI surface — PERSONAS page
+- Sidebar list of all projects with personas, ordered by `sessionsAnalyzed` desc
+- Skipped projects shown in collapsed "not yet generated" section with reason
+- Selected project: render its `.md` via the same MD-rendering path the brief uses (grep for how `/api/regen-brief` / TODAY page renders the brief — reuse that path)
+- Per-section drill-down: click `[SID:...]` anchor → navigate to `/sessions#session/<sid>` (matches existing FEED card behavior — verify HASH_SESSION_PREFIX in `packages/viewer/src/ChatArchViewer.tsx`)
+- "REGEN PERSONA" per-project button: POSTs `/api/mine-persona` with `{ projectId }`
+
+Sub-agent B:
+- Update `apps/standalone/src/components/AppSidebar.astro`: add PERSONAS entry under WORKSHOP group, short label `PER`. Match existing 3-letter convention (PLB / COR / PRC).
+- Update sidebar test `apps/standalone/test/components/AppSidebar.test.ts` accordingly
+
+**Wave 3 exit gate:** lint + test + build clean. Manual: PERSONAS sidebar entry visible, page renders, "not yet generated" projects shown.
+
+### Wave 4 — docs + manual verification
+
+Single agent (no fan-out needed):
+
+- Update `CHANGELOG.md` with `[1.6.0]` entry covering the persona feature
+- Update `CLAUDE.md` "Data on disk" section: new entry for `analysis/personas/` family + PII classification (high — verbatim user-prompt excerpts)
+- Update `.gitignore`: explicit `analysis/personas/` line (already covered by wildcard, but explicit line is auditable documentation per existing precedent)
+- Update CLAUDE.md "Shape of the workspace" section if a new top-level dir was added
+- Add a brief "Persona mining" subsection to README.md if appropriate
+
+**Wave 4 exit gate:** `pnpm lint && pnpm test && pnpm build` clean. Manual: click SCAN → verify 5 POSTs in dev server log → verify `analysis/personas/chat-arch.md` appears on disk → verify PERSONAS sidebar entry renders the generated markdown for chat-arch project.
+
+## Test gates (per project CLAUDE.md)
+
+Before opening the PR:
+- `pnpm lint` — clean (max 1 pre-existing warning in `apply-correction.ts`; no new warnings)
+- `pnpm test` — clean (2154+ pass / 5 skipped baseline)
+- `pnpm build` — clean
+- Manual: SCAN button on TODAY → 5 POSTs in dev server log: `/api/rescan` → `/api/mine-corrections` → `/api/curate` → `/api/falsify` → `/api/mine-persona`
+- Manual: `analysis/personas/chat-arch.md` exists on disk after SCAN
+- Manual: PERSONAS sidebar entry renders the generated persona
+
+If the auto-generated chat-arch persona quality is < 70% of `bryce.md`'s, surface that in the PR description as a known V1 limitation — do NOT block on perfecting the synthesis prompt (that's V2 calibration work).
+
+## Project conventions (reminders, per chat-arch CLAUDE.md)
+
+**Staging:**
+- NEVER `git add -A` / `.` — stage by explicit path
+- `apps/standalone/public/chat-arch-data/manifest.json` is local PII — leave unstaged
+- `analysis/personas/*.md` files are PII — they should be gitignored (and they are, by the wildcard), but never stage them explicitly even by mistake
+
+**Git workflow:**
+- Branch off main + PR, never push to main
+- `gh pr create` after `git push -u origin feature/persona-mining`
+- Squash-merge default
+- Bryce merges his own PRs unless he says otherwise — open the PR, surface CI status, do NOT merge
+
+**Out of scope (V1) — do NOT do these:**
+- Cross-project composite persona
+- Persona-drift detection (diffing successive scans)
+- Curator weighting by persona-derived preference vector
+- Persona-aware skill argument substitution
+- Falsifier extension to verify persona evidence citations (Stage-3 follow-up per spec)
+- Replacing the hand-authored `research/persona-evals/bryce.md` with auto-generated output (the hand-authored stays as canonical for the chat-arch project specifically — auto-gen lives at `analysis/personas/chat-arch.md` separately)
+
+Each of the above is listed in `research/persona-mining-spec.md` § "Out of scope (V1)". If you find yourself wanting to do any of them, stop and surface as a follow-up note in the PR description.
+
+## When done
+
+1. Open the PR via `gh pr create` with title `feat(persona-mining): per-project persona auto-generation as SCAN chain step 5`
+2. PR description: summary, decisions pinned (cite spec), waves shipped, test plan checked off, known limitations (V1 quality calibration TBD)
+3. Surface CI status. Do not merge.
+4. Report back with the PR URL.
+
+## Estimated complexity
+
+~15-25 files, mostly new, ~1500-2500 LOC including tests. Single bundled PR. If any wave exit-gate fails repeatedly, stop and ask Bryce — do not silently scope-cut.

--- a/research/persona-mining-spec.md
+++ b/research/persona-mining-spec.md
@@ -1,0 +1,220 @@
+# Persona mining — V1 spec
+
+**Status:** spec only — no implementation. Awaiting Bryce's "act on the plan" before any code lands.
+
+**Origin:** Bryce mined his own chat-arch sessions to author [`research/persona-evals/bryce.md`](persona-evals/bryce.md), found the result more useful than the original user-modeling pass, and requested automatic generation of equivalent personas for every project he uses Claude Code on.
+
+**Decisions pinned (per design conversation 2026-05-25):**
+
+1. **Scope:** per-project personas only — no cross-project composite in V1.
+2. **Trigger:** on SCAN, as chain step 5 (after `/falsify`).
+3. **UI surface:** new PERSONAS sidebar entry under WORKSHOP, alongside CORRECTIONS / PRACTICE / PLAYBOOK.
+
+This doc covers what ships in V1, not the eventual maturity path. Cross-project composite, persona-drift detection, persona-aware skill argument substitution, and curator weighting against persona-derived preference vectors are all listed in the [Future surface] section.
+
+---
+
+## What V1 ships
+
+Per project with ≥ `THRESHOLDS.persona.minSessionsForGeneration` (default 30) sessions in the corpus:
+
+- One markdown persona at `apps/standalone/public/chat-arch-data/analysis/personas/<project-id>.md`
+- Structured metadata in `apps/standalone/public/chat-arch-data/analysis/personas.json` (index + per-project record)
+- A PERSONAS page rendering the markdown + cross-project nav (sidebar list)
+- Wipe coverage: `personas/` family added to `/api/clear`
+
+Projects below the session threshold get a skip-row in `personas.json` with reason `"insufficient-corpus"` — no thin personas emitted.
+
+---
+
+## File changes
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `.claude/skills/mine-persona/SKILL.md` | Skill driving the LLM synthesis stage |
+| `.claude/skills/mine-persona/lib/extractor.ts` | Heuristic prompt-pattern extraction (pre-LLM stage) |
+| `apps/standalone/src/pages/api/mine-persona.ts` | NDJSON-streaming endpoint, follows `mine-corrections.ts` template |
+| `apps/standalone/src/pages/api/clear-personas.ts` | Selective wipe endpoint |
+| `apps/standalone/src/pages/personas.astro` | New PERSONAS surface |
+| `packages/schema/src/personas.ts` | `PersonasIndex`, `PersonaRecord`, `PersonaMetadata` types |
+| `packages/exporter/src/analysis/personaCandidates.ts` | Per-project heuristic candidate extractor (writes `persona-candidates.json`) |
+| `packages/exporter/test/integration/personaCandidates.test.ts` | Integration coverage |
+| `research/persona-evals/<project-id>.md` (generated, NOT checked in) | Symlink target / mirror of `analysis/personas/<project-id>.md` for fresh-contributor visibility — TBD whether we actually need this mirror or whether the analysis dir is sufficient |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `apps/standalone/src/scripts/fullScan.ts` | Add 5th entry to `FULL_SCAN_STEPS` for `/api/mine-persona` |
+| `apps/standalone/test/scripts/fullScan.test.ts` | Update step count + header-pinning assertions to 5 |
+| `apps/standalone/src/components/AppSidebar.astro` | Add PERSONAS link under WORKSHOP group |
+| `apps/standalone/src/pages/api/clear.ts` | Extend orphan-sweep to `analysis/personas/` |
+| `packages/analysis/src/thresholds.ts` | New `persona.minSessionsForGeneration` (default 30) + `persona.maxSessionsForCorpus` (cap on what gets fed to LLM, default 200, sample by recency) |
+| `packages/exporter/src/analysis/index.ts` | Run `personaCandidates` as part of `runAnalysis` |
+| `packages/exporter/src/analysis/EXPORTER_VERSION` | Bump 1.5.0 → 1.6.0 (new sidecar family) |
+| `CHANGELOG.md` | `[1.6.0]` entry |
+| `CLAUDE.md` | New entry under "Data on disk" describing the persona sidecar family + PII classification |
+
+---
+
+## Sidecar shapes
+
+### `analysis/personas.json` — index
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": 1716673200000,
+  "exporterVersion": "1.6.0",
+  "thresholds": {
+    "minSessionsForGeneration": 30,
+    "maxSessionsForCorpus": 200
+  },
+  "personas": [
+    {
+      "projectId": "chat-arch",
+      "projectName": "chat-arch",
+      "sessionsAnalyzed": 160,
+      "sessionsTotal": 627,
+      "personaPath": "analysis/personas/chat-arch.md",
+      "generatedAt": 1716673200000,
+      "status": "generated"
+    },
+    {
+      "projectId": "shopforge-v4",
+      "projectName": "shopforge-v4",
+      "sessionsAnalyzed": 0,
+      "sessionsTotal": 12,
+      "personaPath": null,
+      "generatedAt": null,
+      "status": "insufficient-corpus"
+    }
+  ]
+}
+```
+
+### `analysis/personas/<project-id>.md` — content
+
+Mirror the structure pioneered by `bryce.md`:
+
+1. Header block (project name, sessions analyzed, time-span covered, "data-grounded from N sessions" disclaimer)
+2. 6-10 numbered pattern sections, each with **Pattern.** / **Evidence.** (≥2 `[SID:...]`-cited quotes per section, verbatim) / **What this implies.**
+3. Coverage notes (files sampled, false positives filtered, confidence assessment)
+4. Optional "preserve / automate / get out of the way of" table — emit only when patterns are durable enough across time buckets
+
+PII classification: **high.** Every persona file contains verbatim user prompt excerpts. Already covered by the existing `apps/standalone/public/chat-arch-data/*` gitignore wildcard; explicit `analysis/personas/` line added to `.gitignore` for auditable documentation.
+
+### `analysis/persona-candidates.json` — intermediate
+
+Heuristic extraction output (Stage 1, exporter-side, deterministic). Per-project records of:
+
+- Prompt count by 6-category heuristic bucket (role/expertise prompts, preference statements, etc.)
+- Top-N candidate prompts per category by length + uniqueness
+- Time-bucket coverage (founding / mid / recent) so the LLM stage can verify durability
+
+This sidecar is the input to `/mine-persona`. Skipping it directly to the LLM would re-do work every scan and lose the determinism of the heuristic layer.
+
+---
+
+## Skill template
+
+`.claude/skills/mine-persona/SKILL.md` follows the existing `mine-corrections` skill structure:
+
+- **Stage 1 (heuristic, pre-skill):** `personaCandidates.ts` runs as part of `runAnalysis`, writes `persona-candidates.json` with per-project candidate buckets.
+- **Stage 2 (LLM, skill-driven):** `/mine-persona` reads `persona-candidates.json`, dispatches sub-agents per project (parallel, similar to the 4-agent dispatch used to author `bryce.md`), each sub-agent returns 6-section observations, parent synthesizes into final `<project-id>.md`.
+- **Stage 3 (falsifier hookup):** existing `/falsify` skill is extended (separate follow-up PR) to verify persona evidence citations the same way it verifies finding evidence — every `[SID:...]` quote must be present in the cited session's actual messages.
+
+LLM budget cap: `THRESHOLDS.persona.maxLlmUsdPerProject` (default $0.50). Skip projects when the cap would be exceeded; surface as `status: "budget-exceeded"` in the index.
+
+---
+
+## Chain integration
+
+`FULL_SCAN_STEPS` becomes:
+
+```ts
+[
+  { id: 'rescan',   label: 'rescan (exporter)',  url: '/api/rescan',           header: 'chat-arch-rescan' },
+  { id: 'mine',     label: 'mine corrections',   url: '/api/mine-corrections', header: 'chat-arch-mine-corrections' },
+  { id: 'curate',   label: 'curate feed',        url: '/api/curate',           header: 'chat-arch-curate' },
+  { id: 'falsify',  label: 'falsify findings',   url: '/api/falsify',          header: 'chat-arch-falsify' },
+  { id: 'persona',  label: 'mine personas',      url: '/api/mine-persona',     header: 'chat-arch-mine-persona' },
+]
+```
+
+Failure semantics unchanged: persona failure halts the chain (no step 6 to run, so this is effectively the new chain terminus). The fullScan test gets a parallel header-pinning entry + the existing 4-step tests reused as 5-step.
+
+REGEN BRIEF unchanged. The brief kernel could eventually pull a one-line persona summary, but that's a follow-up.
+
+---
+
+## UI surface — PERSONAS page
+
+`apps/standalone/src/pages/personas.astro`:
+
+- Sidebar list of all projects with personas, ordered by `sessionsAnalyzed` desc
+- Skipped projects (insufficient-corpus / budget-exceeded) shown in a collapsed "not yet generated" section with the skip reason
+- Selected project: renders its `.md` via the same MD-rendering path the brief uses
+- Per-section drill-down to `[SID:...]` evidence: click an SID anchor → navigate to `/sessions#session/<sid>` (matches existing FEED card behavior)
+- "REGEN PERSONA" per-project button (POSTs to `/api/mine-persona` with `{ projectId }`) — same affordance pattern as REGEN BRIEF
+
+`AppSidebar.astro` change:
+
+```
+WORKSHOP
+  PLAYBOOK
+  CORRECTIONS
+  PRACTICE
+  PERSONAS   ← new
+```
+
+Short label / icon: `PER`. Match the existing 3-letter convention.
+
+---
+
+## Test plan
+
+- **`personaCandidates.test.ts`** — fixture-driven; assert each of the 6 heuristic buckets fills correctly from a synthetic transcript with known prompt patterns.
+- **`fullScan.test.ts` updates** — step count → 5, header pinning entry, all existing chain-semantics tests run as 5-step.
+- **`mine-persona` skill integration test** — mock the `claude -p` spawn (per existing `mine-corrections` test pattern), assert `analysis/personas.json` + at least one `<project-id>.md` write.
+- **Manual end-to-end** — click SCAN, verify 5 POSTs in dev server log, verify `analysis/personas/chat-arch.md` appears on disk, verify PERSONAS sidebar entry renders the generated markdown.
+
+---
+
+## Out of scope (V1)
+
+Listed here so a future spec can pull from a known menu:
+
+- **Cross-project composite persona** ("who is the user across all repos"). Adds 1 more LLM call regardless of project count; saves seeing context-switch costs across projects.
+- **Persona-drift detection** — diff successive scans' personas; surface when a section's evidence quotes turn over rapidly (signal of changing working style).
+- **Curator weighting by persona-derived preference vector** — current curator ranks findings by composite outcome + tier; could additionally weight by alignment with persona patterns (e.g., findings that match "specification-as-prompt" preference rank higher).
+- **Persona-aware skill argument substitution** — when invoking a skill, auto-supply persona patterns as context ("the user prefers X / dislikes Y").
+- **Hosted-demo persona generation** — the `chat-arch.dev` static deploy has no LLM access, so personas are local-only in V1. Demo bundle could ship a sample persona for the demo project, but that's a demo-data PR.
+
+---
+
+## Estimated PR shape
+
+Single bundled PR per `feedback_claude_code_paced_prs` (Claude-Code-paced, not human-paced):
+
+- Wave 1: schema + thresholds + exporter heuristic + sidecar producers + tests
+- Wave 2: skill + API endpoint + chain integration + clear-personas
+- Wave 3: viewer surface + sidebar + e2e wiring
+- Wave 4: docs (CHANGELOG, CLAUDE.md, exporter version bump) + manual verification
+
+Rough size: ~15-25 files, mostly new, ~1500-2500 LOC including tests. Should comfortably fit one PR with sub-agent fan-out per wave.
+
+---
+
+## Decision log
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Per-project, composite, or both? | **Per-project only** | Composite costs 2N LLM calls; defer to V2 once we know V1 lands. |
+| When to trigger? | **On SCAN as chain step 5** | Matches existing chain discipline; always-fresh personas without manual button-pressing. |
+| Where to surface? | **New PERSONAS sidebar entry** | First-class discoverability; matches CORRECTIONS / PRACTICE / PLAYBOOK pattern. |
+| LLM budget? | **$0.50/project default, skip on overage** | Personas should never become a surprise cost. |
+| Min sessions to generate? | **30, configurable via threshold** | Below 30 sessions, patterns aren't durable enough to be useful (this number is itself a placeholder — calibrate after first run). |
+| PII gitignore? | **Yes, explicit `analysis/personas/` line** | Already covered by wildcard, but explicit line is auditable documentation per existing precedent. |


### PR DESCRIPTION
## Summary

Models the hand-authored [`research/persona-evals/bryce.md`](research/persona-evals/bryce.md) workflow as a general feature. Any project with ≥ `THRESHOLDS.persona.minSessionsForGeneration` (default 30) sessions in the corpus gets its own data-grounded persona auto-generated on every SCAN — verbatim user-prompt excerpts cited as `[SID:<prefix>]` anchors, structured into 6-10 numbered pattern sections matching the originating prototype.

**Decisions pinned** (per [`research/persona-mining-spec.md`](research/persona-mining-spec.md), pinned before any code landed):

1. **Per-project only** in V1 — no cross-project composite.
2. **On SCAN, chain step 5** — fires after `/falsify`, no manual button needed.
3. **New PERSONAS sidebar entry** under WORKSHOP (short label `PER`) — first-class discoverability.

Hand-authored personas under `research/persona-evals/` stay canonical for the projects they cover (`bryce.md` is the chat-arch canonical); auto-generated output lives under `analysis/personas/` separately.

## Waves shipped

**Wave 1 — schema + thresholds + heuristic extractor** ([`packages/schema/src/personas.ts`](packages/schema/src/personas.ts), [`packages/exporter/src/analysis/personaCandidates.ts`](packages/exporter/src/analysis/personaCandidates.ts), [`packages/analysis/src/thresholds.ts`](packages/analysis/src/thresholds.ts))
- Stage-1 deterministic extractor: per-project user-prompt excerpts bucketed into 6 heuristic categories (`role-expertise` / `preferences` / `project-specific` / `working-rhythm` / `frictions` / `voice`)
- Sampled by recency up to `THRESHOLDS.persona.maxSessionsForCorpus` (default 200), capped at 40 candidates per bucket
- Wired into `runAnalysis`; bumps `EXPORTER_VERSION` 1.5.0 → 1.6.0
- 4 new integration tests in [`packages/exporter/test/integration/personaCandidates.test.ts`](packages/exporter/test/integration/personaCandidates.test.ts) (6-bucket fan-out + empty-corpus + zero-session + per-bucket cap)

**Wave 2 — skill + API endpoint + chain integration** ([`.claude/skills/mine-persona/SKILL.md`](.claude/skills/mine-persona/SKILL.md), [`apps/standalone/src/pages/api/mine-persona.ts`](apps/standalone/src/pages/api/mine-persona.ts), [`apps/standalone/src/pages/api/clear-personas.ts`](apps/standalone/src/pages/api/clear-personas.ts))
- Stage-2 LLM skill: 4 sub-agents per project (one per time-bucket: founding / mid-early / mid-late / recent) + 1 synthesis sub-agent that writes the final markdown
- `/api/mine-persona` NDJSON endpoint mirrors `/api/mine-corrections` line-for-line (CSRF gate + inFlight + spawn `claude -p` + fallback prompt)
- `/api/clear-personas` selective wipe (mirrors `/api/clear-corrections`)
- 5th `FULL_SCAN_STEPS` entry; chain semantics tests run as 5-step

**Wave 3 — viewer surface** ([`apps/standalone/src/pages/personas.astro`](apps/standalone/src/pages/personas.astro), [`apps/standalone/src/components/AppSidebar.astro`](apps/standalone/src/components/AppSidebar.astro))
- PERSONAS sidebar entry under WORKSHOP
- `/personas` page: sidebar list (generated + skipped sections); body renders the active project's markdown with clickable `[SID:...]` anchors that navigate to `/sessions#session/<full-sid>`
- Per-project REGEN PERSONA button

**Wave 4 — docs + version bump** ([CHANGELOG.md](CHANGELOG.md), [CLAUDE.md](CLAUDE.md), [.gitignore](.gitignore), [README.md](README.md))
- `[1.6.0]` CHANGELOG entry
- CLAUDE.md "Data on disk" extended with the persona-mining V1 family + PII classification (high)
- `.gitignore` explicit lines for the personas/ family (already covered by wildcard; added per auditability precedent)
- README capability table + Personas mode row

## Test plan

- [x] `pnpm lint` clean (1 pre-existing `apply-correction.ts` warning, no new warnings)
- [x] `pnpm test` clean (**2163 pass / 5 skipped**, vs. 2154 baseline = +9 from this PR)
- [x] `pnpm build` clean
- [ ] Manual: click SCAN on TODAY → verify 5 POSTs in dev server log (`/api/rescan` → `/api/mine-corrections` → `/api/curate` → `/api/falsify` → `/api/mine-persona`)
- [ ] Manual: `analysis/personas/chat-arch.md` appears on disk after SCAN
- [ ] Manual: PERSONAS sidebar entry renders the generated persona

## Known V1 limitations (deferred to V2)

- **Synthesis quality calibration TBD.** The auto-generated chat-arch persona's quality vs. the hand-authored `bryce.md` won't be measurable until the skill runs end-to-end on the live corpus. V2 calibration may need to refine the sub-agent prompts.
- **`maxLlmUsdPerProject` is a candidate-count proxy.** The real-USD calculation needs a token-counting harness; for now we gate on `candidates > 1500` as a structural proxy.
- **No falsifier integration yet.** Persona evidence citations aren't currently verified by `/falsify` — that's a Stage-3 follow-up per the spec.

## Out of scope (V1 — explicitly deferred per spec)

- Cross-project composite persona
- Persona-drift detection (diffing successive scans)
- Curator weighting by persona-derived preference vector
- Persona-aware skill argument substitution
- Replacing the hand-authored `research/persona-evals/bryce.md` (it stays canonical for the chat-arch project; auto-gen lives at `analysis/personas/chat-arch.md` separately)