### PR TITLE
feat(project-identity-v2): Move-to-project affordance + resolvedVia display + sweep runbook (PR2/3)

### DIFF
--- a/apps/standalone/src/pages/api/move-to-project.ts
+++ b/apps/standalone/src/pages/api/move-to-project.ts
@@ -1,0 +1,174 @@
+/**
+ * Project Identity v2 (plan §5/§6) — "Move to a different project" affordance.
+ *
+ * Appends a user override row to `chat-arch-data/projectOverrides.json` so the
+ * next rescan re-buckets the given session(s) under `projectId` (cascade rule 0,
+ * confidence 1.00). The file is consumed by `loadProjectOverrides` in
+ * `@chat-arch/exporter`; it accepts a bare array of override rows, which is the
+ * shape this endpoint maintains.
+ *
+ * Override row shape: `{ projectId, displayName?, match: { sessionIds: [...] } }`.
+ *
+ * Local-only: gated by the same Origin + `X-Requested-With` CSRF checks as the
+ * other mutating endpoints (the hosted static build has no `/api`). Writes are
+ * serialized via an in-flight gate and land atomically (tmp + rename).
+ */
+import type { APIRoute } from 'astro';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+export const prerender = false;
+export const REQUIRED_HEADER = 'chat-arch-move-to-project';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+interface OverrideRow {
+  projectId: string;
+  displayName?: string;
+  match: { cwdGlob?: string; sessionIds?: string[] };
+}
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function repoRoot(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', '..', '..');
+}
+function overridesPath(): string {
+  return join(repoRoot(), 'apps', 'standalone', 'public', 'chat-arch-data', 'projectOverrides.json');
+}
+
+/** Load existing overrides as a flat array (tolerates the `{overrides:[]}` envelope). */
+async function loadRows(path: string): Promise<OverrideRow[]> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return []; // malformed → start fresh (caller rewrites a clean array)
+  }
+  const rows = Array.isArray(parsed)
+    ? parsed
+    : parsed !== null && typeof parsed === 'object' && Array.isArray((parsed as { overrides?: unknown }).overrides)
+      ? (parsed as { overrides: unknown[] }).overrides
+      : [];
+  return rows.filter(
+    (r): r is OverrideRow =>
+      r !== null &&
+      typeof r === 'object' &&
+      typeof (r as OverrideRow).projectId === 'string' &&
+      // Require a `match` object so the prune/strip loops below can read
+      // `r.match.sessionIds` unguarded (a hand-edited match-less row is
+      // dropped here rather than crashing the write).
+      typeof (r as OverrideRow).match === 'object' &&
+      (r as OverrideRow).match !== null,
+  );
+}
+
+async function atomicWrite(path: string, rows: OverrideRow[]): Promise<void> {
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  await writeFile(tmp, JSON.stringify(rows, null, 2) + '\n', 'utf8');
+  await rename(tmp, path);
+}
+
+let inFlight: Promise<Response> | null = null;
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return json({ ok: false, error: 'Forbidden: cross-origin or missing Origin' }, 403);
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return json({ ok: false, error: 'Forbidden: missing X-Requested-With token' }, 403);
+  }
+  if (inFlight) {
+    return json({ ok: false, error: 'Another override write is in flight. Retry in a moment.' }, 409);
+  }
+
+  let release!: (r: Response) => void;
+  const slot = new Promise<Response>((res) => {
+    release = res;
+  });
+  inFlight = slot;
+  try {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      const r = json({ ok: false, error: 'invalid JSON body' }, 400);
+      release(r);
+      return r;
+    }
+    const b = body as { sessionId?: unknown; projectId?: unknown; displayName?: unknown };
+    const sessionId = typeof b.sessionId === 'string' ? b.sessionId.trim() : '';
+    const projectId = typeof b.projectId === 'string' ? b.projectId.trim() : '';
+    if (sessionId === '' || projectId === '') {
+      const r = json({ ok: false, error: 'sessionId and projectId are required non-empty strings' }, 400);
+      release(r);
+      return r;
+    }
+    const displayName = typeof b.displayName === 'string' && b.displayName.trim() !== '' ? b.displayName.trim() : undefined;
+
+    const path = overridesPath();
+    try {
+      await mkdir(dirname(path), { recursive: true });
+      const rows = await loadRows(path);
+      // Idempotent merge: if an override for this projectId already has a
+      // sessionIds match, add the session there; else append a new row. Also
+      // drop the sessionId from any OTHER row's sessionIds so a re-move wins.
+      for (const row of rows) {
+        if (Array.isArray(row.match?.sessionIds)) {
+          row.match.sessionIds = row.match.sessionIds.filter((s) => s !== sessionId);
+        }
+      }
+      let target = rows.find((r) => r.projectId === projectId && Array.isArray(r.match?.sessionIds));
+      if (target === undefined) {
+        target = { projectId, ...(displayName ? { displayName } : {}), match: { sessionIds: [] } };
+        rows.push(target);
+      } else if (displayName !== undefined) {
+        target.displayName = displayName;
+      }
+      target.match.sessionIds = [...new Set([...(target.match.sessionIds ?? []), sessionId])];
+      // Prune now-empty rows (a session moved away from a singleton override).
+      const cleaned = rows.filter(
+        (r) => (r.match.sessionIds && r.match.sessionIds.length > 0) || (r.match.cwdGlob && r.match.cwdGlob !== ''),
+      );
+      await atomicWrite(path, cleaned);
+      const r = json(
+        { ok: true, projectId, sessionId, overridesCount: cleaned.length, note: 'Run a rescan to apply.' },
+        200,
+      );
+      release(r);
+      return r;
+    } catch (err) {
+      const r = json({ ok: false, error: err instanceof Error ? err.message : String(err) }, 500);
+      release(r);
+      return r;
+    }
+  } finally {
+    if (inFlight === slot) inFlight = null;
+  }
+};
+
+/** Availability probe (the viewer hides the affordance when this 404s on the hosted build). */
+export const GET: APIRoute = () => json({ ok: true, available: true }, 200);

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -471,6 +471,7 @@ export function ChatArchViewer({
     v2Projects: null,
     v2Topics: null,
     v2Narratives: null,
+    v2Attribution: null,
   });
 
   // Phase 2a: lift the applied-improvements ledger to the viewer level
@@ -1239,6 +1240,7 @@ export function ChatArchViewer({
         v2Projects: v2.projects,
         v2Topics: v2.topics,
         v2Narratives: v2.narratives,
+        v2Attribution: v2.attribution,
       });
     })();
     return () => {
@@ -3161,6 +3163,13 @@ export function ChatArchViewer({
                       nextId={nextId}
                       onPrev={onPrev}
                       onNext={onNext}
+                      {...(effectiveV2Entities.projects
+                        ? { projects: effectiveV2Entities.projects }
+                        : {})}
+                      {...(analysisState.v2Attribution &&
+                      analysisState.v2Attribution[selectedSession.id]
+                        ? { attribution: analysisState.v2Attribution[selectedSession.id] }
+                        : {})}
                       {...(uploadedData
                         ? { uploadedConversationsById: uploadedData.conversationsById }
                         : {})}

--- a/packages/viewer/src/components/modes/DetailMode.test.tsx
+++ b/packages/viewer/src/components/modes/DetailMode.test.tsx
@@ -153,6 +153,46 @@ describe('DetailMode prev/next (AC9)', () => {
   });
 });
 
+describe('DetailMode RESOLVED VIA (Project Identity v2 PR2)', () => {
+  it('renders the resolvedVia value + confidence when attribution is present', () => {
+    render(
+      <DetailMode
+        session={entry('s1')}
+        dataRoot="/x"
+        cache={new Map()}
+        setCache={() => {}}
+        onBack={() => {}}
+        prevId={null}
+        nextId={null}
+        onPrev={() => {}}
+        onNext={() => {}}
+        attribution={{ resolvedVia: 'scheduled-task', confidence: 0.9 }}
+      />,
+    );
+    expect(screen.getByText('RESOLVED VIA')).toBeDefined();
+    expect(screen.getByText('scheduled-task · 0.90')).toBeDefined();
+  });
+
+  it('renders an em dash when attribution is absent', () => {
+    render(
+      <DetailMode
+        session={entry('s1')}
+        dataRoot="/x"
+        cache={new Map()}
+        setCache={() => {}}
+        onBack={() => {}}
+        prevId={null}
+        nextId={null}
+        onPrev={() => {}}
+        onNext={() => {}}
+      />,
+    );
+    const dt = screen.getByText('RESOLVED VIA');
+    const dd = dt.nextElementSibling;
+    expect(dd?.textContent).toBe('—');
+  });
+});
+
 describe('DetailMode copy-transcript (AC10)', () => {
   beforeEach(() => {
     // Stub navigator.clipboard before each test.

--- a/packages/viewer/src/components/modes/DetailMode.tsx
+++ b/packages/viewer/src/components/modes/DetailMode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { CloudConversation, UnifiedSessionEntry } from '@chat-arch/schema';
+import type { CloudConversation, Project, UnifiedSessionEntry } from '@chat-arch/schema';
 import type { ConversationCache, DrillInBody } from '../../types.js';
 import { SOURCE_COLOR, SOURCE_LABEL } from '../../types.js';
 import { SourcePill } from '../SourcePill.js';
@@ -11,6 +11,7 @@ import { fetchConversation, fetchTranscript, resolveDataUrl } from '../../data/f
 import { onActivate } from '../../util/a11y.js';
 import { formatRelative } from '../../util/time.js';
 import { buildTranscriptMarkdown } from '../../data/transcriptMarkdown.js';
+import { useMoveToProject } from '../../data/moveToProject.js';
 
 export interface DetailModeProps {
   session: UnifiedSessionEntry;
@@ -33,7 +34,53 @@ export interface DetailModeProps {
   nextId: string | null;
   onPrev: () => void;
   onNext: () => void;
+  /**
+   * Project Identity v2 per-session provenance. The parent looks this up
+   * by `session.id` from `projects.json`'s `attribution` map and passes
+   * the matched record (or omits the prop when absent / pre-v2). Drives
+   * the RESOLVED VIA meta row.
+   */
+  attribution?: { resolvedVia: string; confidence: number };
+  /**
+   * Project Identity v2 PR2: the list of discovered projects, used to
+   * populate the MOVE TO PROJECT picker. Omitted when v2 entities haven't
+   * been fetched/computed; the picker then offers only the new-name path.
+   */
+  projects?: readonly Project[];
 }
+
+/**
+ * Human-readable gloss for each cascade rule, surfaced as the RESOLVED VIA
+ * cell's title/tooltip. Keep in sync with `ProjectResolvedVia` in
+ * `@chat-arch/schema` (the cascade documented in `inferProject`).
+ */
+const RESOLVED_VIA_TOOLTIP: Record<string, string> = {
+  override: 'Rule 0 — a manual projectOverrides.json entry (e.g. via MOVE TO PROJECT) assigned this session.',
+  project_field: 'Rule 1 — the session declared an explicit project field.',
+  'scheduled-task': 'Rule 2 — a Cowork scheduled-task id mapped to a routine project.',
+  'vm-folder': 'Rule 3 — derived from the VM working-folder basename.',
+  cwd_basename: 'Rule 4 — derived from the host working-directory basename.',
+  title_keyword: 'Rule 5 — matched a title-keyword regex.',
+  unassigned: 'Rule 6 — no cascade rule matched; the session is unassigned.',
+};
+
+function resolvedViaTooltip(resolvedVia: string): string {
+  return (
+    RESOLVED_VIA_TOOLTIP[resolvedVia] ??
+    'Which Project Identity cascade rule assigned this session to its project.'
+  );
+}
+
+/**
+ * Strip the leading `proj_` off a project id so the MOVE TO PROJECT
+ * endpoint stores a raw key the v2 cascade can re-slug back to the same
+ * `proj_…` id. Returns the input unchanged when there's no prefix.
+ */
+function rawProjectKey(id: string): string {
+  return id.startsWith('proj_') ? id.slice('proj_'.length) : id;
+}
+
+const NEW_PROJECT_SENTINEL = '__new__';
 
 function cacheKey(session: UnifiedSessionEntry): string {
   return `${session.source}:${session.id}`;
@@ -68,6 +115,8 @@ export function DetailMode({
   nextId,
   onPrev,
   onNext,
+  attribution,
+  projects,
 }: DetailModeProps) {
   const key = cacheKey(session);
   const current = cache.get(key) ?? { status: 'idle' as const };
@@ -75,6 +124,55 @@ export function DetailMode({
   // Copy-transcript toast state. Transient "COPIED ✓" / "COPY FAILED" label
   // shown next to the button for ~1.5s after a click.
   const [copyState, setCopyState] = useState<'idle' | 'ok' | 'err'>('idle');
+
+  // --- MOVE TO PROJECT (Project Identity v2 PR2, local-dev only) ---
+  const moveCtl = useMoveToProject();
+  // Inline picker open/closed. The picker reveals a project <select> + an
+  // optional new-name text input under the header.
+  const [moveOpen, setMoveOpen] = useState(false);
+  // Selected project id (a real proj_… id) OR NEW_PROJECT_SENTINEL when the
+  // user wants to type a brand-new project name.
+  const [moveSelection, setMoveSelection] = useState<string>('');
+  const [moveNewName, setMoveNewName] = useState('');
+
+  // Reset picker state whenever the active session changes — a stale
+  // selection from a prior session would otherwise leak across drill-in.
+  useEffect(() => {
+    setMoveOpen(false);
+    setMoveSelection('');
+    setMoveNewName('');
+  }, [session.id]);
+
+  const moving = moveCtl.status === 'moving';
+
+  const handleMoveConfirm = async () => {
+    if (moving) return;
+    // Two paths, both feeding `/api/move-to-project`:
+    //  - Existing project: send projectId = that project's id with the
+    //    leading `proj_` stripped, so the v2 cascade (rule 0) re-derives
+    //    the SAME proj_ id from the raw key, plus its displayName so the
+    //    override reinforces the real label.
+    //  - New name: send the raw typed text as BOTH projectId and
+    //    displayName so the cascade slugs a fresh id while preserving the
+    //    label the user typed.
+    if (moveSelection === NEW_PROJECT_SENTINEL) {
+      const name = moveNewName.trim();
+      if (name.length === 0) return;
+      await moveCtl.move(session.id, name, name);
+      return;
+    }
+    if (moveSelection.length === 0) return;
+    // Carry the existing project's displayName so the override row reinforces
+    // the real label (otherwise the raw key becomes a displayName candidate
+    // and could flip a singleton target's displayed name; bucket id is
+    // unaffected either way since stableProjectId re-slugs the raw key).
+    const picked = (projects ?? []).find((p) => p.id === moveSelection);
+    await moveCtl.move(
+      session.id,
+      rawProjectKey(moveSelection),
+      picked?.displayName !== undefined && picked.displayName !== '' ? picked.displayName : undefined,
+    );
+  };
 
   useEffect(() => {
     if (current.status !== 'idle') return;
@@ -261,9 +359,82 @@ export function DetailMode({
               )}
             </span>
           )}
+          {/* MOVE TO PROJECT — local-dev only. Hidden once the probe
+              resolves to a definitive false (hosted static build). */}
+          {moveCtl.available !== false && (
+            <button
+              type="button"
+              className="lcars-detail-mode__copy lcars-detail-mode__move"
+              aria-label="move this session to a different project"
+              aria-expanded={moveOpen}
+              onClick={() => setMoveOpen((v) => !v)}
+            >
+              MOVE TO PROJECT
+            </button>
+          )}
         </div>
         <div className="lcars-detail-mode__time">{formatRelative(session.updatedAt)}</div>
       </header>
+
+      {moveCtl.available !== false && moveOpen && (
+        <div className="lcars-detail-mode__move-panel">
+          <label className="lcars-detail-mode__move-label" htmlFor="move-project-select">
+            MOVE TO PROJECT
+          </label>
+          <select
+            id="move-project-select"
+            className="lcars-detail-mode__move-select"
+            value={moveSelection}
+            disabled={moving}
+            onChange={(e) => setMoveSelection(e.target.value)}
+          >
+            <option value="">— choose a project —</option>
+            {(projects ?? []).map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.displayName} ({p.id})
+              </option>
+            ))}
+            <option value={NEW_PROJECT_SENTINEL}>+ new project…</option>
+          </select>
+          {moveSelection === NEW_PROJECT_SENTINEL && (
+            <input
+              type="text"
+              className="lcars-detail-mode__move-new-name"
+              aria-label="new project name"
+              placeholder="new project name"
+              value={moveNewName}
+              disabled={moving}
+              onChange={(e) => setMoveNewName(e.target.value)}
+            />
+          )}
+          <button
+            type="button"
+            className="lcars-detail-mode__copy lcars-detail-mode__move-confirm"
+            aria-label="confirm move to project"
+            disabled={
+              moving ||
+              moveSelection.length === 0 ||
+              (moveSelection === NEW_PROJECT_SENTINEL && moveNewName.trim().length === 0)
+            }
+            onClick={handleMoveConfirm}
+          >
+            {moving ? 'MOVING…' : 'CONFIRM'}
+          </button>
+          {moveCtl.last && (
+            <span
+              className={`lcars-detail-mode__move-result lcars-detail-mode__move-result--${
+                moveCtl.last.ok ? 'ok' : 'err'
+              }`}
+              role="status"
+              aria-live="polite"
+            >
+              {moveCtl.last.ok
+                ? (moveCtl.last.note ?? 'Moved — run a rescan to apply.')
+                : (moveCtl.last.error ?? 'Move failed.')}
+            </span>
+          )}
+        </div>
+      )}
 
       <dl className="lcars-detail-mode__meta" aria-label="session metadata">
         <div>
@@ -306,6 +477,21 @@ export function DetailMode({
             aria-label={session.project ?? 'No resolved project'}
           >
             {session.project ?? '—'}
+          </dd>
+        </div>
+        <div>
+          <dt>RESOLVED VIA</dt>
+          <dd
+            className="lcars-detail-mode__meta--mono"
+            title={
+              attribution
+                ? resolvedViaTooltip(attribution.resolvedVia)
+                : 'No Project Identity v2 attribution recorded for this session.'
+            }
+          >
+            {attribution
+              ? `${attribution.resolvedVia} · ${attribution.confidence.toFixed(2)}`
+              : '—'}
           </dd>
         </div>
         <div>

--- a/packages/viewer/src/data/moveToProject.ts
+++ b/packages/viewer/src/data/moveToProject.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Hook that encapsulates the `/api/move-to-project` dance (Project
+ * Identity v2 PR2). Mirrors {@link useRescan}'s availability-probe
+ * contract.
+ *
+ * On mount, GETs `/api/move-to-project` to see whether the endpoint is
+ * live. The endpoint only exists when the user is running the Astro dev
+ * server (per-route SSR). The hosted static build doesn't ship it, so
+ * the GET 404s → `available === false` → the caller hides the
+ * MOVE TO PROJECT affordance.
+ *
+ * `move()` POSTs `{ sessionId, projectId, displayName? }`. The endpoint
+ * appends to `chat-arch-data/projectOverrides.json` (consumed by the v2
+ * cascade rule 0); a rescan is needed before the change takes effect.
+ */
+
+export interface MoveToProjectResponse {
+  ok: boolean;
+  projectId?: string;
+  sessionId?: string;
+  overridesCount?: number;
+  note?: string;
+  error?: string;
+}
+
+export type MoveStatus = 'idle' | 'moving' | 'error' | 'ok';
+
+export interface UseMoveToProjectResult {
+  /**
+   * Whether the `/api/move-to-project` endpoint was reachable on mount.
+   * Tri-state to avoid mount-flicker, mirroring {@link useRescan}:
+   * 'probing' means "optimistically local-dev" — render the affordance
+   * until the probe resolves to a definitive `false`. Helper:
+   * `available !== false` ⇒ treat as local dev.
+   */
+  available: boolean | 'probing';
+  status: MoveStatus;
+  /** Response payload from the most recent attempt; cleared on next move. */
+  last: MoveToProjectResponse | null;
+  /**
+   * Trigger a move. Resolves to the response payload. `projectId` is the
+   * raw key the cascade re-slugs (see DetailMode's picker comment for the
+   * proj_-prefix-stripping convention); `displayName` is only sent for a
+   * freshly-typed project name.
+   */
+  move: (
+    sessionId: string,
+    projectId: string,
+    displayName?: string,
+  ) => Promise<MoveToProjectResponse | null>;
+}
+
+const MOVE_PATH = '/api/move-to-project';
+
+export function useMoveToProject(): UseMoveToProjectResult {
+  const [available, setAvailable] = useState<boolean | 'probing'>('probing');
+  const [status, setStatus] = useState<MoveStatus>('idle');
+  const [last, setLast] = useState<MoveToProjectResponse | null>(null);
+
+  // Probe once on mount. Network + 404 + HTML fallbacks all mean "not
+  // available" so we keep the affordance hidden rather than showing it
+  // in a broken state.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(MOVE_PATH, { method: 'GET' });
+        if (cancelled) return;
+        const ct = res.headers.get('content-type') ?? '';
+        if (!res.ok || !ct.includes('application/json')) {
+          setAvailable(false);
+          return;
+        }
+        const body = (await res.json()) as { available?: boolean };
+        setAvailable(body.available === true);
+      } catch {
+        if (!cancelled) setAvailable(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const move = useCallback(
+    async (
+      sessionId: string,
+      projectId: string,
+      displayName?: string,
+    ): Promise<MoveToProjectResponse | null> => {
+      if (status === 'moving') return null;
+      setStatus('moving');
+      setLast(null);
+
+      const fail = (error: string): MoveToProjectResponse => {
+        const payload: MoveToProjectResponse = { ok: false, error };
+        setLast(payload);
+        setStatus('error');
+        return payload;
+      };
+
+      try {
+        // X-Requested-With is the same CSRF gate the rescan endpoint uses:
+        // a hostile cross-origin page cannot set custom headers on a simple
+        // form POST. Keep in sync with
+        // `apps/standalone/src/pages/api/move-to-project.ts`.
+        const res = await fetch(MOVE_PATH, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'chat-arch-move-to-project',
+          },
+          body: JSON.stringify({
+            sessionId,
+            projectId,
+            ...(displayName !== undefined ? { displayName } : {}),
+          }),
+        });
+        const ct = res.headers.get('content-type') ?? '';
+        if (!ct.includes('application/json')) {
+          const text = await res.text();
+          return fail(`Unexpected response (status ${res.status}): ${text.slice(0, 200)}`);
+        }
+        const body = (await res.json()) as MoveToProjectResponse;
+        setLast(body);
+        setStatus(body.ok ? 'ok' : 'error');
+        return body;
+      } catch (err) {
+        return fail(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [status],
+  );
+
+  // After a terminal state, reset to idle so the affordance re-enables.
+  // Longer on error (8s) than on success (4s) so the copy stays readable.
+  useEffect(() => {
+    if (status !== 'ok' && status !== 'error') return undefined;
+    const delay = status === 'error' ? 8000 : 4000;
+    const id = window.setTimeout(() => setStatus('idle'), delay);
+    return () => window.clearTimeout(id);
+  }, [status]);
+
+  return { available, status, last, move };
+}

--- a/packages/viewer/src/data/v2EntitiesFetch.ts
+++ b/packages/viewer/src/data/v2EntitiesFetch.ts
@@ -1,4 +1,4 @@
-import type { Project, Topic, Narrative } from '@chat-arch/schema';
+import type { Project, Topic, Narrative, ProjectResolvedVia } from '@chat-arch/schema';
 
 /**
  * Parallel-fetch the three v2 entity sidecars written by the exporter
@@ -15,15 +15,33 @@ import type { Project, Topic, Narrative } from '@chat-arch/schema';
  *     for the caller; `generatedAt` isn't load-bearing in the viewer.
  */
 
+/**
+ * Per-session provenance record from `projects.json`'s top-level
+ * `attribution` map (Project Identity v2 §5). `resolvedVia` names the
+ * cascade rule that assigned the project; `confidence` is monotonic with
+ * cascade order (0..1). `projectId` is the resolved `proj_…` id.
+ */
+export interface SessionAttribution {
+  projectId: string;
+  resolvedVia: ProjectResolvedVia;
+  confidence: number;
+}
+
 export interface V2EntitiesFetchResult {
   projects: readonly Project[] | null;
   topics: readonly Topic[] | null;
   narratives: readonly Narrative[] | null;
+  /**
+   * sessionId → provenance record (Project Identity v2). `null` when the
+   * `projects.json` sidecar is absent or pre-v2 (no `attribution` key).
+   */
+  attribution: Record<string, SessionAttribution> | null;
 }
 
 interface ProjectsFile {
   generatedAt?: number;
   projects?: readonly Project[];
+  attribution?: Record<string, SessionAttribution>;
 }
 interface TopicsFile {
   generatedAt?: number;
@@ -59,6 +77,7 @@ export async function fetchV2Entities(dataRoot: string): Promise<V2EntitiesFetch
     projects: Array.isArray(projectsFile?.projects) ? projectsFile.projects : null,
     topics: Array.isArray(topicsFile?.topics) ? topicsFile.topics : null,
     narratives: Array.isArray(narrativesFile?.narratives) ? narrativesFile.narratives : null,
+    attribution: projectsFile?.attribution ?? null,
   };
 }
 

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -5113,6 +5113,51 @@
   color: var(--lcars-peach);
 }
 
+/* MOVE TO PROJECT affordance (Project Identity v2 PR2). Reuses the
+   .lcars-detail-mode__copy pill shape; the panel is a thin inline row
+   that appears under the header when the picker is open. */
+.lcars-detail-mode__move {
+  font-family: inherit;
+}
+.lcars-detail-mode__move-panel {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+}
+.lcars-detail-mode__move-label {
+  color: var(--lcars-butterscotch);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+.lcars-detail-mode__move-select,
+.lcars-detail-mode__move-new-name {
+  background: rgba(0, 0, 0, 0.3);
+  color: var(--lcars-text);
+  border: 1px solid var(--lcars-violet);
+  border-radius: 6px;
+  padding: 3px 8px;
+  font-size: 12px;
+  font-family: var(--lcars-font-mono);
+}
+.lcars-detail-mode__move-confirm:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.lcars-detail-mode__move-result {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  font-weight: 700;
+}
+.lcars-detail-mode__move-result--ok {
+  color: var(--lcars-ice);
+}
+.lcars-detail-mode__move-result--err {
+  color: var(--lcars-peach);
+}
+
 /* --- Prose / data-dense weight bump ---
    Antonio at its default 500 weight reads thin at 11-14 px on dark
    backgrounds. Bumping prose and data-cell selectors to 600 weight

--- a/packages/viewer/src/types.ts
+++ b/packages/viewer/src/types.ts
@@ -9,6 +9,7 @@ import type {
   Narrative,
 } from '@chat-arch/schema';
 import type { TierFileState } from './data/analysisFetch.js';
+import type { SessionAttribution } from './data/v2EntitiesFetch.js';
 
 /**
  * In-memory manifest produced by parsing a user-uploaded cloud-export ZIP.
@@ -268,6 +269,12 @@ export interface AnalysisState {
   v2Projects: readonly Project[] | null;
   v2Topics: readonly Topic[] | null;
   v2Narratives: readonly Narrative[] | null;
+  /**
+   * Project Identity v2 per-session provenance map from `projects.json`'s
+   * top-level `attribution` key. `null` when absent / pre-v2. Drives the
+   * RESOLVED VIA row in DetailMode.
+   */
+  v2Attribution: Record<string, SessionAttribution> | null;
 }
 
 export type { SessionManifest, UnifiedSessionEntry, SessionSource };

--- a/research/project-identity-v2-sweep.md
+++ b/research/project-identity-v2-sweep.md
@@ -1,0 +1,69 @@
+# Project Identity v2 — one-time sweep runbook
+
+The v2 cascade re-keys projects (302 → ~34; the haiku-VM singletons collapse,
+scheduled tasks become `proj_routine-*`, `proj_outputs` disappears). Adoption is
+just the next normal rescan — `projects.json` / `topics.json` / `narratives.json`
+heuristic rows and the kernel-built sidecars (`project-trajectories.json`,
+`archetypes.json`, `surprises.json`, …) are **rebuilt fresh every rescan and
+self-heal**, so most of the corpus needs no manual intervention.
+
+Four artifacts are **skill-written and persist across rescans**, so they retain
+stale project-id references until re-mined. Sweep them **once** after the first
+v2 rescan, then re-mine:
+
+| Artifact | Why it's stale | How to clear |
+|---|---|---|
+| `analysis/personas/<old-id>.md` + `personas.json` | per-project markdown keyed to vanished ids | `POST /api/clear-personas` |
+| `analysis/narratives.json` (LLM-derived rows) | `attributedTo:'llm-derived'` rows keyed to vanished project ids | `POST /api/clear-narratives` (preserves heuristic rows) |
+| `analysis/curator-feed.json` | written by `/curate`; embeds project ids + previews | delete the file (regenerated on next `/curate`) |
+| `analysis/falsifier-verdicts.json` | written by `/falsify`; references finding ids | delete the file (regenerated on next `/falsify`) |
+
+## Procedure (local dev only)
+
+```bash
+# 0. PREVIEW FIRST (non-destructive) — review the new bucketing before adopting.
+#    Writes analysis/project-identity-preview.json; touches no live artifact.
+pnpm exporter run start --no-cloud --project-identity-preview
+#    (or the equivalent: node packages/exporter/dist/cli.js all --project-identity-preview)
+#    Inspect analysis/project-identity-preview.json: summary (projects/UNASSIGNED/
+#    moved), resolvedViaCounts, unassignedReasons. If the bucketing looks wrong,
+#    do NOT proceed — adjust projectOverrides.json or stop.
+
+# 1. ADOPT — a normal rescan rebuilds projects.json under the v2 cascade.
+#    (The viewer RESCAN button does the same; the EXPORTER_VERSION 1.9.0 bump
+#    invalidates the cli/cowork caches so the new scheduledTaskId/sessionType
+#    fields repopulate.)
+
+# 2. SWEEP the four skill-written artifacts (curl from the running dev server,
+#    or use the viewer affordances):
+curl -X POST localhost:4321/api/clear-personas   -H 'X-Requested-With: chat-arch-clear-personas'
+curl -X POST localhost:4321/api/clear-narratives -H 'X-Requested-With: chat-arch-clear-narratives'
+rm -f apps/standalone/public/chat-arch-data/analysis/curator-feed.json
+rm -f apps/standalone/public/chat-arch-data/analysis/falsifier-verdicts.json
+
+# 3. RE-MINE: re-run /mine-persona, /mine-narratives, /curate, /falsify so the
+#    swept artifacts regenerate against the new project ids.
+
+# 4. AUDIT — confirm the v2 targets held:
+node scripts/audit-project-identity.mjs
+```
+
+## Manual overrides (`projectOverrides.json`)
+
+Irreducible cases (e.g. the `brycewatson.com` 3-cwd collision, or a basename
+over-merge) are fixed by appending to
+`apps/standalone/public/chat-arch-data/projectOverrides.json` — either via the
+viewer's **"Move to project"** affordance (writes a `sessionIds` row) or by hand:
+
+```json
+[
+  { "projectId": "brycewatson-com", "displayName": "brycewatson.com",
+    "match": { "cwdGlob": "**/Projects/brycewatson.com/**" } },
+  { "projectId": "client-a-docs", "match": { "sessionIds": ["<uuid>", "<uuid>"] } }
+]
+```
+
+`projectId` is a **raw key** (NOT `proj_`-prefixed — the cascade's
+`stableProjectId` normalizes it). Overrides are cascade **rule 0** (confidence
+1.00) — they win over every other signal. The file is gitignored (it carries
+session ids / cwd globs — PII).


### PR DESCRIPTION
## Project Identity v2 — PR2 of 3 (viewer + API)

**Stacked on #111 (PR1).** Base is `feature/project-identity-v2`; merge PR1 first, then this. Adds the user-facing surface on top of PR1's cascade (plan §5/§6).

### What's in PR2
- **`/api/move-to-project`** — POST appends a `{projectId, displayName?, match:{sessionIds:[…]}}` override row to `projectOverrides.json` (cascade **rule 0**, confidence 1.00). Mirrors `apply-correction.ts`: `isLocalOrigin` + `X-Requested-With: chat-arch-move-to-project` CSRF, synchronous in-flight gate, atomic tmp+rename. **Idempotent merge** — strips the session from other rows, finds-or-creates the target, prunes empty rows; tolerant of the bare-array / `{overrides:[]}` shapes `loadProjectOverrides` accepts. GET = availability probe.
- **RESOLVED VIA display** — DetailMode shows the session's provenance (`resolvedVia · confidence`, `—` when absent) from the new per-session `attribution` map, exposed by `v2EntitiesFetch` (projects.json `attribution`) and threaded through `ChatArchViewer`.
- **"MOVE TO PROJECT" affordance** — **local-only** (`useMoveToProject` GET-probe mirrors `useRescan`; hidden on the hosted static build). Inline picker over existing projects + a new-name input. Existing pick sends the `proj_`-stripped raw key (verified to round-trip through `stableProjectId` to the same id) plus the real displayName; new name sends raw text as id + label.
- **`research/project-identity-v2-sweep.md`** — one-time sweep runbook: preview → adopt (rescan) → clear personas/narratives + delete curator-feed/falsifier-verdicts → re-mine → audit; plus `projectOverrides.json` usage.

### Verification
`pnpm lint` (0 errors), `pnpm test` (2331 passed / 5 skipped), `pnpm build` green. New DetailMode props are optional (existing call sites/tests unchanged). Focused adversarial review passed — endpoint CSRF/atomic-write/override-merge correct, projectId slug round-trips, local gating sound, `projectOverrides.json` gitignored (no PII leak); 2 minor findings fixed (match-less-row guard; existing-project displayName).

🤖 Generated with [Claude Code](https://claude.com/claude-code)