### PR TITLE
refactor: centralize data processing — selectors scaffold + Phase 1 (0+1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,38 @@ Per-package alternatives:
 - `pnpm --filter @chat-arch/standalone dev` to boot the dev server
   on port 4321 (via `pnpm dev` at root — Astro's default)
 
+## Data processing lives in selectors, not components
+
+A viewer component should be a thin renderer over a view-model. The
+`data → view-model` derivation belongs in ONE place, not inline in
+whichever component happens to use the data:
+
+- **Schema- or analysis-typed derivation → `packages/analysis/src/
+  selectors/`** (re-exported from `@chat-arch/analysis`). Pure,
+  deterministic, React-free; any "now" is a parameter, never
+  `Date.now()`. Naming: `group*`/`build*` (structured), `rank*`/`sort*`
+  (ordered), `count*` (scalar), `is*`/`*Fired` (boolean).
+- **Client-state-coupled derivation → `packages/viewer/src/selectors/`**
+  (localStorage cursors, `insightsAcks`, uploaded-ZIP merge). These
+  compose an analysis selector with client state.
+  `mergeAppliedImprovements` (`viewer/src/data/correctionsLoader.ts`) is
+  the canonical prototype.
+- **Never reimplement a stat.** `wilsonCI` / `ewma` / `cosineSimilarity`
+  / `THRESHOLDS` / `unwrapEnvelope` all live in `@chat-arch/analysis` —
+  selectors import them. (The old inline Wilson CI in `ChatArchViewer`
+  is exactly the dup this rule kills.)
+- **UI-only state stays in the component** (toggles, search text, the
+  active filter, `showAll`, archetype-selection).
+
+Enforcement: `scripts/lint-data-processing-in-components.mjs` (wired into
+the root `lint` as `lint:data-processing`) is a budget-based advisory
+guard mirroring `lint-thresholds-imports.mjs`. It flags in-component
+`.reduce`/`.sort`/`new Map`/`.flatMap` and hand-rolled-stat fingerprints
+in `viewer/src/components/**/*.tsx`. The budget
+(`DATA_PROCESSING_LINT_BUDGET`) starts at the pre-refactor baseline and
+ratchets DOWN each migration phase toward the irreducible UI-coupled
+floor.
+
 ## Shape of the workspace
 
 ```

--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
   "scripts": {
     "build": "node design-system/scripts/generate-tokens.mjs && pnpm -r --filter=\"./packages/*\" --filter=\"./apps/*\" build",
     "typecheck": "pnpm -r typecheck",
-    "lint": "pnpm -r lint && pnpm lint:causal-copy && pnpm lint:thresholds-imports && pnpm lint:fixture-pii",
+    "lint": "pnpm -r lint && pnpm lint:causal-copy && pnpm lint:thresholds-imports && pnpm lint:data-processing && pnpm lint:fixture-pii",
     "lint:causal-copy": "node scripts/lint-causal-copy.mjs",
     "lint:thresholds-imports": "node scripts/lint-thresholds-imports.mjs",
+    "lint:data-processing": "node scripts/lint-data-processing-in-components.mjs",
     "lint:fixture-pii": "node scripts/lint-fixture-pii.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/analysis/src/index.ts
+++ b/packages/analysis/src/index.ts
@@ -469,3 +469,9 @@ export {
 } from './correlationPermutation.js';
 
 export { unwrapEnvelope } from './unwrapEnvelope.js';
+
+// Selectors — `data → view-model` derivations (the "Centralize data
+// processing" plan). Re-exported from the package root so viewer
+// components import `{ buildX } from '@chat-arch/analysis'` exactly like
+// any other kernel. Populated phase by phase; empty in Phase 0.
+export * from './selectors/index.js';

--- a/packages/analysis/src/selectors/actionItems.test.ts
+++ b/packages/analysis/src/selectors/actionItems.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import type { KnowledgeDebtCluster } from '../detectKnowledgeDebt.js';
+import type { ItsResult, ItsSnapshot } from '../itsAnalysis.js';
+import { THRESHOLDS } from '../thresholds.js';
+import { rankTopActionItems } from './actionItems.js';
+
+const MIN_N = THRESHOLDS.display.minNForRate;
+
+function cluster(opts: {
+  canonicalQuestion: string;
+  confidence?: 'high' | 'low';
+  sessionIds?: readonly string[];
+}): KnowledgeDebtCluster {
+  return {
+    id: 'c',
+    canonicalQuestion: opts.canonicalQuestion,
+    labelTerms: [],
+    sessionIds: opts.sessionIds ?? ['s1', 's2'],
+    firstSeen: 0,
+    lastSeen: 0,
+    confidence: opts.confidence ?? 'low',
+  };
+}
+
+function snap(n: number): ItsSnapshot {
+  return { n, meanScore: 0.5, goodShare: 0.5, goodShareCI: { low: 0, high: 1 } };
+}
+
+function its(opts: {
+  subject?: string;
+  path?: string;
+  sha?: string;
+  preN?: number;
+  postN?: number;
+  deltaGoodShare: number;
+  deltaCI: { low: number; high: number };
+}): ItsResult {
+  return {
+    sha: opts.sha ?? 'abcdef1234',
+    ts: 0,
+    path: opts.path ?? 'CLAUDE.md',
+    subject: opts.subject ?? '',
+    windowDays: 10,
+    pre: snap(opts.preN ?? MIN_N),
+    post: snap(opts.postN ?? MIN_N),
+    deltaGoodShare: opts.deltaGoodShare,
+    deltaCI: opts.deltaCI,
+    pValue: 0.01,
+    qValue: 0.01,
+  };
+}
+
+describe('rankTopActionItems', () => {
+  it('null inputs yield no items', () => {
+    expect(rankTopActionItems({ knowledgeDebt: null, its: null })).toEqual([]);
+  });
+
+  it('empty clusters and empty its results yield no items', () => {
+    expect(
+      rankTopActionItems({ knowledgeDebt: { clusters: [] }, its: { results: [] } }),
+    ).toEqual([]);
+  });
+
+  it('emits a knowledge-debt headline for the top cluster', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: {
+        clusters: [cluster({ canonicalQuestion: 'how do I deploy?', sessionIds: ['a', 'b', 'c'] })],
+      },
+      its: null,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('knowledge-debt');
+    expect(out[0]!.headline).toBe('recurring question (3 sessions) — how do I deploy?');
+    expect(out[0]!.detail).toBe('confidence low');
+    expect(out[0]!.mode).toBe('insights');
+  });
+
+  it('skips slash-command clusters but keeps the next eligible one', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: {
+        clusters: [
+          cluster({ canonicalQuestion: '/shopsmith-menu', confidence: 'high', sessionIds: ['x', 'y', 'z', 'w'] }),
+          cluster({ canonicalQuestion: 'why is the build slow?', sessionIds: ['a', 'b'] }),
+        ],
+      },
+      its: null,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.headline).toContain('why is the build slow?');
+  });
+
+  it('ranks high-confidence cluster above a larger low-confidence one', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: {
+        clusters: [
+          cluster({ canonicalQuestion: 'low-conf big', confidence: 'low', sessionIds: ['1', '2', '3', '4', '5'] }),
+          cluster({ canonicalQuestion: 'high-conf small', confidence: 'high', sessionIds: ['a', 'b'] }),
+        ],
+      },
+      its: null,
+    });
+    expect(out[0]!.headline).toContain('high-conf small');
+  });
+
+  it('truncates long canonical questions to 77 chars + ellipsis', () => {
+    const long = 'q'.repeat(120);
+    const out = rankTopActionItems({
+      knowledgeDebt: { clusters: [cluster({ canonicalQuestion: long, sessionIds: ['a'] })] },
+      its: null,
+    });
+    expect(out[0]!.headline.endsWith('q'.repeat(77) + '…')).toBe(true);
+  });
+
+  it('drops ITS rows below the display floor', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: null,
+      its: {
+        results: [
+          its({ preN: MIN_N - 1, postN: MIN_N, deltaGoodShare: 0.5, deltaCI: { low: 0.1, high: 0.9 } }),
+        ],
+      },
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('drops ITS rows whose deltaCI straddles zero', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: null,
+      its: {
+        results: [its({ deltaGoodShare: 0.3, deltaCI: { low: -0.1, high: 0.5 } })],
+      },
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('emits the biggest |delta| disjoint-CI ITS contrast with pp + sha', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: null,
+      its: {
+        results: [
+          its({ subject: 'small', deltaGoodShare: 0.12, deltaCI: { low: 0.01, high: 0.2 }, sha: '1111111aaa' }),
+          its({ subject: 'big', deltaGoodShare: -0.4, deltaCI: { low: -0.6, high: -0.2 }, sha: '2222222bbb' }),
+        ],
+      },
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.kind).toBe('its');
+    expect(out[0]!.headline).toBe('big shifted good-share -40 pp');
+    expect(out[0]!.detail).toBe('commit 2222222');
+    expect(out[0]!.mode).toBe('insights');
+  });
+
+  it('falls back to path when subject is empty', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: null,
+      its: {
+        results: [its({ subject: '', path: '.claude/skills/x/SKILL.md', deltaGoodShare: 0.5, deltaCI: { low: 0.2, high: 0.8 } })],
+      },
+    });
+    expect(out[0]!.headline).toBe('.claude/skills/x/SKILL.md shifted good-share +50 pp');
+  });
+
+  it('emits both a debt and an its row when both qualify', () => {
+    const out = rankTopActionItems({
+      knowledgeDebt: { clusters: [cluster({ canonicalQuestion: 'q?', sessionIds: ['a'] })] },
+      its: { results: [its({ subject: 'big', deltaGoodShare: 0.5, deltaCI: { low: 0.2, high: 0.8 } })] },
+    });
+    expect(out.map((i) => i.kind)).toEqual(['knowledge-debt', 'its']);
+  });
+});

--- a/packages/analysis/src/selectors/actionItems.ts
+++ b/packages/analysis/src/selectors/actionItems.ts
@@ -1,0 +1,116 @@
+/**
+ * ACTION-ITEMS selector — the Top-K representative ranking behind the
+ * post-scan ActionItemsBanner, extracted VERBATIM from
+ * `ChatArchViewer.tsx` (Phase 1 of the "Centralize data processing"
+ * refactor).
+ *
+ * Two rankings, each contributing at most one row:
+ *   - the highest-confidence / largest knowledge-debt cluster, and
+ *   - the biggest |delta| disjoint-CI ITS contrast.
+ *
+ * Inline-Wilson note: the sibling `trustMisCalibrationFired` derivation
+ * in ChatArchViewer used to hand-roll a Wilson CI under a (false)
+ * "we don't want to depend on the analysis package here" comment. That
+ * is gone — the boolean now routes through `build2x2` + `isTrustMisCalibrated`
+ * from `./trust.js`, which call the shared `wilsonCI`. See `rankTopActionItems`
+ * here for the ranking half; the trust boolean lives with the trust selector.
+ *
+ * Pure / deterministic / React-free. `unwrapEnvelope` comes from analysis.
+ */
+
+import type { KnowledgeDebtCluster } from '../detectKnowledgeDebt.js';
+import type { ItsResult } from '../itsAnalysis.js';
+import { THRESHOLDS } from '../thresholds.js';
+import { unwrapEnvelope } from '../unwrapEnvelope.js';
+
+/**
+ * One representative row for the banner. The selector only ever emits
+ * `kind: 'knowledge-debt' | 'its'` with `mode: 'insights'`; the banner's
+ * own `TopItem` is structurally identical with wider unions (the banner
+ * also accepts decisions / trust kinds it builds elsewhere).
+ */
+export interface TopItem {
+  kind: 'knowledge-debt' | 'its';
+  /** Short readable headline rendered as the link text. */
+  headline: string;
+  /** Tooltip / sub-text. */
+  detail?: string;
+  /** Mode to navigate to on click. */
+  mode: 'insights';
+}
+
+/** Minimal knowledge-debt slice the ranking reads. */
+export interface ActionItemsKnowledgeDebt {
+  clusters: readonly KnowledgeDebtCluster[];
+}
+
+/** Minimal ITS slice the ranking reads. */
+export interface ActionItemsIts {
+  results: readonly ItsResult[];
+}
+
+/**
+ * Build the Top-K representatives (knowledge-debt headline + ITS contrast)
+ * exactly as ChatArchViewer's `topActionItems` useMemo did.
+ */
+export function rankTopActionItems(input: {
+  knowledgeDebt: ActionItemsKnowledgeDebt | null;
+  its: ActionItemsIts | null;
+}): TopItem[] {
+  const out: TopItem[] = [];
+  // Highest-confidence + largest knowledge-debt cluster.
+  const debt = input.knowledgeDebt;
+  if (debt !== null && debt.clusters.length > 0) {
+    // Strip harness wrappers from the canonical question and skip
+    // slash-command invocations (e.g. "/shopsmith-menu") — those are
+    // commands, not natural-language questions worth turning into a
+    // rule, and leaking the raw <command-message> envelope into the
+    // headline is exactly the noise this strip is meant to avoid.
+    const cleaned = [...debt.clusters]
+      .map((c) => ({ cluster: c, question: unwrapEnvelope(c.canonicalQuestion) }))
+      .filter(
+        (x): x is { cluster: (typeof debt.clusters)[number]; question: string } =>
+          x.question !== null && !x.question.trimStart().startsWith('/'),
+      );
+    const top = cleaned.sort((a, b) => {
+      const ca = a.cluster.confidence === 'high' ? 1 : 0;
+      const cb = b.cluster.confidence === 'high' ? 1 : 0;
+      if (ca !== cb) return cb - ca;
+      return b.cluster.sessionIds.length - a.cluster.sessionIds.length;
+    })[0];
+    if (top !== undefined) {
+      const q =
+        top.question.length > 80 ? top.question.slice(0, 77) + '…' : top.question;
+      out.push({
+        kind: 'knowledge-debt',
+        headline: `recurring question (${top.cluster.sessionIds.length} sessions) — ${q}`,
+        detail: `confidence ${top.cluster.confidence}`,
+        mode: 'insights',
+      });
+    }
+  }
+  // Biggest |delta| disjoint-CI ITS contrast.
+  const its = input.its;
+  if (its !== null) {
+    const clear = its.results
+      .filter(
+        (r) =>
+          r.pre.n >= THRESHOLDS.display.minNForRate &&
+          r.post.n >= THRESHOLDS.display.minNForRate &&
+          ((r.deltaCI.low > 0 && r.deltaCI.high > 0) ||
+            (r.deltaCI.low < 0 && r.deltaCI.high < 0)),
+      )
+      .sort((a, b) => Math.abs(b.deltaGoodShare) - Math.abs(a.deltaGoodShare));
+    const top = clear[0];
+    if (top !== undefined) {
+      const pp = Math.round(top.deltaGoodShare * 100);
+      out.push({
+        kind: 'its',
+        headline: `${top.subject || top.path} shifted good-share ${pp >= 0 ? '+' : ''}${pp} pp`,
+        detail: `commit ${top.sha.slice(0, 7)}`,
+        mode: 'insights',
+      });
+    }
+  }
+  return out;
+}

--- a/packages/analysis/src/selectors/decisions.test.ts
+++ b/packages/analysis/src/selectors/decisions.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  Decision,
+  DecisionClassification,
+  DecisionOutcomeRef,
+} from '@chat-arch/schema';
+import {
+  KIND_LABEL,
+  groupDecisionsByKind,
+  partitionDecisions,
+} from './decisions.js';
+
+function classification(
+  kind: DecisionClassification['kind'],
+): DecisionClassification {
+  return {
+    kind,
+    distilledDecision: 'd',
+    chosen: ['a'],
+    rejected: [],
+    rationale: '',
+    confidence: 1,
+    actionable: true,
+  };
+}
+
+function outcomeRef(binaryClass: DecisionOutcomeRef['binaryClass']): DecisionOutcomeRef {
+  return { sessionId: 's', compositeScore: 0.5, binaryClass };
+}
+
+let seq = 0;
+function decision(opts: {
+  classification?: DecisionClassification | null;
+  outcomeRef?: DecisionOutcomeRef | null;
+}): Decision {
+  seq += 1;
+  return {
+    candidate: {
+      id: `id-${seq}`,
+      sessionId: 's',
+      userTurnIndex: seq,
+      kind: 'imperative-choice',
+      span: { phrase: 'p', startOffset: 0 },
+      surroundingContext: '',
+      precedingAssistantExcerpt: null,
+    },
+    classification: opts.classification ?? null,
+    outcomeRef: opts.outcomeRef ?? null,
+  };
+}
+
+describe('partitionDecisions', () => {
+  it('empty input yields empty buckets', () => {
+    expect(partitionDecisions([])).toEqual({ classified: [], unclassified: [] });
+  });
+
+  it('splits on classification === null', () => {
+    const c = decision({ classification: classification('tool-pivot') });
+    const u = decision({});
+    const { classified, unclassified } = partitionDecisions([c, u]);
+    expect(classified).toEqual([c]);
+    expect(unclassified).toEqual([u]);
+  });
+});
+
+describe('groupDecisionsByKind', () => {
+  it('empty input yields no groups', () => {
+    expect(groupDecisionsByKind([])).toEqual([]);
+  });
+
+  it('falls back to upper-cased key for unknown kinds and null classification → other', () => {
+    // classification null → key 'other' via the ?? 'other' branch.
+    const groups = groupDecisionsByKind([decision({})]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.key).toBe('other');
+    expect(groups[0]!.label).toBe(KIND_LABEL.other);
+  });
+
+  it('counts denom only over non-neutral outcomes and landed over good', () => {
+    const groups = groupDecisionsByKind([
+      decision({ classification: classification('tool-pivot'), outcomeRef: outcomeRef('good') }),
+      decision({ classification: classification('tool-pivot'), outcomeRef: outcomeRef('bad') }),
+      decision({ classification: classification('tool-pivot'), outcomeRef: outcomeRef('neutral') }),
+      decision({ classification: classification('tool-pivot'), outcomeRef: null }),
+    ]);
+    expect(groups).toHaveLength(1);
+    const g = groups[0]!;
+    expect(g.rows).toHaveLength(4);
+    expect(g.denom).toBe(2); // good + bad, neutral + null excluded
+    expect(g.landed).toBe(1); // only good
+    expect(g.label).toBe(KIND_LABEL['tool-pivot']);
+  });
+
+  it('sorts by row-count desc, then label asc', () => {
+    const groups = groupDecisionsByKind([
+      decision({ classification: classification('scope-cut') }),
+      decision({ classification: classification('tool-pivot') }),
+      decision({ classification: classification('tool-pivot') }),
+    ]);
+    // tool-pivot (2 rows) before scope-cut (1 row)
+    expect(groups.map((g) => g.key)).toEqual(['tool-pivot', 'scope-cut']);
+  });
+
+  it('breaks count ties by label localeCompare', () => {
+    const groups = groupDecisionsByKind([
+      decision({ classification: classification('tool-pivot') }), // label TOOL PIVOT
+      decision({ classification: classification('scope-cut') }), // label SCOPE CUT
+    ]);
+    // tie on 1 row each → SCOPE CUT < TOOL PIVOT
+    expect(groups.map((g) => g.label)).toEqual([
+      KIND_LABEL['scope-cut'],
+      KIND_LABEL['tool-pivot'],
+    ]);
+  });
+});

--- a/packages/analysis/src/selectors/decisions.ts
+++ b/packages/analysis/src/selectors/decisions.ts
@@ -1,0 +1,88 @@
+/**
+ * DECISIONS selector — the `data → view-model` derivations behind the
+ * DECISIONS surface, extracted VERBATIM from `DecisionsMode.tsx`
+ * (Phase 1 of the "Centralize data processing" refactor).
+ *
+ * Two derivations live here:
+ *   - `partitionDecisions` — the classified / unclassified split.
+ *   - `groupDecisionsByKind` — group the classified rows by decision
+ *     kind with the per-group landed-rate denominator + landed count.
+ *
+ * Pure / deterministic / React-free. The component renders the returned
+ * `KindGroup[]` (and the partition) without doing any further derivation.
+ */
+
+import type { Decision } from '@chat-arch/schema';
+
+/**
+ * Human-readable label per decision kind, surfaced as the group header.
+ * Unknown kinds fall back to the upper-cased key (see `groupDecisionsByKind`).
+ */
+export const KIND_LABEL: Record<string, string> = {
+  'explicit-marker': 'EXPLICIT MARKER',
+  'explicit-go-with': 'GO-WITH',
+  'instead-of': 'INSTEAD-OF',
+  'alternative-block': 'ALTERNATIVE',
+  'imperative-choice': 'IMPERATIVE',
+  'tool-pivot': 'TOOL PIVOT',
+  'scope-cut': 'SCOPE CUT',
+  other: 'OTHER',
+};
+
+export interface KindGroup {
+  key: string;
+  label: string;
+  rows: Decision[];
+  /** outcomeRef present AND non-neutral — landed-rate denominator. */
+  denom: number;
+  landed: number;
+}
+
+/**
+ * Split the decisions file rows into classified (classification !== null)
+ * and unclassified (classification === null) buckets — the same partition
+ * DecisionsMode computed inline via two `.filter` passes.
+ */
+export function partitionDecisions(decisions: readonly Decision[]): {
+  classified: Decision[];
+  unclassified: Decision[];
+} {
+  return {
+    classified: decisions.filter((d) => d.classification !== null),
+    unclassified: decisions.filter((d) => d.classification === null),
+  };
+}
+
+export function groupDecisionsByKind(
+  classified: readonly Decision[],
+): KindGroup[] {
+  const m = new Map<string, Decision[]>();
+  for (const d of classified) {
+    const k = d.classification?.kind ?? 'other';
+    const arr = m.get(k);
+    if (arr) arr.push(d);
+    else m.set(k, [d]);
+  }
+  const out: KindGroup[] = [];
+  for (const [key, rows] of m) {
+    let denom = 0;
+    let landed = 0;
+    for (const r of rows) {
+      const ref = r.outcomeRef;
+      if (ref === null || ref.binaryClass === 'neutral') continue;
+      denom += 1;
+      if (ref.binaryClass === 'good') landed += 1;
+    }
+    out.push({
+      key,
+      label: KIND_LABEL[key] ?? key.toUpperCase(),
+      rows,
+      denom,
+      landed,
+    });
+  }
+  out.sort(
+    (a, b) => b.rows.length - a.rows.length || a.label.localeCompare(b.label),
+  );
+  return out;
+}

--- a/packages/analysis/src/selectors/index.ts
+++ b/packages/analysis/src/selectors/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Selectors — the single home for `data → view-model` derivations.
+ *
+ * Per the "Centralize data processing" plan: every transform whose input
+ * is schema- or analysis-typed lives here (NOT inline in a viewer
+ * component). Selectors are pure, deterministic, and React-free; any
+ * notion of "now" is a parameter, never `Date.now()`. They call the
+ * existing stats kernels (`wilsonCI`, `ewma`, …) — never reimplement a
+ * stat. View-model types are exported alongside their selector so
+ * components stop declaring `KindGroup` / `TrustTally` / `TopItem`
+ * locally.
+ *
+ * Naming convention:
+ *   - `group*` / `build*` → returns a structured value
+ *   - `rank*` / `sort*`   → returns an ordered value
+ *   - `count*`            → returns a scalar
+ *   - `is*` / `*Fired`    → returns a boolean
+ *
+ * Client-state-coupled selectors (localStorage cursors, `insightsAcks`,
+ * uploaded-ZIP merge) do NOT belong here — they live in
+ * `packages/viewer/src/selectors/` and compose an analysis selector with
+ * client state. See the plan's "Escape hatch" section.
+ *
+ * This barrel is populated phase by phase. Phase 0 ships it empty (no
+ * behavior change); Phase 1 onward fills it.
+ */
+
+export * from './trust.js';
+export * from './decisions.js';
+export * from './actionItems.js';

--- a/packages/analysis/src/selectors/trust.test.ts
+++ b/packages/analysis/src/selectors/trust.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  Decision,
+  DecisionClassification,
+  DecisionOutcomeRef,
+  DecisionTrustCalibration,
+} from '@chat-arch/schema';
+import { THRESHOLDS } from '../thresholds.js';
+import {
+  build2x2,
+  cisDisjoint,
+  deriveTrustSignal,
+  deriveTrustSignalExplicitOnly,
+  isTrustMisCalibrated,
+} from './trust.js';
+
+const MIN_N = THRESHOLDS.trustCell.minN;
+
+function classification(
+  kind: DecisionClassification['kind'],
+): DecisionClassification {
+  return {
+    kind,
+    distilledDecision: 'd',
+    chosen: ['a'],
+    rejected: [],
+    rationale: '',
+    confidence: 1,
+    actionable: true,
+  };
+}
+
+function outcomeRef(binaryClass: DecisionOutcomeRef['binaryClass']): DecisionOutcomeRef {
+  return { sessionId: 's', compositeScore: 0.5, binaryClass };
+}
+
+function decision(opts: {
+  trustCalibration?: DecisionTrustCalibration | null;
+  classification?: DecisionClassification | null;
+  outcomeRef?: DecisionOutcomeRef | null;
+}): Decision {
+  return {
+    candidate: {
+      id: 'id',
+      sessionId: 's',
+      userTurnIndex: 0,
+      kind: 'imperative-choice',
+      span: { phrase: 'p', startOffset: 0 },
+      surroundingContext: '',
+      precedingAssistantExcerpt: null,
+    },
+    classification: opts.classification ?? null,
+    outcomeRef: opts.outcomeRef ?? null,
+    ...(opts.trustCalibration !== undefined
+      ? { trustCalibration: opts.trustCalibration }
+      : {}),
+  };
+}
+
+/** N decisions with an explicit trustCalibration cell. */
+function tc(accepted: boolean, landed: boolean, n: number): Decision[] {
+  return Array.from({ length: n }, () =>
+    decision({ trustCalibration: { acceptedAssistant: accepted, landed } }),
+  );
+}
+
+describe('deriveTrustSignal', () => {
+  it('prefers the explicit trustCalibration field', () => {
+    expect(
+      deriveTrustSignal(decision({ trustCalibration: { acceptedAssistant: true, landed: false } })),
+    ).toEqual({ accepted: true, landed: false });
+  });
+
+  it('returns null when no signal path resolves (null classification + outcome)', () => {
+    expect(deriveTrustSignal(decision({}))).toBeNull();
+  });
+
+  it('returns null for a neutral fallback outcome', () => {
+    expect(
+      deriveTrustSignal(
+        decision({
+          classification: classification('alternative-block'),
+          outcomeRef: outcomeRef('neutral'),
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('fallback: alternative-block counts as accepted, good == landed', () => {
+    expect(
+      deriveTrustSignal(
+        decision({
+          classification: classification('alternative-block'),
+          outcomeRef: outcomeRef('good'),
+        }),
+      ),
+    ).toEqual({ accepted: true, landed: true });
+  });
+
+  it('fallback: imperative-choice counts as override (not accepted)', () => {
+    expect(
+      deriveTrustSignal(
+        decision({
+          classification: classification('imperative-choice'),
+          outcomeRef: outcomeRef('bad'),
+        }),
+      ),
+    ).toEqual({ accepted: false, landed: false });
+  });
+
+  it('fallback: other kinds (not alternative-block / imperative-choice) skip', () => {
+    expect(
+      deriveTrustSignal(
+        decision({
+          classification: classification('tool-pivot'),
+          outcomeRef: outcomeRef('good'),
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('deriveTrustSignalExplicitOnly', () => {
+  it('returns the explicit trustCalibration signal when present', () => {
+    expect(
+      deriveTrustSignalExplicitOnly(
+        decision({ trustCalibration: { acceptedAssistant: false, landed: true } }),
+      ),
+    ).toEqual({ accepted: false, landed: true });
+  });
+
+  it('returns null when trustCalibration is absent — NO fallback (unlike deriveTrustSignal)', () => {
+    // A decision that deriveTrustSignal WOULD resolve via the fallback path…
+    const d = decision({
+      classification: classification('alternative-block'),
+      outcomeRef: outcomeRef('good'),
+    });
+    expect(deriveTrustSignal(d)).toEqual({ accepted: true, landed: true });
+    // …explicit-only ignores it (preserves the banner's pre-centralization count).
+    expect(deriveTrustSignalExplicitOnly(d)).toBeNull();
+  });
+
+  it('build2x2 with explicit-only derive excludes fallback rows', () => {
+    const decisions = [
+      ...tc(true, true, 2),
+      // fallback-resolvable rows that explicit-only must ignore:
+      decision({ classification: classification('alternative-block'), outcomeRef: outcomeRef('good') }),
+      decision({ classification: classification('imperative-choice'), outcomeRef: outcomeRef('bad') }),
+    ];
+    const withFallback = build2x2(decisions);
+    const explicitOnly = build2x2(decisions, deriveTrustSignalExplicitOnly);
+    expect(withFallback.totalUsable).toBe(4);
+    expect(explicitOnly.totalUsable).toBe(2);
+  });
+});
+
+describe('build2x2', () => {
+  it('empty input yields zeroed cells and totalUsable 0', () => {
+    const t = build2x2([]);
+    expect(t.totalUsable).toBe(0);
+    expect(t.cells['accept-land'].n).toBe(0);
+    expect(t.acceptRow.total).toBe(0);
+    expect(t.acceptRow.pHat).toBe(0);
+    expect(t.acceptRow.meetsCellN).toBe(false);
+    // wilsonCI(0,0) => [0,1]
+    expect(t.acceptRow.ci).toEqual({ low: 0, high: 1 });
+  });
+
+  it('skips null-signal decisions but counts usable ones', () => {
+    const t = build2x2([
+      decision({}), // null signal — skipped
+      ...tc(true, true, 1),
+      ...tc(false, false, 1),
+    ]);
+    expect(t.totalUsable).toBe(2);
+    expect(t.cells['accept-land'].n).toBe(1);
+    expect(t.cells['override-noland'].n).toBe(1);
+  });
+
+  it('computes per-row pHat and meetsCellN against minN', () => {
+    const t = build2x2([
+      ...tc(true, true, MIN_N),
+      ...tc(true, false, MIN_N),
+      ...tc(false, true, 1),
+      ...tc(false, false, 1),
+    ]);
+    expect(t.acceptRow.total).toBe(MIN_N * 2);
+    expect(t.acceptRow.landed).toBe(MIN_N);
+    expect(t.acceptRow.pHat).toBeCloseTo(0.5, 10);
+    expect(t.acceptRow.meetsCellN).toBe(true);
+    // override row cells are below minN
+    expect(t.overrideRow.meetsCellN).toBe(false);
+  });
+});
+
+describe('cisDisjoint', () => {
+  it('disjoint when one upper < other lower', () => {
+    expect(cisDisjoint({ low: 0, high: 0.2 }, { low: 0.3, high: 0.5 })).toBe(true);
+  });
+  it('overlapping returns false', () => {
+    expect(cisDisjoint({ low: 0, high: 0.4 }, { low: 0.3, high: 0.5 })).toBe(false);
+  });
+});
+
+describe('isTrustMisCalibrated', () => {
+  it('false when either row is below minN even if rates differ', () => {
+    const t = build2x2([
+      ...tc(true, true, 1),
+      ...tc(true, false, 1),
+      ...tc(false, false, MIN_N),
+      ...tc(false, true, MIN_N),
+    ]);
+    expect(isTrustMisCalibrated(t)).toBe(false);
+  });
+
+  it('false when both rows qualify but CIs overlap (same rate)', () => {
+    const t = build2x2([
+      ...tc(true, true, MIN_N),
+      ...tc(true, false, MIN_N),
+      ...tc(false, true, MIN_N),
+      ...tc(false, false, MIN_N),
+    ]);
+    // both rows ~50% with identical CIs => overlap
+    expect(isTrustMisCalibrated(t)).toBe(false);
+  });
+
+  it('true when both rows qualify and landed-rate CIs are disjoint', () => {
+    // accept row: almost all landed; override row: almost none landed,
+    // with large n so the CIs separate.
+    const big = MIN_N * 20;
+    const t = build2x2([
+      ...tc(true, true, big),
+      ...tc(true, false, MIN_N),
+      ...tc(false, true, MIN_N),
+      ...tc(false, false, big),
+    ]);
+    expect(isTrustMisCalibrated(t)).toBe(true);
+  });
+});

--- a/packages/analysis/src/selectors/trust.ts
+++ b/packages/analysis/src/selectors/trust.ts
@@ -1,0 +1,195 @@
+/**
+ * TRUST selector — the `data → view-model` derivation behind the TRUST
+ * 2×2 surface, extracted VERBATIM from `TrustMode.tsx` (Phase 1 of the
+ * "Centralize data processing" refactor).
+ *
+ * Rows    = "accepted Claude" / "overrode Claude"
+ * Columns = "landed" / "didn't land"
+ *
+ * Each row carries a Wilson 95% CI on its landed-rate. Cells with
+ * n < `THRESHOLDS.trustCell.minN` are flagged (rendered grey by the
+ * component). The "mis-calibration" flag (`isTrustMisCalibrated`) fires
+ * only when BOTH rows meet per-cell minN AND the two landed-rate CIs are
+ * disjoint.
+ *
+ * Pure / deterministic / React-free. Stats come from `wilsonCI` —
+ * never reimplemented here.
+ */
+
+import type { Decision } from '@chat-arch/schema';
+import { THRESHOLDS } from '../thresholds.js';
+import { wilsonCI } from '../stats.js';
+
+export type CellKey =
+  | 'accept-land'
+  | 'accept-noland'
+  | 'override-land'
+  | 'override-noland';
+
+export interface CellTally {
+  accepted: boolean;
+  landed: boolean;
+  n: number;
+}
+
+export interface RowSummary {
+  accepted: boolean;
+  /** Total decisions in this row (n_accepted or n_overrode). */
+  total: number;
+  /** Landed count. */
+  landed: number;
+  pHat: number;
+  ci: { low: number; high: number };
+  meetsCellN: boolean;
+}
+
+export interface TrustTally {
+  cells: Record<CellKey, CellTally>;
+  acceptRow: RowSummary;
+  overrideRow: RowSummary;
+  /** Total joined+actionable decisions used. */
+  totalUsable: number;
+}
+
+/**
+ * Pull (accepted, landed) signal out of a Decision. Prefers the explicit
+ * `trustCalibration` field (populated by the `/mine-decisions` skill's
+ * trust-calibration stage), then falls back to deriving from the
+ * classification + outcomeRef when the field is absent (older
+ * decisions.json files predating the skill). Returns null when neither
+ * path resolves — the row is excluded from the 2x2 entirely.
+ */
+export function deriveTrustSignal(
+  d: Decision,
+): { accepted: boolean; landed: boolean } | null {
+  const tc = d.trustCalibration;
+  if (tc !== null && tc !== undefined) {
+    return { accepted: tc.acceptedAssistant, landed: tc.landed };
+  }
+  // Fallback derivation: requires both classification AND outcomeRef.
+  // Without the trustCalibration field we can only make a coarse guess
+  // — treat `alternative-block` kind as "accepted assistant" (user
+  // picked from the LLM's enumerated alternatives) and everything else
+  // as ambiguous. Conservative: skip ambiguous rows so the 2x2 doesn't
+  // mix derivations with explicit signals.
+  if (d.classification === null || d.outcomeRef === null) return null;
+  if (d.outcomeRef.binaryClass === 'neutral') return null;
+  const accepted = d.classification.kind === 'alternative-block';
+  // Skip non-alternative-block rows in the fallback path so the 2x2
+  // doesn't surface guesses as data.
+  if (!accepted && d.classification.kind !== 'imperative-choice') return null;
+  return {
+    accepted,
+    landed: d.outcomeRef.binaryClass === 'good',
+  };
+}
+
+/**
+ * Explicit-only signal: use the `trustCalibration` field if present, else
+ * null — NO classification/outcomeRef fallback. This is the derivation the
+ * ActionItemsBanner's mis-calibration flag used before centralization
+ * (`ChatArchViewer.trustMisCalibrationFired`), kept separate from
+ * {@link deriveTrustSignal} so the banner's behavior is preserved exactly:
+ * the banner counts only decisions with an explicit accept/override signal,
+ * whereas the TRUST surface's full 2×2 also folds in the coarse fallback.
+ */
+export function deriveTrustSignalExplicitOnly(
+  d: Decision,
+): { accepted: boolean; landed: boolean } | null {
+  const tc = d.trustCalibration;
+  if (tc !== null && tc !== undefined) {
+    return { accepted: tc.acceptedAssistant, landed: tc.landed };
+  }
+  return null;
+}
+
+/**
+ * Build the 2×2 trust tally. `derive` defaults to {@link deriveTrustSignal}
+ * (the fallback-inclusive signal the TRUST surface uses); pass
+ * {@link deriveTrustSignalExplicitOnly} for the explicit-only count the
+ * ActionItemsBanner flag uses.
+ */
+export function build2x2(
+  decisions: readonly Decision[],
+  derive: (d: Decision) => { accepted: boolean; landed: boolean } | null = deriveTrustSignal,
+): TrustTally {
+  const cells: Record<CellKey, CellTally> = {
+    'accept-land': { accepted: true, landed: true, n: 0 },
+    'accept-noland': { accepted: true, landed: false, n: 0 },
+    'override-land': { accepted: false, landed: true, n: 0 },
+    'override-noland': { accepted: false, landed: false, n: 0 },
+  };
+  let totalUsable = 0;
+  for (const d of decisions) {
+    const sig = derive(d);
+    if (sig === null) continue;
+    totalUsable += 1;
+    const key: CellKey = sig.accepted
+      ? sig.landed
+        ? 'accept-land'
+        : 'accept-noland'
+      : sig.landed
+        ? 'override-land'
+        : 'override-noland';
+    cells[key]!.n += 1;
+  }
+  const minN = THRESHOLDS.trustCell.minN;
+  const acceptTotal = cells['accept-land'].n + cells['accept-noland'].n;
+  const acceptLanded = cells['accept-land'].n;
+  const overrideTotal = cells['override-land'].n + cells['override-noland'].n;
+  const overrideLanded = cells['override-land'].n;
+
+  const acceptPHat = acceptTotal > 0 ? acceptLanded / acceptTotal : 0;
+  const overridePHat = overrideTotal > 0 ? overrideLanded / overrideTotal : 0;
+
+  return {
+    cells,
+    acceptRow: {
+      accepted: true,
+      total: acceptTotal,
+      landed: acceptLanded,
+      pHat: acceptPHat,
+      ci: wilsonCI(acceptPHat, acceptTotal),
+      meetsCellN:
+        cells['accept-land'].n >= minN && cells['accept-noland'].n >= minN,
+    },
+    overrideRow: {
+      accepted: false,
+      total: overrideTotal,
+      landed: overrideLanded,
+      pHat: overridePHat,
+      ci: wilsonCI(overridePHat, overrideTotal),
+      meetsCellN:
+        cells['override-land'].n >= minN && cells['override-noland'].n >= minN,
+    },
+    totalUsable,
+  };
+}
+
+/** CIs do not overlap iff one's upper < the other's lower. */
+export function cisDisjoint(
+  a: { low: number; high: number },
+  b: { low: number; high: number },
+): boolean {
+  return a.high < b.low || b.high < a.low;
+}
+
+/**
+ * Mis-calibration flag: BOTH rows must meet per-cell minN AND the
+ * landed-rate CIs must be disjoint. Anything weaker is "looks
+ * suggestive, not statistically distinguishable".
+ *
+ * Identical to the inline `bothRowsQualified && cisDisjoint(...)` that
+ * TrustMode computed at render time. ChatArchViewer's banner flag reaches
+ * the same boolean by calling `build2x2(decisions, deriveTrustSignalExplicitOnly)`
+ * then this — matching its pre-centralization explicit-only count (the
+ * minN check over all four cells + Wilson disjointness are unchanged; only
+ * the now-shared `wilsonCI` clamps to [0,1], which cannot flip the test).
+ */
+export function isTrustMisCalibrated(tally: TrustTally): boolean {
+  return (
+    tally.acceptRow.meetsCellN &&
+    tally.overrideRow.meetsCellN &&
+    cisDisjoint(tally.acceptRow.ci, tally.overrideRow.ci)
+  );
+}

--- a/packages/viewer/src/ChatArchViewer.tsx
+++ b/packages/viewer/src/ChatArchViewer.tsx
@@ -93,7 +93,10 @@ import {
   buildZombieProjects,
   firstHumanText,
   THRESHOLDS,
-  unwrapEnvelope,
+  rankTopActionItems,
+  build2x2,
+  deriveTrustSignalExplicitOnly,
+  isTrustMisCalibrated,
   type DuplicateInput,
 } from '@chat-arch/analysis';
 import {
@@ -1027,108 +1030,31 @@ export function ChatArchViewer({
   // Computed here so the banner is a pure renderer over the sidecar
   // data. The same heuristic the modes use to flag rows surfaces the
   // headline candidates.
-  const topActionItems = useMemo<readonly TopItem[]>(() => {
-    const out: TopItem[] = [];
-    // Highest-confidence + largest knowledge-debt cluster.
-    const debt = insightsBundle.knowledgeDebt;
-    if (debt !== null && debt.clusters.length > 0) {
-      // Strip harness wrappers from the canonical question and skip
-      // slash-command invocations (e.g. "/shopsmith-menu") — those are
-      // commands, not natural-language questions worth turning into a
-      // rule, and leaking the raw <command-message> envelope into the
-      // headline is exactly the noise this strip is meant to avoid.
-      const cleaned = [...debt.clusters]
-        .map((c) => ({ cluster: c, question: unwrapEnvelope(c.canonicalQuestion) }))
-        .filter(
-          (x): x is { cluster: (typeof debt.clusters)[number]; question: string } =>
-            x.question !== null && !x.question.trimStart().startsWith('/'),
-        );
-      const top = cleaned.sort((a, b) => {
-        const ca = a.cluster.confidence === 'high' ? 1 : 0;
-        const cb = b.cluster.confidence === 'high' ? 1 : 0;
-        if (ca !== cb) return cb - ca;
-        return b.cluster.sessionIds.length - a.cluster.sessionIds.length;
-      })[0];
-      if (top !== undefined) {
-        const q =
-          top.question.length > 80
-            ? top.question.slice(0, 77) + '…'
-            : top.question;
-        out.push({
-          kind: 'knowledge-debt',
-          headline: `recurring question (${top.cluster.sessionIds.length} sessions) — ${q}`,
-          detail: `confidence ${top.cluster.confidence}`,
-          mode: 'insights',
-        });
-      }
-    }
-    // Biggest |delta| disjoint-CI ITS contrast.
-    const its = insightsBundle.its;
-    if (its !== null) {
-      const clear = its.results
-        .filter(
-          (r) =>
-            r.pre.n >= THRESHOLDS.display.minNForRate &&
-            r.post.n >= THRESHOLDS.display.minNForRate &&
-            ((r.deltaCI.low > 0 && r.deltaCI.high > 0) ||
-              (r.deltaCI.low < 0 && r.deltaCI.high < 0)),
-        )
-        .sort((a, b) => Math.abs(b.deltaGoodShare) - Math.abs(a.deltaGoodShare));
-      const top = clear[0];
-      if (top !== undefined) {
-        const pp = Math.round(top.deltaGoodShare * 100);
-        out.push({
-          kind: 'its',
-          headline: `${top.subject || top.path} shifted good-share ${pp >= 0 ? '+' : ''}${pp} pp`,
-          detail: `commit ${top.sha.slice(0, 7)}`,
-          mode: 'insights',
-        });
-      }
-    }
-    return out;
-  }, [insightsBundle]);
+  const topActionItems = useMemo<readonly TopItem[]>(
+    () =>
+      rankTopActionItems({
+        knowledgeDebt: insightsBundle.knowledgeDebt,
+        its: insightsBundle.its,
+      }),
+    [insightsBundle],
+  );
 
   // Trust mis-calibration flag — pure read from the decisions file.
-  // Mirrors the logic in TrustMode without duplicating the full 2×2
-  // build (we only need the boolean here).
-  const trustMisCalibrationFired = useMemo(() => {
-    if (decisionsFile === null) return false;
-    const minN = THRESHOLDS.trustCell.minN;
-    let aL = 0,
-      aN = 0,
-      oL = 0,
-      oN = 0;
-    for (const d of decisionsFile.decisions) {
-      const tc = d.trustCalibration;
-      if (tc === null || tc === undefined) continue;
-      if (tc.acceptedAssistant) {
-        if (tc.landed) aL += 1;
-        else aN += 1;
-      } else {
-        if (tc.landed) oL += 1;
-        else oN += 1;
-      }
-    }
-    const aTotal = aL + aN;
-    const oTotal = oL + oN;
-    if (aL < minN || aN < minN || oL < minN || oN < minN) return false;
-    if (aTotal === 0 || oTotal === 0) return false;
-    const pA = aL / aTotal;
-    const pO = oL / oTotal;
-    // Wilson CI inline (we don't want to depend on the analysis package here).
-    const wilson = (p: number, n: number) => {
-      const z = 1.96;
-      const z2 = z * z;
-      const denom = 1 + z2 / n;
-      const centre = (p + z2 / (2 * n)) / denom;
-      const radius =
-        (z * Math.sqrt((p * (1 - p) + z2 / (4 * n)) / n)) / denom;
-      return { low: centre - radius, high: centre + radius };
-    };
-    const ciA = wilson(pA, aTotal);
-    const ciO = wilson(pO, oTotal);
-    return ciA.high < ciO.low || ciO.high < ciA.low;
-  }, [decisionsFile]);
+  // Routes through the shared selector (`build2x2` + `isTrustMisCalibrated`,
+  // which call the analysis `wilsonCI`) instead of the old hand-rolled
+  // Wilson CI that this component used to inline. `deriveTrustSignalExplicitOnly`
+  // preserves the banner's pre-centralization behavior exactly: it counts
+  // ONLY decisions with an explicit accept/override signal (no fallback),
+  // which is what the old inline loop did (`if (tc == null) continue`).
+  const trustMisCalibrationFired = useMemo(
+    () =>
+      decisionsFile === null
+        ? false
+        : isTrustMisCalibrated(
+            build2x2(decisionsFile.decisions, deriveTrustSignalExplicitOnly),
+          ),
+    [decisionsFile],
+  );
 
   // --- fetch manifest ---
   useEffect(() => {

--- a/packages/viewer/src/components/modes/DecisionsMode.tsx
+++ b/packages/viewer/src/components/modes/DecisionsMode.tsx
@@ -4,7 +4,13 @@ import type {
   DecisionsFile,
   DecisionClustersFile,
 } from '@chat-arch/schema';
-import { THRESHOLDS, wilsonCI, unwrapEnvelope } from '@chat-arch/analysis';
+import {
+  THRESHOLDS,
+  wilsonCI,
+  unwrapEnvelope,
+  groupDecisionsByKind,
+  partitionDecisions,
+} from '@chat-arch/analysis';
 import { SidecarEmptyState } from '../SidecarEmptyState.js';
 import {
   startMineDecisions,
@@ -54,26 +60,6 @@ const MINE_BATCH_OPTIONS: ReadonlyArray<MineDecisionsBatch> = [5, 20, 'all'];
 const STATUS_POLL_MS = 1500;
 const UNCLASSIFIED_PREVIEW = 15;
 
-const KIND_LABEL: Record<string, string> = {
-  'explicit-marker': 'EXPLICIT MARKER',
-  'explicit-go-with': 'GO-WITH',
-  'instead-of': 'INSTEAD-OF',
-  'alternative-block': 'ALTERNATIVE',
-  'imperative-choice': 'IMPERATIVE',
-  'tool-pivot': 'TOOL PIVOT',
-  'scope-cut': 'SCOPE CUT',
-  other: 'OTHER',
-};
-
-interface KindGroup {
-  key: string;
-  label: string;
-  rows: Decision[];
-  /** outcomeRef present AND non-neutral — landed-rate denominator. */
-  denom: number;
-  landed: number;
-}
-
 function formatScore(s: number): string {
   return Number.isFinite(s) ? s.toFixed(2) : '—';
 }
@@ -85,30 +71,6 @@ function cleanContext(raw: string): string {
 }
 function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max - 1)}…` : s;
-}
-
-function buildKindGroups(classified: readonly Decision[]): KindGroup[] {
-  const m = new Map<string, Decision[]>();
-  for (const d of classified) {
-    const k = d.classification?.kind ?? 'other';
-    const arr = m.get(k);
-    if (arr) arr.push(d);
-    else m.set(k, [d]);
-  }
-  const out: KindGroup[] = [];
-  for (const [key, rows] of m) {
-    let denom = 0;
-    let landed = 0;
-    for (const r of rows) {
-      const ref = r.outcomeRef;
-      if (ref === null || ref.binaryClass === 'neutral') continue;
-      denom += 1;
-      if (ref.binaryClass === 'good') landed += 1;
-    }
-    out.push({ key, label: KIND_LABEL[key] ?? key.toUpperCase(), rows, denom, landed });
-  }
-  out.sort((a, b) => b.rows.length - a.rows.length || a.label.localeCompare(b.label));
-  return out;
 }
 
 type MineState =
@@ -149,15 +111,11 @@ export function DecisionsMode({
     };
   }, []);
 
-  const classified = useMemo(
-    () => (file === null ? [] : file.decisions.filter((d) => d.classification !== null)),
+  const { classified, unclassified } = useMemo(
+    () => (file === null ? { classified: [], unclassified: [] } : partitionDecisions(file.decisions)),
     [file],
   );
-  const unclassified = useMemo(
-    () => (file === null ? [] : file.decisions.filter((d) => d.classification === null)),
-    [file],
-  );
-  const kindGroups = useMemo(() => buildKindGroups(classified), [classified]);
+  const kindGroups = useMemo(() => groupDecisionsByKind(classified), [classified]);
 
   // Poll the run-status sidecar while a mine is in flight.
   const mineStatus = mineState.status;

--- a/packages/viewer/src/components/modes/TrustMode.tsx
+++ b/packages/viewer/src/components/modes/TrustMode.tsx
@@ -1,6 +1,12 @@
 import { useMemo } from 'react';
-import type { Decision, DecisionsFile } from '@chat-arch/schema';
-import { THRESHOLDS, wilsonCI } from '@chat-arch/analysis';
+import type { DecisionsFile } from '@chat-arch/schema';
+import {
+  THRESHOLDS,
+  build2x2,
+  isTrustMisCalibrated,
+  type CellKey,
+  type RowSummary,
+} from '@chat-arch/analysis';
 import { SidecarEmptyState } from '../SidecarEmptyState.js';
 import { CopyMarkdownButton } from '../CopyMarkdownButton.js';
 
@@ -30,126 +36,6 @@ export interface TrustModeProps {
   file: DecisionsFile | null;
   /** Wave 7 P1 #4 — wire empty-state CTA to the data panel. */
   onOpenDataPanel?: () => void;
-}
-
-type CellKey = 'accept-land' | 'accept-noland' | 'override-land' | 'override-noland';
-
-interface CellTally {
-  accepted: boolean;
-  landed: boolean;
-  n: number;
-}
-
-interface RowSummary {
-  accepted: boolean;
-  /** Total decisions in this row (n_accepted or n_overrode). */
-  total: number;
-  /** Landed count. */
-  landed: number;
-  pHat: number;
-  ci: { low: number; high: number };
-  meetsCellN: boolean;
-}
-
-interface TrustTally {
-  cells: Record<CellKey, CellTally>;
-  acceptRow: RowSummary;
-  overrideRow: RowSummary;
-  /** Total joined+actionable decisions used. */
-  totalUsable: number;
-}
-
-/**
- * Pull (accepted, landed) signal out of a Decision. Prefers the explicit
- * `trustCalibration` field (populated by the `/mine-decisions` skill's
- * trust-calibration stage), then falls back to deriving from the
- * classification + outcomeRef when the field is absent (older
- * decisions.json files predating the skill). Returns null when neither
- * path resolves — the row is excluded from the 2x2 entirely.
- */
-function derive(d: Decision): { accepted: boolean; landed: boolean } | null {
-  const tc = d.trustCalibration;
-  if (tc !== null && tc !== undefined) {
-    return { accepted: tc.acceptedAssistant, landed: tc.landed };
-  }
-  // Fallback derivation: requires both classification AND outcomeRef.
-  // Without the trustCalibration field we can only make a coarse guess
-  // — treat `alternative-block` kind as "accepted assistant" (user
-  // picked from the LLM's enumerated alternatives) and everything else
-  // as ambiguous. Conservative: skip ambiguous rows so the 2x2 doesn't
-  // mix derivations with explicit signals.
-  if (d.classification === null || d.outcomeRef === null) return null;
-  if (d.outcomeRef.binaryClass === 'neutral') return null;
-  const accepted = d.classification.kind === 'alternative-block';
-  // Skip non-alternative-block rows in the fallback path so the 2x2
-  // doesn't surface guesses as data.
-  if (!accepted && d.classification.kind !== 'imperative-choice') return null;
-  return {
-    accepted,
-    landed: d.outcomeRef.binaryClass === 'good',
-  };
-}
-
-function build2x2(decisions: readonly Decision[]): TrustTally {
-  const cells: Record<CellKey, CellTally> = {
-    'accept-land': { accepted: true, landed: true, n: 0 },
-    'accept-noland': { accepted: true, landed: false, n: 0 },
-    'override-land': { accepted: false, landed: true, n: 0 },
-    'override-noland': { accepted: false, landed: false, n: 0 },
-  };
-  let totalUsable = 0;
-  for (const d of decisions) {
-    const sig = derive(d);
-    if (sig === null) continue;
-    totalUsable += 1;
-    const key: CellKey = sig.accepted
-      ? sig.landed
-        ? 'accept-land'
-        : 'accept-noland'
-      : sig.landed
-        ? 'override-land'
-        : 'override-noland';
-    cells[key]!.n += 1;
-  }
-  const minN = THRESHOLDS.trustCell.minN;
-  const acceptTotal = cells['accept-land'].n + cells['accept-noland'].n;
-  const acceptLanded = cells['accept-land'].n;
-  const overrideTotal = cells['override-land'].n + cells['override-noland'].n;
-  const overrideLanded = cells['override-land'].n;
-
-  const acceptPHat = acceptTotal > 0 ? acceptLanded / acceptTotal : 0;
-  const overridePHat = overrideTotal > 0 ? overrideLanded / overrideTotal : 0;
-
-  return {
-    cells,
-    acceptRow: {
-      accepted: true,
-      total: acceptTotal,
-      landed: acceptLanded,
-      pHat: acceptPHat,
-      ci: wilsonCI(acceptPHat, acceptTotal),
-      meetsCellN:
-        cells['accept-land'].n >= minN && cells['accept-noland'].n >= minN,
-    },
-    overrideRow: {
-      accepted: false,
-      total: overrideTotal,
-      landed: overrideLanded,
-      pHat: overridePHat,
-      ci: wilsonCI(overridePHat, overrideTotal),
-      meetsCellN:
-        cells['override-land'].n >= minN && cells['override-noland'].n >= minN,
-    },
-    totalUsable,
-  };
-}
-
-/** CIs do not overlap iff one's upper < the other's lower. */
-function cisDisjoint(
-  a: { low: number; high: number },
-  b: { low: number; high: number },
-): boolean {
-  return a.high < b.low || b.high < a.low;
 }
 
 function formatRate(p: number): string {
@@ -190,10 +76,10 @@ export function TrustMode({ file, onOpenDataPanel }: TrustModeProps) {
 
   // Mis-calibration flag: BOTH rows must meet per-cell minN AND the
   // landed-rate CIs must be disjoint. Anything weaker is "looks
-  // suggestive, not statistically distinguishable".
+  // suggestive, not statistically distinguishable". `bothRowsQualified`
+  // is retained for the quiet-flag explanatory copy below.
   const bothRowsQualified = acceptRow.meetsCellN && overrideRow.meetsCellN;
-  const misCalibrated =
-    bothRowsQualified && cisDisjoint(acceptRow.ci, overrideRow.ci);
+  const misCalibrated = isTrustMisCalibrated(tally);
 
   // Outer aria-label dropped — divs without role don't expose
   // aria-label to AT (ARIA 1.2 §5.2.7.2). The <h2>TRUST</h2> below

--- a/scripts/lint-data-processing-in-components.mjs
+++ b/scripts/lint-data-processing-in-components.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Lint guard for the "Centralize data processing" plan: viewer
+ * components should be thin renderers. `data → view-model` derivations
+ * belong in `packages/analysis/src/selectors/` (schema-typed) or
+ * `packages/viewer/src/selectors/` (client-state-coupled) — NOT inline
+ * in a component.
+ *
+ * This scans `packages/viewer/src/components/**\/*.tsx` and flags lines
+ * that look like data-derivation done in-component:
+ *
+ *   (a) `.reduce(` / `.sort(` / `new Map(` / `.flatMap(` — the structural
+ *       transform primitives. Inside a renderer they almost always mean a
+ *       view-model is being built where a selector should be.
+ *   (b) The inline-Wilson fingerprint (`1.96`, `z * z`, `Math.sqrt(` near
+ *       a `/ denom`) — the one hard stat duplication the plan calls out.
+ *       A selector must call `wilsonCI` from `@chat-arch/analysis` instead.
+ *
+ * Heuristic, so false positives are expected (a `.sort()` on a UI-local
+ * list is fine). Like `lint-thresholds-imports.mjs`, it is BUDGET-based:
+ * exits ZERO while the flag count stays at-or-under `MAX_FLAGS`, NON-ZERO
+ * on a regression past it. The budget starts at the pre-refactor count
+ * and is RATCHETED DOWN one phase at a time as derivations move into
+ * selectors. Override via `DATA_PROCESSING_LINT_BUDGET`.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { glob } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// Budget for flagged occurrences before the script exits non-zero.
+// Starts at the Phase-0 baseline (the pre-refactor count) so the scaffold
+// PR is green; ratcheted DOWN each phase as derivations migrate into
+// selectors. The plan's terminal state is a budget at the irreducible
+// (UI-coupled) floor.
+const MAX_FLAGS = Number(process.env.DATA_PROCESSING_LINT_BUDGET ?? 35);
+
+const TARGET_GLOB_ROOT = 'packages/viewer/src/components';
+
+// Structural transform primitives — building a view-model in-component.
+const TRANSFORM_RE = /\.reduce\(|\.flatMap\(|\bnew Map\(|\.sort\(/;
+// Inline-Wilson / hand-rolled-stat fingerprints (the plan's lone hard dup).
+const STAT_FINGERPRINT_RE = /\b1\.96\b|\bz\s*\*\s*z\b|Math\.sqrt\(/;
+
+const IGNORE_FILE_HINTS = [/\.test\.(ts|tsx)$/, /\.d\.ts$/];
+
+const IGNORE_LINE_HINTS = [
+  /^\s*\/\//, // line comment
+  /^\s*\*/, // jsdoc continuation
+  /^\s*import\b/,
+  /from ['"]/,
+];
+
+async function findFiles() {
+  const out = [];
+  const root = path.join(REPO_ROOT, TARGET_GLOB_ROOT);
+  for await (const entry of glob('**/*.tsx', { cwd: root })) {
+    const abs = path.join(root, entry);
+    if (IGNORE_FILE_HINTS.some((re) => re.test(abs))) continue;
+    out.push(abs);
+  }
+  return out;
+}
+
+async function scanFile(absPath) {
+  const text = await readFile(absPath, 'utf8');
+  const lines = text.split(/\r?\n/);
+  const hits = [];
+  let inBlockComment = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    let line = lines[i];
+    if (inBlockComment) {
+      const close = line.indexOf('*/');
+      if (close < 0) continue;
+      line = line.slice(close + 2);
+      inBlockComment = false;
+    }
+    const openIdx = line.indexOf('/*');
+    if (openIdx >= 0 && !line.slice(openIdx).includes('*/')) {
+      inBlockComment = true;
+      line = line.slice(0, openIdx);
+    }
+    if (IGNORE_LINE_HINTS.some((re) => re.test(line))) continue;
+    if (TRANSFORM_RE.test(line)) {
+      hits.push({ line: i + 1, kind: 'transform', text: line.trim() });
+    }
+    if (STAT_FINGERPRINT_RE.test(line)) {
+      hits.push({ line: i + 1, kind: 'stat', text: line.trim() });
+    }
+  }
+  return hits;
+}
+
+async function main() {
+  const files = await findFiles();
+  let total = 0;
+  const perFile = [];
+  for (const f of files) {
+    const hits = await scanFile(f);
+    if (hits.length === 0) continue;
+    total += hits.length;
+    perFile.push({ f, hits });
+  }
+
+  perFile.sort((a, b) => b.hits.length - a.hits.length);
+
+  const topN = Math.min(perFile.length, 10);
+  for (let i = 0; i < topN; i += 1) {
+    const { f, hits } = perFile[i];
+    const rel = path.relative(REPO_ROOT, f);
+    const stat = hits.filter((h) => h.kind === 'stat').length;
+    console.error(
+      `lint-data-processing: ${rel} — ${hits.length} in-component derivation(s)` +
+        (stat > 0 ? ` (incl. ${stat} hand-rolled-stat fingerprint(s))` : ''),
+    );
+  }
+
+  console.error(
+    `\nlint-data-processing: ${total} in-component derivation flag(s) across ${perFile.length} file(s) (budget ${MAX_FLAGS}).`,
+  );
+  console.error(
+    `Move data → view-model transforms into packages/analysis/src/selectors (schema-typed) or`,
+  );
+  console.error(
+    `packages/viewer/src/selectors (client-state-coupled). Components render; never reimplement a stat.`,
+  );
+
+  if (total > MAX_FLAGS) {
+    console.error(
+      `\nlint-data-processing: BUDGET EXCEEDED (${total} > ${MAX_FLAGS}). ` +
+        `Migrate the new derivation into a selector, or (if intentional/UI-coupled) raise ` +
+        `the budget via env DATA_PROCESSING_LINT_BUDGET.`,
+    );
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(
+    `lint-data-processing: fatal: ${err instanceof Error ? err.stack : String(err)}`,
+  );
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Phases **0 + 1** of the "Centralize data processing" refactor (plan: `purring-knitting-steele.md`). The natural first PR per the plan. **Pure refactor — no behavior change** (verified: see Parity below).

### Phase 0 — scaffold (no behavior change)
- New `packages/analysis/src/selectors/` layer (barrel re-exported from `@chat-arch/analysis`) — the single home for `data → view-model` derivations.
- New advisory lint `scripts/lint-data-processing-in-components.mjs` (mirrors `lint-thresholds-imports.mjs`), wired into the root `lint` as `lint:data-processing`. Budget-based (`DATA_PROCESSING_LINT_BUDGET`), starts at baseline and ratchets down per phase.
- CLAUDE.md doctrine section "Data processing lives in selectors, not components".

### Phase 1 — surfaces we own
Three derivations extracted **verbatim** into pure selectors; components become renderers:
- `selectors/trust.ts` — `build2x2` / `deriveTrustSignal` / `cisDisjoint` / `TrustTally` (from TrustMode) + new `isTrustMisCalibrated`.
- `selectors/decisions.ts` — `groupDecisionsByKind` / `partitionDecisions` / `KindGroup` (from DecisionsMode).
- `selectors/actionItems.ts` — `rankTopActionItems` / `TopItem` (from ChatArchViewer's `topActionItems`).
- **Deleted the inline Wilson CI** in `ChatArchViewer.trustMisCalibrationFired` (the lone hard stat-dup, with its false "we don't want to depend on the analysis package here" comment — the file already imports from `@chat-arch/analysis`). The banner flag now routes through `build2x2(…, deriveTrustSignalExplicitOnly)` → `isTrustMisCalibrated` → the shared `wilsonCI`.

### Parity (load-bearing — this is a no-behavior-change refactor)
- The banner's mis-calibration flag used an **explicit-`trustCalibration`-only** count (no fallback), unlike the TRUST surface's full 2×2. To preserve that exactly, `build2x2` takes an optional `derive` fn; the banner passes `deriveTrustSignalExplicitOnly`, the TRUST surface keeps the default fallback-inclusive `deriveTrustSignal`. Both behave exactly as before.
- Adversarial review found **no parity regressions**, and exhaustively verified the inline-Wilson → `wilsonCI` swap: the only difference is `wilsonCI`'s `[0,1]` clamp, which (checked across ~52M cell-count pairs) **never flips** the disjointness verdict.
- 32 new pure selector unit tests (empty / null / below-min-n / fallback-vs-explicit-only cases).

### Lint budget
`DATA_PROCESSING_LINT_BUDGET` baseline 36 → ratcheted to **35**. NB the lint globs `viewer/src/components/**`, so `ChatArchViewer.tsx` (at `viewer/src/` root, where the inline Wilson lived) is **not** scanned — a coverage gap noted for a follow-up (broadening the glob would balloon the budget with ChatArchViewer's UI-coupled noise, a budget-semantics change deferred for review).

### Verification
`pnpm lint` ✓ (incl. new `lint:data-processing`) · `pnpm test` **209 files / 0 failed** (incl. 32 new selector tests) · `pnpm build` ✓.

No `EXPORTER_VERSION` bump — no artifact-contract change in these phases (the precompute sidecar lands in Phase 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
