### PR TITLE
fix: TrendsMode empty sparklines + chat-answer inactivity timeout (#121, #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,34 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+Bounded bug fixes (PR #124). `main` is now at 1.9.0; 1.10.0 is reserved
+for the pending #113 version reconcile, so no `EXPORTER_VERSION` number is
+assigned here yet — assign the next free number at merge time. The
+`skill-curves.json` shape change below is purely additive (older bundles
+simply lack the field; the viewer falls back to an empty sparkline), so
+deferring the number is safe.
+
+### Fixed
+
+- **TrendsMode skill-curve sparklines rendered empty.** The
+  `analyzeSkillCurves` kernel computed the per-week `points` but dropped
+  them from `SkillCurveResult`, so the viewer hard-coded an empty series
+  and every sparkline collapsed to the placeholder. `SkillCurveResult`
+  now carries `points: readonly SkillCurvePoint[]` (echoed from the
+  input series, including for `Insufficient`/filtered rows), and
+  `TrendsMode` derives the sparkline from it (guarded `?? []` so a
+  pre-fix `skill-curves.json` still loads). **On-disk shape change:**
+  `analysis/skill-curves.json` `results[]` now each include a `points`
+  array. Additive — older files without it still load. (#121)
+- **`chat-answer` inactivity watchdog killed legitimate multi-agent
+  runs.** The 120s no-events timeout aborted a `claude -p` turn whenever
+  the parent process was event-quiet during a long sub-agent `Task`
+  (which is normal). The watchdog now also re-arms on any raw
+  stdout/stderr chunk from the child (process liveness, not just parsed
+  events) via a `keepAlive` callback, and the grace is raised 120s → 5m
+  — still well under the 10-minute hard cap that backstops a genuinely
+  stuck agent. (#123)
+
 ## [1.9.0] — 2026-05-29
 
 Decisions LLM pipeline — the DECISIONS surface goes from a raw

--- a/apps/standalone/src/pages/api/chat-answer.ts
+++ b/apps/standalone/src/pages/api/chat-answer.ts
@@ -67,9 +67,18 @@ const MAX_CONCURRENT = 3;
 // the grace window — a real silent-abort signal. An agentic flow that
 // dispatches sub-agents legitimately runs for minutes; what we care
 // about is "did the agent stop producing output?", not "is the total
-// duration too long." So this resets on every successful send. The
-// hard cap below catches genuine runaway cases.
-const INACTIVITY_GRACE_MS = 120_000;
+// duration too long." So this resets on every successful send AND on
+// any raw stdout/stderr chunk from the child (see ctx.keepAlive) — a
+// sub-agent fan-out that's silent on parsed events but still producing
+// process output keeps the stream alive. The hard cap below catches
+// genuine runaway cases.
+//
+// Sized at 5 minutes (was 2): a single Task sub-agent can run several
+// minutes producing no parent-visible events, and 120s truncated those
+// legitimate runs. 5 min still trips well before the 10-min hard cap
+// for an agent that goes truly silent early (e.g. blocked on a headless
+// permission prompt).
+const INACTIVITY_GRACE_MS = 300_000;
 // Hard upper bound on a single turn, regardless of activity. Sized for
 // fan-out questions that legitimately spawn 2-3 sub-agents each doing
 // minutes of corpus work. Past this, we declare the turn lost — most
@@ -251,6 +260,12 @@ function summarizeToolUse(name: string, input: unknown): string {
 
 interface SpawnContext {
   send: (ev: ChatStreamEvent) => void;
+  /**
+   * Re-arm the inactivity watchdog without emitting an event. Called on
+   * every raw stdout/stderr chunk so process liveness — not just parsed
+   * ChatStreamEvents — keeps a long, event-quiet sub-agent run alive.
+   */
+  keepAlive?: () => void;
   validator: CitationValidator;
   /** SIDs already emitted as `citation` events this turn. */
   emittedCitations: Set<string>;
@@ -433,6 +448,7 @@ function buildRequestBundle(body: ParsedBody, turnIndex: number): string {
 async function runChatAnswer(
   body: ParsedBody,
   send: (ev: ChatStreamEvent) => void,
+  keepAlive?: () => void,
 ): Promise<void> {
   const requestId = randomUUID();
   const startedAt = Date.now();
@@ -444,6 +460,7 @@ async function runChatAnswer(
   const validator = new CitationValidator();
   const ctx: SpawnContext = {
     send,
+    keepAlive,
     validator,
     emittedCitations: new Set<string>(),
     assistantBuf: { v: '' },
@@ -491,6 +508,9 @@ async function runChatAnswer(
     let spawnError: Error | null = null;
 
     child.stdout.on('data', (chunk: Buffer) => {
+      // Any byte from the child is liveness — re-arm the inactivity
+      // watchdog even if this chunk holds no complete/parseable event.
+      ctx.keepAlive?.();
       stdoutBuf += chunk.toString('utf8');
       // Process complete lines; keep the trailing partial in the buffer.
       const lines = stdoutBuf.split('\n');
@@ -518,6 +538,8 @@ async function runChatAnswer(
       }
     });
     child.stderr.on('data', (chunk: Buffer) => {
+      // Liveness too — stderr diagnostics mean the child is still working.
+      ctx.keepAlive?.();
       stderrBuf += chunk.toString('utf8');
       // stderr lines surface as collapsed thinking traces — they're
       // usually claude's own diagnostics, not user-facing errors.
@@ -618,9 +640,12 @@ export const POST: APIRoute = async ({ request }) => {
   totalInFlight += 1;
 
   // Two watchdogs:
-  //   - inactivityTimer: fires after INACTIVITY_GRACE_MS of no events.
-  //     Reset on every successful `send()` so an agent that's actively
-  //     emitting tool_use / token / trace events keeps the stream alive.
+  //   - inactivityTimer: fires after INACTIVITY_GRACE_MS of no output.
+  //     Reset on every successful `send()` AND on any raw stdout/stderr
+  //     chunk from the child (via the keepAlive callback passed to
+  //     runChatAnswer) so an agent that's actively working — even one
+  //     whose parent process is event-quiet during a sub-agent run —
+  //     keeps the stream alive.
   //   - hardCapTimer: absolute upper bound — fires even if events flow,
   //     to catch a stuck loop that's emitting noise but making no
   //     progress on the actual answer.
@@ -672,7 +697,10 @@ export const POST: APIRoute = async ({ request }) => {
       }, HARD_CAP_MS);
 
       try {
-        await runChatAnswer(body, send);
+        // keepAlive re-arms the inactivity watchdog on raw child output
+        // (stdout/stderr chunks) without enqueuing a client event — so a
+        // long, event-quiet sub-agent run isn't killed at the grace mark.
+        await runChatAnswer(body, send, armInactivity);
       } finally {
         if (inactivityTimer) clearTimeout(inactivityTimer);
         if (hardCapTimer) clearTimeout(hardCapTimer);

--- a/packages/analysis/src/skillCurve.test.ts
+++ b/packages/analysis/src/skillCurve.test.ts
@@ -118,6 +118,38 @@ describe('analyzeSkillCurves', () => {
     expect(Number.isNaN(out[0]!.pValue)).toBe(true);
   });
 
+  it('carries the weekly points through to the result (both branches)', () => {
+    // Regression for the empty-sparkline bug: the builder computed the
+    // per-week points but the result dropped them, so the viewer always
+    // rendered an empty sparkline. The result must echo the input series.
+    const inFamily: SkillCurveSeries = {
+      topicId: 'in-family',
+      points: Array.from({ length: 8 }, (_, i) => ({
+        week: `W${i + 1}`,
+        askCount: 8 - i,
+        activeSessions: 10,
+      })),
+    };
+    const insufficient: SkillCurveSeries = {
+      topicId: 'too-short',
+      points: [
+        { week: 'W1', askCount: 3, activeSessions: 10 },
+        { week: 'W2', askCount: 2, activeSessions: 10 },
+      ], // < minWeeksPresent → Insufficient branch
+    };
+    const out = analyzeSkillCurves([inFamily, insufficient]);
+    const byId = new Map(out.map((r) => [r.topicId, r]));
+
+    const a = byId.get('in-family')!;
+    expect(a.classification).not.toBe('Insufficient');
+    expect(a.points.map((p) => p.askCount)).toEqual([8, 7, 6, 5, 4, 3, 2, 1]);
+
+    const b = byId.get('too-short')!;
+    expect(b.classification).toBe('Insufficient');
+    // Even filtered-out series keep their points so the UI can still draw them.
+    expect(b.points.map((p) => p.askCount)).toEqual([3, 2]);
+  });
+
   it('applies BH-FDR across the multi-topic family', () => {
     // Three series — two declining (real signal), one flat (no signal).
     const declining1: SkillCurveSeries = {

--- a/packages/analysis/src/skillCurve.ts
+++ b/packages/analysis/src/skillCurve.ts
@@ -76,6 +76,13 @@ export interface SkillCurveResult {
   readonly askPerActiveSession: number;
   /** Number of weeks present in the series (after filtering empty padding). */
   readonly weeksPresent: number;
+  /**
+   * The weekly series this result was computed from, preserved so the
+   * viewer can draw the sparkline. Carried verbatim from the input
+   * {@link SkillCurveSeries.points}; chronological order is the caller's
+   * responsibility. Empty for series that never had points.
+   */
+  readonly points: readonly SkillCurvePoint[];
 }
 
 export interface AnalyzeSkillCurvesOptions {
@@ -167,6 +174,7 @@ export function analyzeSkillCurves(
         pValueAdjusted: Number.NaN,
         askPerActiveSession: r.askPerActiveSession,
         weeksPresent: r.weeksPresent,
+        points: r.points,
       };
     }
     const mk = mkByTopic.get(r.topicId)!;
@@ -191,6 +199,7 @@ export function analyzeSkillCurves(
       pValueAdjusted: pAdj,
       askPerActiveSession: r.askPerActiveSession,
       weeksPresent: r.weeksPresent,
+      points: r.points,
     };
   });
 

--- a/packages/viewer/src/components/modes/TrendsMode.test.tsx
+++ b/packages/viewer/src/components/modes/TrendsMode.test.tsx
@@ -122,6 +122,11 @@ const skillCurves: SkillCurvesFile = {
       pValueAdjusted: 0.02,
       askPerActiveSession: 0.4,
       weeksPresent: 10,
+      points: [
+        { week: 'W1', askCount: 8, activeSessions: 20 },
+        { week: 'W2', askCount: 4, activeSessions: 20 },
+        { week: 'W3', askCount: 2, activeSessions: 20 },
+      ],
     },
     {
       topicId: 't2',
@@ -133,6 +138,10 @@ const skillCurves: SkillCurvesFile = {
       pValueAdjusted: 0.4,
       askPerActiveSession: 0.9,
       weeksPresent: 8,
+      points: [
+        { week: 'W1', askCount: 9, activeSessions: 10 },
+        { week: 'W2', askCount: 9, activeSessions: 10 },
+      ],
     },
   ],
 };

--- a/packages/viewer/src/components/modes/TrendsMode.tsx
+++ b/packages/viewer/src/components/modes/TrendsMode.tsx
@@ -620,12 +620,13 @@ function SkillCurvesSection({ skillCurves }: SkillCurvesSectionProps) {
             </header>
             <ul className="lcars-trends__skill-list" role="list">
               {rows.map((r) => {
-                const series: readonly number[] = []; // builder doesn't ship the points array
-                // back into SkillCurveResult — only the summary stats.
-                // The 0-length list collapses TinySpark into the empty
-                // placeholder, which is the honest rendering. A future
-                // builder pass can ship the points if we want
-                // per-topic sparklines.
+                // Per-week ask counts, now shipped on the result by the
+                // skill-curves builder. Guarded with `?? []` because a
+                // skill-curves.json emitted by a pre-fix exporter has no
+                // `points` field; that falls back to the empty placeholder,
+                // the prior behavior. Empty also when the topic truly had no
+                // points.
+                const series: readonly number[] = (r.points ?? []).map((p) => p.askCount);
                 return (
                   <li key={r.topicId} className="lcars-trends__skill-row">
                     <span


### PR DESCRIPTION
## Summary

Two bounded bug fixes off `main`, from the verified QA pass. Both reproduce on `main` (confirmed by reading the code there before branching).

Fixes #121 · Fixes #123

> **Note on the third bug:** #122 (mine-decisions clustering silently skips when Ollama is down) is **not** in this PR — its target file `packages/exporter/src/cli/cluster-decisions-cli.ts` does not exist on `main`; it only lives on the unmerged decisions branch (#116). That fix should land either on #116 or on a follow-up branch after #116 merges. A fourth originally-suspected bug ("knowledge-debt per-cluster confidence absent from the model") was **refuted** during verification — `KnowledgeDebtCluster` does carry `confidence`, so there is nothing to fix.

## Bug 1 — TrendsMode skill-curve sparklines render empty (#121)

`analyzeSkillCurves` computed the per-week `points` internally but dropped them from `SkillCurveResult`, so `TrendsMode` hard-coded `const series = []` and every sparkline collapsed to the placeholder.

- `SkillCurveResult` now carries `points: readonly SkillCurvePoint[]`, echoed from the input series in **both** result branches (in-family and `Insufficient`/filtered).
- `TrendsMode` derives the sparkline from `r.points` (guarded with `?? []` so a `skill-curves.json` emitted by a pre-fix exporter still loads — it falls back to the prior empty-placeholder behavior).
- **On-disk shape change (additive):** `analysis/skill-curves.json` `results[]` now each include a `points` array.

## Bug 3 — chat-answer inactivity watchdog kills legitimate multi-agent runs (#123)

The 120s "no events" timeout aborted a `claude -p` turn whenever the parent process was event-quiet during a long sub-agent `Task` — which is normal for fan-out questions.

- The watchdog now re-arms on **any** raw stdout/stderr chunk from the child (process liveness, not just parsed `ChatStreamEvent`s) via a `keepAlive` callback threaded into `runChatAnswer`.
- Grace raised 120s → 5m, still well under the 10-minute hard cap that backstops a genuinely stuck agent (e.g. blocked on a headless permission prompt).

## Versioning

**No `EXPORTER_VERSION` number assigned here, on purpose.** `main` is at 1.7.0 while in-flight PRs reserve 1.8.0 / 1.9.0 (and 1.10.0 is earmarked for their reconciliation), so any number planted here would collide or leapfrog once those merge. The `skill-curves.json` change is purely additive (older bundles simply lack the field; the viewer falls back gracefully), so deferring the number to merge-time reconciliation is safe. CHANGELOG entry added under `[Unreleased]`. **Assign the version when this lands relative to the other PRs.**

## Tests

- New regression in `skillCurve.test.ts`: asserts `points` flows through to the result in both branches.
- `TrendsMode.test.tsx` fixtures updated to include `points` (now required on the type).
- Full suite: `pnpm lint` ✓ · `pnpm test` (199 files, 0 failed) ✓ · `pnpm build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
