### PR TITLE
fix: honest disclosure of skipped / withheld / unverified state (#122, #119, #120)

### DIFF
--- a/.claude/skills/mine-decisions/SKILL.md
+++ b/.claude/skills/mine-decisions/SKILL.md
@@ -137,13 +137,24 @@ populates the TRUST 2×2.
 ### Stage 3 — Cluster recurring decisions (optional; needs Ollama)
 
 Only meaningful with >= 2 classified decisions total (this run's kept
-results + any pre-existing classified rows in `decisions.json`).
+results + any pre-existing classified rows in `decisions.json`). With
+< 2 there's nothing to cluster — skip Stage 3 entirely (this is NOT a
+skip-marker case; there are simply no recurring decisions to find, so no
+`decision-clusters.json` is written).
 
-1. Probe Ollama: `curl -s -m 1 http://localhost:11434/api/tags`. If it's
-   not up, **skip this stage** (log "Ollama down — skipping clustering;
-   classification still written") and continue. Clustering is an
-   enhancement, not a gate — unlike mine-corrections, classification
-   here doesn't need embeddings.
+1. (Optional) Probe Ollama for a friendly log line only:
+   `curl -s -m 1 http://localhost:11434/api/tags`. **Do NOT use the probe
+   to bypass the CLI.** As of EXPORTER_VERSION 1.11.0 the clusterer handles
+   an unreachable embedding backend itself: on an embed failure it writes a
+   *soft-skip marker* to `decision-clusters.json`
+   (`{ clusters: [], skipped: true, skipReason: 'embeddings-unavailable' }`)
+   and **exits 0**, so the viewer can disclose "clustering skipped — Ollama
+   unavailable" instead of showing nothing (indistinguishable from "no
+   recurring decisions"). So whenever there are >= 2 classified decisions,
+   **always run the CLI** (step 3) regardless of the probe result — that's
+   what guarantees the marker is written on the Ollama-down path too.
+   Clustering is an enhancement, not a gate; classification doesn't need
+   embeddings.
 2. Collect `{ id, distilledDecision, sessionId, binaryClass, updatedAt }`
    for every classified decision (this run + already-classified rows).
    `binaryClass` is each row's `outcomeRef.binaryClass`, or `null` when
@@ -159,10 +170,12 @@ results + any pre-existing classified rows in `decisions.json`).
      --classified ${dataDir}/analysis/_decisions-classified.json \
      --output ${dataDir}/analysis/decision-clusters.json
    ```
-   The CLI writes a `DecisionClustersFile` (clusters of >=2 distinct
-   sessions, each with `canonicalDecision`, `instanceIds`,
-   `occurrenceCount`, `firstSeen`/`lastSeen`, and `landedRate`). Surface
-   any stderr.
+   The CLI writes a `DecisionClustersFile`. On a successful run that's
+   clusters of >=2 distinct sessions (each with `canonicalDecision`,
+   `instanceIds`, `occurrenceCount`, `firstSeen`/`lastSeen`, `landedRate`,
+   `landedDenom`). On an embed failure it instead writes the soft-skip
+   marker described in step 1 and **exits 0** — do NOT treat that clean
+   exit as a failure or retry it. Surface any stderr either way.
 
 ### Stage 4 — Merge + write (compare-and-swap)
 
@@ -200,7 +213,7 @@ Write `${dataDir}/analysis/decision-status-${requestId}.json`:
   "completedAt": <ms>,
   "classifiedCount": <kept after filter>,
   "candidatesConsidered": <work-set size>,
-  "clusterCount": <decision-clusters.json clusters, 0 if skipped>,
+  "clusterCount": <decision-clusters.json clusters; 0 when the CLI wrote a skip marker (embeddings-unavailable) or the stage was skipped>,
   "tokenCost": "<estimate>"
 }
 ```
@@ -230,7 +243,10 @@ shape to `correction-status-*.json`:
 ## Error handling
 
 - `decisions.json` missing → stop, tell the user to run the exporter.
-- Ollama down → skip clustering (NOT fatal); classification still writes.
+- Ollama down → run the cluster CLI anyway; it writes a soft-skip marker to
+  `decision-clusters.json` (`skipped:true`, `skipReason:'embeddings-unavailable'`)
+  and exits 0. NOT fatal; classification still writes. Do NOT pre-empt the
+  CLI with the Ollama probe — that suppresses the marker the viewer needs.
 - Sub-agent malformed JSON → retry once, then drop that batch.
 - Concurrent rescan that survives a re-read retry → `status: error`
   (`concurrent-rescan-aborted`), exit 1.
@@ -246,4 +262,7 @@ shape to `correction-status-*.json`:
   coexist in one file).
 - Don't re-classify already-classified rows unless `--reclassify`.
 - Don't fail the whole run because Ollama is down — clustering is optional.
+- Don't pre-probe Ollama and skip the cluster CLI when there are >= 2
+  classified decisions — that suppresses the soft-skip marker the viewer
+  relies on to disclose the skip (issue #122). Let the CLI write it.
 - Don't invent `chosen`/`rejected` options not grounded in the context.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,62 @@ on-disk shape with this changelog.
 
 ## [Unreleased]
 
+## [1.11.0] — 2026-06-26
+
+Honest disclosure of skipped / withheld / unverified state — three related
+"silent disclosure" bugs where a surface showed *nothing* in a state that
+should have shown *why there's nothing*, so "skipped / withheld / unverified"
+read as "no data / verified" (#122, #119, #120).
+
+> **Version note:** `decision-clusters.json` is a *skill*-written sidecar (the
+> exporter never emits it), but `EXPORTER_VERSION` is the bundle-wide
+> provenance label in `meta.json`, and the documented bump trigger is "the
+> shape of an existing artifact changes" — which it does here. Precedent:
+> 1.9.0 bumped for the decisions pipeline, whose classification is also
+> skill-merged. If #113 (project-identity-v2) already claimed the 1.11.0 slot
+> on merge, the second-merged reconciles to the next free version (Step-5
+> convention).
+
+### Fixed
+
+- **`mine-decisions` clustering no longer fails silently when Ollama is down**
+  (#122). `cluster-decisions-cli` previously threw and exited 1 on an
+  unreachable embedding backend, writing no `decision-clusters.json` — so the
+  DECISIONS surface showed no recurring section, indistinguishable from "no
+  recurring decisions found." Now the clusterer soft-skips: it writes
+  `decision-clusters.json` with a visible marker (`{ clusters: [],
+  skipped: true, skipReason: 'embeddings-unavailable' }`) and exits 0, and the
+  viewer renders "clustering skipped — embeddings unavailable (Ollama not
+  reachable)" in the RECURRING section. Genuine errors (bad args, unreadable
+  input, a vectors/decisions length mismatch on a *successful* embed) still
+  hard-fail. The `/mine-decisions` skill no longer uses its Ollama pre-probe to
+  bypass the CLI, so the marker is written on the Ollama-down path too.
+- **Recurring-cluster landed-rate floor now discloses instead of blanking**
+  (#119). When a recurring-decision cluster has fewer than
+  `THRESHOLDS.display.minNForRate` (8) decided members, its landed-rate was
+  set to `null` and the row simply showed nothing. It now shows
+  "landed-rate hidden — n=k of 8", at parity with the Trust-cell and
+  Trajectory-bootstrap disclosures that already existed.
+
+### Changed
+
+- **Curator feed discloses its scaffold status** (#120). The PRACTICE curator
+  feed presented `VERIFIED` falsifier badges and "passed the falsifier" copy,
+  but the curator ranker (F3), falsifier verifier (F4), and meta-validation
+  (F8) kernels are not wired into any production path. A new
+  `CURATOR_PIPELINE_LIVE` gate (currently `false`, with a flip-guardrail) now
+  drives a standing scaffold disclaimer, suppresses the affirmative
+  "passed the falsifier" claim, and renders any falsifier tag as a
+  `(placeholder)`. The gate must not be flipped true until real per-item
+  verdict provenance exists. Wiring the F3/F4/F8 kernels and the MCP transport
+  remains separate project work.
+
+### Schema
+
+- `DecisionClustersFile` gains two additive optional fields — `skipped?:
+  boolean` and `skipReason?: 'embeddings-unavailable'`. Existing readers ignore
+  them; the loader already passes unknown fields through.
+
 ## [1.10.0] — 2026-05-30
 
 Automation classify + collapse — programmatic / templated `claude` runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,7 +353,12 @@ analysis/` (all gitignored — locally generated, may carry PII):
 - `decision-clusters.json` — recurring-decision clusters
   (`DecisionPattern[]`) produced by the `/mine-decisions` clustering
   stage. Skill-only writer (the exporter never touches it). PII: decision
-  prose. Reset by `/api/clear-decisions`.
+  prose. Reset by `/api/clear-decisions`. As of EXPORTER_VERSION 1.11.0
+  (#122) the file may also carry a soft-skip marker — `skipped: true` +
+  `skipReason: 'embeddings-unavailable'` with `clusters: []` — written by
+  `cluster-decisions-cli` when the Ollama embedding backend is unreachable,
+  so the viewer can disclose "clustering skipped" instead of showing nothing.
+  Non-PII (the marker carries no decision prose).
 - `archetypes.json` — k-means workflow-archetype centroids + per-
   session assignments. PII: session-archetype mapping.
 - `project-trajectories.json` — Theil-Sen slope per project +

--- a/packages/exporter/src/analysis/index.ts
+++ b/packages/exporter/src/analysis/index.ts
@@ -265,7 +265,17 @@ export interface RunAnalysisResult {
 // re-classified on next rescan. NB: #113 (project-identity-v2) also
 // targets the 1.9.0→1.10.0 slot; if it lands, the second-merged bumps to
 // 1.11.0 (version reconcile per the centralize plan / Step-5 convention).
-export const EXPORTER_VERSION = '1.10.0';
+//
+// 1.11.0 — honest disclosure of skipped / withheld / unverified state
+// (#122/#119/#120). `analysis/decision-clusters.json` gains two additive
+// optional fields (`skipped` + `skipReason`): the cluster CLI now writes a
+// soft-skip marker on an unreachable embedding backend instead of crashing,
+// so the viewer can disclose "clustering skipped — Ollama unavailable"
+// rather than showing nothing. Skill-written sidecar, but the version label
+// in meta.json is the bundle-wide provenance anchor for the shape change.
+// (If #113 already took the 1.11.0 slot on merge, reconcile to the next
+// free version per the Step-5 convention.)
+export const EXPORTER_VERSION = '1.11.0';
 
 export async function runAnalysis(
   manifest: SessionManifest,

--- a/packages/exporter/src/cli/cluster-decisions-cli.test.ts
+++ b/packages/exporter/src/cli/cluster-decisions-cli.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { THRESHOLDS } from '@chat-arch/analysis';
 import {
+  buildClustersFileOrSkip,
   buildDecisionClusters,
   normalizeDecision,
   parseArgs,
@@ -107,6 +108,64 @@ describe('buildDecisionClusters', () => {
 
   it('returns [] for empty input', () => {
     expect(buildDecisionClusters([], [], OPTS)).toEqual([]);
+  });
+});
+
+describe('buildClustersFileOrSkip — soft skip on embed failure (issue #122)', () => {
+  const FILE_OPTS = {
+    clusterThreshold: 0.65,
+    minOccurrences: 2,
+    landedRateMinN: 2,
+    model: 'mxbai-embed-large',
+  };
+
+  it('returns a visible skip marker (no throw) when embeddings are unavailable', async () => {
+    const embedFn = vi.fn(async () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:11434');
+    });
+    const decisions = [
+      dec('d1', 'sessA', 'use ripgrep instead of grep'),
+      dec('d2', 'sessB', 'switch from grep to ripgrep'),
+    ];
+    const out = await buildClustersFileOrSkip(decisions, FILE_OPTS, embedFn, 1234);
+    expect(out.skipped).toBe(true);
+    expect(out.skipReason).toBe('embeddings-unavailable');
+    expect(out.clusters).toEqual([]);
+    expect(out.generatedAt).toBe(1234);
+    expect(embedFn).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT mark empty input as skipped (honest empty result, embedFn never called)', async () => {
+    const embedFn = vi.fn(async () => [] as Float32Array[]);
+    const out = await buildClustersFileOrSkip([], FILE_OPTS, embedFn, 9);
+    expect(out.skipped).toBeUndefined();
+    expect(out.skipReason).toBeUndefined();
+    expect(out.clusters).toEqual([]);
+    expect(embedFn).not.toHaveBeenCalled();
+  });
+
+  it('builds real clusters (no skip marker) when embeddings succeed', async () => {
+    const embedFn = vi.fn(async (texts: string[]) =>
+      texts.map(() => unitVec([1, 0, 0])),
+    );
+    const decisions = [
+      dec('d1', 'sessA', 'use ripgrep instead of grep', 'good', 100),
+      dec('d2', 'sessB', 'switch from grep to ripgrep', 'bad', 300),
+    ];
+    const out = await buildClustersFileOrSkip(decisions, FILE_OPTS, embedFn, 7);
+    expect(out.skipped).toBeUndefined();
+    expect(out.clusters).toHaveLength(1);
+    expect(out.clusters[0]?.occurrenceCount).toBe(2);
+  });
+
+  it('still throws on a genuine length mismatch from a successful embed (hard-fail)', async () => {
+    // embedFn returns the wrong number of vectors — a bug, not an
+    // availability problem, so it must NOT be soft-skipped.
+    const embedFn = vi.fn(async () => [unitVec([1, 0, 0])]);
+    const decisions = [dec('d1', 'sessA', 'a'), dec('d2', 'sessB', 'b')];
+    await expect(
+      buildClustersFileOrSkip(decisions, FILE_OPTS, embedFn, 1),
+    ).rejects.toThrow(/length mismatch/);
   });
 });
 

--- a/packages/exporter/src/cli/cluster-decisions-cli.ts
+++ b/packages/exporter/src/cli/cluster-decisions-cli.ts
@@ -17,12 +17,13 @@
  * CLAUDE.md. The extra signal we DO carry is `landedRate`: the share of
  * cluster members whose joined outcome was 'good'.
  */
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { clusterByThreshold, sha256Hex, THRESHOLDS } from '@chat-arch/analysis';
 import type { DecisionClustersFile, DecisionPattern } from '@chat-arch/schema';
 import { embed, DEFAULT_EMBEDDING_MODEL } from '../embeddings/index.js';
+import { atomicWriteJson } from '../lib/atomicWrite.js';
 
 /** One classified decision the skill hands to the clusterer. */
 export interface ClassifiedDecisionInput {
@@ -313,7 +314,12 @@ async function main(): Promise<void> {
   );
 
   await mkdir(path.dirname(args.output), { recursive: true });
-  await writeFile(args.output, JSON.stringify(out, null, 2) + '\n', 'utf8');
+  // Atomic tmp+rename (with Windows transient-lock retry) so the skip
+  // marker / clusters land whole — a half-written file would defeat the
+  // very disclosure #122 adds (the viewer would parse-fail → null → show
+  // nothing, indistinguishable from "no recurring decisions"). Matches the
+  // analysis-sidecar writers (decisionsBuilder, archetypesBuilder).
+  await atomicWriteJson(args.output, JSON.stringify(out, null, 2) + '\n');
 }
 
 const entry = process.argv[1];

--- a/packages/exporter/src/cli/cluster-decisions-cli.ts
+++ b/packages/exporter/src/cli/cluster-decisions-cli.ts
@@ -223,6 +223,73 @@ interface ClassifiedFile {
   decisions?: readonly ClassifiedDecisionInput[];
 }
 
+/** Embedding function shape — injectable so the skip path is testable without Ollama. */
+export type EmbedFn = (
+  texts: string[],
+  opts: { model: string; baseUrl?: string },
+) => Promise<readonly Float32Array[]>;
+
+export interface BuildClustersFileOptions extends BuildDecisionClustersOptions {
+  model: string;
+  baseUrl?: string;
+}
+
+/**
+ * Compute the `DecisionClustersFile` to persist, embedding the
+ * `distilledDecision` text via `embedFn`.
+ *
+ * Clustering is an OPTIONAL enhancement of the decision-mining pipeline
+ * (unlike corrections, classification doesn't need embeddings). So on an
+ * embed failure — the Ollama backend unreachable, mid-run or up-front —
+ * this does NOT throw: it returns a soft *skip marker* (`skipped: true`,
+ * `skipReason: 'embeddings-unavailable'`, empty clusters). The caller
+ * still writes a file, so the viewer can disclose "clustering skipped —
+ * Ollama unavailable" rather than showing nothing (which is
+ * indistinguishable from "no recurring decisions found"). See issue #122.
+ *
+ * Empty input is NOT a skip — it's an honest empty result. A
+ * vectors/decisions length mismatch on a *successful* embed still throws
+ * (a genuine bug, not an availability problem), so the CLI hard-fails.
+ */
+export async function buildClustersFileOrSkip(
+  decisions: readonly ClassifiedDecisionInput[],
+  opts: BuildClustersFileOptions,
+  embedFn: EmbedFn,
+  now: number,
+): Promise<DecisionClustersFile> {
+  if (decisions.length === 0) {
+    return { generatedAt: now, clusters: [] };
+  }
+
+  const texts = decisions.map((d) => d.distilledDecision);
+  const embedOpts: { model: string; baseUrl?: string } = { model: opts.model };
+  if (opts.baseUrl !== undefined) embedOpts.baseUrl = opts.baseUrl;
+
+  let vectors: readonly Float32Array[];
+  try {
+    vectors = await embedFn(texts, embedOpts);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `cluster-decisions-cli: embeddings unavailable — clustering skipped ` +
+        `(${msg}). Wrote a soft-skip marker; classification is unaffected.\n`,
+    );
+    return {
+      generatedAt: now,
+      clusters: [],
+      skipped: true,
+      skipReason: 'embeddings-unavailable',
+    };
+  }
+
+  const patterns = buildDecisionClusters(decisions, vectors, {
+    clusterThreshold: opts.clusterThreshold,
+    minOccurrences: opts.minOccurrences,
+    landedRateMinN: opts.landedRateMinN,
+  });
+  return { generatedAt: now, clusters: patterns };
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
 
@@ -232,20 +299,19 @@ async function main(): Promise<void> {
     (d) => typeof d.distilledDecision === 'string' && d.distilledDecision.trim().length > 0,
   );
 
-  let patterns: DecisionPattern[] = [];
-  if (decisions.length > 0) {
-    const texts = decisions.map((d) => d.distilledDecision);
-    const embedOpts: { model: string; baseUrl?: string } = { model: args.model };
-    if (args.baseUrl !== undefined) embedOpts.baseUrl = args.baseUrl;
-    const vectors = await embed(texts, embedOpts);
-    patterns = buildDecisionClusters(decisions, vectors, {
+  const out = await buildClustersFileOrSkip(
+    decisions,
+    {
       clusterThreshold: args.clusterThreshold,
       minOccurrences: args.minOccurrences,
       landedRateMinN: args.landedRateMinN,
-    });
-  }
+      model: args.model,
+      ...(args.baseUrl !== undefined ? { baseUrl: args.baseUrl } : {}),
+    },
+    (texts, embedOpts) => embed(texts, embedOpts),
+    Date.now(),
+  );
 
-  const out: DecisionClustersFile = { generatedAt: Date.now(), clusters: patterns };
   await mkdir(path.dirname(args.output), { recursive: true });
   await writeFile(args.output, JSON.stringify(out, null, 2) + '\n', 'utf8');
 }

--- a/packages/schema/src/decision.ts
+++ b/packages/schema/src/decision.ts
@@ -265,4 +265,16 @@ export interface DecisionPattern {
 export interface DecisionClustersFile {
   generatedAt: number;
   clusters: readonly DecisionPattern[];
+  /**
+   * True when the clusterer ran but could NOT cluster because the
+   * embedding backend (Ollama) was unreachable. Clustering is an
+   * optional enhancement, so this is a soft, *visible* skip rather than
+   * a silent no-op: the file is still written (with `clusters: []`) so
+   * the viewer can disclose "clustering skipped — Ollama unavailable"
+   * instead of showing nothing (indistinguishable from "no recurring
+   * decisions"). Absent on a normal run. See issue #122.
+   */
+  skipped?: boolean;
+  /** Machine-readable reason for the skip. Currently the only reason. */
+  skipReason?: 'embeddings-unavailable';
 }

--- a/packages/viewer/src/components/CuratorFeed.test.tsx
+++ b/packages/viewer/src/components/CuratorFeed.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type * as CuratorFeedClient from '../data/curatorFeedClient.js';
+
+/**
+ * CuratorFeed tests — scaffold-disclosure contract (issue #120).
+ *
+ * The curator ranker / falsifier / meta-validation kernels are not yet
+ * wired into a production path, so any `falsifierStatus` tag is a
+ * placeholder. The surface must (a) carry a standing scaffold disclaimer,
+ * (b) NOT assert "passed the falsifier" as fact, and (c) render any
+ * falsifier tag as a placeholder rather than an affirmative verdict.
+ */
+
+const mockLoad = vi.fn();
+vi.mock('../data/curatorFeedClient.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof CuratorFeedClient>();
+  return {
+    ...actual,
+    loadCuratorFeed: () => mockLoad(),
+  };
+});
+
+import { CuratorFeed } from './CuratorFeed.js';
+import type { CuratorFeedFile } from '../data/curatorFeedClient.js';
+
+afterEach(() => {
+  cleanup();
+  mockLoad.mockReset();
+});
+
+describe('CuratorFeed — scaffold disclosure (issue #120)', () => {
+  it('shows a standing scaffold disclaimer (curator/falsifier not wired to production)', async () => {
+    mockLoad.mockResolvedValue(null);
+    render(<CuratorFeed />);
+    const note = await screen.findByTestId('curator-scaffold-note');
+    expect(note.textContent).toMatch(/scaffold/i);
+    expect(note.textContent).toMatch(/placeholders, not real verdicts/i);
+  });
+
+  it('does not assert "passed the falsifier" as fact while the pipeline is a scaffold', async () => {
+    mockLoad.mockResolvedValue(null);
+    render(<CuratorFeed />);
+    await screen.findByTestId('curator-scaffold-note');
+    expect(screen.queryByText(/passed the falsifier/i)).toBeNull();
+  });
+
+  it('renders a falsifierStatus tag as a placeholder, not an affirmative verdict', async () => {
+    const feed: CuratorFeedFile = {
+      schemaVersion: 1,
+      generatedAt: 1,
+      ranAt: '2026-01-01T00:00:00.000Z',
+      items: [
+        {
+          kind: 'narrative',
+          entityId: 'nar_1',
+          title: 'Some narrative',
+          rank: 1,
+          compositeScore: 0.9,
+          falsifierStatus: 'verified',
+        },
+      ],
+    };
+    mockLoad.mockResolvedValue(feed);
+    render(<CuratorFeed />);
+    const tag = await screen.findByLabelText(/falsifier verified \(placeholder/i);
+    expect(tag.textContent).toMatch(/\(placeholder\)/);
+    expect(tag.className).toMatch(/--placeholder/);
+  });
+});

--- a/packages/viewer/src/components/CuratorFeed.tsx
+++ b/packages/viewer/src/components/CuratorFeed.tsx
@@ -36,6 +36,26 @@ const FALSIFIER_TAG_LABEL: Record<CuratorFalsifierStatus, string> = {
   unavailable: 'UNVERIFIED',
 };
 
+/**
+ * Scaffold gate (issue #120). The curator ranker (F3), falsifier verifier
+ * (F4), and meta-validation (F8) kernels are NOT yet wired into any
+ * production path, and the MCP server has no transport — so any
+ * `falsifierStatus` tag on a feed item is a PLACEHOLDER, not a real
+ * verdict. While this is `false` the UI must not present "VERIFIED" as an
+ * affirmative "passed the falsifier" claim, and it shows a standing
+ * scaffold disclaimer so a reader can't mistake a placeholder for a
+ * verified finding.
+ *
+ * FLIP-GUARDRAIL — do NOT set this to `true` until per-item verdict
+ * provenance actually exists: F4 must write a real per-finding verdict
+ * AND `curator-feed.json` must carry a provenance field the UI can trust.
+ * A coarse global flip WITHOUT that provenance would re-introduce blanket
+ * "VERIFIED" for items that never passed a real falsifier — the exact
+ * trust bug #120 names. Gate the flip on the provenance landing, not on
+ * the kernels merely existing.
+ */
+export const CURATOR_PIPELINE_LIVE = false;
+
 export interface CuratorFeedProps {
   /** Base URL for the chat-arch-data sidecar tree. */
   dataDirBaseUrl?: string;
@@ -74,14 +94,31 @@ export function CuratorFeed({
         <p className="lcars-curator-feed__lead">
           Top items the curator surfaced this run. Ranking is deterministic
           (tier &gt; confidence &gt; recency &gt; correlation tie-break) —
-          not a model judgement. Items tagged{' '}
-          <span className="lcars-curator-feed__falsifier-inline lcars-curator-feed__falsifier-inline--verified">
-            VERIFIED
-          </span>{' '}
-          passed the falsifier; others carry their citation-hygiene tag for
-          audit.
+          not a model judgement.
+          {CURATOR_PIPELINE_LIVE ? (
+            <>
+              {' '}
+              Items tagged{' '}
+              <span className="lcars-curator-feed__falsifier-inline lcars-curator-feed__falsifier-inline--verified">
+                VERIFIED
+              </span>{' '}
+              passed the falsifier; others carry their citation-hygiene tag for
+              audit.
+            </>
+          ) : null}
         </p>
       </header>
+      {!CURATOR_PIPELINE_LIVE && (
+        <p
+          className="lcars-curator-feed__scaffold-note"
+          role="note"
+          data-testid="curator-scaffold-note"
+        >
+          The curator ranker and falsifier are a scaffold — not yet wired into a
+          production path. Any status tags shown below (VERIFIED / UNVERIFIED)
+          are placeholders, not real verdicts.
+        </p>
+      )}
       {feed?.metaAccuracy?.inDrift === true && (
         <p
           className="lcars-curator-feed__drift-banner"
@@ -152,10 +189,21 @@ function CuratorFeedRow({ item }: { item: CuratorFeedItem }): JSX.Element {
       )}
       {item.falsifierStatus !== undefined && (
         <span
-          className={`lcars-curator-feed__falsifier lcars-curator-feed__falsifier--${item.falsifierStatus}`}
-          aria-label={`falsifier ${item.falsifierStatus}`}
+          className={
+            `lcars-curator-feed__falsifier lcars-curator-feed__falsifier--${item.falsifierStatus}` +
+            (CURATOR_PIPELINE_LIVE ? '' : ' lcars-curator-feed__falsifier--placeholder')
+          }
+          aria-label={
+            CURATOR_PIPELINE_LIVE
+              ? `falsifier ${item.falsifierStatus}`
+              : `falsifier ${item.falsifierStatus} (placeholder — pipeline is a scaffold)`
+          }
+          {...(CURATOR_PIPELINE_LIVE
+            ? {}
+            : { title: 'placeholder — the falsifier pipeline is a scaffold, not a real verdict' })}
         >
           {FALSIFIER_TAG_LABEL[item.falsifierStatus]}
+          {CURATOR_PIPELINE_LIVE ? '' : ' (placeholder)'}
         </span>
       )}
       {item.reasoning !== undefined && item.reasoning.length > 0 && (

--- a/packages/viewer/src/components/modes/DecisionsMode.test.tsx
+++ b/packages/viewer/src/components/modes/DecisionsMode.test.tsx
@@ -219,6 +219,82 @@ describe('DecisionsMode', () => {
     expect(recurring.textContent).toMatch(/2 sessions/);
   });
 
+  it('discloses a skipped clustering run instead of hiding it (issue #122)', () => {
+    const clustersFile: DecisionClustersFile = {
+      generatedAt: 1,
+      clusters: [],
+      skipped: true,
+      skipReason: 'embeddings-unavailable',
+    };
+    render(
+      <DecisionsMode
+        file={buildFile([decision('d1', 'explicit-go-with', 'good')])}
+        clustersFile={clustersFile}
+      />,
+    );
+    const skipped = screen.getByTestId('decisions-recurring-skipped');
+    expect(skipped.textContent).toMatch(/Clustering skipped/i);
+    expect(skipped.textContent).toMatch(/Ollama not reachable/i);
+    // The normal recurring section must NOT render alongside the skip note.
+    expect(screen.queryByTestId('decisions-recurring')).toBeNull();
+  });
+
+  it('discloses the n<minN landed-rate floor on a recurring cluster (issue #119)', () => {
+    const min = THRESHOLDS.display.minNForRate;
+    const clustersFile: DecisionClustersFile = {
+      generatedAt: 1,
+      clusters: [
+        {
+          id: 'dpat_low',
+          canonicalDecision: 'use ripgrep instead of grep',
+          instanceIds: ['d1', 'd2'],
+          occurrenceCount: 2,
+          firstSeen: 0,
+          lastSeen: 0,
+          landedRate: null,
+          landedDenom: 2,
+        },
+      ],
+    };
+    render(
+      <DecisionsMode
+        file={buildFile([decision('d1', 'explicit-go-with', 'good')])}
+        clustersFile={clustersFile}
+      />,
+    );
+    const hidden = screen.getByTestId('cluster-rate-hidden-dpat_low');
+    expect(hidden.textContent).toContain(`of ${min}`);
+    expect(hidden.textContent).toMatch(/n=2/);
+  });
+
+  it('does NOT show skip/floor disclosures for a normal clusters file (absence check)', () => {
+    const clustersFile: DecisionClustersFile = {
+      generatedAt: 1,
+      clusters: [
+        {
+          id: 'dpat_ok',
+          canonicalDecision: 'use ripgrep instead of grep',
+          instanceIds: ['d1', 'd2'],
+          occurrenceCount: 2,
+          firstSeen: 0,
+          lastSeen: 0,
+          landedRate: 0.5,
+          landedDenom: 2,
+        },
+      ],
+    };
+    render(
+      <DecisionsMode
+        file={buildFile([decision('d1', 'explicit-go-with', 'good')])}
+        clustersFile={clustersFile}
+      />,
+    );
+    expect(screen.getByTestId('decisions-recurring')).toBeDefined();
+    expect(screen.queryByTestId('decisions-recurring-skipped')).toBeNull();
+    expect(screen.queryByTestId('cluster-rate-hidden-dpat_ok')).toBeNull();
+    expect(screen.getByText(/landed 50% of 2 decided/)).toBeDefined();
+  });
+
   it('shows the clear-classifications control when classified rows exist (probe ok)', async () => {
     render(<DecisionsMode file={buildFile([decision('d1', 'explicit-go-with', 'good')])} />);
     // Probe resolves in an effect → control appears asynchronously.

--- a/packages/viewer/src/components/modes/DecisionsMode.tsx
+++ b/packages/viewer/src/components/modes/DecisionsMode.tsx
@@ -480,8 +480,25 @@ export function DecisionsMode({
         </div>
       )}
 
-      {/* RECURRING — clusters of the same call made across sessions. */}
-      {clusters.length > 0 && (
+      {/* RECURRING — clusters of the same call made across sessions.
+          When clustering was soft-skipped (embeddings/Ollama unavailable,
+          issue #122) surface that explicitly rather than hiding the
+          section — a skip must not read as "no recurring decisions". */}
+      {clustersFile?.skipped ? (
+        <section
+          className="lcars-decisions__recurring"
+          aria-label="recurring decisions"
+          data-testid="decisions-recurring-skipped"
+        >
+          <h3 className="lcars-decisions__bucket-title">RECURRING DECISIONS</h3>
+          <p className="lcars-decisions__recurring-skip" role="status">
+            Clustering skipped — embeddings unavailable (Ollama not reachable).
+            Recurring-decision detection is an optional enhancement; the
+            classification above is unaffected. Start Ollama and re-run MINE to
+            populate this section.
+          </p>
+        </section>
+      ) : clusters.length > 0 ? (
         <section
           className="lcars-decisions__recurring"
           aria-label="recurring decisions"
@@ -500,10 +517,22 @@ export function DecisionsMode({
                     {cl.occurrenceCount} sessions
                   </span>
                 </div>
-                {cl.landedRate !== null && (
+                {cl.landedRate !== null ? (
                   <div className="lcars-decisions__choice">
                     <span className="lcars-decisions__chose">
                       landed {formatRate(cl.landedRate)} of {cl.landedDenom} decided
+                    </span>
+                  </div>
+                ) : (
+                  // #119 — disclose the n<minN landed-rate floor instead of
+                  // blanking silently (parity with the per-kind / Trust /
+                  // Trajectory disclosures). landedDenom is always a number.
+                  <div className="lcars-decisions__choice">
+                    <span
+                      className="lcars-decisions__rate lcars-decisions__rate--hidden"
+                      data-testid={`cluster-rate-hidden-${cl.id}`}
+                    >
+                      landed-rate hidden — n={cl.landedDenom} of {minN}
                     </span>
                   </div>
                 )}
@@ -511,7 +540,7 @@ export function DecisionsMode({
             ))}
           </ul>
         </section>
-      )}
+      ) : null}
 
       {/* UNCLASSIFIED — clean browsable list, collapsed. */}
       {unclassified.length > 0 && (

--- a/packages/viewer/src/styles.css
+++ b/packages/viewer/src/styles.css
@@ -4817,6 +4817,20 @@
   font-size: 12px;
   color: color-mix(in srgb, var(--lcars-text) 70%, transparent);
 }
+/* Standing scaffold disclaimer (#120). Deliberately MUTED/informational
+   — a dashed quiet caption, NOT the peach warning of the drift banner —
+   because it's permanent; a warning-styled permanent banner trains
+   banner-blindness against the transient actionable notices. */
+.lcars-curator-feed__scaffold-note {
+  margin: 0;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px dashed color-mix(in srgb, var(--lcars-text) 30%, transparent);
+  background: color-mix(in srgb, var(--lcars-bg-1) 70%, transparent);
+  color: color-mix(in srgb, var(--lcars-text) 65%, transparent);
+  font-size: 11px;
+  line-height: 1.5;
+}
 .lcars-curator-feed__list {
   list-style: none;
   margin: 0;
@@ -4892,6 +4906,16 @@
 .lcars-curator-feed__falsifier--skipped-by-user,
 .lcars-curator-feed__falsifier--unavailable {
   color: var(--lcars-peach);
+}
+/* Placeholder treatment (#120) — while the falsifier pipeline is a
+   scaffold, de-emphasize the tag so a placeholder can't read as an
+   affirmative verdict. Declared AFTER the per-status colors so it wins
+   the cascade. */
+.lcars-curator-feed__falsifier--placeholder {
+  color: color-mix(in srgb, var(--lcars-text) 45%, transparent);
+  font-weight: 400;
+  opacity: 0.75;
+  border-style: dashed;
 }
 .lcars-curator-feed__reasoning {
   flex: 1 0 100%;
@@ -10664,6 +10688,14 @@ button.lcars-applied-summary__stale--button:focus-visible {
   font-size: 12px;
   color: color-mix(in srgb, var(--lcars-text) 70%, var(--lcars-bg-1));
   margin: 2px 0 8px;
+}
+/* Soft clustering-skip note (#122) — muted/informational, not a warning;
+   an OPTIONAL skip must not read as a must-fix error. */
+.lcars-decisions__recurring-skip {
+  font-size: 12px;
+  color: color-mix(in srgb, var(--lcars-text) 60%, var(--lcars-bg-1));
+  margin: 2px 0 8px;
+  line-height: 1.5;
 }
 .lcars-decisions__show-all {
   margin-top: 8px;

--- a/research/honest-disclosure-122-119-120-plan.md
+++ b/research/honest-disclosure-122-119-120-plan.md
@@ -1,0 +1,230 @@
+# Plan — honest disclosure of skipped / withheld / unverified state
+
+Fixes three related "silent disclosure" issues on the DECISIONS + PRACTICE
+surfaces. All three share one theme: the UI shows *nothing* in a state that
+should show *an explanation of why there's nothing*, so "withheld / skipped /
+unverified" reads as "no data / verified."
+
+## Source of truth
+
+- Issue [#122](https://github.com/BryceEWatson/chat-arch/issues/122) (bug) — `mine-decisions` clustering silently no-ops when Ollama (embeddings) is unreachable.
+- Issue [#119](https://github.com/BryceEWatson/chat-arch/issues/119) (rigor) — cluster landed-rate floor (n<8) silently blanks; the other two floors already disclose.
+- Issue [#120](https://github.com/BryceEWatson/chat-arch/issues/120) (trust) — scaffold curator/falsifier surfaced as live; findings shown VERIFIED though unverified.
+
+Read in full via `gh issue view`. Evidence in each issue verified against the
+code (see "Grounding" below).
+
+## PR structure decision (contestable)
+
+**One PR, three commits** (one per issue), closing all three. Rationale:
+- The recent operator rule "keep open PRs to 1 only — consolidate onto a single
+  integration branch/PR" (memory `feedback_single_open_pr`) is the strongest,
+  most specific constraint and points to one PR.
+- The Claude-Code-paced override explicitly allows bundling into 1–2 PRs when
+  Claude Code is doing the implementation.
+- The three issues are one coherent theme (honest disclosure) and overlap in
+  files (#122 + #119 both touch `DecisionsMode.tsx` + the decision-clusters
+  path). Splitting would create artificial churn and >1 open PR.
+- Each issue gets its own commit so it stays independently reviewable.
+
+If the operator wants #122 split out to merge independently of the more
+subjective #119/#120 disclosure-copy changes, that's a cheap reversal — flag at
+the plan-approval gate. **This is a scope decision surfaced for consent, not a
+silent choice.**
+
+## Grounding (measured, from the code)
+
+- `cluster-decisions-cli.ts` `main()` calls `embed()` at line 240; on Ollama-down
+  it throws → `main().catch()` writes stderr + `process.exit(1)`; `decision-clusters.json`
+  is never written. Tests cover only the pure functions (`buildDecisionClusters`,
+  `parseArgs`, `normalizeDecision`), not `main()`.
+- `embed()` (`packages/exporter/src/embeddings/index.ts`) throws on connection
+  failure; wrapping the single `embed()` call catches the Ollama-down case
+  (including mid-run failures), which `isOllamaAvailable` pre-probing cannot.
+- The skill (`.claude/skills/mine-decisions/SKILL.md` Stage 3) **pre-probes**
+  Ollama and *bypasses the CLI entirely* when the probe fails → in that path
+  `decision-clusters.json` is never written either (a second silent path the
+  issue's CLI-only fix wouldn't cover).
+- `loadDecisionClustersFile` (`decisionsLoader.ts`) casts the parsed body to
+  `DecisionClustersFile` and only validates `Array.isArray(body.clusters)`, so
+  added optional fields (`skipped`/`skipReason`) pass through untouched — **no
+  loader change needed.**
+- `DecisionsMode.tsx`: the RECURRING section renders only when `clusters.length > 0`
+  (≈ line 484), so a skip is indistinguishable from "no clusters." The per-cluster
+  landed-rate renders only `cl.landedRate !== null` (≈ lines 503–509) with **no**
+  "n too low" note — that's the silent floor in #119. The per-*kind* rate (≈ lines
+  362–380) already discloses ("landed-rate hidden — n=… of {minN}"), as do TrustMode
+  and TrendsMode — so #119 only needs the cluster path brought to parity.
+- `THRESHOLDS.display.minNForRate = 8` (the n<8 floor).
+- `CuratorFeed.tsx`: lead copy asserts items tagged VERIFIED "passed the
+  falsifier" (lines 74–83) and the empty states (lines 99–111) carry no scaffold
+  disclaimer. `curatorFeedClient.ts` has **no provenance field** distinguishing a
+  real verdict from a scaffold placeholder. `/curate` + `/falsify` SKILL.md are
+  `status: scaffold`; F3/F4/F8 kernels run only in tests; the MCP server has no
+  transport. There is **no MCP "live" affordance in the viewer** (grep clean), so
+  #120 is scoped to CuratorFeed only.
+- `EXPORTER_VERSION = '1.10.0'` (`packages/exporter/src/analysis/index.ts`).
+
+## In scope
+
+### Issue #122 — soft, visible clustering skip
+1. **Schema** (`packages/schema/src/decision.ts`): add to `DecisionClustersFile`
+   two additive optional fields: `skipped?: boolean` and
+   `skipReason?: 'embeddings-unavailable'`. Update the doc comment.
+2. **CLI** (`packages/exporter/src/cli/cluster-decisions-cli.ts`): refactor the
+   embed-and-build block in `main()` into an exported, testable async helper
+   (e.g. `buildClustersFileOrSkip(decisions, opts, embedFn, embedOpts)`) that:
+   - returns `{ generatedAt, clusters }` on success;
+   - on `embedFn` throw, returns `{ generatedAt, clusters: [], skipped: true,
+     skipReason: 'embeddings-unavailable' }` and writes a stderr note (no throw);
+   - returns `{ generatedAt, clusters: [] }` (NOT skipped) when `decisions` is empty.
+   `main()` writes whatever the helper returns and exits 0 on a skip. Genuine
+   errors (bad args, unreadable input, vectors/decisions length mismatch on a
+   *successful* embed) still hard-fail via `main().catch()` → exit 1.
+3. **Skill** (`.claude/skills/mine-decisions/SKILL.md` Stage 3 + Stage 5 + Error
+   handling): stop using the Ollama pre-probe to *bypass* the CLI. Always run the
+   CLI when there are ≥2 classified decisions; it now soft-skips and writes the
+   marker, so `decision-clusters.json` is always written in the "would-have-clustered"
+   case. Keep the ≥2-classified guard (with <2 there's nothing to cluster — not a
+   skip). Note `clusterCount: 0` + `decision-clusters.json skipped:true` on the
+   skip path in Stage 5.
+4. **Viewer** (`DecisionsMode.tsx`): when `clustersFile?.skipped`, render the
+   RECURRING section header with a skip note ("Clustering skipped — embeddings
+   unavailable (Ollama not reachable). Recurring-decision detection is optional;
+   classification above is unaffected. Start Ollama and re-MINE to populate this.")
+   instead of hiding the section. `data-testid="decisions-recurring-skipped"`. The
+   note is styled **muted/informational, NOT a warning color** (per operator-empathy
+   review — a soft optional-skip must not read as a must-fix error or train
+   banner-blindness). The "classification above is unaffected" clause is load-bearing:
+   it stops the optional skip from reading as a blocking failure.
+
+**Endpoint (`mine-decisions.ts:197-227` `probeOutcome`) — deliberately UNCHANGED.**
+Issue #122 names this file, so the non-change is a decision, not an omission: with
+the soft-skip the CLI now exits 0, the skill still writes `decision-status-*.json`
+`status:'complete'` (clustering is an optional sub-step, not the run), so
+`probeOutcome` correctly reports the mine run *succeeded*. The clusters-file marker —
+not the endpoint — is what conveys the optional-skip detail to the viewer. The
+issue's "**and/or** a `decision-status-*.json status:'skipped'`" is satisfied by the
+`decision-clusters.json` marker leg; the per-request status-file leg is intentionally
+NOT used because the CLI has no `--request-id` (the skill owns the request-scoped
+status file, and it reports run-level `complete`, which is honest).
+
+### Issue #119 — cluster landed-rate floor disclosure
+5. **Viewer** (`DecisionsMode.tsx` RECURRING rows): when `cl.landedRate === null`,
+   render a muted "landed-rate hidden — n={cl.landedDenom} of {minN}" note (reusing
+   `lcars-decisions__rate--hidden`), mirroring the per-kind / Trust / Trajectory
+   pattern. `data-testid="cluster-rate-hidden-<id>"`. **`landedDenom` is always a
+   number** (`DecisionPattern.landedDenom: number`, set unconditionally as
+   `decided.length` in `buildDecisionClusters` line 189), so the "n=k of 8" message
+   is always well-formed even when `landedRate` is null — no schema/CLI change needed
+   for #119, viewer-only.
+
+### Issue #120 — scaffold disclosure on the curator feed
+6. **Viewer** (`CuratorFeed.tsx`): add a module constant
+   `CURATOR_PIPELINE_LIVE = false`. **Flip-guardrail (per vision review):** the
+   constant is a coarse scaffold-era global gate — it must NOT be flipped `true`
+   until **per-item verdict provenance** exists (F4 falsifier writing a real
+   per-finding verdict, surfaced via a provenance field on `curator-feed.json`).
+   Document this directly in the code comment so a future contributor can't flip
+   it and silently re-introduce blanket "VERIFIED" for items that never passed a
+   real falsifier. (That provenance field is itself out of scope here — see
+   Out-of-scope; the guardrail comment is what prevents the regression.) While not
+   live:
+   - render a persistent scaffold note (`data-testid="curator-scaffold-note"`,
+     **muted/informational styling**, NOT the peach drift-banner) stating the
+     curator/falsifier are a scaffold, not yet wired to production, and any
+     VERIFIED/UNVERIFIED tags are placeholders;
+   - reword the lead so it does **not** assert "VERIFIED = passed the falsifier"
+     as fact (gate that sentence behind `CURATOR_PIPELINE_LIVE`);
+   - in `CuratorFeedRow`, when not live, present the falsifier tag as a placeholder
+     (append "(placeholder)" / `--placeholder` class + tooltip) rather than an
+     affirmative verdict;
+   - add the scaffold disclosure to the empty states too.
+7. **CSS** (`packages/viewer/src/styles.css`): add `lcars-curator-feed__scaffold-note`
+   (**muted/informational** — a quiet caption, NOT the peach warning of the drift
+   banner, since it's permanent), `lcars-decisions__recurring-skip` (muted), and a
+   curator falsifier `--placeholder` treatment (de-emphasized). Reuse existing tokens.
+
+### Cross-cutting
+8. **Tests**:
+   - `cluster-decisions-cli.test.ts`: new case — a throwing `embedFn` yields a
+     file with `skipped: true`, `skipReason: 'embeddings-unavailable'`, `clusters: []`;
+     and the empty-decisions case is NOT marked skipped.
+   - `DecisionsMode.test.tsx`: (a) `clustersFile.skipped` renders the skip note +
+     no recurring rows; (b) a cluster with `landedRate: null` renders the
+     "landed-rate hidden — n=… of 8" note; (c) **absence assertion** — a normal
+     clusters file (no `skipped`, non-null `landedRate`) renders neither
+     `decisions-recurring-skipped` nor `cluster-rate-hidden-<id>`.
+   - New `CuratorFeed.test.tsx`: scaffold note present; lead does not assert
+     "passed the falsifier" as fact while scaffold; a feed item with
+     `falsifierStatus: 'verified'` renders as a placeholder (not an affirmative
+     verdict) while scaffold.
+9. **Docs**:
+   - `CHANGELOG.md`: new `[1.11.0]` entry covering all three fixes (note the
+     version-reconcile caveat vs. the 1.10.0/#113 slot already recorded).
+   - `EXPORTER_VERSION` → `1.11.0`. **Contestable Tier-1 decision (per architecture
+     review), surfaced not asserted:** `decision-clusters.json` is *skill-written*,
+     not exporter-emitted, so one could argue the exporter version shouldn't move
+     for it. Decision: **bump anyway.** Rationale — (a) `EXPORTER_VERSION` is the
+     *bundle-wide* provenance label in `meta.json`, and CLAUDE.md's documented
+     trigger is literally "the shape of an existing artifact changes," which this
+     is; (b) precedent: 1.9.0 bumped for the decisions pipeline whose classification
+     is *also* skill-merged into `decisions.json`; (c) the version is what lets an
+     operator correlate "this bundle's `decision-clusters.json` may carry
+     `skipped`/`skipReason`" with the CHANGELOG. If the operator prefers to leave
+     `EXPORTER_VERSION` and bump only the SKILL.md doc + CHANGELOG, that's a clean
+     alternative — flag at the plan-approval gate.
+   - `CLAUDE.md` "Data on disk" / decisions-sidecar section: note
+     `decision-clusters.json` may now carry `skipped`/`skipReason`.
+   - `.claude/skills/mine-decisions/SKILL.md`: the Stage 3/5 changes above.
+
+## Out of scope / Deferred (do NOT build)
+
+- Wiring the F3 curator ranker / F4 falsifier / F8 meta-validation kernels into a
+  production path, or the H3 MCP stdio transport. #120's own severity note says
+  these "are project work"; only the *disclosure* is in scope. `CURATOR_PIPELINE_LIVE`
+  is the single switch that flips when they land.
+- Adding a real verdict-provenance field to `curator-feed.json` (would require
+  the scaffold skills to write it). The boolean gate is the bounded fix.
+- Changing clustering thresholds, the embedding model, or the landed-rate floor
+  value itself (#119 is disclosure-only).
+- Any change to `mine-corrections` clustering (sibling CLI) — not in these issues.
+- Reworking the Ollama pre-probe into the CLI (the skill keeps an optional probe
+  only for a friendly log line; the CLI owns the skip).
+
+## Definition of done (testable)
+
+- `pnpm lint` + `pnpm test` + `pnpm build` green from the repo root.
+- New unit tests above pass and assert the skip-marker shape + both disclosures +
+  the scaffold gating.
+- **Real-app exercise:** rebuild the viewer, run `pnpm dev`, and drive the live
+  app via the browser preview. **Forcing the skip state** (so the browser check is
+  actually reachable, not dependent on Ollama happening to be down): hand-write
+  `apps/standalone/public/chat-arch-data/analysis/decision-clusters.json` as
+  `{"generatedAt":<ms>,"clusters":[],"skipped":true,"skipReason":"embeddings-unavailable"}`
+  and reload — this is exactly the file the soft-skip path writes.
+  - DECISIONS surface with the forced `skipped:true` file shows the skip note
+    (success path); and with a cluster `landedRate:null` shows the "n too low" note.
+  - **Failure-path / falsifiable absence check:** with a *normal* clusters file
+    (no `skipped`, a cluster with a non-null `landedRate`), the elements
+    `decisions-recurring-skipped` and `cluster-rate-hidden-<id>` MUST be **absent**
+    (assert via `queryByTestId === null` in the unit test + visual confirm), while
+    the rate text renders — i.e. the disclosures don't fire spuriously.
+  - PRACTICE surface shows the curator scaffold disclaimer and no affirmative
+    "VERIFIED = passed the falsifier" claim.
+  - Capture screenshots as proof.
+- Docs updated (CHANGELOG, EXPORTER_VERSION, CLAUDE.md, SKILL.md).
+- PR opened against **`main`** on a fresh branch off `main`; `/review-loop`
+  (PR/code mode) returns `<promise>review-clean</promise>` with a commit-pinned
+  verdict comment.
+
+## Risks / notes
+
+- Version-reconcile: `main` may already be at/above 1.10.0 via #113. If a higher
+  version landed, bump to the next free slot and note it (per the Step-5 convention
+  already recorded in CHANGELOG `[1.10.0]`).
+- The skill is LLM-driven instructions, not executable code, so the SKILL.md
+  change is a behavior-doc change; the CLI soft-skip is the load-bearing,
+  deterministic guarantee that survives whatever the skill does.
+- `Date.now()` in the CLI is fine (it's a CLI, not a workflow script); tests
+  assert structural fields, not the timestamp.


### PR DESCRIPTION
Three related "silent disclosure" bugs where a surface showed *nothing* in a state that should have shown *why there's nothing*, so "skipped / withheld / unverified" read as "no data / verified."

## #122 — `mine-decisions` clustering silently skipped when Ollama is down
`cluster-decisions-cli` threw and exited 1 on an unreachable embedding backend, writing no `decision-clusters.json` — the DECISIONS surface showed no recurring section, indistinguishable from "no recurring decisions found."

- The clusterer now **soft-skips**: writes `decision-clusters.json` with `{ clusters: [], skipped: true, skipReason: 'embeddings-unavailable' }` and exits 0. Genuine errors (bad args, unreadable input, a vectors/decisions length mismatch on a *successful* embed) still hard-fail.
- The `/mine-decisions` skill no longer uses its Ollama pre-probe to bypass the CLI, so the marker is written on the Ollama-down path too.
- `DecisionsMode` renders a muted "clustering skipped — embeddings unavailable (Ollama not reachable)" note instead of hiding the section. The endpoint's `probeOutcome` is deliberately unchanged (the run still reports success; the marker conveys the optional-skip detail).

## #119 — recurring-cluster landed-rate floor silently blanked
When a recurring cluster had fewer than `THRESHOLDS.display.minNForRate` (8) decided members, its rate was `null` and the row showed nothing. It now shows **"landed-rate hidden — n=k of 8"**, at parity with the Trust-cell and Trajectory-bootstrap disclosures that already existed.

## #120 — scaffold curator/falsifier surfaced as live/verified
The PRACTICE curator feed showed `VERIFIED` badges and "passed the falsifier" copy, but the F3/F4/F8 kernels are not wired into any production path.

- New `CURATOR_PIPELINE_LIVE` gate (`false`, with a **flip-guardrail**: don't flip until real per-item verdict provenance exists).
- While not live: a standing scaffold disclaimer, the affirmative "passed the falsifier" claim suppressed, and any falsifier tag rendered as a `(placeholder)`.
- Wiring the F3/F4/F8 kernels + the MCP transport remains separate project work (per the issue's own severity note).

## Schema / versioning
`DecisionClustersFile` gains two additive optional fields (`skipped?`, `skipReason?`). `EXPORTER_VERSION` 1.10.0 → 1.11.0 (the on-disk shape of an existing artifact changed; skill-written, but the version is the bundle-wide provenance label). Reconcile to the next free slot if #113 takes 1.11.0 first.

## Verification
- `pnpm build` + `pnpm lint` (data-processing budget unchanged at 26/26) + `pnpm test` (**2527 passing**, 5 skipped) all green.
- New unit tests: CLI skip-marker / empty-not-skipped / length-mismatch-hard-fail; viewer skip-note, floor-note, and absence (normal file → neither note); curator scaffold note / no "passed the falsifier" / placeholder tag.
- **Real-app exercise** (dev server, browser): confirmed via DOM + computed-style assertions that each disclosure fires only in its intended state and the normal path stays clean (skip note `skipped:true`; floor note `landedRate:null` → "n=2 of 8"; scaffold note on PRACTICE with the claim gone; normal cluster → "landed 50% of 2 decided", no spurious notes). Bitmap screenshots stalled on the 21 MB ORT wasm asset, so DOM-level evidence was used instead.
- Docs: CLAUDE.md (data-on-disk), `/mine-decisions` SKILL.md, CHANGELOG `[1.11.0]`.

Built via the `ship-it` chain (researched → plan reviewed clean by a 4-lens plan review-loop → implemented → tested → this PR).

Closes #122
Closes #119
Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
