### PR TITLE
feat(decisions): real LLM classification pipeline (PR1 — data layer)

### DIFF
--- a/.claude/skills/mine-decisions/SKILL.md
+++ b/.claude/skills/mine-decisions/SKILL.md
@@ -1,92 +1,239 @@
 ---
 name: mine-decisions
-description: STUB (Phase 2 #1 follow-up). Mine the chat-arch corpus for decision points — moments where the user chose between alternatives — and extract {question, alternatives, chosen, rationale} for each. Reads chat-arch-data/analysis/decisions.json (the heuristic-recall candidate file produced by the chat-arch exporter) and overwrites it with classified entries. Local Ollama optional. Currently a stub that emits a "not yet implemented" message and exits.
+description: Mine the chat-arch corpus for decision points — moments where the user chose between alternatives — and classify each into {kind, distilledDecision, chosen, rejected, rationale, confidence, actionable} plus a trust-calibration cell (did the user take the AI's recommendation, and did it land?). Reads chat-arch-data/analysis/decisions.json (heuristic-recall candidates produced by the exporter), merges classification + trustCalibration back into it, and clusters recurring decisions into analysis/decision-clusters.json. Local Ollama optional (only the clustering stage uses it).
 ---
 
 # /mine-decisions
 
-> **STATUS:** Phase 2 #1 follow-up — STUB ONLY. The endpoint and UI
-> affordance are live so the user can see where this will plug in,
-> but the classification pipeline itself is not yet implemented.
-> Running this skill prints a "not yet implemented" message and
-> exits non-zero. Track follow-up work under plan §Phase 2 #1.
+You are running the LLM stages of chat-arch's decision-mining pipeline.
+The exporter has already produced a heuristic-recall list of candidate
+decisions in `decisions.json` (each row a `DecisionCandidate` with
+`classification: null`). Your job: classify each into a structured
+decision, compute its trust-calibration cell, cluster recurring
+decisions, and merge the results back into `decisions.json` without
+disturbing rows you didn't touch.
 
-## When invoked
+This mirrors `/mine-corrections` (read its SKILL.md for the shared
+conventions). The differences: decisions live in a SINGLE file written
+by two writers (the exporter + you), so the merge is compare-and-swap
+guarded; classification additionally emits an `acceptedAssistant` axis
+for trust calibration; and clustering output lives in its own sidecar.
 
-The viewer's `/api/mine-decisions` endpoint shells out to
-`claude -p "/mine-decisions --request-id=<uuid> --data-dir=<path>"`.
-Direct CLI invocation works the same way.
+## When to invoke
 
-## Arguments (planned)
+- The user runs `/mine-decisions` (optionally with the arguments below).
+- The viewer's `/api/mine-decisions` endpoint shells out to
+  `claude -p "/mine-decisions --request-id=<uuid> --data-dir=<path> --batch=<N>"`.
 
-- `--data-dir <path>` — chat-arch-data directory (default:
-  `./apps/standalone/public/chat-arch-data`).
-- `--request-id <uuid>` — correlates skill output with the requesting
-  UI client when invoked from the viewer.
-- `--window-days <N>` — process candidates from sessions updated
-  within the last N days (default: 30). Same shape as mine-corrections.
-- `--no-llm` — dry-run; skip the classification LLM stage.
-- `--max-sub-agents <N>` — abort if the plan would dispatch more than
-  this many sub-agents. Matches mine-corrections's safety bound.
+## Arguments
 
-## Stub behavior (current)
+Parse from the user's message. Defaults in brackets.
 
-When invoked, this skill MUST:
+- `--data-dir <path>` [`./apps/standalone/public/chat-arch-data`] — the
+  chat-arch-data directory.
+- `--request-id <uuid>` [omitted] — present when invoked from the viewer;
+  correlates the status file with the requesting UI.
+- `--batch <N|all>` [5] — classify at most N currently-unclassified
+  candidates this run (`all` = no cap). The viewer's batch selector
+  drives this. Selection order: candidates WITH a joined `outcomeRef`
+  first (more analytically useful — they can form a trust cell), then by
+  candidate `id` (stable, deterministic).
+- `--self-consistency <K>` [3] — majority-vote count for borderline
+  classifications (same mechanism as mine-corrections). `1` disables.
+- `--reclassify` [false] — re-process rows that already have a
+  `classification` (default skips them).
+- `--no-llm` [false] — dry-run: skip classification + clustering, only
+  exercise the read/select/status plumbing. Used by CI.
+- `--max-sub-agents <N>` [40] — abort if the plan would dispatch more
+  than N sub-agents. Each batch of 20 candidates = 1 sub-agent.
 
-1. Print a single line to stdout:
-   `mine-decisions: not yet implemented (Phase 2 #1 follow-up). See plan §Phase 2 #1.`
-2. Exit with status code 1 so the calling endpoint records the run as
-   a non-success (the viewer surfaces the message via the NDJSON
-   stderr stream).
+## Pipeline
 
-Do not attempt to read decisions.json, write any sidecar, or
-dispatch any sub-agent. The stub exists purely so the UI affordance
-(`MINE DECISIONS` button in DecisionsMode) has a real endpoint to
-post to.
-
-## Pipeline (planned — for follow-up implementation)
-
-Mirrors mine-corrections's six-stage pipeline:
+You orchestrate five stages. Update the status file at every transition.
 
 ### Stage 0 — Setup
-Read `${dataDir}/analysis/decisions.json`. Filter by window. Verify
-Ollama is up (optional for the LF classification pass; required for
-clustering by canonical question similarity).
+
+1. Resolve `--data-dir`. Read `${dataDir}/analysis/decisions.json`. If
+   absent, tell the user to run the exporter (SCAN LOCAL) first and stop.
+2. **Capture `decisions.json`'s `generatedAt` value now** — call it
+   `baseGeneratedAt`. Stage 4's compare-and-swap uses it to detect a
+   concurrent rescan.
+3. Select the work set: rows where `classification === null` (unless
+   `--reclassify`, then all rows). Order by `outcomeRef != null` desc,
+   then `candidate.id` asc. Cap to `--batch` (no cap when `all`).
+4. If the work set is empty, write a `complete` status with
+   `classifiedCount: 0` and exit 0 (nothing to do is success).
+5. Estimate sub-agents: `ceil(workSet.length / 20)`. If it exceeds
+   `--max-sub-agents` AND there is no `--request-id` (direct CLI, a human
+   is present), ask before proceeding. When `--request-id` is set
+   (viewer run), proceed regardless and log "viewer-run — skipping cap".
+6. Write the initial status file (`status: "classifying"`).
+
+If `--no-llm`: skip to Stage 5 and write `complete` with
+`classifiedCount: 0`, `dryRun: true`.
 
 ### Stage 1 — Classification
-For each `DecisionCandidate` row, extract:
-- **Question** — what alternative was being chosen between.
-- **Alternatives** — the considered options (chosen + rejected).
-- **Chosen** — the selected option(s).
-- **Rationale** — short prose explaining why.
-- **Confidence** — model self-rated, 0..1.
-- **Actionable** — true when the row represents a substantive
-  decision (not a pleasantry / wave of the hand).
 
-Batch in groups of 20 → one Haiku sub-agent per batch (matches the
-mine-corrections cost profile). Parallelize up to 4 batches at a time.
+Batch the work set into groups of 20. For each batch dispatch a
+`general-purpose` sub-agent **with `model: "haiku"`** (structured-output
+task — Haiku is cost-correct here). Run up to 4 batches in parallel
+(multiple Agent calls in one message).
 
-### Stage 2 — Outcome join
-The exporter's `decisionsBuilder.ts` already attaches
-`outcomeRef` from composite-outcomes. Re-verify against the current
-composite-outcomes.json (older runs may have outdated joins).
+Build each input row as
+`{ id, kind, phrase, context, precedingAssistant }` from the candidate
+(`kind` = `candidate.kind`, `phrase` = `candidate.span.phrase`,
+`context` = `candidate.surroundingContext`, `precedingAssistant` =
+`candidate.precedingAssistantExcerpt`).
 
-### Stage 3 — Trust calibration cell
-Compute the 2×2 cell (accepted-assistant × landed) for each
-classified decision, populating the optional
-`trustCalibration` field on the on-disk Decision row.
+Sub-agent prompt template (substitute the batch JSON for `<<CANDIDATES>>`):
 
-### Stage 4 — Cluster by canonical question (optional)
-Embed canonicalized question text via Ollama (`mxbai-embed-large`),
-cluster by cosine similarity, surface recurring decisions as
-"pattern" candidates (same shape as corrections patterns).
+```
+You are classifying DECISIONS a user made mid-conversation with an AI coding assistant. Each input is a {id, kind, phrase, context, precedingAssistant} object: `context` is the user's turn, `precedingAssistant` is the assistant turn just before it (may be null).
+
+For each input decide:
+1. actionable: is this a genuine decision — the user choosing a path, tool, approach, or scope — vs. an aside, a question, a restated earlier decision, or a pleasantry?
+2. kind: normalize to one of 'explicit-marker' | 'explicit-go-with' | 'instead-of' | 'alternative-block' | 'imperative-choice' | 'tool-pivot' | 'scope-cut' | 'other'. Reclassify away from the heuristic `kind` when context shows it's really a tool-pivot (switching tool/library/framework) or scope-cut (dropping or deferring planned scope).
+3. distilledDecision: ONE imperative sentence naming the decision. No first person, no quotes, no pleasantries. e.g. "use ripgrep instead of grep", "drop the staging server and deploy direct".
+4. chosen: array of the option(s) the user took (>=1 entry).
+5. rejected: array of option(s) turned down (may be []).
+6. rationale: <=200 chars on WHY, in the user's framing. "" if not evident from context.
+7. acceptedAssistant: did the user TAKE the assistant's recommendation (true) or go a different way / override it (false)? Judge from precedingAssistant. If there is no preceding assistant turn, or it made no recommendation, use false.
+8. confidence: 0..1 that this is a real, substantive decision.
+
+Output ONLY a JSON array, one entry per input, same order:
+[{"id":"<id>","actionable":true|false,"kind":"...","distilledDecision":"...","chosen":["..."],"rejected":["..."],"rationale":"...","acceptedAssistant":true|false,"confidence":0.0-1.0}]
+
+Inputs:
+<<CANDIDATES>>
+```
+
+Concatenate results. On malformed JSON from a sub-agent, retry once,
+then drop that batch's candidates with a status note.
+
+**Self-consistency vote** (same shape as mine-corrections): before the
+filter, identify the borderline subset (`actionable:true` with
+`0.5<=confidence<0.75`, or `actionable:false` with
+`0.4<=confidence<0.65`). If `--self-consistency >= 2` and the set is
+non-empty, re-run those K-1 more times in parallel and aggregate:
+`actionable` = majority (ties → false), `kind` = mode among
+actionable-true runs (else 'other'), `distilledDecision`/`rationale`/
+`chosen`/`rejected` from the first majority-voting run, `confidence` =
+mean, `acceptedAssistant` = majority (ties → false).
+
+**Filter**: keep `actionable: true` AND `confidence >= 0.6`. Map each
+kept result to a `DecisionClassification` = `{ kind, distilledDecision,
+chosen, rejected, rationale, confidence, actionable: true }`. Update
+status: `"classified N of M, K kept after filter"`.
+
+### Stage 2 — Trust calibration
+
+For each kept classification, look up the candidate's `outcomeRef` in
+`decisions.json`. When `outcomeRef !== null`, set
+`trustCalibration = { acceptedAssistant: <from Stage 1>, landed:
+outcomeRef.binaryClass === 'good' }`. When `outcomeRef === null`, leave
+`trustCalibration` unset (no outcome to calibrate against). This is what
+populates the TRUST 2×2.
+
+### Stage 3 — Cluster recurring decisions (optional; needs Ollama)
+
+Only meaningful with >= 2 classified decisions total (this run's kept
+results + any pre-existing classified rows in `decisions.json`).
+
+1. Probe Ollama: `curl -s -m 1 http://localhost:11434/api/tags`. If it's
+   not up, **skip this stage** (log "Ollama down — skipping clustering;
+   classification still written") and continue. Clustering is an
+   enhancement, not a gate — unlike mine-corrections, classification
+   here doesn't need embeddings.
+2. Collect `{ id, distilledDecision, sessionId, binaryClass }` for every
+   classified decision (this run + already-classified rows; `binaryClass`
+   from each row's `outcomeRef`, or `null` when unjoined). Write them to
+   `_decisions-classified.json` as `{ decisions: [...] }`.
+3. Cluster (the CLI embeds `distilledDecision` internally via Ollama, so
+   no separate embed-cli call is needed):
+   ```bash
+   node packages/exporter/dist/cli/cluster-decisions-cli.js \
+     --classified ${dataDir}/analysis/_decisions-classified.json \
+     --output ${dataDir}/analysis/decision-clusters.json
+   ```
+   The CLI writes a `DecisionClustersFile` (clusters of >=2 distinct
+   sessions, each with `canonicalDecision`, `instanceIds`,
+   `occurrenceCount`, `firstSeen`/`lastSeen`, and `landedRate`). Surface
+   any stderr.
+
+### Stage 4 — Merge + write (compare-and-swap)
+
+1. **Re-read** `${dataDir}/analysis/decisions.json` fresh.
+2. If its `generatedAt !== baseGeneratedAt`, a rescan landed mid-run.
+   The candidate `id`s are stable across rescans, so re-applying by id
+   is safe — proceed, but if the re-read fails or the file is gone,
+   retry once; on a second failure write `status: error` with
+   `"concurrent-rescan-aborted"` and exit 1.
+3. Build a map `id → { classification, trustCalibration? }` from this
+   run. Map over `decisions[]`: for a row whose `candidate.id` is in the
+   map, set `classification` (and `trustCalibration` when present),
+   preserving `candidate` + `outcomeRef`. Leave every other row
+   untouched (their `classification` stays as-is — `null` or a prior
+   run's value). Drop map entries whose id is no longer present.
+4. Bump `generatedAt` to now; keep `decisionHeuristicVersion` and
+   `scannedSessionIds` as read. Write atomically: write to
+   `decisions.json.tmp.<requestId>` then rename over `decisions.json`.
+5. Delete the `_*.json` intermediates.
 
 ### Stage 5 — Status finalization
-Write status file
-`${dataDir}/analysis/decision-status-${requestId}.json` with
-the final state (`status: 'complete' | 'error'`, `error: string?`,
-counts).
 
-### Stage 6 — Cleanup
-Remove the request-id file (if any), bump
-`decisionHeuristicVersion` if the LLM-classification config changed.
+Write `${dataDir}/analysis/decision-status-${requestId}.json`:
+
+```json
+{
+  "requestId": "<id or 'manual'>",
+  "status": "complete",
+  "completedAt": <ms>,
+  "classifiedCount": <kept after filter>,
+  "candidatesConsidered": <work-set size>,
+  "clusterCount": <decision-clusters.json clusters, 0 if skipped>,
+  "tokenCost": "<estimate>"
+}
+```
+
+Also keep the rolling status file (`status` field cycling
+`classifying` → `clustering` → `writing` → `complete`) updated through
+the run so the viewer's poller shows live progress — same shape as
+`correction-status-*.json`.
+
+## Status file format
+
+`${dataDir}/analysis/decision-status-${requestId}.json` — identical
+shape to `correction-status-*.json`:
+
+```json
+{
+  "requestId": "<id or 'manual'>",
+  "status": "starting" | "classifying" | "clustering" | "writing" | "complete" | "error",
+  "progress": { "phase": "<current>", "current": N, "total": M },
+  "startedAt": <ms>,
+  "updatedAt": <ms>,
+  "log": ["<recent message>", "..."],
+  "error": "<message if status=error>"
+}
+```
+
+## Error handling
+
+- `decisions.json` missing → stop, tell the user to run the exporter.
+- Ollama down → skip clustering (NOT fatal); classification still writes.
+- Sub-agent malformed JSON → retry once, then drop that batch.
+- Concurrent rescan that survives a re-read retry → `status: error`
+  (`concurrent-rescan-aborted`), exit 1.
+- Any unrecoverable error → write `status: error` with the message, exit 1.
+
+## What you must NOT do
+
+- Don't write to `decisions.json` before Stage 4. Use `_`-prefixed names
+  for all intermediates.
+- Don't touch rows outside this run's work set — the merge must preserve
+  every other row's `classification`/`trustCalibration` verbatim (this
+  is what lets the exporter's cache reuse and your classification
+  coexist in one file).
+- Don't re-classify already-classified rows unless `--reclassify`.
+- Don't fail the whole run because Ollama is down — clustering is optional.
+- Don't invent `chosen`/`rejected` options not grounded in the context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,47 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.9.0] — 2026-05-29
+
+Decisions LLM pipeline — the DECISIONS surface goes from a raw
+heuristic-candidate dump fronted by a stubbed MINE button to a real
+classify → trust-calibrate → cluster pipeline. The exporter still emits
+heuristic candidates into `analysis/decisions.json`; the now-implemented
+`/mine-decisions` skill classifies them and merges the results back in.
+
+> **Version note:** `1.8.0` is the concurrent UI-content /
+> `unwrapEnvelope` release shipped on its own branch. This entry is
+> `1.9.0` to keep the two artifact-contract bumps from colliding; the
+> `1.8.0 → 1.9.0` ordering is nominal, not a dependency.
+
+### Added
+
+- **`analysis/decision-clusters.json`** sidecar (`DecisionClustersFile`)
+  — recurring-decision clusters (`DecisionPattern[]`) produced by the
+  `/mine-decisions` clustering stage via the new
+  `packages/exporter/dist/cli/cluster-decisions-cli.js` (reuses the
+  shared `clusterByThreshold` kernel + `embed` over `distilledDecision`).
+  Skill-only writer; carries PII (decision prose). Gitignored under the
+  existing `chat-arch-data/*` wildcard.
+- **`/api/clear-decisions`** endpoint — resets `classification` +
+  `trustCalibration` to null in `decisions.json` (preserving candidates),
+  deletes `decision-clusters.json` + `decision-status-*.json`. Lets the
+  user re-mine without re-running the exporter.
+- `DecisionClassification.rationale` (the "why" behind each choice) and
+  `DecisionCandidate.precedingAssistantExcerpt` (≤500-char prior
+  assistant turn) — the latter feeds the accept-vs-override axis of the
+  trust 2×2.
+
+### Changed
+
+- `DECISION_HEURISTIC_VERSION` 1 → 2 (candidate shape gained
+  `precedingAssistantExcerpt`) — the exporter's decisions cache
+  self-invalidates and re-scans on next run.
+- `/api/mine-decisions` now validates run success via a status-file /
+  `generatedAt` probe (mirrors `/api/mine-corrections`) instead of the
+  bare exit code; `decisionsBuilder` preserves `trustCalibration` across
+  cache reuse alongside `classification`.
+
 ## [1.7.0] — 2026-05-26
 
 Narrative-mining V1 — per-project LLM-driven thematic narratives,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,8 @@ Per-package alternatives:
 ```
 apps/standalone/     Astro shell + /api/rescan + /api/clear endpoints
                      + /api/mine-corrections + /api/clear-corrections
-                     + /api/mine-decisions + /api/generate-exports
+                     + /api/mine-decisions + /api/clear-decisions
+                     + /api/generate-exports
                      + /api/insights-ack + /api/entity-states
                      + /api/apply-correction + /api/regen-brief
 packages/schema/     UnifiedSessionEntry + manifest + correction types
@@ -132,8 +133,18 @@ scripts/             One-off audits (audit-correction-recall.mjs) +
                      lint-thresholds-imports.mjs, lint-fixture-pii.mjs)
 .claude/skills/
   mine-corrections/  Skill driving the corrections LLM stages
-  mine-decisions/    Skill driving the decisions LLM stages (stub UI
-                     until LLM pipeline lands; see Phase Rev3-F)
+  mine-decisions/    Skill driving the decisions LLM stages (LIVE as of
+                     EXPORTER_VERSION 1.9.0). Reads heuristic candidates
+                     from analysis/decisions.json, classifies each via
+                     Haiku sub-agents (kind / distilledDecision / chosen /
+                     rejected / rationale / confidence / actionable +
+                     acceptedAssistant), computes the trustCalibration
+                     cell, clusters recurring decisions into
+                     analysis/decision-clusters.json (via
+                     cluster-decisions-cli, Ollama-gated + skippable), and
+                     CAS-merges classification + trustCalibration back into
+                     decisions.json (two writers: exporter cache-reuse +
+                     this skill). Ollama optional (clustering only).
   curate/            Phase Rev3-F F1 curator skill — ranks tier-2 +
                      tier-3 narratives + knowledge-debt + applied-
                      pattern watcher items into analysis/curator-feed.json
@@ -300,7 +311,17 @@ analysis/` (all gitignored — locally generated, may carry PII):
 - `reflexive.json` — matched-pair contrast for "touched chat-arch"
   sessions. PII: session IDs + composite scores.
 - `decisions.json` — extracted decisions (LF candidates) joined to
-  composite outcome. PII: decision prose.
+  composite outcome. As of EXPORTER_VERSION 1.9.0 the `/mine-decisions`
+  skill merges `classification` (kind / distilledDecision / chosen /
+  rejected / rationale / confidence / actionable) + `trustCalibration`
+  into the rows the exporter emits — TWO writers on one file, the skill's
+  write is CAS-guarded on `generatedAt`. The candidate now also carries
+  `precedingAssistantExcerpt`. PII: decision prose + the prior assistant
+  excerpt.
+- `decision-clusters.json` — recurring-decision clusters
+  (`DecisionPattern[]`) produced by the `/mine-decisions` clustering
+  stage. Skill-only writer (the exporter never touches it). PII: decision
+  prose. Reset by `/api/clear-decisions`.
 - `archetypes.json` — k-means workflow-archetype centroids + per-
   session assignments. PII: session-archetype mapping.
 - `project-trajectories.json` — Theil-Sen slope per project +

--- a/apps/standalone/src/pages/api/clear-decisions.ts
+++ b/apps/standalone/src/pages/api/clear-decisions.ts
@@ -1,0 +1,165 @@
+import type { APIRoute } from 'astro';
+import { readdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import type { Decision, DecisionsFile } from '@chat-arch/schema';
+
+/**
+ * Reset the decision-mining pipeline's OUTPUT so the user can re-mine
+ * from scratch — without destroying the candidates they'd have to
+ * re-run the exporter to regenerate.
+ *
+ * This is NOT a simple delete-by-allowlist like `/api/clear-corrections`,
+ * because `decisions.json` is a SINGLE file holding both the exporter's
+ * candidates (INPUT) and the skill's classification (OUTPUT). So:
+ *
+ *   - `analysis/decisions.json` — REWRITTEN in place: every row's
+ *     `classification` + `trustCalibration` reset to null, `candidate` +
+ *     `outcomeRef` preserved. The candidates (and the
+ *     `decisionHeuristicVersion` / `scannedSessionIds` cache keys) survive.
+ *   - `analysis/decision-clusters.json` — DELETED (pure skill output).
+ *   - `analysis/decision-status-*.json` — DELETED (orphan status files).
+ *   - `analysis/decisions.json.tmp.*` — DELETED (atomic-write orphans).
+ *
+ * NOT touched: any other analysis file. The kitchen-sink `/api/clear`
+ * still nukes everything under chat-arch-data/.
+ *
+ * CSRF posture matches `/api/clear-corrections`:
+ *   1. Origin parses to a local-only hostname.
+ *   2. Custom `X-Requested-With: chat-arch-clear-decisions` header.
+ */
+export const prerender = false;
+
+export const REQUIRED_HEADER = 'chat-arch-clear-decisions';
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+export function isLocalOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  try {
+    const u = new URL(origin);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+    return LOCAL_HOSTNAMES.has(u.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function csrfReject(reason: string): Response {
+  return new Response(JSON.stringify({ ok: false, error: `Forbidden: ${reason}` }), {
+    status: 403,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/** apps/standalone/src/pages/api/clear-decisions.ts → apps/standalone/public/chat-arch-data/analysis/ */
+function analysisDir(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', '..', 'public', 'chat-arch-data', 'analysis');
+}
+
+/**
+ * Skill-output sidecars safe to DELETE outright (decisions.json itself is
+ * rewritten, not deleted — see module doc). Conservative: reject any name
+ * with path separators or `..` segments.
+ *
+ * NOTE FOR FUTURE MAINTAINERS: keep in sync with
+ * `.claude/skills/mine-decisions/SKILL.md` — the sidecars the skill writes.
+ */
+export function isDecisionSidecar(name: string): boolean {
+  if (name.length === 0) return false;
+  if (name.includes('/') || name.includes('\\')) return false;
+  if (name.split(/[._-]/).includes('..')) return false;
+  if (name === 'decision-clusters.json') return true;
+  if (name.startsWith('decision-status-') && name.endsWith('.json')) return true;
+  if (name.startsWith('decisions.json.tmp.')) return true;
+  return false;
+}
+
+/** Strip classification + trustCalibration from every row, keep the rest. */
+export function resetDecisionsFile(file: DecisionsFile, now: number): DecisionsFile {
+  const decisions: Decision[] = file.decisions.map((d) => ({
+    candidate: d.candidate,
+    classification: null,
+    outcomeRef: d.outcomeRef,
+  }));
+  return {
+    generatedAt: now,
+    decisionHeuristicVersion: file.decisionHeuristicVersion,
+    decisions,
+    scannedSessionIds: file.scannedSessionIds,
+  };
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  if (!isLocalOrigin(request.headers.get('origin'))) {
+    return csrfReject('cross-origin or missing Origin');
+  }
+  if (request.headers.get('x-requested-with') !== REQUIRED_HEADER) {
+    return csrfReject('missing X-Requested-With token');
+  }
+
+  const dir = analysisDir();
+  const removed: string[] = [];
+  let reset = 0;
+
+  // 1. Reset decisions.json in place (preserve candidates).
+  const decisionsPath = join(dir, 'decisions.json');
+  try {
+    const raw = await readFile(decisionsPath, 'utf8');
+    const parsed = JSON.parse(raw) as DecisionsFile;
+    if (Array.isArray(parsed.decisions)) {
+      reset = parsed.decisions.filter((d) => d.classification !== null).length;
+      const next = resetDecisionsFile(parsed, Date.now());
+      await writeFile(decisionsPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+    }
+  } catch (err) {
+    // Missing file → nothing to reset; malformed → skip the reset but
+    // still sweep sidecars below.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      // leave `reset` at 0; not fatal
+    }
+  }
+
+  // 2. Sweep skill-output sidecars.
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return new Response(JSON.stringify({ ok: true, removed: [], reset }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  await Promise.all(
+    entries.map(async (e) => {
+      if (!e.isFile()) return;
+      if (!isDecisionSidecar(e.name)) return;
+      try {
+        await rm(join(dir, e.name), { force: true });
+        removed.push(e.name);
+      } catch {
+        // Best-effort.
+      }
+    }),
+  );
+
+  return new Response(JSON.stringify({ ok: true, removed, reset }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify({ ok: true, available: true }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+};

--- a/apps/standalone/src/pages/api/mine-decisions.ts
+++ b/apps/standalone/src/pages/api/mine-decisions.ts
@@ -16,8 +16,9 @@
 
 import type { APIRoute } from 'astro';
 import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { resolveClaudeBin } from '../../lib/resolveClaude.js';
 import { assertDataDirContained, handleDataDirGuardError } from '../../lib/dataDirGuard.js';
@@ -174,6 +175,47 @@ function runClaudeOnce(
   });
 }
 
+/**
+ * Decide whether a mine run actually succeeded, rather than trusting the
+ * exit code alone (a `claude -p` wrapper can exit 0 having done nothing,
+ * or exit non-zero on a benign teardown). Mirrors mine-corrections'
+ * outcome probe: the skill's `decision-status-${requestId}.json` is
+ * authoritative when present; otherwise fall back to "decisions.json was
+ * rewritten after we started" + a clean exit.
+ */
+async function probeOutcome(
+  dataDir: string,
+  requestId: string,
+  startedAt: number,
+  exitCode: number | null,
+  spawnError: Error | null,
+): Promise<boolean> {
+  if (spawnError !== null) return false;
+  const analysisDir = join(resolve(repoRoot(), dataDir), 'analysis');
+  // 1. Status file is authoritative when the skill wrote it.
+  try {
+    const raw = await readFile(join(analysisDir, `decision-status-${requestId}.json`), 'utf8');
+    const status = (JSON.parse(raw) as { status?: unknown }).status;
+    if (status === 'complete') return true;
+    if (status === 'error') return false;
+  } catch {
+    // no status file — fall through
+  }
+  // 2. Fallback: decisions.json bumped its generatedAt past our start AND
+  //    the process exited cleanly (the skill rewrites the file on a
+  //    non-empty classification run).
+  try {
+    const raw = await readFile(join(analysisDir, 'decisions.json'), 'utf8');
+    const gen = (JSON.parse(raw) as { generatedAt?: unknown }).generatedAt;
+    if (exitCode === 0 && typeof gen === 'number' && gen >= startedAt) return true;
+  } catch {
+    // no decisions file — fall through
+  }
+  // 3. Last resort: trust a clean exit (e.g. a legitimate no-op run with
+  //    an empty work set that exited 0 without a status file).
+  return exitCode === 0;
+}
+
 async function streamMineDecisions(
   params: MineParams,
   controller: ReadableStreamDefaultController<Uint8Array>,
@@ -205,9 +247,17 @@ async function streamMineDecisions(
     ? '\nspawn error: ' + (outcome.spawnError.message ?? String(outcome.spawnError))
     : '';
 
+  const ok = await probeOutcome(
+    dataDir,
+    requestId,
+    started,
+    outcome.exitCode,
+    outcome.spawnError,
+  );
+
   send({
     type: 'done',
-    ok: outcome.exitCode === 0 && outcome.spawnError === null,
+    ok,
     exitCode: outcome.exitCode,
     durationMs: Date.now() - started,
     requestId,

--- a/apps/standalone/test/api/clear-decisions.test.ts
+++ b/apps/standalone/test/api/clear-decisions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import type { Decision, DecisionsFile } from '@chat-arch/schema';
+import { isDecisionSidecar, resetDecisionsFile } from '../../src/pages/api/clear-decisions.js';
+
+function candidate(id: string, sessionId = 'sessA') {
+  return {
+    id,
+    sessionId,
+    userTurnIndex: 0,
+    kind: 'explicit-go-with' as const,
+    span: { phrase: "let's go with X", startOffset: 0 },
+    surroundingContext: "let's go with X instead of Y",
+    precedingAssistantExcerpt: 'I recommend X',
+  };
+}
+
+function classifiedRow(id: string): Decision {
+  return {
+    candidate: candidate(id),
+    classification: {
+      kind: 'explicit-go-with',
+      distilledDecision: 'use X',
+      chosen: ['X'],
+      rejected: ['Y'],
+      rationale: 'X is simpler',
+      confidence: 0.9,
+      actionable: true,
+    },
+    outcomeRef: { sessionId: 'sessA', compositeScore: 0.8, binaryClass: 'good' },
+    trustCalibration: { acceptedAssistant: true, landed: true },
+  };
+}
+
+describe('resetDecisionsFile', () => {
+  it('strips classification + trustCalibration but preserves candidate + outcomeRef', () => {
+    const file: DecisionsFile = {
+      generatedAt: 1000,
+      decisionHeuristicVersion: 2,
+      decisions: [
+        classifiedRow('dec_1'),
+        { candidate: candidate('dec_2', 'sessB'), classification: null, outcomeRef: null },
+      ],
+      scannedSessionIds: ['sessA', 'sessB'],
+    };
+    const out = resetDecisionsFile(file, 5000);
+
+    expect(out.generatedAt).toBe(5000);
+    expect(out.decisionHeuristicVersion).toBe(2);
+    expect(out.scannedSessionIds).toEqual(['sessA', 'sessB']);
+    expect(out.decisions).toHaveLength(2);
+
+    const [r1, r2] = out.decisions;
+    expect(r1?.classification).toBeNull();
+    expect(r1?.candidate.id).toBe('dec_1');
+    expect(r1?.candidate.precedingAssistantExcerpt).toBe('I recommend X');
+    expect(r1?.outcomeRef).toEqual({
+      sessionId: 'sessA',
+      compositeScore: 0.8,
+      binaryClass: 'good',
+    });
+    expect(r1?.trustCalibration).toBeUndefined();
+    expect(r2?.classification).toBeNull();
+  });
+});
+
+describe('isDecisionSidecar', () => {
+  it('matches the skill-output sidecars', () => {
+    expect(isDecisionSidecar('decision-clusters.json')).toBe(true);
+    expect(isDecisionSidecar('decision-status-abc-123.json')).toBe(true);
+    expect(isDecisionSidecar('decisions.json.tmp.req9')).toBe(true);
+  });
+
+  it('does NOT match decisions.json itself (rewritten, not deleted)', () => {
+    expect(isDecisionSidecar('decisions.json')).toBe(false);
+  });
+
+  it('does NOT match unrelated or corrections files', () => {
+    expect(isDecisionSidecar('corrections.json')).toBe(false);
+    expect(isDecisionSidecar('decision-candidates.json')).toBe(false);
+    expect(isDecisionSidecar('narratives.json')).toBe(false);
+  });
+
+  it('rejects names with path separators or empty names', () => {
+    // readdir only yields flat entries, but reject separators defensively
+    // (matches the corrections isMiningArtifact guard).
+    expect(isDecisionSidecar('../decisions.json.tmp.x')).toBe(false);
+    expect(isDecisionSidecar('sub/decision-clusters.json')).toBe(false);
+    expect(isDecisionSidecar('sub\\decision-clusters.json')).toBe(false);
+    expect(isDecisionSidecar('')).toBe(false);
+  });
+});

--- a/packages/analysis/src/detectDecisions.test.ts
+++ b/packages/analysis/src/detectDecisions.test.ts
@@ -293,3 +293,30 @@ describe('runLabelingFunction', () => {
     expect(hits).toEqual([]);
   });
 });
+
+describe('precedingAssistantExcerpt (v2 — trust-calibration input)', () => {
+  it('carries the prior assistant turn, trimmed', () => {
+    const out = detectDecisions([
+      turn(1, 'Decision: ship it', '  go with the SDK, it is simpler  '),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.precedingAssistantExcerpt).toBe('go with the SDK, it is simpler');
+  });
+
+  it('is null when there is no preceding assistant turn', () => {
+    const out = detectDecisions([turn(0, 'Decision: ship it', null)]);
+    expect(out[0]?.precedingAssistantExcerpt).toBeNull();
+  });
+
+  it('truncates a long preceding assistant turn to the window', () => {
+    const long = 'y'.repeat(900);
+    const out = detectDecisions([turn(1, 'Decision: ship it', long)]);
+    const got = out[0]?.precedingAssistantExcerpt ?? '';
+    expect(got.length).toBeLessThanOrEqual(500);
+    expect(got.endsWith('…')).toBe(true);
+  });
+
+  it('v2 bump: DECISION_HEURISTIC_VERSION is at least 2', () => {
+    expect(DECISION_HEURISTIC_VERSION).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/analysis/src/detectDecisions.ts
+++ b/packages/analysis/src/detectDecisions.ts
@@ -51,8 +51,14 @@ import type { DecisionCandidate, DecisionKind } from '@chat-arch/schema';
  * History:
  *   1 — initial release (explicit-marker, explicit-go-with, instead-of,
  *       alternative-block, imperative-choice)
+ *   2 — candidate gains `precedingAssistantExcerpt` (≤500-char excerpt
+ *       of the prior assistant turn) so the classifier can judge the
+ *       accept-vs-override axis of trust calibration. No LF ruleset
+ *       change, but the emitted candidate shape changed — bumping
+ *       forces a rescan so existing cache entries re-emit with the
+ *       new field populated.
  */
-export const DECISION_HEURISTIC_VERSION = 1;
+export const DECISION_HEURISTIC_VERSION = 2;
 
 /** Minimal turn shape — extracted from any source's transcript. */
 export interface DecisionTurnPair {
@@ -246,6 +252,13 @@ export function detectDecisions(
     if (hits.length === 0) continue;
 
     const surrounding = truncate(t.userText.trim(), CONTEXT_WINDOW);
+    // Prior assistant turn, truncated to the same window. Stored raw
+    // (assistant prose carries no harness envelope — wrappers live in
+    // user turns); the viewer unwraps user-side excerpts at display.
+    const precedingAssistantExcerpt =
+      t.precedingAssistantText === null
+        ? null
+        : truncate(t.precedingAssistantText.trim(), CONTEXT_WINDOW);
 
     for (const h of hits) {
       out.push({
@@ -258,6 +271,7 @@ export function detectDecisions(
           startOffset: h.startOffset,
         },
         surroundingContext: surrounding,
+        precedingAssistantExcerpt,
       });
     }
   }

--- a/packages/exporter/src/analysis/decisionsBuilder.test.ts
+++ b/packages/exporter/src/analysis/decisionsBuilder.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type {
   CompositeOutcomesFile,
+  DecisionsFile,
   SessionManifest,
   UnifiedSessionEntry,
 } from '@chat-arch/schema';
@@ -162,6 +163,67 @@ describe('buildDecisionsFile', () => {
     expect(second.scannedSessions).toBe(0);
     expect(second.reusedSessions).toBe(1);
     expect(second.totalCandidates).toBe(first.totalCandidates);
+  });
+
+  it('cache reuse: preserves skill-written classification + trustCalibration', async () => {
+    const outDir = path.join(tmpRoot, 'reuse-classified');
+    await mkdir(path.join(outDir, 'analysis'), { recursive: true });
+    await mkdir(path.join(outDir, 'transcripts'), { recursive: true });
+
+    const transcript = [
+      JSON.stringify({
+        type: 'user',
+        message: { role: 'user', content: "We've decided to use ripgrep." },
+      }),
+    ].join('\n');
+    const transcriptPath = path.join('transcripts', 'sess-c.jsonl');
+    await writeFile(path.join(outDir, transcriptPath), transcript, 'utf8');
+
+    const entry = makeEntry({ id: 'sess-c', transcriptPath, updatedAt: 50 });
+    const manifest: SessionManifest = {
+      schemaVersion: 4,
+      generatedAt: 0,
+      counts: { 'cli-direct': 1, 'cli-desktop': 0, cowork: 0, cloud: 0 },
+      sessions: [entry],
+    } as SessionManifest;
+
+    // First build emits the candidate with classification: null.
+    await buildDecisionsFile(manifest, { outDir, now: 100 });
+
+    // Simulate the /mine-decisions skill merging its results in.
+    const decPath = path.join(outDir, 'analysis', 'decisions.json');
+    const file = JSON.parse(await readFile(decPath, 'utf8')) as DecisionsFile;
+    const patched = {
+      ...file,
+      decisions: file.decisions.map((d, i) =>
+        i === 0
+          ? {
+              ...d,
+              classification: {
+                kind: 'explicit-go-with',
+                distilledDecision: 'use ripgrep',
+                chosen: ['ripgrep'],
+                rejected: ['grep'],
+                rationale: 'faster on large trees',
+                confidence: 0.9,
+                actionable: true,
+              },
+              trustCalibration: { acceptedAssistant: true, landed: true },
+            }
+          : d,
+      ),
+    };
+    await writeFile(decPath, JSON.stringify(patched), 'utf8');
+
+    // Rescan (unchanged session → reuse path).
+    const second = await buildDecisionsFile(manifest, { outDir, now: 200 });
+    expect(second.reusedSessions).toBe(1);
+
+    const after = JSON.parse(await readFile(decPath, 'utf8')) as DecisionsFile;
+    const row = after.decisions[0];
+    expect(row?.classification?.distilledDecision).toBe('use ripgrep');
+    expect(row?.classification?.rationale).toBe('faster on large trees');
+    expect(row?.trustCalibration).toEqual({ acceptedAssistant: true, landed: true });
   });
 
   it('missing-input-graceful: counts missing transcripts, still writes file', async () => {

--- a/packages/exporter/src/analysis/decisionsBuilder.ts
+++ b/packages/exporter/src/analysis/decisionsBuilder.ts
@@ -244,13 +244,19 @@ export async function buildDecisionsFile(
       // Cached decisions already carry their outcomeRef from the
       // prior run. If the composite-outcomes file has since changed
       // (e.g. weightsHash bumped), re-attach so the denormalized
-      // values stay current.
+      // values stay current. `classification` + `trustCalibration`
+      // are written by the `/mine-decisions` skill, NOT this builder —
+      // preserve them across the rescan so an unchanged session doesn't
+      // lose its mined results (the whole point of the cache reuse).
       for (const d of r.decisions) {
         const outcome = outcomesById?.get(d.candidate.sessionId);
         allDecisions.push({
           candidate: d.candidate,
           classification: d.classification,
           outcomeRef: outcome !== undefined ? compositeToOutcomeRef(outcome) : null,
+          ...(d.trustCalibration !== undefined && d.trustCalibration !== null
+            ? { trustCalibration: d.trustCalibration }
+            : {}),
         });
       }
     } else {

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -228,7 +228,14 @@ export interface RunAnalysisResult {
  * `attributedTo: 'deterministic'`; existing on-disk legacy rows still
  * read via `normalizeNarrativeRow`'s reader-side defaults.
  */
-export const EXPORTER_VERSION = '1.7.0';
+// 1.9.0 — decisions LLM pipeline goes live: the `/mine-decisions` skill
+// merges `classification` (now incl. `rationale`) + `trustCalibration`
+// into `decisions.json`, the candidate gains `precedingAssistantExcerpt`
+// (DECISION_HEURISTIC_VERSION 1→2, forces a rescan), and a new
+// `analysis/decision-clusters.json` sidecar holds recurring-decision
+// clusters. (1.8.0 is the concurrent UI-content / unwrapEnvelope release
+// on its own branch — this number is kept distinct to avoid a collision.)
+export const EXPORTER_VERSION = '1.9.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/cli/cluster-decisions-cli.test.ts
+++ b/packages/exporter/src/cli/cluster-decisions-cli.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDecisionClusters,
+  normalizeDecision,
+  parseArgs,
+  type ClassifiedDecisionInput,
+} from './cluster-decisions-cli.js';
+
+function unitVec(values: number[]): Float32Array {
+  let sq = 0;
+  for (const v of values) sq += v * v;
+  const n = Math.sqrt(sq) || 1;
+  return Float32Array.from(values.map((v) => v / n));
+}
+
+function dec(
+  id: string,
+  sessionId: string,
+  distilledDecision: string,
+  binaryClass: ClassifiedDecisionInput['binaryClass'] = null,
+  updatedAt?: number,
+): ClassifiedDecisionInput {
+  return {
+    id,
+    sessionId,
+    distilledDecision,
+    binaryClass,
+    ...(updatedAt !== undefined ? { updatedAt } : {}),
+  };
+}
+
+const OPTS = { clusterThreshold: 0.65, minOccurrences: 2, landedRateMinN: 2 };
+
+describe('normalizeDecision', () => {
+  it('lowercases, collapses whitespace, strips trailing punctuation', () => {
+    expect(normalizeDecision('Use  Ripgrep instead of grep.')).toBe(
+      'use ripgrep instead of grep',
+    );
+  });
+});
+
+describe('buildDecisionClusters', () => {
+  it('clusters near-identical decisions across sessions into one pattern', () => {
+    const decisions = [
+      dec('d1', 'sessA', 'use ripgrep instead of grep', 'good', 100),
+      dec('d2', 'sessB', 'switch from grep to ripgrep', 'bad', 300),
+    ];
+    const vectors = [unitVec([1, 0, 0]), unitVec([1, 0, 0])];
+    const out = buildDecisionClusters(decisions, vectors, OPTS);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.occurrenceCount).toBe(2);
+    expect(out[0]?.instanceIds).toEqual(expect.arrayContaining(['d1', 'd2']));
+    // Canonical = alphabetically-first distilled text (deterministic).
+    expect(out[0]?.canonicalDecision).toBe('switch from grep to ripgrep');
+    expect(out[0]?.id).toMatch(/^dpat_[0-9a-f]{12}$/);
+    expect(out[0]?.firstSeen).toBe(100);
+    expect(out[0]?.lastSeen).toBe(300);
+  });
+
+  it('drops clusters below the distinct-session floor', () => {
+    // Two identical vectors but SAME session → 1 distinct session < 2.
+    const decisions = [
+      dec('d1', 'sessA', 'use ripgrep', 'good'),
+      dec('d2', 'sessA', 'use ripgrep', 'good'),
+    ];
+    const vectors = [unitVec([1, 0, 0]), unitVec([1, 0, 0])];
+    expect(buildDecisionClusters(decisions, vectors, OPTS)).toHaveLength(0);
+  });
+
+  it('keeps distinct decisions in separate clusters (singletons dropped)', () => {
+    const decisions = [
+      dec('d1', 'sessA', 'use ripgrep'),
+      dec('d2', 'sessB', 'drop the staging server'),
+    ];
+    const vectors = [unitVec([1, 0, 0]), unitVec([0, 1, 0])];
+    // Orthogonal → two singleton clusters → both below min-occurrences.
+    expect(buildDecisionClusters(decisions, vectors, OPTS)).toHaveLength(0);
+  });
+
+  it('computes landedRate over non-neutral members when ≥ minN', () => {
+    const decisions = [
+      dec('d1', 'sessA', 'use ripgrep', 'good'),
+      dec('d2', 'sessB', 'use ripgrep', 'bad'),
+    ];
+    const vectors = [unitVec([1, 0, 0]), unitVec([1, 0, 0])];
+    const out = buildDecisionClusters(decisions, vectors, OPTS);
+    expect(out[0]?.landedRate).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns null landedRate when too few members have a joined outcome', () => {
+    const decisions = [
+      dec('d1', 'sessA', 'use ripgrep', 'good'),
+      dec('d2', 'sessB', 'use ripgrep', null), // unjoined
+    ];
+    const vectors = [unitVec([1, 0, 0]), unitVec([1, 0, 0])];
+    const out = buildDecisionClusters(decisions, vectors, OPTS);
+    expect(out[0]?.landedRate).toBeNull();
+  });
+
+  it('throws on a vectors/decisions length mismatch', () => {
+    expect(() =>
+      buildDecisionClusters([dec('d1', 'sessA', 'x')], [], OPTS),
+    ).toThrow(/length mismatch/);
+  });
+
+  it('returns [] for empty input', () => {
+    expect(buildDecisionClusters([], [], OPTS)).toEqual([]);
+  });
+});
+
+describe('parseArgs', () => {
+  it('requires --classified and --output', () => {
+    expect(() => parseArgs(['--classified', 'a.json'])).toThrow();
+    expect(() => parseArgs(['--output', 'o.json'])).toThrow();
+  });
+
+  it('applies decision-tuned defaults (min-occurrences 2)', () => {
+    const a = parseArgs(['--classified', 'a.json', '--output', 'o.json']);
+    expect(a.minOccurrences).toBe(2);
+    expect(a.clusterThreshold).toBeCloseTo(0.65, 5);
+  });
+
+  it('rejects an out-of-range cluster threshold', () => {
+    expect(() =>
+      parseArgs(['--classified', 'a.json', '--output', 'o.json', '--cluster-threshold', '2']),
+    ).toThrow(/cluster-threshold/);
+  });
+});

--- a/packages/exporter/src/cli/cluster-decisions-cli.ts
+++ b/packages/exporter/src/cli/cluster-decisions-cli.ts
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Clustering stage of the decision-mining pipeline: cluster classified
+ * decisions by semantic similarity of their `distilledDecision` text and
+ * emit a `DecisionClustersFile` (recurring decisions — the same call made
+ * across multiple sessions). Sibling of `cluster-corrections-cli.ts`;
+ * reuses the same `clusterByThreshold` single-linkage kernel + `embed`
+ * embedding helper, so a recurring decision surfaces the way a recurring
+ * correction pattern does.
+ *
+ * Cluster id stability: id = `dpat_` + sha256(normalized canonical).slice(12).
+ * Normalization = lowercase + collapse whitespace + strip trailing
+ * punctuation. Same drift-absorption tradeoff as the corrections CLI.
+ *
+ * Unlike corrections clustering there is no config cross-check
+ * (`alreadyEncoded`) — decisions aren't matched against the user's
+ * CLAUDE.md. The extra signal we DO carry is `landedRate`: the share of
+ * cluster members whose joined outcome was 'good'.
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { clusterByThreshold, sha256Hex } from '@chat-arch/analysis';
+import type { DecisionClustersFile, DecisionPattern } from '@chat-arch/schema';
+import { embed, DEFAULT_EMBEDDING_MODEL } from '../embeddings/index.js';
+
+/** One classified decision the skill hands to the clusterer. */
+export interface ClassifiedDecisionInput {
+  id: string;
+  distilledDecision: string;
+  sessionId: string;
+  /** Joined outcome bucket, or null when the decision has no outcomeRef. */
+  binaryClass: 'good' | 'bad' | 'neutral' | null;
+  /** Session updatedAt (ms) when known; used for firstSeen/lastSeen. */
+  updatedAt?: number;
+}
+
+interface ParsedArgs {
+  classified: string;
+  output: string;
+  clusterThreshold: number;
+  minOccurrences: number;
+  /** Min non-neutral members before a `landedRate` is reported (else null). */
+  landedRateMinN: number;
+  baseUrl?: string;
+  model: string;
+}
+
+const USAGE = `\
+cluster-decisions-cli
+  --classified <path>                 JSON { decisions: ClassifiedDecisionInput[] }
+  --output <path>                     DecisionClustersFile JSON
+  [--cluster-threshold <0..1>=0.65]
+  [--min-occurrences <N>=2]           distinct sessions for a cluster to count
+  [--landed-rate-min-n <N>=2]
+  [--base-url <url>=http://localhost:11434]
+  [--model <name>=mxbai-embed-large]
+`;
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  let classified: string | undefined;
+  let output: string | undefined;
+  // 0.65 mirrors the corrections clusterer — calibrated against
+  // mxbai-embed-large rule-similarity (same-rule paraphrases cluster,
+  // distinct rules don't). Tune via flag for other models.
+  let clusterThreshold = 0.65;
+  // A recurring decision needs >=2 distinct sessions — a one-session
+  // cluster isn't "recurring". (Corrections uses 3; decisions are rarer
+  // per session, so 2 is the floor.)
+  let minOccurrences = 2;
+  let landedRateMinN = 2;
+  let baseUrl: string | undefined;
+  let model = DEFAULT_EMBEDDING_MODEL;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (next === undefined) break;
+    if (a === '--classified') {
+      classified = next;
+      i += 1;
+    } else if (a === '--output') {
+      output = next;
+      i += 1;
+    } else if (a === '--cluster-threshold') {
+      clusterThreshold = Number(next);
+      i += 1;
+    } else if (a === '--min-occurrences') {
+      minOccurrences = Number(next);
+      i += 1;
+    } else if (a === '--landed-rate-min-n') {
+      landedRateMinN = Number(next);
+      i += 1;
+    } else if (a === '--base-url') {
+      baseUrl = next;
+      i += 1;
+    } else if (a === '--model') {
+      model = next;
+      i += 1;
+    }
+  }
+
+  if (!classified || !output) throw new Error(USAGE);
+  if (!Number.isFinite(clusterThreshold) || clusterThreshold < 0 || clusterThreshold > 1) {
+    throw new Error('--cluster-threshold must be a number in [0, 1]');
+  }
+  if (!Number.isInteger(minOccurrences) || minOccurrences < 1) {
+    throw new Error('--min-occurrences must be a positive integer');
+  }
+  if (!Number.isInteger(landedRateMinN) || landedRateMinN < 1) {
+    throw new Error('--landed-rate-min-n must be a positive integer');
+  }
+
+  return {
+    classified,
+    output,
+    clusterThreshold,
+    minOccurrences,
+    landedRateMinN,
+    model,
+    ...(baseUrl !== undefined ? { baseUrl } : {}),
+  };
+}
+
+/** Lowercase, collapse whitespace, strip trailing punctuation (for hashing). */
+export function normalizeDecision(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, ' ').trim().replace(/[\s.,;:!?]+$/u, '');
+}
+
+export interface BuildDecisionClustersOptions {
+  clusterThreshold: number;
+  minOccurrences: number;
+  landedRateMinN: number;
+}
+
+/**
+ * Pure inner builder. Takes the classified decisions + their embedded
+ * `distilledDecision` vectors (index-aligned), returns sorted
+ * `DecisionPattern[]`. Exposed for unit testing without Ollama.
+ */
+export function buildDecisionClusters(
+  decisions: readonly ClassifiedDecisionInput[],
+  vectors: readonly Float32Array[],
+  opts: BuildDecisionClustersOptions,
+): DecisionPattern[] {
+  if (decisions.length === 0) return [];
+  if (decisions.length !== vectors.length) {
+    throw new Error(
+      `buildDecisionClusters: decisions (${decisions.length}) and vectors (${vectors.length}) length mismatch`,
+    );
+  }
+
+  const assignments = clusterByThreshold(vectors, opts.clusterThreshold);
+  const clusterCount = assignments.length === 0 ? 0 : Math.max(...assignments) + 1;
+
+  const patterns: DecisionPattern[] = [];
+  for (let cid = 0; cid < clusterCount; cid += 1) {
+    const memberIdx: number[] = [];
+    for (let i = 0; i < assignments.length; i += 1) {
+      if (assignments[i] === cid) memberIdx.push(i);
+    }
+    if (memberIdx.length === 0) continue;
+
+    const members = memberIdx.map((i) => decisions[i] as ClassifiedDecisionInput);
+    const distinctSessions = new Set(members.map((m) => m.sessionId));
+    if (distinctSessions.size < opts.minOccurrences) continue;
+
+    // Canonical = alphabetically-first distilled text — deterministic and
+    // stable across runs (no confidence field on the cluster input).
+    const canonicalDecision = [...members]
+      .map((m) => m.distilledDecision)
+      .sort((a, b) => a.localeCompare(b))[0] as string;
+    const id = `dpat_${sha256Hex(normalizeDecision(canonicalDecision)).slice(0, 12)}`;
+
+    // landedRate over members with a non-neutral joined outcome.
+    const decided = members.filter(
+      (m) => m.binaryClass === 'good' || m.binaryClass === 'bad',
+    );
+    const landed = decided.filter((m) => m.binaryClass === 'good').length;
+    const landedRate =
+      decided.length >= opts.landedRateMinN ? landed / decided.length : null;
+
+    // firstSeen/lastSeen from updatedAt where known, else 0 (placeholder,
+    // same convention as the corrections clusterer).
+    const stamps = members
+      .map((m) => m.updatedAt)
+      .filter((t): t is number => typeof t === 'number');
+    const firstSeen = stamps.length > 0 ? Math.min(...stamps) : 0;
+    const lastSeen = stamps.length > 0 ? Math.max(...stamps) : 0;
+
+    patterns.push({
+      id,
+      canonicalDecision,
+      instanceIds: members.map((m) => m.id),
+      occurrenceCount: distinctSessions.size,
+      firstSeen,
+      lastSeen,
+      landedRate,
+    });
+  }
+
+  // Most-recurring first; tiebreak by landedRate desc (nulls last), then id.
+  patterns.sort((a, b) => {
+    if (b.occurrenceCount !== a.occurrenceCount) return b.occurrenceCount - a.occurrenceCount;
+    const ra = a.landedRate ?? -1;
+    const rb = b.landedRate ?? -1;
+    if (rb !== ra) return rb - ra;
+    return a.id.localeCompare(b.id);
+  });
+  return patterns;
+}
+
+interface ClassifiedFile {
+  decisions?: readonly ClassifiedDecisionInput[];
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+
+  const raw = await readFile(args.classified, 'utf8');
+  const parsed = JSON.parse(raw) as ClassifiedFile;
+  const decisions = (parsed.decisions ?? []).filter(
+    (d) => typeof d.distilledDecision === 'string' && d.distilledDecision.trim().length > 0,
+  );
+
+  let patterns: DecisionPattern[] = [];
+  if (decisions.length > 0) {
+    const texts = decisions.map((d) => d.distilledDecision);
+    const embedOpts: { model: string; baseUrl?: string } = { model: args.model };
+    if (args.baseUrl !== undefined) embedOpts.baseUrl = args.baseUrl;
+    const vectors = await embed(texts, embedOpts);
+    patterns = buildDecisionClusters(decisions, vectors, {
+      clusterThreshold: args.clusterThreshold,
+      minOccurrences: args.minOccurrences,
+      landedRateMinN: args.landedRateMinN,
+    });
+  }
+
+  const out: DecisionClustersFile = { generatedAt: Date.now(), clusters: patterns };
+  await mkdir(path.dirname(args.output), { recursive: true });
+  await writeFile(args.output, JSON.stringify(out, null, 2) + '\n', 'utf8');
+}
+
+const entry = process.argv[1];
+if (entry !== undefined && import.meta.url === pathToFileURL(entry).href) {
+  main().catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`cluster-decisions-cli: ${msg}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/exporter/test/migration/v1.1.0-fixture.test.ts
+++ b/packages/exporter/test/migration/v1.1.0-fixture.test.ts
@@ -41,7 +41,7 @@ import type {
   CorrectionsFile,
   SessionManifest,
 } from '@chat-arch/schema';
-import { runAnalysis } from '../../src/analysis/index.js';
+import { runAnalysis, EXPORTER_VERSION } from '../../src/analysis/index.js';
 import { runSemanticAnalysis } from '../../src/analysis/semanticAnalysis.js';
 import { logger } from '../../src/lib/logger.js';
 
@@ -159,7 +159,10 @@ describe('migration v1.1.0 → 1.2.0', () => {
       tiers: { browser: { files: readonly string[] } };
       counts: Record<string, unknown>;
     }>(path.join(tmpDataDir, 'analysis', 'meta.json'));
-    expect(meta.exporterVersion).toBe('1.7.0');
+    // Assert against the constant, not a literal — the migration writes
+    // whatever EXPORTER_VERSION currently says, so a version bump should
+    // not break this test.
+    expect(meta.exporterVersion).toBe(EXPORTER_VERSION);
 
     // The Wave-5 sidecars (+ feed-redesign Phase A surprises.json)
     // must all be registered in the browser tier.

--- a/packages/schema/src/decision.ts
+++ b/packages/schema/src/decision.ts
@@ -65,6 +65,17 @@ export interface DecisionCandidate {
    * LLM classification stage and the audit script for hand-labeling.
    */
   surroundingContext: string;
+  /**
+   * ≤500-char excerpt of the assistant turn immediately preceding this
+   * user turn, harness-envelope-stripped. `null` when this is the first
+   * user turn (no prior assistant text). The classifier reads it to
+   * judge whether the user TOOK the assistant's recommendation
+   * (accept) or went a different way (override) — the
+   * `acceptedAssistant` axis of the trust-calibration 2×2. Older
+   * `decisions.json` files written before this field may omit it; the
+   * builder treats a missing value as `null`.
+   */
+  precedingAssistantExcerpt: string | null;
 }
 
 /**
@@ -118,6 +129,14 @@ export interface DecisionClassification {
    * it" with no enumerated alternatives).
    */
   rejected: readonly string[];
+  /**
+   * Short prose (≤200 chars) on WHY the user made this choice, in the
+   * user's framing — surfaced in the UI so the decision reads as a
+   * narrative ("chose X because Y"), not just a labeled span. Empty
+   * string when the rationale isn't evident from the surrounding
+   * context.
+   */
+  rationale: string;
   /** 0..1, classifier-reported. */
   confidence: number;
   /**
@@ -186,4 +205,51 @@ export interface DecisionsFile {
    * (cache hit) from "newly added session" (scan needed).
    */
   scannedSessionIds: readonly string[];
+}
+
+/**
+ * A cluster of recurring decisions — the same kind of choice made
+ * across multiple sessions, grouped by semantic similarity of the
+ * `classification.distilledDecision` text. Produced by the
+ * `/mine-decisions` skill's clustering stage (Ollama embeddings +
+ * the shared analysis clustering kernel), NOT the exporter. Lets the
+ * viewer surface "you keep making this call" patterns the way the
+ * corrections pipeline surfaces recurring correction patterns.
+ */
+export interface DecisionPattern {
+  /** Stable hash-derived id (`dpat_<12 hex>` from the canonical text). */
+  id: string;
+  /**
+   * Cluster-representative decision statement, imperative voice. The
+   * medoid `distilledDecision` of the member decisions.
+   */
+  canonicalDecision: string;
+  /**
+   * Member decision ids — `DecisionCandidate.id` values of every
+   * decision in this cluster. ≥2 (a cluster of one isn't recurring).
+   */
+  instanceIds: readonly string[];
+  /** Distinct sessions the members span. */
+  occurrenceCount: number;
+  /** Earliest / latest member `outcomeRef`-bearing session timestamp (ms). */
+  firstSeen: number;
+  lastSeen: number;
+  /**
+   * Share of members whose joined outcome was 'good', over members
+   * with a non-neutral joined outcome. `null` when too few members
+   * have a joined outcome to be informative (mirrors the per-kind
+   * landed-rate display floor). Aggregate, not per-session.
+   */
+  landedRate: number | null;
+}
+
+/**
+ * The persisted file shape under `analysis/decision-clusters.json`.
+ * Skill-only writer (the exporter never touches it), so it survives
+ * the exporter's full rewrite of `decisions.json`. The viewer reads
+ * it to render the "recurring decisions" section.
+ */
+export interface DecisionClustersFile {
+  generatedAt: number;
+  clusters: readonly DecisionPattern[];
 }


### PR DESCRIPTION
## What

Implements the **DECISIONS LLM classification pipeline** (previously a stub that returned "not yet implemented"). This is **PR1 of 2** — the data layer. PR2 redesigns the DECISIONS/TRUST UI to render this output and fix the page's confusion.

Motivation: the DECISIONS page reads as "overwhelming and confusing — not clear what to do or why" because it shows raw heuristic detector output fronted by a broken MINE button. This PR makes MINE real.

## Changes

- **schema**: `DecisionClassification.rationale` (the "why") + `DecisionCandidate.precedingAssistantExcerpt` (feeds trust-calibration accept/override) + `DecisionPattern`/`DecisionClustersFile`.
- **detector** (`detectDecisions`): `DECISION_HEURISTIC_VERSION` 1→2, emits `precedingAssistantExcerpt` (cache self-invalidates → rescan).
- **builder**: preserves `classification` + `trustCalibration` across cache reuse (was silently dropping calibration).
- **skill** (`/mine-decisions`): real pipeline mirroring `/mine-corrections` — Haiku classify → trust cell → Ollama-gated clustering → CAS-merge into `decisions.json` → status file.
- **`cluster-decisions-cli`**: reuses the shared `clusterByThreshold` kernel over `distilledDecision`; writes `decision-clusters.json`.
- **endpoint**: success now validated via status-file/`generatedAt` probe (was bare exit code).
- **`/api/clear-decisions`**: resets classification, **preserves candidates** (so re-mining doesn't need a re-export).
- **`EXPORTER_VERSION` 1.7.0 → 1.9.0** + CHANGELOG + CLAUDE.md.

### Version note
`1.8.0` is reserved for the concurrent `unwrapEnvelope`/UI-content work on its own branch; this is `1.9.0` to avoid a collision. The `1.8.0 → 1.9.0` ordering is nominal, not a dependency.

## Verification
`pnpm lint` + `pnpm test` (all packages) + `pnpm build` green. New tests: detector `precedingAssistantExcerpt`, builder reuse preserves classification/trustCalibration, `cluster-decisions-cli` clustering/landedRate, `clear-decisions` reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)